### PR TITLE
test: ページコンポーネントのインタラクションテスト追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@eslint/js": "^9.39.2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/howler": "^2.2.12",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -3780,6 +3781,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@eslint/js": "^9.39.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/howler": "^2.2.12",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/frontend/src/pages/__tests__/Members.test.tsx
+++ b/frontend/src/pages/__tests__/Members.test.tsx
@@ -1,7 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Members from '../Members';
+
+const mockCreateMember = vi.fn().mockResolvedValue({
+  id: 'member-3',
+  userId: 'user-1',
+  name: '新メンバー',
+  memberType: 'human',
+  createdAt: new Date(),
+});
+const mockDeleteMember = vi.fn().mockResolvedValue(undefined);
 
 // memberApiをモック
 vi.mock('../../data/api/memberApi', () => ({
@@ -23,14 +33,16 @@ vi.mock('../../data/api/memberApi', () => ({
         createdAt: new Date(),
       },
     ]),
-    createMember: vi.fn().mockResolvedValue({
-      id: 'member-3',
+    getMemberById: vi.fn().mockResolvedValue({
+      id: 'member-1',
       userId: 'user-1',
-      name: '新メンバー',
+      name: 'パパ',
       memberType: 'human',
       createdAt: new Date(),
     }),
-    deleteMember: vi.fn().mockResolvedValue(undefined),
+    createMember: (...args: unknown[]) => mockCreateMember(...args),
+    updateMember: vi.fn().mockResolvedValue({}),
+    deleteMember: (...args: unknown[]) => mockDeleteMember(...args),
   },
 }));
 
@@ -93,5 +105,67 @@ describe('Members Page', () => {
     );
 
     expect(screen.getByText('ホーム')).toBeInTheDocument();
+  });
+
+  it('フォーム送信でメンバーが作成される', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Members />
+      </MemoryRouter>
+    );
+
+    // フォームを開く
+    await user.click(screen.getByText('+ 追加'));
+
+    // 名前を入力して送信
+    await user.type(screen.getByPlaceholderText('名前を入力'), '花子');
+    await user.click(screen.getByText('追加する'));
+
+    await waitFor(() => {
+      expect(mockCreateMember).toHaveBeenCalled();
+    });
+  });
+
+  it('フォーム送信後にフォームが閉じる', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Members />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByText('+ 追加'));
+    expect(screen.getByText('新しいメンバーを追加')).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText('名前を入力'), '花子');
+    await user.click(screen.getByText('追加する'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('新しいメンバーを追加')).not.toBeInTheDocument();
+    });
+  });
+
+  it('削除ボタンでメンバーが削除される', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <Members />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('パパ')).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByLabelText('削除');
+    await user.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(mockDeleteMember).toHaveBeenCalledWith('member-1');
+    });
   });
 });


### PR DESCRIPTION
## 概要
- Members.tsx、Medications.tsxにフォーム送信・削除ハンドラーのテストを追加
- @testing-library/user-eventを導入してユーザーインタラクションをより正確にテスト
- カバレッジが Statements 94.83% → 96.51% に向上

## テスト結果
- フロントエンド：175テスト / 29ファイル 全パス
- Members.tsx：69.23% → 100%
- Medications.tsx：67.39% → 100%

## 追加テスト
- フォーム送信でメンバー/薬が作成される
- フォーム送信後にフォームが閉じる
- 削除ボタンでメンバー/薬が削除される

Closes #45