### PR TITLE
fix: バックエンド全ルーターにエラーログ出力を追加

### DIFF
--- a/backend/src/functions/appointments/router.ts
+++ b/backend/src/functions/appointments/router.ts
@@ -5,6 +5,7 @@ import { docClient, TABLE_NAMES } from '../../shared/dynamodb.js';
 import { success, created, notFound, error } from '../../shared/response.js';
 import { getUserId } from '../../shared/auth.js';
 import { pickAllowedFields } from '../../shared/validation.js';
+import { logger } from '../../shared/logger.js';
 
 const ALLOWED_APPOINTMENT_FIELDS = [
   'memberId', 'hospitalId', 'appointmentDate', 'appointmentTime',
@@ -29,7 +30,8 @@ appointmentsRouter.get('/', async (req, res) => {
       ScanIndexForward: true,
     }));
     return success(res, result.Items || []);
-  } catch {
+  } catch (err) {
+    logger.error('予約一覧取得に失敗', err);
     return error(res, '一覧取得に失敗しました', 500);
   }
 });
@@ -53,7 +55,8 @@ appointmentsRouter.post('/', async (req, res) => {
       Item: item,
     }));
     return created(res, item);
-  } catch {
+  } catch (err) {
+    logger.error('予約登録に失敗', err);
     return error(res, '登録に失敗しました', 500);
   }
 });
@@ -100,7 +103,8 @@ appointmentsRouter.put('/:appointmentId', async (req, res) => {
       ReturnValues: 'ALL_NEW',
     }));
     return success(res, result.Attributes);
-  } catch {
+  } catch (err) {
+    logger.error('予約更新に失敗', err);
     return error(res, '更新に失敗しました', 500);
   }
 });
@@ -122,7 +126,8 @@ appointmentsRouter.delete('/:appointmentId', async (req, res) => {
       Key: { appointmentId: req.params.appointmentId },
     }));
     return success(res, { message: '削除しました' });
-  } catch {
+  } catch (err) {
+    logger.error('予約削除に失敗', err);
     return error(res, '削除に失敗しました', 500);
   }
 });

--- a/backend/src/functions/hospitals/router.ts
+++ b/backend/src/functions/hospitals/router.ts
@@ -5,6 +5,7 @@ import { docClient, TABLE_NAMES } from '../../shared/dynamodb.js';
 import { success, created, notFound, error } from '../../shared/response.js';
 import { getUserId } from '../../shared/auth.js';
 import { pickAllowedFields, isNonEmptyString } from '../../shared/validation.js';
+import { logger } from '../../shared/logger.js';
 
 const ALLOWED_HOSPITAL_FIELDS = ['name', 'address', 'phone', 'type', 'notes', 'memberId'];
 const ALLOWED_HOSPITAL_UPDATE_FIELDS = ['name', 'address', 'phone', 'type', 'notes'];
@@ -22,7 +23,8 @@ hospitalsRouter.get('/', async (req, res) => {
       ExpressionAttributeValues: { ':userId': userId },
     }));
     return success(res, result.Items || []);
-  } catch {
+  } catch (err) {
+    logger.error('病院一覧取得に失敗', err);
     return error(res, '一覧取得に失敗しました', 500);
   }
 });
@@ -48,7 +50,8 @@ hospitalsRouter.post('/', async (req, res) => {
       Item: item,
     }));
     return created(res, item);
-  } catch {
+  } catch (err) {
+    logger.error('病院登録に失敗', err);
     return error(res, '登録に失敗しました', 500);
   }
 });
@@ -95,7 +98,8 @@ hospitalsRouter.put('/:hospitalId', async (req, res) => {
       ReturnValues: 'ALL_NEW',
     }));
     return success(res, result.Attributes);
-  } catch {
+  } catch (err) {
+    logger.error('病院更新に失敗', err);
     return error(res, '更新に失敗しました', 500);
   }
 });
@@ -117,7 +121,8 @@ hospitalsRouter.delete('/:hospitalId', async (req, res) => {
       Key: { hospitalId: req.params.hospitalId },
     }));
     return success(res, { message: '削除しました' });
-  } catch {
+  } catch (err) {
+    logger.error('病院削除に失敗', err);
     return error(res, '削除に失敗しました', 500);
   }
 });

--- a/backend/src/functions/medications/router.ts
+++ b/backend/src/functions/medications/router.ts
@@ -5,6 +5,7 @@ import { docClient, TABLE_NAMES } from '../../shared/dynamodb.js';
 import { success, created, notFound, error } from '../../shared/response.js';
 import { getUserId } from '../../shared/auth.js';
 import { pickAllowedFields, isNonEmptyString } from '../../shared/validation.js';
+import { logger } from '../../shared/logger.js';
 
 const ALLOWED_MEDICATION_FIELDS = [
   'memberId', 'name', 'category', 'dosageAmount', 'frequency',
@@ -23,7 +24,8 @@ medicationsRouter.get('/member/:memberId', async (req, res) => {
       ExpressionAttributeValues: { ':memberId': req.params.memberId },
     }));
     return success(res, result.Items || []);
-  } catch {
+  } catch (err) {
+    logger.error('お薬一覧取得に失敗', err);
     return error(res, '一覧取得に失敗しました', 500);
   }
 });
@@ -52,7 +54,8 @@ medicationsRouter.post('/', async (req, res) => {
       Item: item,
     }));
     return created(res, item);
-  } catch {
+  } catch (err) {
+    logger.error('お薬登録に失敗', err);
     return error(res, '登録に失敗しました', 500);
   }
 });
@@ -68,7 +71,8 @@ medicationsRouter.get('/:medicationId', async (req, res) => {
     if (!result.Item) return notFound(res, 'お薬');
     if (result.Item.userId !== userId) return notFound(res, 'お薬');
     return success(res, result.Item);
-  } catch {
+  } catch (err) {
+    logger.error('お薬詳細取得に失敗', err);
     return error(res, '取得に失敗しました', 500);
   }
 });
@@ -102,7 +106,8 @@ medicationsRouter.put('/:medicationId/stock', async (req, res) => {
       ReturnValues: 'ALL_NEW',
     }));
     return success(res, result.Attributes);
-  } catch {
+  } catch (err) {
+    logger.error('お薬在庫更新に失敗', err);
     return error(res, '更新に失敗しました', 500);
   }
 });
@@ -124,7 +129,8 @@ medicationsRouter.delete('/:medicationId', async (req, res) => {
       Key: { medicationId: req.params.medicationId },
     }));
     return success(res, { message: '削除しました' });
-  } catch {
+  } catch (err) {
+    logger.error('お薬削除に失敗', err);
     return error(res, '削除に失敗しました', 500);
   }
 });

--- a/backend/src/functions/members/router.ts
+++ b/backend/src/functions/members/router.ts
@@ -5,6 +5,7 @@ import { docClient, TABLE_NAMES } from '../../shared/dynamodb.js';
 import { success, created, notFound, error } from '../../shared/response.js';
 import { getUserId } from '../../shared/auth.js';
 import { pickAllowedFields, isNonEmptyString } from '../../shared/validation.js';
+import { logger } from '../../shared/logger.js';
 
 const ALLOWED_MEMBER_FIELDS = ['name', 'memberType', 'petType', 'birthDate', 'notes'];
 
@@ -21,7 +22,8 @@ membersRouter.get('/', async (req, res) => {
       ExpressionAttributeValues: { ':userId': userId },
     }));
     return success(res, result.Items || []);
-  } catch {
+  } catch (err) {
+    logger.error('メンバー一覧取得に失敗', err);
     return error(res, '一覧取得に失敗しました', 500);
   }
 });
@@ -49,7 +51,8 @@ membersRouter.post('/', async (req, res) => {
       Item: item,
     }));
     return created(res, item);
-  } catch {
+  } catch (err) {
+    logger.error('メンバー登録に失敗', err);
     return error(res, '登録に失敗しました', 500);
   }
 });
@@ -65,7 +68,8 @@ membersRouter.get('/:memberId', async (req, res) => {
     if (!result.Item) return notFound(res, 'メンバー');
     if (result.Item.userId !== userId) return notFound(res, 'メンバー');
     return success(res, result.Item);
-  } catch {
+  } catch (err) {
+    logger.error('メンバー詳細取得に失敗', err);
     return error(res, '取得に失敗しました', 500);
   }
 });
@@ -87,7 +91,8 @@ membersRouter.delete('/:memberId', async (req, res) => {
       Key: { memberId: req.params.memberId },
     }));
     return success(res, { message: '削除しました' });
-  } catch {
+  } catch (err) {
+    logger.error('メンバー削除に失敗', err);
     return error(res, '削除に失敗しました', 500);
   }
 });

--- a/backend/src/functions/records/router.ts
+++ b/backend/src/functions/records/router.ts
@@ -5,6 +5,7 @@ import { docClient, TABLE_NAMES } from '../../shared/dynamodb.js';
 import { success, created, error } from '../../shared/response.js';
 import { getUserId } from '../../shared/auth.js';
 import { pickAllowedFields } from '../../shared/validation.js';
+import { logger } from '../../shared/logger.js';
 
 const ALLOWED_RECORD_FIELDS = [
   'memberId', 'medicationId', 'scheduleId', 'notes', 'dosageAmount',
@@ -29,7 +30,8 @@ recordsRouter.post('/', async (req, res) => {
       Item: item,
     }));
     return created(res, item);
-  } catch {
+  } catch (err) {
+    logger.error('服薬記録登録に失敗', err);
     return error(res, '記録に失敗しました', 500);
   }
 });
@@ -47,7 +49,8 @@ recordsRouter.get('/', async (req, res) => {
       Limit: 50,
     }));
     return success(res, result.Items || []);
-  } catch {
+  } catch (err) {
+    logger.error('服薬記録一覧取得に失敗', err);
     return error(res, '一覧取得に失敗しました', 500);
   }
 });
@@ -64,7 +67,8 @@ recordsRouter.get('/member/:memberId', async (req, res) => {
       Limit: 50,
     }));
     return success(res, result.Items || []);
-  } catch {
+  } catch (err) {
+    logger.error('メンバー別服薬記録取得に失敗', err);
     return error(res, '取得に失敗しました', 500);
   }
 });

--- a/backend/src/functions/schedules/router.ts
+++ b/backend/src/functions/schedules/router.ts
@@ -5,6 +5,7 @@ import { docClient, TABLE_NAMES } from '../../shared/dynamodb.js';
 import { success, created, notFound, error } from '../../shared/response.js';
 import { getUserId } from '../../shared/auth.js';
 import { pickAllowedFields } from '../../shared/validation.js';
+import { logger } from '../../shared/logger.js';
 
 const ALLOWED_SCHEDULE_FIELDS = [
   'medicationId', 'memberId', 'scheduledTime', 'daysOfWeek',
@@ -24,7 +25,8 @@ schedulesRouter.get('/', async (req, res) => {
       ExpressionAttributeValues: { ':userId': userId },
     }));
     return success(res, result.Items || []);
-  } catch {
+  } catch (err) {
+    logger.error('スケジュール一覧取得に失敗', err);
     return error(res, '一覧取得に失敗しました', 500);
   }
 });
@@ -48,7 +50,8 @@ schedulesRouter.post('/', async (req, res) => {
       Item: item,
     }));
     return created(res, item);
-  } catch {
+  } catch (err) {
+    logger.error('スケジュール登録に失敗', err);
     return error(res, '登録に失敗しました', 500);
   }
 });
@@ -81,7 +84,8 @@ schedulesRouter.put('/:scheduleId', async (req, res) => {
       ReturnValues: 'ALL_NEW',
     }));
     return success(res, result.Attributes);
-  } catch {
+  } catch (err) {
+    logger.error('スケジュール更新に失敗', err);
     return error(res, '更新に失敗しました', 500);
   }
 });
@@ -103,7 +107,8 @@ schedulesRouter.delete('/:scheduleId', async (req, res) => {
       Key: { scheduleId: req.params.scheduleId },
     }));
     return success(res, { message: '削除しました' });
-  } catch {
+  } catch (err) {
+    logger.error('スケジュール削除に失敗', err);
     return error(res, '削除に失敗しました', 500);
   }
 });

--- a/backend/src/shared/__tests__/logger.test.ts
+++ b/backend/src/shared/__tests__/logger.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { logger } from '../logger';
+
+describe('logger', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('infoログをJSON形式で出力する', () => {
+    logger.info('テストメッセージ', { key: 'value' });
+
+    expect(console.log).toHaveBeenCalledOnce();
+    const output = JSON.parse((console.log as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(output.level).toBe('info');
+    expect(output.message).toBe('テストメッセージ');
+    expect(output.context.key).toBe('value');
+    expect(output.timestamp).toBeDefined();
+  });
+
+  it('warnログをJSON形式で出力する', () => {
+    logger.warn('警告メッセージ');
+
+    expect(console.warn).toHaveBeenCalledOnce();
+    const output = JSON.parse((console.warn as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(output.level).toBe('warn');
+    expect(output.message).toBe('警告メッセージ');
+  });
+
+  it('errorログにErrorオブジェクトの情報を含める', () => {
+    const err = new Error('テストエラー');
+    logger.error('エラー発生', err, { userId: 'user-1' });
+
+    expect(console.error).toHaveBeenCalledOnce();
+    const output = JSON.parse((console.error as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(output.level).toBe('error');
+    expect(output.message).toBe('エラー発生');
+    expect(output.context.error.message).toBe('テストエラー');
+    expect(output.context.error.stack).toBeDefined();
+    expect(output.context.userId).toBe('user-1');
+  });
+
+  it('errorログに文字列エラーを含める', () => {
+    logger.error('エラー発生', 'string error');
+
+    const output = JSON.parse((console.error as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(output.context.error).toBe('string error');
+  });
+});

--- a/backend/src/shared/logger.ts
+++ b/backend/src/shared/logger.ts
@@ -1,0 +1,42 @@
+/**
+ * シンプルなロガー
+ * CloudWatch Logs等の外部サービスに将来置き換え可能
+ */
+
+type LogLevel = 'info' | 'warn' | 'error';
+
+interface LogEntry {
+  level: LogLevel;
+  message: string;
+  context?: Record<string, unknown>;
+  timestamp: string;
+}
+
+function createLogEntry(level: LogLevel, message: string, context?: Record<string, unknown>): LogEntry {
+  return {
+    level,
+    message,
+    context,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export const logger = {
+  info(message: string, context?: Record<string, unknown>) {
+    const entry = createLogEntry('info', message, context);
+    console.log(JSON.stringify(entry));
+  },
+
+  warn(message: string, context?: Record<string, unknown>) {
+    const entry = createLogEntry('warn', message, context);
+    console.warn(JSON.stringify(entry));
+  },
+
+  error(message: string, err?: unknown, context?: Record<string, unknown>) {
+    const entry = createLogEntry('error', message, {
+      ...context,
+      error: err instanceof Error ? { message: err.message, stack: err.stack } : String(err),
+    });
+    console.error(JSON.stringify(entry));
+  },
+};


### PR DESCRIPTION
## 概要
- 構造化ログ出力のloggerモジュール（`src/shared/logger.ts`）を追加
- 全6ルーターのcatchブロックにlogger.errorを追加してデバッグ性を向上
- loggerのユニットテスト4件を追加

## loggerの機能
- JSON形式でログ出力（CloudWatch Logs等に将来連携可能）
- info / warn / error の3レベル
- Errorオブジェクトのmessage/stackを自動抽出
- タイムスタンプ・コンテキスト情報を含む

## テスト結果
- バックエンド：95テスト / 11ファイル 全パス

Closes #50