### PR TITLE
環境変数バリデーションの追加

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,20 @@
+# サーバー設定
+PORT=3001
+NODE_ENV=development
+ALLOWED_ORIGINS=http://localhost:5173
+
+# AWS設定
+AWS_REGION=ap-northeast-1
+DYNAMODB_ENDPOINT=http://localhost:8000
+
+# DynamoDBテーブル名（省略時はデフォルト値を使用）
+# USERS_TABLE=HealthFamily-Users
+# MEMBERS_TABLE=HealthFamily-Members
+# MEDICATIONS_TABLE=HealthFamily-Medications
+# SCHEDULES_TABLE=HealthFamily-Schedules
+# MEDICATION_RECORDS_TABLE=HealthFamily-MedicationRecords
+# HOSPITALS_TABLE=HealthFamily-Hospitals
+# APPOINTMENTS_TABLE=HealthFamily-Appointments
+# MEDICAL_HISTORY_TABLE=HealthFamily-MedicalHistory
+# NUTRITION_RECORDS_TABLE=HealthFamily-NutritionRecords
+# EXERCISE_RECORDS_TABLE=HealthFamily-ExerciseRecords

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -7,14 +7,13 @@ import { recordsRouter } from './functions/records/router.js';
 import { hospitalsRouter } from './functions/hospitals/router.js';
 import { appointmentsRouter } from './functions/appointments/router.js';
 import { requireAuth } from './shared/auth.js';
+import { env } from './shared/env.js';
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+const PORT = env.PORT;
 
 // CORS設定（許可オリジンを制限）
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(',')
-  : ['http://localhost:5173'];
+const allowedOrigins = env.ALLOWED_ORIGINS.split(',');
 app.use(cors({
   origin: allowedOrigins,
   methods: ['GET', 'POST', 'PUT', 'DELETE'],

--- a/backend/src/shared/__tests__/env.test.ts
+++ b/backend/src/shared/__tests__/env.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { env } from '../env';
+
+describe('env', () => {
+  it('デフォルト値が設定される', () => {
+    expect(env.PORT).toBe(3001);
+    expect(env.NODE_ENV).toBe('test');
+    expect(env.AWS_REGION).toBe('ap-northeast-1');
+  });
+
+  it('テーブル名のデフォルト値が設定される', () => {
+    expect(env.MEMBERS_TABLE).toBe('HealthFamily-Members');
+    expect(env.MEDICATIONS_TABLE).toBe('HealthFamily-Medications');
+    expect(env.SCHEDULES_TABLE).toBe('HealthFamily-Schedules');
+    expect(env.MEDICATION_RECORDS_TABLE).toBe('HealthFamily-MedicationRecords');
+    expect(env.HOSPITALS_TABLE).toBe('HealthFamily-Hospitals');
+    expect(env.APPOINTMENTS_TABLE).toBe('HealthFamily-Appointments');
+  });
+
+  it('ALLOWED_ORIGINSのデフォルト値が設定される', () => {
+    expect(env.ALLOWED_ORIGINS).toContain('localhost');
+  });
+});

--- a/backend/src/shared/dynamodb.ts
+++ b/backend/src/shared/dynamodb.ts
@@ -1,9 +1,10 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { env } from './env.js';
 
 const client = new DynamoDBClient({
-  region: process.env.AWS_REGION || 'ap-northeast-1',
-  endpoint: process.env.DYNAMODB_ENDPOINT || undefined,
+  region: env.AWS_REGION,
+  endpoint: env.DYNAMODB_ENDPOINT || undefined,
 });
 
 export const docClient = DynamoDBDocumentClient.from(client, {
@@ -13,14 +14,14 @@ export const docClient = DynamoDBDocumentClient.from(client, {
 });
 
 export const TABLE_NAMES = {
-  USERS: process.env.USERS_TABLE || 'HealthFamily-Users',
-  MEMBERS: process.env.MEMBERS_TABLE || 'HealthFamily-Members',
-  MEDICATIONS: process.env.MEDICATIONS_TABLE || 'HealthFamily-Medications',
-  SCHEDULES: process.env.SCHEDULES_TABLE || 'HealthFamily-Schedules',
-  MEDICATION_RECORDS: process.env.MEDICATION_RECORDS_TABLE || 'HealthFamily-MedicationRecords',
-  HOSPITALS: process.env.HOSPITALS_TABLE || 'HealthFamily-Hospitals',
-  APPOINTMENTS: process.env.APPOINTMENTS_TABLE || 'HealthFamily-Appointments',
-  MEDICAL_HISTORY: process.env.MEDICAL_HISTORY_TABLE || 'HealthFamily-MedicalHistory',
-  NUTRITION_RECORDS: process.env.NUTRITION_RECORDS_TABLE || 'HealthFamily-NutritionRecords',
-  EXERCISE_RECORDS: process.env.EXERCISE_RECORDS_TABLE || 'HealthFamily-ExerciseRecords',
+  USERS: env.USERS_TABLE,
+  MEMBERS: env.MEMBERS_TABLE,
+  MEDICATIONS: env.MEDICATIONS_TABLE,
+  SCHEDULES: env.SCHEDULES_TABLE,
+  MEDICATION_RECORDS: env.MEDICATION_RECORDS_TABLE,
+  HOSPITALS: env.HOSPITALS_TABLE,
+  APPOINTMENTS: env.APPOINTMENTS_TABLE,
+  MEDICAL_HISTORY: env.MEDICAL_HISTORY_TABLE,
+  NUTRITION_RECORDS: env.NUTRITION_RECORDS_TABLE,
+  EXERCISE_RECORDS: env.EXERCISE_RECORDS_TABLE,
 } as const;

--- a/backend/src/shared/env.ts
+++ b/backend/src/shared/env.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  // サーバー設定
+  PORT: z.coerce.number().default(3001),
+  NODE_ENV: z.enum(['development', 'staging', 'production', 'test']).default('development'),
+  ALLOWED_ORIGINS: z.string().default('http://localhost:5173'),
+
+  // AWS設定
+  AWS_REGION: z.string().default('ap-northeast-1'),
+  DYNAMODB_ENDPOINT: z.string().optional(),
+
+  // テーブル名（デフォルト値あり）
+  USERS_TABLE: z.string().default('HealthFamily-Users'),
+  MEMBERS_TABLE: z.string().default('HealthFamily-Members'),
+  MEDICATIONS_TABLE: z.string().default('HealthFamily-Medications'),
+  SCHEDULES_TABLE: z.string().default('HealthFamily-Schedules'),
+  MEDICATION_RECORDS_TABLE: z.string().default('HealthFamily-MedicationRecords'),
+  HOSPITALS_TABLE: z.string().default('HealthFamily-Hospitals'),
+  APPOINTMENTS_TABLE: z.string().default('HealthFamily-Appointments'),
+  MEDICAL_HISTORY_TABLE: z.string().default('HealthFamily-MedicalHistory'),
+  NUTRITION_RECORDS_TABLE: z.string().default('HealthFamily-NutritionRecords'),
+  EXERCISE_RECORDS_TABLE: z.string().default('HealthFamily-ExerciseRecords'),
+});
+
+function validateEnv() {
+  const result = envSchema.safeParse(process.env);
+  if (!result.success) {
+    console.error('環境変数のバリデーションに失敗しました:');
+    for (const error of result.error.errors) {
+      console.error(`  ${error.path.join('.')}: ${error.message}`);
+    }
+    process.exit(1);
+  }
+  return result.data;
+}
+
+export const env = validateEnv();

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# API設定
+VITE_API_URL=http://localhost:3001
+
+# AWS設定
+VITE_REGION=ap-northeast-1


### PR DESCRIPTION
## 概要
- Zodによる環境変数バリデーションモジュール（env.ts）を新規作成
- server.tsとdynamodb.tsのprocess.env直接参照をenv経由に変更
- backend/frontend両方に.env.exampleファイルを追加

## 変更内容
- `env.ts`: サーバー設定、AWS設定、全10テーブル名をZodスキーマで定義
- バリデーション失敗時はエラーメッセージを出力してfail-fast（process.exit(1)）
- 全環境変数にデフォルト値を設定し、ローカル開発を容易に

## テスト結果
- 13ファイル / 125テスト全パス

## テスト計画
- [x] デフォルト値が正しく設定されることを確認
- [x] 既存テストが全てパスすることを確認

closes #56