### PR TITLE
feat: APIルートハンドラー実装

### DIFF
--- a/src/app/api/appointments/[appointmentId]/route.ts
+++ b/src/app/api/appointments/[appointmentId]/route.ts
@@ -1,0 +1,48 @@
+import { prisma } from '@/lib/prisma';
+import { updateAppointmentSchema } from '@/lib/schemas';
+import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
+
+export async function PUT(request: Request, { params }: { params: Promise<{ appointmentId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { appointmentId } = await params;
+    const appointment = await prisma.appointment.findUnique({ where: { id: appointmentId } });
+    if (!appointment || appointment.userId !== userId) return notFound('予約');
+
+    const body = await request.json();
+    const parsed = updateAppointmentSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const updated = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data: {
+        appointmentDate: parsed.data.appointmentDate ? new Date(parsed.data.appointmentDate) : undefined,
+        appointmentType: parsed.data.type,
+        description: parsed.data.notes,
+        reminderEnabled: parsed.data.reminderEnabled,
+        reminderDaysBefore: parsed.data.reminderDaysBefore,
+      },
+    });
+    return success(updated);
+  } catch {
+    return errorResponse('更新に失敗しました', 500);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ appointmentId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { appointmentId } = await params;
+    const appointment = await prisma.appointment.findUnique({ where: { id: appointmentId } });
+    if (!appointment || appointment.userId !== userId) return notFound('予約');
+
+    await prisma.appointment.delete({ where: { id: appointmentId } });
+    return success({ message: '削除しました' });
+  } catch {
+    return errorResponse('削除に失敗しました', 500);
+  }
+}

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@/lib/prisma';
+import { createAppointmentSchema } from '@/lib/schemas';
+import { getAuthUserId, success, created, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET() {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const appointments = await prisma.appointment.findMany({
+      where: { userId },
+      orderBy: { appointmentDate: 'asc' },
+    });
+    return success(appointments);
+  } catch {
+    return errorResponse('一覧取得に失敗しました', 500);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const body = await request.json();
+    const parsed = createAppointmentSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const appointment = await prisma.appointment.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        hospitalId: parsed.data.hospitalId,
+        appointmentType: parsed.data.type,
+        appointmentDate: new Date(parsed.data.appointmentDate),
+        description: parsed.data.notes,
+        reminderEnabled: parsed.data.reminderEnabled ?? true,
+        reminderDaysBefore: parsed.data.reminderDaysBefore ?? 1,
+      },
+    });
+    return created(appointment);
+  } catch {
+    return errorResponse('登録に失敗しました', 500);
+  }
+}

--- a/src/app/api/hospitals/[hospitalId]/route.ts
+++ b/src/app/api/hospitals/[hospitalId]/route.ts
@@ -1,0 +1,48 @@
+import { prisma } from '@/lib/prisma';
+import { updateHospitalSchema } from '@/lib/schemas';
+import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
+
+export async function PUT(request: Request, { params }: { params: Promise<{ hospitalId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { hospitalId } = await params;
+    const hospital = await prisma.hospital.findUnique({ where: { id: hospitalId } });
+    if (!hospital || hospital.userId !== userId) return notFound('病院');
+
+    const body = await request.json();
+    const parsed = updateHospitalSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const updated = await prisma.hospital.update({
+      where: { id: hospitalId },
+      data: {
+        name: parsed.data.name,
+        hospitalType: parsed.data.type,
+        address: parsed.data.address,
+        phoneNumber: parsed.data.phone,
+        notes: parsed.data.notes,
+      },
+    });
+    return success(updated);
+  } catch {
+    return errorResponse('更新に失敗しました', 500);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ hospitalId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { hospitalId } = await params;
+    const hospital = await prisma.hospital.findUnique({ where: { id: hospitalId } });
+    if (!hospital || hospital.userId !== userId) return notFound('病院');
+
+    await prisma.hospital.delete({ where: { id: hospitalId } });
+    return success({ message: '削除しました' });
+  } catch {
+    return errorResponse('削除に失敗しました', 500);
+  }
+}

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -1,0 +1,40 @@
+import { prisma } from '@/lib/prisma';
+import { createHospitalSchema } from '@/lib/schemas';
+import { getAuthUserId, success, created, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET() {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const hospitals = await prisma.hospital.findMany({ where: { userId } });
+    return success(hospitals);
+  } catch {
+    return errorResponse('一覧取得に失敗しました', 500);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const body = await request.json();
+    const parsed = createHospitalSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const hospital = await prisma.hospital.create({
+      data: {
+        userId,
+        name: parsed.data.name,
+        hospitalType: parsed.data.type,
+        address: parsed.data.address,
+        phoneNumber: parsed.data.phone,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(hospital);
+  } catch {
+    return errorResponse('登録に失敗しました', 500);
+  }
+}

--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -1,0 +1,33 @@
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { medicationId } = await params;
+    const medication = await prisma.medication.findUnique({ where: { id: medicationId } });
+    if (!medication || medication.userId !== userId) return notFound('お薬');
+
+    return success(medication);
+  } catch {
+    return errorResponse('取得に失敗しました', 500);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { medicationId } = await params;
+    const medication = await prisma.medication.findUnique({ where: { id: medicationId } });
+    if (!medication || medication.userId !== userId) return notFound('お薬');
+
+    await prisma.medication.delete({ where: { id: medicationId } });
+    return success({ message: '削除しました' });
+  } catch {
+    return errorResponse('削除に失敗しました', 500);
+  }
+}

--- a/src/app/api/medications/[medicationId]/stock/route.ts
+++ b/src/app/api/medications/[medicationId]/stock/route.ts
@@ -1,0 +1,26 @@
+import { prisma } from '@/lib/prisma';
+import { updateStockSchema } from '@/lib/schemas';
+import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
+
+export async function PUT(request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { medicationId } = await params;
+    const medication = await prisma.medication.findUnique({ where: { id: medicationId } });
+    if (!medication || medication.userId !== userId) return notFound('お薬');
+
+    const body = await request.json();
+    const parsed = updateStockSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const updated = await prisma.medication.update({
+      where: { id: medicationId },
+      data: { stockQuantity: parsed.data.stockQuantity },
+    });
+    return success(updated);
+  } catch {
+    return errorResponse('更新に失敗しました', 500);
+  }
+}

--- a/src/app/api/medications/member/[memberId]/route.ts
+++ b/src/app/api/medications/member/[memberId]/route.ts
@@ -1,0 +1,15 @@
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, success, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { memberId } = await params;
+    const medications = await prisma.medication.findMany({ where: { memberId, userId } });
+    return success(medications);
+  } catch {
+    return errorResponse('一覧取得に失敗しました', 500);
+  }
+}

--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -1,0 +1,32 @@
+import { prisma } from '@/lib/prisma';
+import { createMedicationSchema } from '@/lib/schemas';
+import { getAuthUserId, created, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function POST(request: Request) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const body = await request.json();
+    const parsed = createMedicationSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const medication = await prisma.medication.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId!,
+        name: parsed.data.name,
+        category: parsed.data.category ?? 'regular',
+        dosageAmount: parsed.data.dosageAmount,
+        frequency: parsed.data.frequency,
+        stockQuantity: parsed.data.stockQuantity,
+        lowStockThreshold: parsed.data.lowStockThreshold,
+        instructions: parsed.data.instructions,
+        isActive: true,
+      },
+    });
+    return created(medication);
+  } catch {
+    return errorResponse('登録に失敗しました', 500);
+  }
+}

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -1,0 +1,33 @@
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { memberId } = await params;
+    const member = await prisma.member.findUnique({ where: { id: memberId } });
+    if (!member || member.userId !== userId) return notFound('メンバー');
+
+    return success(member);
+  } catch {
+    return errorResponse('取得に失敗しました', 500);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { memberId } = await params;
+    const member = await prisma.member.findUnique({ where: { id: memberId } });
+    if (!member || member.userId !== userId) return notFound('メンバー');
+
+    await prisma.member.delete({ where: { id: memberId } });
+    return success({ message: '削除しました' });
+  } catch {
+    return errorResponse('削除に失敗しました', 500);
+  }
+}

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,0 +1,40 @@
+import { prisma } from '@/lib/prisma';
+import { createMemberSchema } from '@/lib/schemas';
+import { getAuthUserId, success, created, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET() {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const members = await prisma.member.findMany({ where: { userId } });
+    return success(members);
+  } catch {
+    return errorResponse('一覧取得に失敗しました', 500);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const body = await request.json();
+    const parsed = createMemberSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const member = await prisma.member.create({
+      data: {
+        userId,
+        name: parsed.data.name,
+        memberType: parsed.data.memberType ?? 'human',
+        petType: parsed.data.petType,
+        birthDate: parsed.data.birthDate ? new Date(parsed.data.birthDate) : undefined,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(member);
+  } catch {
+    return errorResponse('登録に失敗しました', 500);
+  }
+}

--- a/src/app/api/records/member/[memberId]/route.ts
+++ b/src/app/api/records/member/[memberId]/route.ts
@@ -1,0 +1,19 @@
+import { prisma } from '@/lib/prisma';
+import { getAuthUserId, success, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { memberId } = await params;
+    const records = await prisma.medicationRecord.findMany({
+      where: { memberId, userId },
+      orderBy: { takenAt: 'desc' },
+      take: 50,
+    });
+    return success(records);
+  } catch {
+    return errorResponse('一覧取得に失敗しました', 500);
+  }
+}

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -1,0 +1,44 @@
+import { prisma } from '@/lib/prisma';
+import { createRecordSchema } from '@/lib/schemas';
+import { getAuthUserId, success, created, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET() {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const records = await prisma.medicationRecord.findMany({
+      where: { userId },
+      orderBy: { takenAt: 'desc' },
+      take: 50,
+    });
+    return success(records);
+  } catch {
+    return errorResponse('一覧取得に失敗しました', 500);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const body = await request.json();
+    const parsed = createRecordSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const record = await prisma.medicationRecord.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        medicationId: parsed.data.medicationId,
+        scheduleId: parsed.data.scheduleId,
+        notes: parsed.data.notes,
+        dosageAmount: parsed.data.dosageAmount,
+      },
+    });
+    return created(record);
+  } catch {
+    return errorResponse('登録に失敗しました', 500);
+  }
+}

--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -1,0 +1,42 @@
+import { prisma } from '@/lib/prisma';
+import { updateScheduleSchema } from '@/lib/schemas';
+import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
+
+export async function PUT(request: Request, { params }: { params: Promise<{ scheduleId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { scheduleId } = await params;
+    const schedule = await prisma.schedule.findUnique({ where: { id: scheduleId } });
+    if (!schedule || schedule.userId !== userId) return notFound('スケジュール');
+
+    const body = await request.json();
+    const parsed = updateScheduleSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const updated = await prisma.schedule.update({
+      where: { id: scheduleId },
+      data: parsed.data,
+    });
+    return success(updated);
+  } catch {
+    return errorResponse('更新に失敗しました', 500);
+  }
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ scheduleId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { scheduleId } = await params;
+    const schedule = await prisma.schedule.findUnique({ where: { id: scheduleId } });
+    if (!schedule || schedule.userId !== userId) return notFound('スケジュール');
+
+    await prisma.schedule.delete({ where: { id: scheduleId } });
+    return success({ message: '削除しました' });
+  } catch {
+    return errorResponse('削除に失敗しました', 500);
+  }
+}

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,0 +1,41 @@
+import { prisma } from '@/lib/prisma';
+import { createScheduleSchema } from '@/lib/schemas';
+import { getAuthUserId, success, created, errorResponse, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET() {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const schedules = await prisma.schedule.findMany({ where: { userId } });
+    return success(schedules);
+  } catch {
+    return errorResponse('一覧取得に失敗しました', 500);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const body = await request.json();
+    const parsed = createScheduleSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const schedule = await prisma.schedule.create({
+      data: {
+        userId,
+        medicationId: parsed.data.medicationId,
+        memberId: parsed.data.memberId,
+        scheduledTime: parsed.data.scheduledTime,
+        daysOfWeek: parsed.data.daysOfWeek ?? [],
+        isEnabled: parsed.data.isEnabled ?? true,
+        reminderMinutesBefore: parsed.data.reminderMinutesBefore ?? 5,
+      },
+    });
+    return created(schedule);
+  } catch {
+    return errorResponse('登録に失敗しました', 500);
+  }
+}

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,49 @@
+import { prisma } from '@/lib/prisma';
+import { updateUserProfileSchema } from '@/lib/schemas';
+import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
+
+export async function GET() {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) return notFound('ユーザー');
+
+    return success({
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+      characterType: user.characterType,
+      characterName: user.characterName,
+    });
+  } catch {
+    return errorResponse('取得に失敗しました', 500);
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const body = await request.json();
+    const parsed = updateUserProfileSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const updated = await prisma.user.update({
+      where: { id: userId },
+      data: { displayName: parsed.data.displayName },
+    });
+
+    return success({
+      id: updated.id,
+      email: updated.email,
+      displayName: updated.displayName,
+      characterType: updated.characterType,
+      characterName: updated.characterName,
+    });
+  } catch {
+    return errorResponse('更新に失敗しました', 500);
+  }
+}


### PR DESCRIPTION
## Summary
- Express/Lambda APIをNext.js API Route Handlersに移行
- Members, Medications, Schedules, Records, Hospitals, Appointments, Users の全CRUD API
- Prismaによるデータ操作 + NextAuth認証チェック + userId所有権チェック
- レスポンス形式 `{ success, data, error }` を維持

## Test plan
- [ ] 各APIエンドポイントが認証チェックを実施すること
- [ ] CRUD操作が正しく動作すること
- [ ] 所有権チェックで他ユーザーのデータにアクセスできないこと

closes #61