### PR TITLE
test: バックエンド共有モジュールのテスト追加

### DIFF
--- a/backend/src/shared/__tests__/auth.test.ts
+++ b/backend/src/shared/__tests__/auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { requireAuth, getUserId } from '../auth';
+import type { Request, Response, NextFunction } from 'express';
+
+const createMockReq = (headers: Record<string, string> = {}): Request => {
+  return { headers } as Request;
+};
+
+const createMockRes = () => {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+};
+
+describe('auth', () => {
+  describe('requireAuth', () => {
+    it('x-user-idヘッダーがある場合、nextを呼ぶ', () => {
+      const req = createMockReq({ 'x-user-id': 'user-123' });
+      const res = createMockRes();
+      const next = vi.fn() as NextFunction;
+
+      requireAuth(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('x-user-idヘッダーがない場合、401を返す', () => {
+      const req = createMockReq({});
+      const res = createMockRes();
+      const next = vi.fn() as NextFunction;
+
+      requireAuth(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: '認証が必要です',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('x-user-idが空文字の場合、401を返す', () => {
+      const req = createMockReq({ 'x-user-id': '' });
+      const res = createMockRes();
+      const next = vi.fn() as NextFunction;
+
+      requireAuth(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('x-user-idが空白のみの場合、401を返す', () => {
+      const req = createMockReq({ 'x-user-id': '   ' });
+      const res = createMockRes();
+      const next = vi.fn() as NextFunction;
+
+      requireAuth(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUserId', () => {
+    it('x-user-idヘッダーの値を返す', () => {
+      const req = createMockReq({ 'x-user-id': 'user-456' });
+
+      expect(getUserId(req)).toBe('user-456');
+    });
+  });
+});

--- a/backend/src/shared/__tests__/response.test.ts
+++ b/backend/src/shared/__tests__/response.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { success, created, error, notFound } from '../response';
+import type { Response } from 'express';
+
+const createMockRes = () => {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+};
+
+describe('response', () => {
+  describe('success', () => {
+    it('200ステータスとデータを返す', () => {
+      const res = createMockRes();
+      success(res, { id: 1 });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { id: 1 },
+      });
+    });
+
+    it('カスタムステータスコードを指定できる', () => {
+      const res = createMockRes();
+      success(res, { id: 1 }, 202);
+
+      expect(res.status).toHaveBeenCalledWith(202);
+    });
+  });
+
+  describe('created', () => {
+    it('201ステータスを返す', () => {
+      const res = createMockRes();
+      created(res, { id: 1 });
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        success: true,
+        data: { id: 1 },
+      });
+    });
+  });
+
+  describe('error', () => {
+    it('エラーメッセージを返す', () => {
+      const res = createMockRes();
+      error(res, 'エラー', 500);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'エラー',
+      });
+    });
+
+    it('デフォルトで400ステータスを返す', () => {
+      const res = createMockRes();
+      error(res, 'バリデーションエラー');
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('notFound', () => {
+    it('404ステータスとリソース名を返す', () => {
+      const res = createMockRes();
+      notFound(res, 'メンバー');
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'メンバーが見つかりません',
+      });
+    });
+
+    it('デフォルトのリソース名を使用する', () => {
+      const res = createMockRes();
+      notFound(res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        success: false,
+        error: 'リソースが見つかりません',
+      });
+    });
+  });
+});

--- a/backend/src/shared/__tests__/validation.test.ts
+++ b/backend/src/shared/__tests__/validation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { pickAllowedFields, isNonEmptyString, isValidLength } from '../validation';
+
+describe('validation', () => {
+  describe('pickAllowedFields', () => {
+    it('許可されたフィールドのみを抽出する', () => {
+      const body = { name: 'テスト', age: 30, role: 'admin' };
+      const result = pickAllowedFields(body, ['name', 'age']);
+
+      expect(result).toEqual({ name: 'テスト', age: 30 });
+    });
+
+    it('存在しないフィールドは無視される', () => {
+      const body = { name: 'テスト' };
+      const result = pickAllowedFields(body, ['name', 'age']);
+
+      expect(result).toEqual({ name: 'テスト' });
+    });
+
+    it('undefinedのフィールドは除外される', () => {
+      const body = { name: 'テスト', age: undefined };
+      const result = pickAllowedFields(body, ['name', 'age']);
+
+      expect(result).toEqual({ name: 'テスト' });
+    });
+
+    it('空のbodyの場合、空オブジェクトを返す', () => {
+      const body = {};
+      const result = pickAllowedFields(body, ['name', 'age']);
+
+      expect(result).toEqual({});
+    });
+
+    it('システムフィールド（userId, createdAt等）をブロックする', () => {
+      const body = {
+        name: 'テスト',
+        userId: 'attacker-id',
+        createdAt: '2020-01-01',
+        memberId: 'fake-id',
+      };
+      const result = pickAllowedFields(body, ['name']);
+
+      expect(result).toEqual({ name: 'テスト' });
+      expect(result).not.toHaveProperty('userId');
+      expect(result).not.toHaveProperty('createdAt');
+    });
+
+    it('プロトタイプ汚染を防止する', () => {
+      const body = { __proto__: { polluted: true }, name: 'テスト' };
+      const result = pickAllowedFields(body, ['name', '__proto__']);
+
+      expect(result).toEqual({ name: 'テスト' });
+    });
+  });
+
+  describe('isNonEmptyString', () => {
+    it('通常の文字列はtrueを返す', () => {
+      expect(isNonEmptyString('テスト')).toBe(true);
+    });
+
+    it('空文字はfalseを返す', () => {
+      expect(isNonEmptyString('')).toBe(false);
+    });
+
+    it('空白のみはfalseを返す', () => {
+      expect(isNonEmptyString('   ')).toBe(false);
+    });
+
+    it('nullはfalseを返す', () => {
+      expect(isNonEmptyString(null)).toBe(false);
+    });
+
+    it('undefinedはfalseを返す', () => {
+      expect(isNonEmptyString(undefined)).toBe(false);
+    });
+
+    it('数値はfalseを返す', () => {
+      expect(isNonEmptyString(123)).toBe(false);
+    });
+  });
+
+  describe('isValidLength', () => {
+    it('制限内の文字列はtrueを返す', () => {
+      expect(isValidLength('abc', 5)).toBe(true);
+    });
+
+    it('制限と同じ長さはtrueを返す', () => {
+      expect(isValidLength('abcde', 5)).toBe(true);
+    });
+
+    it('制限を超える文字列はfalseを返す', () => {
+      expect(isValidLength('abcdef', 5)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## 概要
バックエンドに追加した認証ミドルウェア、バリデーション、レスポンスヘルパーのユニットテストを追加。

## 追加テスト（27件）
- **auth.test.ts**: 5件（requireAuth: ヘッダー有無/空文字/空白、getUserId）
- **validation.test.ts**: 15件（pickAllowedFields: フィールド抽出/除外/プロトタイプ汚染防止、isNonEmptyString: 各型チェック、isValidLength: 境界値）
- **response.test.ts**: 7件（success/created/error/notFound: ステータスコード、デフォルト値）

## テスト
- バックエンド全27テストパス

closes #41