### PR TITLE
AWSアーキテクチャ図の追加（draw.io）

### DIFF
--- a/architecture/healthfamily-aws-architecture.drawio
+++ b/architecture/healthfamily-aws-architecture.drawio
@@ -1,0 +1,269 @@
+<mxfile host="65bd71144e">
+    <diagram name="HealthFamily AWS Architecture" id="healthfamily-arch">
+        <mxGraphModel dx="2834" dy="2363" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="3300" pageHeight="2800" background="#ffffff" math="0" shadow="1">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+
+                <!-- ===== External: Users ===== -->
+                <mxCell id="users" value="&lt;font style=&quot;font-size: 23px;&quot;&gt;Users&lt;/font&gt;" style="sketch=0;outlineConnect=0;gradientColor=none;fontColor=#545B64;strokeColor=none;fillColor=#879196;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.illustration_users;pointerEvents=1" parent="1" vertex="1">
+                    <mxGeometry x="40" y="700" width="100" height="100" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== External: GitHub ===== -->
+                <mxCell id="github" value="" style="verticalLabelPosition=bottom;html=1;verticalAlign=top;align=center;strokeColor=none;fillColor=#00BEF2;shape=mxgraph.azure.github_code;pointerEvents=1;" parent="1" vertex="1">
+                    <mxGeometry x="60" y="88" width="97" height="92" as="geometry"/>
+                </mxCell>
+                <mxCell id="github_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;GitHub Actions&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="22" y="180" width="173" height="40" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== AWS Cloud Container ===== -->
+                <mxCell id="aws_cloud" value="&lt;font style=&quot;font-size: 23px;&quot;&gt;AWS Cloud&lt;/font&gt;" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;strokeColor=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;" parent="1" vertex="1">
+                    <mxGeometry x="250" y="50" width="2800" height="2200" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== CloudFront ===== -->
+                <mxCell id="cf_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="30" y="350" width="173" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="cf_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudfront;" parent="cf_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="cf_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;CloudFront&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="cf_group" vertex="1">
+                    <mxGeometry y="90" width="173" height="50" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== S3 (React Frontend) ===== -->
+                <mxCell id="s3fe_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="30" y="620" width="173" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3fe_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" parent="s3fe_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3fe_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;S3（React SPA）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="s3fe_group" vertex="1">
+                    <mxGeometry y="90" width="173" height="50" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== Cognito ===== -->
+                <mxCell id="cognito_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="500" y="50" width="173" height="146" as="geometry"/>
+                </mxCell>
+                <mxCell id="cognito_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#DD344C;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cognito;" parent="cognito_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="cognito_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;Cognito（JWT）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="cognito_group" vertex="1">
+                    <mxGeometry y="86" width="173" height="60" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== API Gateway ===== -->
+                <mxCell id="apigw_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="350" y="330" width="173" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="apigw_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.api_gateway;" parent="apigw_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="apigw_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;API Gateway&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="apigw_group" vertex="1">
+                    <mxGeometry y="90" width="173" height="50" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== Lambda (API) Group ===== -->
+                <mxCell id="lambda_area" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#D86613&quot;&gt;Lambda Functions&lt;/font&gt;" style="fillColor=none;strokeColor=#D86613;dashed=1;verticalAlign=top;fontStyle=0;fontColor=#D86613;whiteSpace=wrap;html=1;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="650" y="230" width="650" height="500" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda API -->
+                <mxCell id="lambda_api_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="700" y="310" width="220" height="170" as="geometry"/>
+                </mxCell>
+                <mxCell id="lambda_api_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lambda;" parent="lambda_api_group" vertex="1">
+                    <mxGeometry x="71" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="lambda_api_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;API Lambda&lt;br&gt;（Express.js）&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="lambda_api_group" vertex="1">
+                    <mxGeometry y="90" width="220" height="80" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda Notifications -->
+                <mxCell id="lambda_notif_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="1000" y="310" width="250" height="170" as="geometry"/>
+                </mxCell>
+                <mxCell id="lambda_notif_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lambda;" parent="lambda_notif_group" vertex="1">
+                    <mxGeometry x="86" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="lambda_notif_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;Notification Lambda&lt;br&gt;（リマインダー）&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="lambda_notif_group" vertex="1">
+                    <mxGeometry y="90" width="250" height="80" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== Database Area ===== -->
+                <mxCell id="db_area" value="&lt;font style=&quot;font-size: 23px;&quot;&gt;Database&lt;/font&gt;" style="fillColor=none;strokeColor=#5A6C86;dashed=1;verticalAlign=top;fontStyle=0;fontColor=#5A6C86;whiteSpace=wrap;html=1;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="1500" y="230" width="350" height="500" as="geometry"/>
+                </mxCell>
+
+                <!-- DynamoDB -->
+                <mxCell id="ddb_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="1585" y="310" width="176" height="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="ddb_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.dynamodb;" parent="ddb_group" vertex="1">
+                    <mxGeometry x="48" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="ddb_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;DynamoDB&lt;br&gt;（10 tables）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="ddb_group" vertex="1">
+                    <mxGeometry y="82" width="176" height="78" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== S3 (Assets) ===== -->
+                <mxCell id="s3assets_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="1585" y="560" width="176" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3assets_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" parent="s3assets_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3assets_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;S3（Assets）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="s3assets_group" vertex="1">
+                    <mxGeometry y="90" width="176" height="50" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== SNS ===== -->
+                <mxCell id="sns_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="1585" y="830" width="173" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="sns_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.sns;" parent="sns_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="sns_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;SNS&lt;br&gt;（Push通知）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="sns_group" vertex="1">
+                    <mxGeometry y="90" width="173" height="60" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== EventBridge ===== -->
+                <mxCell id="eb_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="1000" y="570" width="250" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="eb_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.eventbridge;" parent="eb_group" vertex="1">
+                    <mxGeometry x="86" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="eb_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;EventBridge&lt;br&gt;（スケジュール）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="eb_group" vertex="1">
+                    <mxGeometry y="80" width="250" height="60" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== Monitoring Area ===== -->
+                <mxCell id="mon_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;モニタリング &amp;amp; ログ&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="700" y="830" width="300" height="60" as="geometry"/>
+                </mxCell>
+
+                <!-- CloudWatch -->
+                <mxCell id="cw_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="700" y="900" width="173" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="cw_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;" parent="cw_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="cw_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;CloudWatch&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="cw_group" vertex="1">
+                    <mxGeometry y="90" width="173" height="60" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== Terraform State ===== -->
+                <mxCell id="tf_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;Terraform State&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+                    <mxGeometry x="2100" y="50" width="250" height="50" as="geometry"/>
+                </mxCell>
+
+                <!-- S3 Terraform State -->
+                <mxCell id="s3tf_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="2100" y="110" width="173" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3tf_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" parent="s3tf_group" vertex="1">
+                    <mxGeometry x="47.5" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="s3tf_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;S3（tfstate）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="s3tf_group" vertex="1">
+                    <mxGeometry y="90" width="173" height="50" as="geometry"/>
+                </mxCell>
+
+                <!-- DynamoDB Lock -->
+                <mxCell id="ddb_lock_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+                    <mxGeometry x="2350" y="110" width="176" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="ddb_lock_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.dynamodb;" parent="ddb_lock_group" vertex="1">
+                    <mxGeometry x="48" width="78" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="ddb_lock_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;DynamoDB&lt;br&gt;（State Lock）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="ddb_lock_group" vertex="1">
+                    <mxGeometry y="82" width="176" height="58" as="geometry"/>
+                </mxCell>
+
+                <!-- ===== Edges ===== -->
+
+                <!-- Users → CloudFront -->
+                <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="users" target="cf_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- CloudFront → S3 (React) -->
+                <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="cf_icon" target="s3fe_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- CloudFront → API Gateway -->
+                <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="cf_icon" target="apigw_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Cognito → API Gateway (auth) -->
+                <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="cognito_icon" target="apigw_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- API Gateway → Lambda API -->
+                <mxCell id="e5" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="apigw_icon" target="lambda_api_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda API → DynamoDB -->
+                <mxCell id="e6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="lambda_api_icon" target="ddb_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda API → S3 Assets -->
+                <mxCell id="e7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="lambda_api_icon" target="s3assets_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda API → SNS -->
+                <mxCell id="e8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="lambda_api_icon" target="sns_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- EventBridge → Lambda Notification -->
+                <mxCell id="e9" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="eb_icon" target="lambda_notif_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda Notification → DynamoDB -->
+                <mxCell id="e10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;dashed=1;" parent="1" source="lambda_notif_icon" target="ddb_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda Notification → SNS -->
+                <mxCell id="e11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="lambda_notif_icon" target="sns_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda API → CloudWatch (logs) -->
+                <mxCell id="e12" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="lambda_api_icon" target="cw_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- Lambda Notification → CloudWatch (logs) -->
+                <mxCell id="e13" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="lambda_notif_icon" target="cw_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- GitHub → S3 Frontend (CI/CD deploy) -->
+                <mxCell id="e14" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="github" target="s3fe_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <!-- GitHub → Lambda (CI/CD deploy) -->
+                <mxCell id="e15" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="github" target="lambda_api_icon" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>


### PR DESCRIPTION
## 概要
- HealthFamilyのAWSアーキテクチャをdraw.io形式で図式化
- リファレンスファイル（freestyle-aws-architecture.drawio）と同じmxgraph.aws4アイコンスタイルを使用

## 対象サービス
- **フロントエンド**: CloudFront → S3（React SPA）
- **API**: API Gateway → Lambda（Express.js）
- **認証**: Cognito（JWT）
- **データ**: DynamoDB（10テーブル）、S3（Assets）
- **通知**: EventBridge → Lambda → SNS（Push通知）
- **監視**: CloudWatch（ログ・メトリクス）
- **IaC**: S3 + DynamoDB（Terraform State）
- **CI/CD**: GitHub Actions

## テスト計画
- [x] draw.ioで正常に開けることを確認
- [x] サービス間の接続が正しいことを確認

closes #52