### PR TITLE
feat: 服薬スケジュール作成・編集機能の実装

### DIFF
--- a/frontend/src/components/schedules/ScheduleForm.tsx
+++ b/frontend/src/components/schedules/ScheduleForm.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { DayOfWeek } from '../../domain/entities/Schedule';
+
+export interface ScheduleFormData {
+  scheduledTime: string;
+  daysOfWeek: DayOfWeek[];
+  reminderMinutesBefore: number;
+}
+
+interface ScheduleFormProps {
+  onSubmit: (data: ScheduleFormData) => void;
+}
+
+const DAY_OPTIONS: { value: DayOfWeek; label: string }[] = [
+  { value: 'mon', label: '月' },
+  { value: 'tue', label: '火' },
+  { value: 'wed', label: '水' },
+  { value: 'thu', label: '木' },
+  { value: 'fri', label: '金' },
+  { value: 'sat', label: '土' },
+  { value: 'sun', label: '日' },
+];
+
+export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
+  const [scheduledTime, setScheduledTime] = useState('08:00');
+  const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
+  const [reminderMinutes, setReminderMinutes] = useState('10');
+
+  const toggleDay = (day: DayOfWeek) => {
+    setSelectedDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (selectedDays.length === 0) return;
+
+    onSubmit({
+      scheduledTime,
+      daysOfWeek: selectedDays,
+      reminderMinutesBefore: parseInt(reminderMinutes, 10) || 0,
+    });
+
+    setScheduledTime('08:00');
+    setSelectedDays([]);
+    setReminderMinutes('10');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="schedule-time" className="block text-sm font-medium text-gray-700 mb-1">
+          服薬時刻
+        </label>
+        <input
+          id="schedule-time"
+          type="time"
+          value={scheduledTime}
+          onChange={(e) => setScheduledTime(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-gray-700 mb-2">曜日</span>
+        <div className="flex flex-wrap gap-2">
+          {DAY_OPTIONS.map(({ value, label }) => (
+            <label
+              key={value}
+              className={`flex items-center justify-center w-10 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
+                selectedDays.includes(value)
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={selectedDays.includes(value)}
+                onChange={() => toggleDay(value)}
+                className="sr-only"
+                aria-label={label}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="reminder-minutes" className="block text-sm font-medium text-gray-700 mb-1">
+          リマインダー（分前）
+        </label>
+        <select
+          id="reminder-minutes"
+          value={reminderMinutes}
+          onChange={(e) => setReminderMinutes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="0">なし</option>
+          <option value="5">5分前</option>
+          <option value="10">10分前</option>
+          <option value="15">15分前</option>
+          <option value="30">30分前</option>
+          <option value="60">1時間前</option>
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+      >
+        スケジュールを追加
+      </button>
+    </form>
+  );
+};

--- a/frontend/src/components/schedules/__tests__/ScheduleForm.test.tsx
+++ b/frontend/src/components/schedules/__tests__/ScheduleForm.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ScheduleForm } from '../ScheduleForm';
+
+describe('ScheduleForm', () => {
+  it('フォームが正しく表示される', () => {
+    render(<ScheduleForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByLabelText('服薬時刻')).toBeInTheDocument();
+    expect(screen.getByText('曜日')).toBeInTheDocument();
+    expect(screen.getByLabelText('リマインダー（分前）')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'スケジュールを追加' })).toBeInTheDocument();
+  });
+
+  it('全曜日のチェックボックスが表示される', () => {
+    render(<ScheduleForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByLabelText('月')).toBeInTheDocument();
+    expect(screen.getByLabelText('火')).toBeInTheDocument();
+    expect(screen.getByLabelText('水')).toBeInTheDocument();
+    expect(screen.getByLabelText('木')).toBeInTheDocument();
+    expect(screen.getByLabelText('金')).toBeInTheDocument();
+    expect(screen.getByLabelText('土')).toBeInTheDocument();
+    expect(screen.getByLabelText('日')).toBeInTheDocument();
+  });
+
+  it('フォーム送信時にonSubmitが呼ばれる', () => {
+    const onSubmit = vi.fn();
+    render(<ScheduleForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('服薬時刻'), { target: { value: '08:00' } });
+    fireEvent.click(screen.getByLabelText('月'));
+    fireEvent.click(screen.getByLabelText('水'));
+    fireEvent.click(screen.getByLabelText('金'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'スケジュールを追加' }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduledTime: '08:00',
+        daysOfWeek: expect.arrayContaining(['mon', 'wed', 'fri']),
+      })
+    );
+  });
+
+  it('曜日が選択されていない場合、送信されない', () => {
+    const onSubmit = vi.fn();
+    render(<ScheduleForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('服薬時刻'), { target: { value: '08:00' } });
+    fireEvent.click(screen.getByRole('button', { name: 'スケジュールを追加' }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('リマインダー時間を設定できる', () => {
+    const onSubmit = vi.fn();
+    render(<ScheduleForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('服薬時刻'), { target: { value: '12:00' } });
+    fireEvent.change(screen.getByLabelText('リマインダー（分前）'), { target: { value: '30' } });
+    fireEvent.click(screen.getByLabelText('月'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'スケジュールを追加' }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduledTime: '12:00',
+        reminderMinutesBefore: 30,
+      })
+    );
+  });
+});

--- a/frontend/src/presentation/hooks/useScheduleManagement.ts
+++ b/frontend/src/presentation/hooks/useScheduleManagement.ts
@@ -1,0 +1,58 @@
+/**
+ * スケジュール管理カスタムフック（ViewModel）
+ */
+
+import { useState, useCallback } from 'react';
+import { ScheduleRepositoryImpl } from '../../data/repositories/ScheduleRepositoryImpl';
+import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
+
+const scheduleRepository = new ScheduleRepositoryImpl();
+
+export interface CreateScheduleInput {
+  medicationId: string;
+  userId: string;
+  memberId: string;
+  scheduledTime: string;
+  daysOfWeek: DayOfWeek[];
+  reminderMinutesBefore: number;
+}
+
+export interface UseScheduleManagementResult {
+  isCreating: boolean;
+  error: Error | null;
+  createSchedule: (input: CreateScheduleInput) => Promise<void>;
+}
+
+export const useScheduleManagement = (): UseScheduleManagementResult => {
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const handleCreateSchedule = useCallback(async (input: CreateScheduleInput) => {
+    try {
+      setIsCreating(true);
+      setError(null);
+
+      const scheduleData: Omit<Schedule, 'id' | 'createdAt'> = {
+        medicationId: input.medicationId,
+        userId: input.userId,
+        memberId: input.memberId,
+        scheduledTime: input.scheduledTime,
+        daysOfWeek: input.daysOfWeek,
+        isEnabled: true,
+        reminderMinutesBefore: input.reminderMinutesBefore,
+      };
+
+      await scheduleRepository.createSchedule(scheduleData);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsCreating(false);
+    }
+  }, []);
+
+  return {
+    isCreating,
+    error,
+    createSchedule: handleCreateSchedule,
+  };
+};


### PR DESCRIPTION
## 概要
薬に対して服薬スケジュール（時刻・曜日・リマインダー）を作成できる機能を実装しました。

## 実装内容
- **UI層**: ScheduleFormコンポーネント（時刻、曜日チェックボックス、リマインダー設定）
- **Presentation層**: useScheduleManagementカスタムフック

## テスト（TDD）
- ScheduleFormコンポーネント: 5テスト通過（フォーム表示、曜日選択、バリデーション、送信）

## 関連Issue
closes #29