### PR TITLE
feat: キャラクター選択・表示機能の実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Members from './pages/Members';
 import Medications from './pages/Medications';
+import Settings from './pages/Settings';
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/members" element={<Members />} />
         <Route path="/members/:memberId/medications" element={<Medications />} />
+        <Route path="/settings" element={<Settings />} />
       </Routes>
     </div>
   );

--- a/frontend/src/components/character/CharacterSelector.tsx
+++ b/frontend/src/components/character/CharacterSelector.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { CharacterType, CHARACTER_CONFIGS } from '../../types/character';
+import { useCharacterStore } from '../../stores/characterStore';
+
+const characterTypes: CharacterType[] = ['dog', 'cat', 'rabbit', 'bird'];
+
+export const CharacterSelector: React.FC = () => {
+  const { selectedCharacter, setCharacter } = useCharacterStore();
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {characterTypes.map((type) => {
+        const config = CHARACTER_CONFIGS[type];
+        const isSelected = selectedCharacter === type;
+
+        return (
+          <button
+            key={type}
+            onClick={() => setCharacter(type)}
+            className={`flex flex-col items-center p-4 rounded-xl border-2 transition-all ${
+              isSelected
+                ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-200'
+                : 'border-gray-200 bg-white hover:border-blue-300'
+            }`}
+          >
+            <span className="text-4xl mb-2">{config.icon}</span>
+            <span className={`text-sm font-medium ${isSelected ? 'text-blue-700' : 'text-gray-600'}`}>
+              {config.name}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/components/character/__tests__/CharacterSelector.test.tsx
+++ b/frontend/src/components/character/__tests__/CharacterSelector.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CharacterSelector } from '../CharacterSelector';
+import { useCharacterStore } from '../../../stores/characterStore';
+
+describe('CharacterSelector', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ selectedCharacter: 'cat' });
+  });
+
+  it('4種類のキャラクターが表示される', () => {
+    render(<CharacterSelector />);
+
+    expect(screen.getByText('いぬ')).toBeInTheDocument();
+    expect(screen.getByText('ねこ')).toBeInTheDocument();
+    expect(screen.getByText('うさぎ')).toBeInTheDocument();
+    expect(screen.getByText('インコ')).toBeInTheDocument();
+  });
+
+  it('各キャラクターのアイコンが表示される', () => {
+    render(<CharacterSelector />);
+
+    expect(screen.getByText('🐕')).toBeInTheDocument();
+    expect(screen.getByText('🐈️')).toBeInTheDocument();
+    expect(screen.getByText('🐇')).toBeInTheDocument();
+    expect(screen.getByText('🦜')).toBeInTheDocument();
+  });
+
+  it('キャラクターをクリックして選択できる', () => {
+    render(<CharacterSelector />);
+
+    fireEvent.click(screen.getByText('いぬ'));
+
+    expect(useCharacterStore.getState().selectedCharacter).toBe('dog');
+  });
+
+  it('選択中のキャラクターが視覚的に強調される', () => {
+    render(<CharacterSelector />);
+
+    // 初期状態ではcatが選択されている
+    const catButton = screen.getByText('ねこ').closest('button');
+    expect(catButton?.className).toContain('ring-2');
+  });
+});

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,10 +1,13 @@
 import { Link } from 'react-router-dom';
 import { TodayScheduleList } from '../components/dashboard/TodayScheduleList';
 import { useTodaySchedules } from '../presentation/hooks/useTodaySchedules';
+import { useCharacterStore } from '../stores/characterStore';
 
 export default function Dashboard() {
   // ViewModelから状態を取得（クリーンアーキテクチャ）
   const { schedules, isLoading, markAsCompleted } = useTodaySchedules('user-1'); // TODO: 実際のuserIdに置き換え
+  const { getConfig, getMessage } = useCharacterStore();
+  const character = getConfig();
 
   const handleMarkCompleted = async (scheduleId: string) => {
     await markAsCompleted(scheduleId);
@@ -17,9 +20,9 @@ export default function Dashboard() {
       </header>
 
       <div className="bg-white rounded-2xl shadow-sm p-4 mb-4 text-center">
-        <div className="text-4xl mb-2">🐈️</div>
+        <div className="text-4xl mb-2">{character.icon}</div>
         <p className="text-lg font-medium text-gray-700">
-          お薬の時間だにゃい！
+          {getMessage('medicationReminder')}
         </p>
       </div>
 
@@ -44,10 +47,10 @@ export default function Dashboard() {
             <span className="text-lg">💊</span>
             お薬
           </button>
-          <button className="flex flex-col items-center text-gray-400 text-xs">
+          <Link to="/settings" className="flex flex-col items-center text-gray-400 text-xs">
             <span className="text-lg">👤</span>
             設定
-          </button>
+          </Link>
         </div>
       </nav>
     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router-dom';
+import { CharacterSelector } from '../components/character/CharacterSelector';
+
+export default function Settings() {
+  return (
+    <div className="max-w-md mx-auto p-4 pb-20">
+      <header className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-bold text-primary-700">設定</h1>
+      </header>
+
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold text-gray-500 mb-3">キャラクター選択</h2>
+        <div className="bg-white rounded-xl shadow-sm p-4">
+          <CharacterSelector />
+        </div>
+      </section>
+
+      <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
+        <div className="max-w-md mx-auto flex justify-around py-2">
+          <Link to="/" className="flex flex-col items-center text-gray-400 text-xs">
+            <span className="text-lg">🏠</span>
+            ホーム
+          </Link>
+          <Link to="/members" className="flex flex-col items-center text-gray-400 text-xs">
+            <span className="text-lg">👥</span>
+            メンバー
+          </Link>
+          <button className="flex flex-col items-center text-gray-400 text-xs">
+            <span className="text-lg">💊</span>
+            お薬
+          </button>
+          <Link to="/settings" className="flex flex-col items-center text-primary-600 text-xs">
+            <span className="text-lg">👤</span>
+            設定
+          </Link>
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/frontend/src/stores/__tests__/characterStore.test.ts
+++ b/frontend/src/stores/__tests__/characterStore.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCharacterStore } from '../characterStore';
+
+describe('characterStore', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ selectedCharacter: 'cat' });
+  });
+
+  it('初期キャラクターはcatである', () => {
+    const state = useCharacterStore.getState();
+    expect(state.selectedCharacter).toBe('cat');
+  });
+
+  it('キャラクターを変更できる', () => {
+    useCharacterStore.getState().setCharacter('dog');
+    expect(useCharacterStore.getState().selectedCharacter).toBe('dog');
+  });
+
+  it('キャラクター設定を取得できる', () => {
+    const config = useCharacterStore.getState().getConfig();
+    expect(config.type).toBe('cat');
+    expect(config.icon).toBe('🐈️');
+    expect(config.name).toBe('ねこ');
+  });
+
+  it('服薬リマインダーメッセージを取得できる', () => {
+    const message = useCharacterStore.getState().getMessage('medicationReminder');
+    expect(message).toBe('にゃいにゃい！お薬の時間にゃ！');
+  });
+
+  it('犬に切り替えるとメッセージが変わる', () => {
+    useCharacterStore.getState().setCharacter('dog');
+    const message = useCharacterStore.getState().getMessage('medicationReminder');
+    expect(message).toBe('わんわん！お薬の時間だよ！');
+  });
+});

--- a/frontend/src/stores/characterStore.ts
+++ b/frontend/src/stores/characterStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { CharacterType, CharacterConfig, CHARACTER_CONFIGS } from '../types/character';
+
+type MessageKey = keyof CharacterConfig['messages'];
+
+interface CharacterState {
+  selectedCharacter: CharacterType;
+  setCharacter: (character: CharacterType) => void;
+  getConfig: () => CharacterConfig;
+  getMessage: (key: MessageKey) => string;
+}
+
+export const useCharacterStore = create<CharacterState>((set, get) => ({
+  selectedCharacter: 'cat',
+
+  setCharacter: (character: CharacterType) => {
+    set({ selectedCharacter: character });
+  },
+
+  getConfig: () => {
+    return CHARACTER_CONFIGS[get().selectedCharacter];
+  },
+
+  getMessage: (key: MessageKey) => {
+    return CHARACTER_CONFIGS[get().selectedCharacter].messages[key];
+  },
+}));


### PR DESCRIPTION
## 概要
4種類のキャラクター（犬・猫・うさぎ・鳥）から選択して、ダッシュボードに動的に表示する機能を実装しました。

## 実装内容
- **状態管理**: Zustand characterStore（キャラクター切り替え、設定取得、メッセージ取得）
- **UI**: CharacterSelectorコンポーネント、設定ページ
- **ダッシュボード統合**: キャラクターアイコン・メッセージの動的表示
- **ルーティング**: /settingsルート追加、ナビバー更新

## テスト（TDD）
- characterStore: 5テスト（初期値、切り替え、設定取得、メッセージ）
- CharacterSelector: 4テスト（表示、選択、ハイライト）

## 関連Issue
closes #31