### PR TITLE
フロントエンドのアクセシビリティ改善

### DIFF
--- a/frontend/src/components/shared/BottomNavigation.tsx
+++ b/frontend/src/components/shared/BottomNavigation.tsx
@@ -20,7 +20,7 @@ interface BottomNavigationProps {
 
 export const BottomNavigation: React.FC<BottomNavigationProps> = ({ activePath }) => {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200" aria-label="メインナビゲーション">
       <div className="max-w-md mx-auto flex justify-around py-2">
         {navItems.map(({ path, icon, label }) => {
           const isActive = activePath === path;
@@ -28,11 +28,12 @@ export const BottomNavigation: React.FC<BottomNavigationProps> = ({ activePath }
             <Link
               key={path}
               to={path}
+              {...(isActive && { 'aria-current': 'page' as const })}
               className={`flex flex-col items-center text-xs ${
                 isActive ? 'text-primary-600' : 'text-gray-400'
               }`}
             >
-              <span className="text-lg">{icon}</span>
+              <span className="text-lg" role="img" aria-hidden="true">{icon}</span>
               {label}
             </Link>
           );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -13,26 +13,28 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="max-w-md mx-auto p-4 pb-20">
-      <header className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-bold text-primary-700">HealthFamily</h1>
-      </header>
+    <>
+      <main className="max-w-md mx-auto p-4 pb-20">
+        <header className="flex items-center justify-between mb-6">
+          <h1 className="text-xl font-bold text-primary-700">HealthFamily</h1>
+        </header>
 
-      <div className="bg-white rounded-2xl shadow-sm p-4 mb-4 text-center">
-        <div className="text-4xl mb-2">{character.icon}</div>
-        <p className="text-lg font-medium text-gray-700">
-          {getMessage('medicationReminder')}
-        </p>
-      </div>
-
-      <section className="mb-6">
-        <h2 className="text-sm font-semibold text-gray-500 mb-3">今日の予定</h2>
-        <div className="bg-white rounded-xl shadow-sm">
-          <TodayScheduleList schedules={schedules} isLoading={isLoading} onMarkCompleted={handleMarkCompleted} />
+        <div className="bg-white rounded-2xl shadow-sm p-4 mb-4 text-center" role="status" aria-live="polite">
+          <div className="text-4xl mb-2" role="img" aria-label={`${character.name}キャラクター`}>{character.icon}</div>
+          <p className="text-lg font-medium text-gray-700">
+            {getMessage('medicationReminder')}
+          </p>
         </div>
-      </section>
+
+        <section className="mb-6" aria-labelledby="today-schedule-heading">
+          <h2 id="today-schedule-heading" className="text-sm font-semibold text-gray-500 mb-3">今日の予定</h2>
+          <div className="bg-white rounded-xl shadow-sm">
+            <TodayScheduleList schedules={schedules} isLoading={isLoading} onMarkCompleted={handleMarkCompleted} />
+          </div>
+        </section>
+      </main>
 
       <BottomNavigation activePath="/" />
-    </div>
+    </>
   );
 }

--- a/frontend/src/pages/Medications.tsx
+++ b/frontend/src/pages/Medications.tsx
@@ -29,16 +29,18 @@ export default function Medications() {
   };
 
   return (
-    <div className="max-w-md mx-auto p-4 pb-20">
+    <main className="max-w-md mx-auto p-4 pb-20">
       <header className="flex items-center justify-between mb-6">
         <div className="flex items-center space-x-2">
-          <Link to="/members" className="text-gray-500 hover:text-gray-700">
+          <Link to="/members" className="text-gray-500 hover:text-gray-700" aria-label="メンバー一覧に戻る">
             &larr;
           </Link>
           <h1 className="text-xl font-bold text-primary-700">お薬管理</h1>
         </div>
         <button
           onClick={() => setShowForm(!showForm)}
+          aria-expanded={showForm}
+          aria-controls="medication-form-section"
           className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 transition-colors"
         >
           {showForm ? '閉じる' : '+ 追加'}
@@ -46,15 +48,15 @@ export default function Medications() {
       </header>
 
       {showForm && (
-        <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
+        <div id="medication-form-section" className="bg-white rounded-xl shadow-sm p-4 mb-4">
           <h2 className="text-lg font-semibold mb-3">新しい薬を追加</h2>
           <MedicationForm onSubmit={handleSubmit} />
         </div>
       )}
 
-      <section>
+      <section aria-label="お薬一覧">
         <MedicationList medications={medications} isLoading={isLoading} onDelete={handleDelete} />
       </section>
-    </div>
+    </main>
   );
 }

--- a/frontend/src/pages/Members.tsx
+++ b/frontend/src/pages/Members.tsx
@@ -25,29 +25,33 @@ export default function Members() {
   };
 
   return (
-    <div className="max-w-md mx-auto p-4 pb-20">
-      <header className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-bold text-primary-700">メンバー管理</h1>
-        <button
-          onClick={() => setShowForm(!showForm)}
-          className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 transition-colors"
-        >
-          {showForm ? '閉じる' : '+ 追加'}
-        </button>
-      </header>
+    <>
+      <main className="max-w-md mx-auto p-4 pb-20">
+        <header className="flex items-center justify-between mb-6">
+          <h1 className="text-xl font-bold text-primary-700">メンバー管理</h1>
+          <button
+            onClick={() => setShowForm(!showForm)}
+            aria-expanded={showForm}
+            aria-controls="member-form-section"
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700 transition-colors"
+          >
+            {showForm ? '閉じる' : '+ 追加'}
+          </button>
+        </header>
 
-      {showForm && (
-        <div className="bg-white rounded-xl shadow-sm p-4 mb-4">
-          <h2 className="text-lg font-semibold mb-3">新しいメンバーを追加</h2>
-          <MemberForm onSubmit={handleSubmit} />
-        </div>
-      )}
+        {showForm && (
+          <div id="member-form-section" className="bg-white rounded-xl shadow-sm p-4 mb-4">
+            <h2 className="text-lg font-semibold mb-3">新しいメンバーを追加</h2>
+            <MemberForm onSubmit={handleSubmit} />
+          </div>
+        )}
 
-      <section>
-        <MemberList members={members} isLoading={isLoading} onDelete={handleDelete} />
-      </section>
+        <section aria-label="メンバー一覧">
+          <MemberList members={members} isLoading={isLoading} onDelete={handleDelete} />
+        </section>
+      </main>
 
       <BottomNavigation activePath="/members" />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## 概要
WCAG 2.1 Level A/AA準拠に向けたアクセシビリティ改善

## 変更内容
- **BottomNavigation**: `aria-current="page"`でアクティブページを明示、`aria-label`でナビの目的を説明
- **Dashboard**: `<main>`ランドマーク追加、キャラクターメッセージに`aria-live="polite"`
- **Members**: トグルボタンに`aria-expanded`/`aria-controls`追加、`<main>`ランドマーク追加
- **Medications**: 戻るリンクに`aria-label`追加、`aria-expanded`追加、`<main>`ランドマーク追加

## テスト結果
- フロントエンド: 27ファイル / 175テスト全パス
- バックエンド: 13ファイル / 125テスト全パス

## テスト計画
- [x] 全既存テストがパスすることを確認
- [x] スクリーンリーダーでの動作を想定したHTML構造を確認

closes #58