### PR TITLE
feat: フロントエンド移行（ドメイン層・データ層・コンポーネント・ページ）

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Providers } from './providers';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -13,7 +14,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ja">
-      <body className="font-sans antialiased">{children}</body>
+      <body className="font-sans antialiased">
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage('');
+    setIsSubmitting(true);
+
+    try {
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+      });
+
+      if (result?.error) {
+        setErrorMessage('メールアドレスまたはパスワードが正しくありません');
+      } else {
+        router.push('/');
+      }
+    } catch {
+      setErrorMessage('ログインに失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
+          <p className="mt-2 text-gray-500">ログイン</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="bg-white shadow-md rounded-lg p-6 space-y-4">
+          {errorMessage && (
+            <div className="bg-red-50 text-red-700 p-3 rounded-md text-sm" role="alert">
+              {errorMessage}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="example@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-primary-600 text-white py-2 rounded-md font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? 'ログイン中...' : 'ログイン'}
+          </button>
+
+          <p className="text-center text-sm text-gray-500">
+            アカウントをお持ちでない方は{' '}
+            <Link href="/signup" className="text-primary-600 hover:underline">
+              新規登録
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/members/[memberId]/medications/page.tsx
+++ b/src/app/members/[memberId]/medications/page.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+import { useMedications } from '@/presentation/hooks/useMedications';
+import { useScheduleManagement } from '@/presentation/hooks/useScheduleManagement';
+import { MedicationList } from '@/components/medications/MedicationList';
+import { MedicationForm, MedicationFormData } from '@/components/medications/MedicationForm';
+import { ScheduleForm, ScheduleFormData } from '@/components/schedules/ScheduleForm';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { useState } from 'react';
+import { ArrowLeft, Plus, X, Clock } from 'lucide-react';
+import { MedicationViewModel } from '@/domain/usecases/ManageMedications';
+
+export default function Medications() {
+  const params = useParams();
+  const router = useRouter();
+  const memberId = params.memberId as string;
+  const { userId } = useAuth();
+  const { medications, isLoading, createMedication, deleteMedication } = useMedications(memberId);
+  const { createSchedule } = useScheduleManagement();
+  const [showMedForm, setShowMedForm] = useState(false);
+  const [scheduleTarget, setScheduleTarget] = useState<MedicationViewModel | null>(null);
+
+  const handleCreateMedication = async (data: MedicationFormData) => {
+    await createMedication({
+      memberId,
+      userId,
+      name: data.name,
+      category: data.category,
+      dosage: data.dosage,
+      frequency: data.frequency,
+      stockQuantity: data.stockQuantity,
+      lowStockThreshold: data.lowStockThreshold,
+      instructions: data.instructions,
+    });
+    setShowMedForm(false);
+  };
+
+  const handleCreateSchedule = async (data: ScheduleFormData) => {
+    if (!scheduleTarget) return;
+    await createSchedule({
+      medicationId: scheduleTarget.medication.id,
+      userId,
+      memberId,
+      scheduledTime: data.scheduledTime,
+      daysOfWeek: data.daysOfWeek,
+      reminderMinutesBefore: data.reminderMinutesBefore,
+    });
+    setScheduleTarget(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-20">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={() => router.push('/members')}
+              className="text-gray-600 hover:text-gray-800 transition-colors"
+              aria-label="メンバー一覧に戻る"
+            >
+              <ArrowLeft size={20} />
+            </button>
+            <h1 className="text-xl font-bold text-primary-600">薬管理</h1>
+          </div>
+          <button
+            onClick={() => setShowMedForm(!showMedForm)}
+            className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
+            aria-label={showMedForm ? '閉じる' : '薬を追加'}
+          >
+            {showMedForm ? <X size={20} /> : <Plus size={20} />}
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4">
+        {showMedForm && (
+          <div className="mb-6">
+            <MedicationForm onSubmit={handleCreateMedication} />
+          </div>
+        )}
+
+        {scheduleTarget && (
+          <div className="mb-6 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center space-x-2">
+                <Clock size={18} className="text-primary-600" />
+                <h2 className="font-semibold text-gray-800">
+                  {scheduleTarget.medication.name} のスケジュール
+                </h2>
+              </div>
+              <button
+                onClick={() => setScheduleTarget(null)}
+                className="text-gray-400 hover:text-gray-600 transition-colors"
+                aria-label="閉じる"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <ScheduleForm onSubmit={handleCreateSchedule} />
+          </div>
+        )}
+
+        <MedicationList
+          medications={medications}
+          isLoading={isLoading}
+          onDelete={deleteMedication}
+        />
+
+        {medications.length > 0 && !scheduleTarget && (
+          <div className="mt-6">
+            <h2 className="text-sm font-medium text-gray-600 mb-3">スケジュール追加</h2>
+            <div className="space-y-2">
+              {medications.map((vm) => (
+                <button
+                  key={vm.medication.id}
+                  onClick={() => setScheduleTarget(vm)}
+                  className="w-full flex items-center justify-between bg-white rounded-lg p-3 border border-gray-200 hover:border-primary-300 transition-colors text-left"
+                >
+                  <span className="text-sm text-gray-700">{vm.medication.name}</span>
+                  <Clock size={16} className="text-gray-400" />
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </main>
+
+      <BottomNavigation activePath="/members" />
+    </div>
+  );
+}

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+import { useMembers } from '@/presentation/hooks/useMembers';
+import { MemberList } from '@/components/members/MemberList';
+import { MemberForm, MemberFormData } from '@/components/members/MemberForm';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { useState } from 'react';
+import { Plus, X } from 'lucide-react';
+
+export default function Members() {
+  const { userId } = useAuth();
+  const { members, isLoading, createMember, deleteMember } = useMembers(userId);
+  const [showForm, setShowForm] = useState(false);
+
+  const handleCreate = async (data: MemberFormData) => {
+    await createMember({
+      userId,
+      name: data.name,
+      memberType: data.memberType,
+      petType: data.petType,
+      birthDate: data.birthDate ? new Date(data.birthDate) : undefined,
+      notes: data.notes,
+    });
+    setShowForm(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-20">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
+          <h1 className="text-xl font-bold text-primary-600">メンバー</h1>
+          <button
+            onClick={() => setShowForm(!showForm)}
+            className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
+            aria-label={showForm ? '閉じる' : 'メンバーを追加'}
+          >
+            {showForm ? <X size={20} /> : <Plus size={20} />}
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4">
+        {showForm && (
+          <div className="mb-6">
+            <MemberForm onSubmit={handleCreate} />
+          </div>
+        )}
+
+        <MemberList
+          members={members}
+          isLoading={isLoading}
+          onDelete={deleteMember}
+        />
+      </main>
+
+      <BottomNavigation activePath="/members" />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,44 @@
-export default function Home() {
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+import { useTodaySchedules } from '@/presentation/hooks/useTodaySchedules';
+import { useCharacterStore } from '@/stores/characterStore';
+import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { CharacterIcon } from '@/components/shared/CharacterIcon';
+
+export default function Dashboard() {
+  const { userId } = useAuth();
+  const { schedules, isLoading, markAsCompleted } = useTodaySchedules(userId);
+  const { getConfig, getMessage } = useCharacterStore();
+  const characterConfig = getConfig();
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold text-primary-600">HealthFamily</h1>
-        <p className="text-gray-500 mt-2">セットアップ中...</p>
-      </div>
+    <div className="min-h-screen bg-gray-50 pb-20">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-md mx-auto px-4 py-3">
+          <h1 className="text-xl font-bold text-primary-600">HealthFamily</h1>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4">
+        <div className="bg-primary-50 rounded-lg p-4 mb-6 flex items-center space-x-3">
+          <CharacterIcon type={characterConfig.type} size={40} />
+          <div>
+            <p className="text-sm font-medium text-primary-800">{characterConfig.name}</p>
+            <p className="text-sm text-primary-700">{getMessage('medicationReminder')}</p>
+          </div>
+        </div>
+
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">今日の予定</h2>
+        <TodayScheduleList
+          schedules={schedules}
+          isLoading={isLoading}
+          onMarkCompleted={markAsCompleted}
+        />
+      </main>
+
+      <BottomNavigation activePath="/" />
     </div>
   );
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60 * 5,
+            retry: 1,
+          },
+        },
+      })
+  );
+
+  return (
+    <SessionProvider>
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    </SessionProvider>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+import { CharacterSelector } from '@/components/character/CharacterSelector';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { signOut } from 'next-auth/react';
+import { LogOut } from 'lucide-react';
+
+export default function Settings() {
+  const { email } = useAuth();
+
+  const handleLogout = async () => {
+    await signOut({ callbackUrl: '/login' });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-20">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-md mx-auto px-4 py-3">
+          <h1 className="text-xl font-bold text-primary-600">設定</h1>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4 space-y-6">
+        <section className="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-800 mb-2">アカウント</h2>
+          <p className="text-sm text-gray-600">{email}</p>
+        </section>
+
+        <section className="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-800 mb-4">キャラクター選択</h2>
+          <CharacterSelector />
+        </section>
+
+        <button
+          onClick={handleLogout}
+          className="w-full flex items-center justify-center space-x-2 bg-white text-red-600 border border-red-200 rounded-lg py-3 px-4 hover:bg-red-50 transition-colors font-medium"
+        >
+          <LogOut size={18} />
+          <span>ログアウト</span>
+        </button>
+      </main>
+
+      <BottomNavigation activePath="/settings" />
+    </div>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+export default function SignUp() {
+  const router = useRouter();
+  const [displayName, setDisplayName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage('');
+    setIsSubmitting(true);
+
+    try {
+      const res = await fetch('/api/auth/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, displayName }),
+      });
+
+      const data = await res.json();
+
+      if (!data.success) {
+        setErrorMessage(data.error || '登録に失敗しました');
+        return;
+      }
+
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+      });
+
+      if (result?.error) {
+        setErrorMessage('登録は完了しましたが、ログインに失敗しました。ログイン画面からお試しください。');
+      } else {
+        router.push('/');
+      }
+    } catch {
+      setErrorMessage('登録に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
+          <p className="mt-2 text-gray-500">新規登録</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="bg-white shadow-md rounded-lg p-6 space-y-4">
+          {errorMessage && (
+            <div className="bg-red-50 text-red-700 p-3 rounded-md text-sm" role="alert">
+              {errorMessage}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="displayName" className="block text-sm font-medium text-gray-700 mb-1">
+              表示名
+            </label>
+            <input
+              id="displayName"
+              type="text"
+              required
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="example@example.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="8文字以上"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-primary-600 text-white py-2 rounded-md font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? '登録中...' : '登録'}
+          </button>
+
+          <p className="text-center text-sm text-gray-500">
+            既にアカウントをお持ちの方は{' '}
+            <Link href="/login" className="text-primary-600 hover:underline">
+              ログイン
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/character/CharacterSelector.tsx
+++ b/src/components/character/CharacterSelector.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { CharacterType, CHARACTER_CONFIGS } from '../../domain/entities/Character';
+import { useCharacterStore } from '../../stores/characterStore';
+import { CharacterIcon } from '../shared/CharacterIcon';
+
+const characterTypes: CharacterType[] = ['dog', 'cat', 'rabbit', 'bird'];
+
+export const CharacterSelector: React.FC = () => {
+  const { selectedCharacter, setCharacter } = useCharacterStore();
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {characterTypes.map((type) => {
+        const config = CHARACTER_CONFIGS[type];
+        const isSelected = selectedCharacter === type;
+
+        return (
+          <button
+            key={type}
+            onClick={() => setCharacter(type)}
+            className={`flex flex-col items-center p-4 rounded-xl border-2 transition-all ${
+              isSelected
+                ? 'border-blue-500 bg-blue-50 ring-2 ring-blue-200'
+                : 'border-gray-200 bg-white hover:border-blue-300'
+            }`}
+          >
+            <CharacterIcon type={type} size={40} className="mb-2 text-gray-700" />
+            <span className={`text-sm font-medium ${isSelected ? 'text-blue-700' : 'text-gray-600'}`}>
+              {config.name}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/dashboard/TodayScheduleList.tsx
+++ b/src/components/dashboard/TodayScheduleList.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { Dog, User } from 'lucide-react';
+import { TodayScheduleViewModel } from '../../domain/usecases/GetTodaySchedules';
+
+interface TodayScheduleListProps {
+  schedules: TodayScheduleViewModel[];
+  isLoading: boolean;
+  onMarkCompleted?: (scheduleId: string) => void;
+}
+
+export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules, isLoading, onMarkCompleted }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (schedules.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-12">
+        <p className="text-gray-500 text-lg">今日の服薬スケジュールはありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {schedules.map((schedule) => (
+        <ScheduleCard
+          key={schedule.scheduleId}
+          schedule={schedule}
+          onMarkCompleted={onMarkCompleted}
+        />
+      ))}
+    </div>
+  );
+};
+
+interface ScheduleCardProps {
+  schedule: TodayScheduleViewModel;
+  onMarkCompleted?: (scheduleId: string) => void;
+}
+
+const ScheduleCard: React.FC<ScheduleCardProps> = ({ schedule, onMarkCompleted }) => {
+  const showCompleteButton = schedule.status !== 'completed';
+
+  return (
+    <div
+      className="bg-white rounded-lg shadow-md p-4 border border-gray-200 hover:shadow-lg transition-shadow"
+      data-testid="schedule-item"
+      role="article"
+      aria-label={`${schedule.scheduledTime}の服薬スケジュール - ${schedule.medicationName}`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-4">
+          <div className="flex flex-col items-center">
+            <span
+              className="text-2xl font-bold text-gray-800"
+              data-testid="schedule-time"
+            >
+              {schedule.scheduledTime}
+            </span>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <MemberIcon memberType={schedule.memberType} />
+            <div className="flex flex-col">
+              <span className="text-sm font-medium text-gray-900">
+                {schedule.memberName}
+              </span>
+              <span className="text-lg font-semibold text-gray-800">
+                {schedule.medicationName}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center space-x-2">
+          {showCompleteButton && onMarkCompleted && (
+            <button
+              onClick={() => onMarkCompleted(schedule.scheduleId)}
+              className="bg-green-500 text-white px-3 py-1 rounded-full text-sm font-medium hover:bg-green-600 transition-colors"
+              aria-label="飲んだ"
+            >
+              飲んだ
+            </button>
+          )}
+          <StatusBadge status={schedule.status} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface MemberIconProps {
+  memberType: 'human' | 'pet';
+}
+
+const MemberIcon: React.FC<MemberIconProps> = ({ memberType }) => {
+  if (memberType === 'pet') {
+    return (
+      <div
+        className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center"
+        data-testid="member-type-pet"
+        aria-label="ペット"
+      >
+        <Dog size={22} className="text-amber-700" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center"
+      data-testid="member-type-human"
+      aria-label="人間"
+    >
+      <User size={22} className="text-blue-700" />
+    </div>
+  );
+};
+
+interface StatusBadgeProps {
+  status: 'pending' | 'completed' | 'overdue';
+}
+
+const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
+  const styles = {
+    pending: {
+      bg: 'bg-yellow-100',
+      text: 'text-yellow-800',
+      label: '未服薬',
+    },
+    completed: {
+      bg: 'bg-green-100',
+      text: 'text-green-800',
+      label: '服薬済み',
+    },
+    overdue: {
+      bg: 'bg-red-100',
+      text: 'text-red-800',
+      label: '時間超過',
+    },
+  };
+
+  const style = styles[status];
+
+  return (
+    <span
+      className={`px-3 py-1 rounded-full text-sm font-semibold ${style.bg} ${style.text}`}
+      role="status"
+      aria-label={`ステータス: ${style.label}`}
+    >
+      {style.label}
+    </span>
+  );
+};

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import { MedicationCategory } from '../../domain/entities/Medication';
+
+export interface MedicationFormData {
+  name: string;
+  category: MedicationCategory;
+  dosage: string;
+  frequency: string;
+  stockQuantity?: number;
+  lowStockThreshold?: number;
+  instructions?: string;
+}
+
+interface MedicationFormProps {
+  onSubmit: (data: MedicationFormData) => void;
+}
+
+export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState<MedicationCategory>('regular');
+  const [dosage, setDosage] = useState('');
+  const [frequency, setFrequency] = useState('');
+  const [stockQuantity, setStockQuantity] = useState('');
+  const [lowStockThreshold, setLowStockThreshold] = useState('');
+  const [instructions, setInstructions] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) return;
+
+    const data: MedicationFormData = {
+      name: name.trim(),
+      category,
+      dosage: dosage.trim(),
+      frequency: frequency.trim(),
+      ...(stockQuantity ? { stockQuantity: parseInt(stockQuantity, 10) } : {}),
+      ...(lowStockThreshold ? { lowStockThreshold: parseInt(lowStockThreshold, 10) } : {}),
+      ...(instructions.trim() ? { instructions: instructions.trim() } : {}),
+    };
+
+    onSubmit(data);
+
+    setName('');
+    setCategory('regular');
+    setDosage('');
+    setFrequency('');
+    setStockQuantity('');
+    setLowStockThreshold('');
+    setInstructions('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="med-name" className="block text-sm font-medium text-gray-700 mb-1">
+          薬の名前
+        </label>
+        <input
+          id="med-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          placeholder="薬の名前を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="med-category" className="block text-sm font-medium text-gray-700 mb-1">
+          カテゴリ
+        </label>
+        <select
+          id="med-category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value as MedicationCategory)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="regular">常用薬</option>
+          <option value="supplement">サプリメント</option>
+          <option value="prn">頓服薬</option>
+          <option value="flea_tick">ノミ・ダニ薬</option>
+          <option value="heartworm">フィラリア薬</option>
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="med-dosage" className="block text-sm font-medium text-gray-700 mb-1">
+            用量
+          </label>
+          <input
+            id="med-dosage"
+            type="text"
+            value={dosage}
+            onChange={(e) => setDosage(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            placeholder="例: 1錠"
+          />
+        </div>
+        <div>
+          <label htmlFor="med-frequency" className="block text-sm font-medium text-gray-700 mb-1">
+            頻度
+          </label>
+          <input
+            id="med-frequency"
+            type="text"
+            value={frequency}
+            onChange={(e) => setFrequency(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+            placeholder="例: 1日1回"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="med-stock" className="block text-sm font-medium text-gray-700 mb-1">
+            在庫数
+          </label>
+          <input
+            id="med-stock"
+            type="number"
+            min="0"
+            value={stockQuantity}
+            onChange={(e) => setStockQuantity(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="med-threshold" className="block text-sm font-medium text-gray-700 mb-1">
+            在庫警告
+          </label>
+          <input
+            id="med-threshold"
+            type="number"
+            min="0"
+            value={lowStockThreshold}
+            onChange={(e) => setLowStockThreshold(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="med-instructions" className="block text-sm font-medium text-gray-700 mb-1">
+          服用方法
+        </label>
+        <textarea
+          id="med-instructions"
+          value={instructions}
+          onChange={(e) => setInstructions(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          rows={2}
+          placeholder="例: 食後に水と一緒に服用"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+      >
+        追加する
+      </button>
+    </form>
+  );
+};

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Pill } from 'lucide-react';
+import { MedicationViewModel } from '../../domain/usecases/ManageMedications';
+
+interface MedicationListProps {
+  medications: MedicationViewModel[];
+  isLoading: boolean;
+  onDelete: (medicationId: string) => void;
+}
+
+export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (medications.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-12">
+        <p className="text-gray-500 text-lg">薬がまだ登録されていません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {medications.map((vm) => (
+        <MedicationCard key={vm.medication.id} viewModel={vm} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface MedicationCardProps {
+  viewModel: MedicationViewModel;
+  onDelete: (medicationId: string) => void;
+}
+
+const MedicationCard: React.FC<MedicationCardProps> = ({ viewModel, onDelete }) => {
+  const { medication, isLowStock, displayInfo } = viewModel;
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <div className="flex items-center space-x-2">
+            <Pill size={20} className="text-primary-600" />
+            <p className="font-semibold text-gray-800">{displayInfo.name}</p>
+            {isLowStock && (
+              <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-medium">
+                在庫少
+              </span>
+            )}
+          </div>
+          <div className="mt-1 text-sm text-gray-500 space-y-0.5">
+            <p>{displayInfo.categoryLabel}</p>
+            {displayInfo.dosageInfo && <p>{displayInfo.dosageInfo}</p>}
+            {medication.stockQuantity !== undefined && (
+              <p>在庫: {medication.stockQuantity}個</p>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={() => onDelete(medication.id)}
+          className="text-red-500 hover:text-red-700 text-sm px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
+          aria-label="削除"
+        >
+          削除
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/members/MemberForm.tsx
+++ b/src/components/members/MemberForm.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { MemberType, PetType } from '../../domain/entities/Member';
+
+export interface MemberFormData {
+  name: string;
+  memberType: MemberType;
+  petType?: PetType;
+  birthDate?: string;
+  notes?: string;
+}
+
+interface MemberFormProps {
+  onSubmit: (data: MemberFormData) => void;
+}
+
+export const MemberForm: React.FC<MemberFormProps> = ({ onSubmit }) => {
+  const [name, setName] = useState('');
+  const [memberType, setMemberType] = useState<MemberType>('human');
+  const [petType, setPetType] = useState<PetType>('dog');
+  const [birthDate, setBirthDate] = useState('');
+  const [notes, setNotes] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) return;
+
+    const data: MemberFormData = {
+      name: name.trim(),
+      memberType,
+      ...(memberType === 'pet' ? { petType } : {}),
+      ...(birthDate ? { birthDate } : {}),
+      ...(notes.trim() ? { notes: notes.trim() } : {}),
+    };
+
+    onSubmit(data);
+
+    // フォームリセット
+    setName('');
+    setMemberType('human');
+    setPetType('dog');
+    setBirthDate('');
+    setNotes('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="member-name" className="block text-sm font-medium text-gray-700 mb-1">
+          名前
+        </label>
+        <input
+          id="member-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="名前を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="member-type" className="block text-sm font-medium text-gray-700 mb-1">
+          タイプ
+        </label>
+        <select
+          id="member-type"
+          value={memberType}
+          onChange={(e) => setMemberType(e.target.value as MemberType)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        >
+          <option value="human">家族</option>
+          <option value="pet">ペット</option>
+        </select>
+      </div>
+
+      {memberType === 'pet' && (
+        <div>
+          <label htmlFor="pet-type" className="block text-sm font-medium text-gray-700 mb-1">
+            ペットの種類
+          </label>
+          <select
+            id="pet-type"
+            value={petType}
+            onChange={(e) => setPetType(e.target.value as PetType)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="dog">犬</option>
+            <option value="cat">猫</option>
+            <option value="rabbit">うさぎ</option>
+            <option value="bird">鳥</option>
+            <option value="other">その他</option>
+          </select>
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="birth-date" className="block text-sm font-medium text-gray-700 mb-1">
+          生年月日
+        </label>
+        <input
+          id="birth-date"
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="member-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ
+        </label>
+        <textarea
+          id="member-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={3}
+          placeholder="メモを入力（任意）"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+      >
+        追加する
+      </button>
+    </form>
+  );
+};

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import Link from 'next/link';
+import { Member, MemberEntity } from '../../domain/entities/Member';
+import { MemberIcon } from '../shared/MemberIcon';
+import { Pill } from 'lucide-react';
+
+interface MemberListProps {
+  members: Member[];
+  isLoading: boolean;
+  onDelete: (memberId: string) => void;
+}
+
+export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (members.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-12">
+        <p className="text-gray-500 text-lg">メンバーがまだ登録されていません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {members.map((member) => (
+        <MemberCard key={member.id} member={member} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface MemberCardProps {
+  member: Member;
+  onDelete: (memberId: string) => void;
+}
+
+const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete }) => {
+  const entity = new MemberEntity(member);
+  const displayInfo = entity.getDisplayInfo();
+  const age = entity.getAge();
+
+  return (
+    <div
+      className="bg-white rounded-lg shadow-md p-4 border border-gray-200"
+      data-testid="member-item"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <MemberIcon memberType={displayInfo.memberType} petType={displayInfo.petType} size={28} className="text-gray-600" />
+          <div>
+            <p className="font-semibold text-gray-800">{displayInfo.name}</p>
+            <div className="flex items-center space-x-2 text-sm text-gray-500">
+              <span>{displayInfo.typeLabel}</span>
+              {age !== null && <span>{age}歳</span>}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Link
+            href={`/members/${member.id}/medications`}
+            className="flex items-center space-x-1 text-primary-600 hover:text-primary-700 text-sm px-3 py-1 rounded-md hover:bg-primary-50 transition-colors"
+            aria-label="薬管理"
+          >
+            <Pill size={14} />
+            <span>薬管理</span>
+          </Link>
+          <button
+            onClick={() => onDelete(member.id)}
+            className="text-red-500 hover:text-red-700 text-sm px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
+            aria-label="削除"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+      {member.notes && (
+        <p className="mt-2 text-sm text-gray-500">{member.notes}</p>
+      )}
+    </div>
+  );
+};

--- a/src/components/schedules/ScheduleForm.tsx
+++ b/src/components/schedules/ScheduleForm.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { DayOfWeek } from '../../domain/entities/Schedule';
+
+export interface ScheduleFormData {
+  scheduledTime: string;
+  daysOfWeek: DayOfWeek[];
+  reminderMinutesBefore: number;
+}
+
+interface ScheduleFormProps {
+  onSubmit: (data: ScheduleFormData) => void;
+}
+
+const DAY_OPTIONS: { value: DayOfWeek; label: string }[] = [
+  { value: 'mon', label: '月' },
+  { value: 'tue', label: '火' },
+  { value: 'wed', label: '水' },
+  { value: 'thu', label: '木' },
+  { value: 'fri', label: '金' },
+  { value: 'sat', label: '土' },
+  { value: 'sun', label: '日' },
+];
+
+export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
+  const [scheduledTime, setScheduledTime] = useState('08:00');
+  const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
+  const [reminderMinutes, setReminderMinutes] = useState('10');
+
+  const toggleDay = (day: DayOfWeek) => {
+    setSelectedDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (selectedDays.length === 0) return;
+
+    onSubmit({
+      scheduledTime,
+      daysOfWeek: selectedDays,
+      reminderMinutesBefore: parseInt(reminderMinutes, 10) || 0,
+    });
+
+    setScheduledTime('08:00');
+    setSelectedDays([]);
+    setReminderMinutes('10');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="schedule-time" className="block text-sm font-medium text-gray-700 mb-1">
+          服薬時刻
+        </label>
+        <input
+          id="schedule-time"
+          type="time"
+          value={scheduledTime}
+          onChange={(e) => setScheduledTime(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-gray-700 mb-2">曜日</span>
+        <div className="flex flex-wrap gap-2">
+          {DAY_OPTIONS.map(({ value, label }) => (
+            <label
+              key={value}
+              className={`flex items-center justify-center w-10 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
+                selectedDays.includes(value)
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={selectedDays.includes(value)}
+                onChange={() => toggleDay(value)}
+                className="sr-only"
+                aria-label={label}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="reminder-minutes" className="block text-sm font-medium text-gray-700 mb-1">
+          リマインダー（分前）
+        </label>
+        <select
+          id="reminder-minutes"
+          value={reminderMinutes}
+          onChange={(e) => setReminderMinutes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="0">なし</option>
+          <option value="5">5分前</option>
+          <option value="10">10分前</option>
+          <option value="15">15分前</option>
+          <option value="30">30分前</option>
+          <option value="60">1時間前</option>
+        </select>
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+      >
+        スケジュールを追加
+      </button>
+    </form>
+  );
+};

--- a/src/components/shared/BottomNavigation.tsx
+++ b/src/components/shared/BottomNavigation.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Link from 'next/link';
+import { Home, Users, Pill, Settings, type LucideIcon } from 'lucide-react';
+
+interface NavItem {
+  path: string;
+  icon: LucideIcon;
+  label: string;
+}
+
+const navItems: NavItem[] = [
+  { path: '/', icon: Home, label: 'ホーム' },
+  { path: '/members', icon: Users, label: 'メンバー' },
+  { path: '/medications', icon: Pill, label: 'お薬' },
+  { path: '/settings', icon: Settings, label: '設定' },
+];
+
+interface BottomNavigationProps {
+  activePath: string;
+}
+
+export const BottomNavigation: React.FC<BottomNavigationProps> = ({ activePath }) => {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200" aria-label="メインナビゲーション">
+      <div className="max-w-md mx-auto flex justify-around py-2">
+        {navItems.map(({ path, icon, label }) => {
+          const isActive = activePath === path;
+          return (
+            <Link
+              key={path}
+              href={path}
+              {...(isActive && { 'aria-current': 'page' as const })}
+              className={`flex flex-col items-center text-xs ${
+                isActive ? 'text-primary-600' : 'text-gray-400'
+              }`}
+            >
+              {React.createElement(icon, { size: 20, className: 'mb-0.5' })}
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};

--- a/src/components/shared/CharacterIcon.tsx
+++ b/src/components/shared/CharacterIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Dog, Cat, Rabbit, Bird } from 'lucide-react';
+import { CharacterType } from '../../domain/entities/Character';
+
+interface CharacterIconProps {
+  type: CharacterType;
+  size?: number;
+  className?: string;
+}
+
+const iconMap = {
+  dog: Dog,
+  cat: Cat,
+  rabbit: Rabbit,
+  bird: Bird,
+} as const;
+
+export const CharacterIcon: React.FC<CharacterIconProps> = ({ type, size = 32, className }) => {
+  const Icon = iconMap[type];
+  return <Icon size={size} className={className} aria-hidden="true" />;
+};

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ErrorBoundary caught:', error, errorInfo);
+  }
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-50">
+          <div className="text-center p-8">
+            <h1 className="text-xl font-bold text-red-600 mb-4">エラーが発生しました</h1>
+            <p className="text-gray-600 mb-6">{this.state.error?.message}</p>
+            <button
+              onClick={this.handleReload}
+              className="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              再読み込み
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/shared/MemberIcon.tsx
+++ b/src/components/shared/MemberIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { User, Dog, Cat, Rabbit, Bird, PawPrint, type LucideIcon } from 'lucide-react';
+import { MemberType, PetType } from '../../domain/entities/Member';
+
+interface MemberIconProps {
+  memberType: MemberType;
+  petType?: PetType;
+  size?: number;
+  className?: string;
+}
+
+const petIconMap: Record<PetType, LucideIcon> = {
+  dog: Dog,
+  cat: Cat,
+  rabbit: Rabbit,
+  bird: Bird,
+  other: PawPrint,
+};
+
+export const MemberIcon: React.FC<MemberIconProps> = ({ memberType, petType, size = 24, className }) => {
+  if (memberType === 'pet') {
+    const Icon = petIconMap[petType || 'other'];
+    return <Icon size={size} className={className} aria-hidden="true" />;
+  }
+  return <User size={size} className={className} aria-hidden="true" />;
+};

--- a/src/data/api/apiClient.ts
+++ b/src/data/api/apiClient.ts
@@ -1,0 +1,54 @@
+const BASE_URL = '/api';
+
+interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  error?: string;
+}
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  if (res.status === 401) {
+    window.location.href = '/login';
+    throw new Error('認証エラー');
+  }
+
+  const json: ApiResponse<T> = await res.json();
+
+  if (!json.success) {
+    throw new Error(json.error || 'APIエラー');
+  }
+
+  return json.data;
+}
+
+export const apiClient = {
+  get<T>(path: string): Promise<T> {
+    return request<T>(path);
+  },
+
+  post<T>(path: string, body?: unknown): Promise<T> {
+    return request<T>(path, {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  },
+
+  put<T>(path: string, body?: unknown): Promise<T> {
+    return request<T>(path, {
+      method: 'PUT',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  },
+
+  del<T>(path: string): Promise<T> {
+    return request<T>(path, { method: 'DELETE' });
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -1,0 +1,50 @@
+import { Member, MemberType } from '../../domain/entities/Member';
+import { Medication, MedicationCategory } from '../../domain/entities/Medication';
+import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
+import { BackendMember, BackendMedication, BackendSchedule } from './types';
+
+export function toMember(b: BackendMember): Member {
+  return {
+    id: b.memberId,
+    userId: b.userId,
+    memberType: (b.memberType as MemberType) || 'human',
+    name: b.name,
+    petType: b.petType as Member['petType'],
+    birthDate: b.birthDate ? new Date(b.birthDate) : undefined,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+    updatedAt: new Date(b.updatedAt),
+  };
+}
+
+export function toMedication(b: BackendMedication): Medication {
+  return {
+    id: b.medicationId,
+    memberId: b.memberId,
+    userId: b.userId,
+    name: b.name,
+    category: (b.category as MedicationCategory) || 'regular',
+    dosage: b.dosageAmount,
+    frequency: b.frequency,
+    stockQuantity: b.stockQuantity,
+    lowStockThreshold: b.lowStockThreshold,
+    instructions: b.instructions,
+    isActive: b.isActive ?? true,
+    createdAt: new Date(b.createdAt),
+    updatedAt: new Date(b.updatedAt),
+  };
+}
+
+export function toSchedule(b: BackendSchedule): Schedule {
+  return {
+    id: b.scheduleId,
+    medicationId: b.medicationId,
+    userId: b.userId,
+    memberId: b.memberId,
+    scheduledTime: b.scheduledTime,
+    daysOfWeek: (b.daysOfWeek as DayOfWeek[]) || [],
+    isEnabled: b.isEnabled ?? true,
+    reminderMinutesBefore: b.reminderMinutesBefore ?? 10,
+    createdAt: new Date(b.createdAt),
+  };
+}

--- a/src/data/api/medicationApi.ts
+++ b/src/data/api/medicationApi.ts
@@ -1,0 +1,53 @@
+import { Medication } from '../../domain/entities/Medication';
+import { CreateMedicationInput, UpdateMedicationInput } from '../../domain/repositories/MedicationRepository';
+import { apiClient } from './apiClient';
+import { BackendMedication } from './types';
+import { toMedication } from './mappers';
+
+export const medicationApi = {
+  async getMedicationsByMember(memberId: string): Promise<Medication[]> {
+    const data = await apiClient.get<BackendMedication[]>(`/medications/member/${memberId}`);
+    return data.map(toMedication);
+  },
+
+  async getMedicationById(medicationId: string): Promise<Medication | null> {
+    try {
+      const data = await apiClient.get<BackendMedication>(`/medications/${medicationId}`);
+      return toMedication(data);
+    } catch {
+      return null;
+    }
+  },
+
+  async createMedication(input: CreateMedicationInput): Promise<Medication> {
+    const data = await apiClient.post<BackendMedication>('/medications', {
+      name: input.name,
+      memberId: input.memberId,
+      category: input.category,
+      dosageAmount: input.dosage,
+      frequency: input.frequency,
+      stockQuantity: input.stockQuantity,
+      lowStockThreshold: input.lowStockThreshold,
+      instructions: input.instructions,
+    });
+    return toMedication(data);
+  },
+
+  async updateMedication(medicationId: string, input: UpdateMedicationInput): Promise<Medication> {
+    const body: Record<string, unknown> = {};
+    if (input.stockQuantity !== undefined) body.stockQuantity = input.stockQuantity;
+    if (input.name !== undefined) body.name = input.name;
+    if (input.dosage !== undefined) body.dosageAmount = input.dosage;
+    if (input.frequency !== undefined) body.frequency = input.frequency;
+    if (input.lowStockThreshold !== undefined) body.lowStockThreshold = input.lowStockThreshold;
+    if (input.instructions !== undefined) body.instructions = input.instructions;
+    if (input.isActive !== undefined) body.isActive = input.isActive;
+
+    const data = await apiClient.put<BackendMedication>(`/medications/${medicationId}`, body);
+    return toMedication(data);
+  },
+
+  async deleteMedication(medicationId: string): Promise<void> {
+    await apiClient.del(`/medications/${medicationId}`);
+  },
+};

--- a/src/data/api/memberApi.ts
+++ b/src/data/api/memberApi.ts
@@ -1,0 +1,46 @@
+import { Member } from '../../domain/entities/Member';
+import { CreateMemberInput, UpdateMemberInput } from '../../domain/repositories/MemberRepository';
+import { apiClient } from './apiClient';
+import { BackendMember } from './types';
+import { toMember } from './mappers';
+
+export const memberApi = {
+  async getMembers(_userId: string): Promise<Member[]> {
+    const data = await apiClient.get<BackendMember[]>('/members');
+    return data.map(toMember);
+  },
+
+  async getMemberById(memberId: string): Promise<Member | null> {
+    try {
+      const data = await apiClient.get<BackendMember>(`/members/${memberId}`);
+      return toMember(data);
+    } catch {
+      return null;
+    }
+  },
+
+  async createMember(input: CreateMemberInput): Promise<Member> {
+    const data = await apiClient.post<BackendMember>('/members', {
+      name: input.name,
+      memberType: input.memberType,
+      petType: input.petType,
+      birthDate: input.birthDate?.toISOString(),
+      notes: input.notes,
+    });
+    return toMember(data);
+  },
+
+  async updateMember(memberId: string, input: UpdateMemberInput): Promise<Member> {
+    const data = await apiClient.put<BackendMember>(`/members/${memberId}`, {
+      name: input.name,
+      petType: input.petType,
+      birthDate: input.birthDate?.toISOString(),
+      notes: input.notes,
+    });
+    return toMember(data);
+  },
+
+  async deleteMember(memberId: string): Promise<void> {
+    await apiClient.del(`/members/${memberId}`);
+  },
+};

--- a/src/data/api/recordApi.ts
+++ b/src/data/api/recordApi.ts
@@ -1,0 +1,24 @@
+import { apiClient } from './apiClient';
+import { BackendRecord } from './types';
+
+interface CreateRecordInput {
+  memberId: string;
+  medicationId: string;
+  scheduleId?: string;
+  notes?: string;
+  dosageAmount?: string;
+}
+
+export const recordApi = {
+  async createRecord(input: CreateRecordInput): Promise<BackendRecord> {
+    return apiClient.post<BackendRecord>('/records', input);
+  },
+
+  async getRecords(): Promise<BackendRecord[]> {
+    return apiClient.get<BackendRecord[]>('/records');
+  },
+
+  async getRecordsByMember(memberId: string): Promise<BackendRecord[]> {
+    return apiClient.get<BackendRecord[]>(`/records/member/${memberId}`);
+  },
+};

--- a/src/data/api/scheduleApi.ts
+++ b/src/data/api/scheduleApi.ts
@@ -1,0 +1,88 @@
+import { Schedule } from '../../domain/entities/Schedule';
+import { TodayScheduleItem } from '../../domain/repositories/ScheduleRepository';
+import { apiClient } from './apiClient';
+import { BackendSchedule, BackendMember, BackendMedication, BackendRecord } from './types';
+import { toSchedule } from './mappers';
+
+export const scheduleApi = {
+  async getTodaySchedules(_userId: string, _date: Date): Promise<TodayScheduleItem[]> {
+    const [schedules, members, records] = await Promise.all([
+      apiClient.get<BackendSchedule[]>('/schedules'),
+      apiClient.get<BackendMember[]>('/members'),
+      apiClient.get<BackendRecord[]>('/records'),
+    ]);
+
+    const memberMap = new Map(members.map((m) => [m.memberId, m]));
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const todayRecordScheduleIds = new Set(
+      records
+        .filter((r) => r.takenAt.slice(0, 10) === todayStr)
+        .map((r) => r.scheduleId)
+        .filter(Boolean)
+    );
+
+    const medicationIds = [...new Set(schedules.map((s) => s.medicationId))];
+    const medications = await Promise.all(
+      medicationIds.map((id) =>
+        apiClient.get<BackendMedication>(`/medications/${id}`).catch(() => null)
+      )
+    );
+    const medMap = new Map(
+      medications.filter(Boolean).map((m) => [m!.medicationId, m!])
+    );
+
+    return schedules
+      .filter((s) => s.isEnabled !== false)
+      .map((s) => {
+        const member = memberMap.get(s.memberId);
+        const med = medMap.get(s.medicationId);
+        return {
+          schedule: toSchedule(s),
+          medicationName: med?.name || '',
+          memberName: member?.name || '',
+          memberType: (member?.memberType as 'human' | 'pet') || 'human',
+          isCompleted: todayRecordScheduleIds.has(s.scheduleId),
+        };
+      });
+  },
+
+  async createSchedule(
+    schedule: Omit<Schedule, 'id' | 'createdAt'>
+  ): Promise<Schedule> {
+    const data = await apiClient.post<BackendSchedule>('/schedules', {
+      medicationId: schedule.medicationId,
+      memberId: schedule.memberId,
+      scheduledTime: schedule.scheduledTime,
+      daysOfWeek: [...schedule.daysOfWeek],
+      isEnabled: schedule.isEnabled,
+      reminderMinutesBefore: schedule.reminderMinutesBefore,
+    });
+    return toSchedule(data);
+  },
+
+  async updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule> {
+    const body: Record<string, unknown> = {};
+    if (schedule.scheduledTime !== undefined) body.scheduledTime = schedule.scheduledTime;
+    if (schedule.daysOfWeek !== undefined) body.daysOfWeek = [...schedule.daysOfWeek];
+    if (schedule.isEnabled !== undefined) body.isEnabled = schedule.isEnabled;
+    if (schedule.reminderMinutesBefore !== undefined) body.reminderMinutesBefore = schedule.reminderMinutesBefore;
+
+    const data = await apiClient.put<BackendSchedule>(`/schedules/${id}`, body);
+    return toSchedule(data);
+  },
+
+  async deleteSchedule(id: string): Promise<void> {
+    await apiClient.del(`/schedules/${id}`);
+  },
+
+  async markAsCompleted(scheduleId: string, _completedAt: Date): Promise<void> {
+    const scheduleData = await apiClient.get<BackendSchedule>(`/schedules/${scheduleId}`).catch(() => null);
+    if (!scheduleData) return;
+
+    await apiClient.post('/records', {
+      memberId: scheduleData.memberId,
+      medicationId: scheduleData.medicationId,
+      scheduleId,
+    });
+  },
+};

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -1,0 +1,50 @@
+export interface BackendMember {
+  memberId: string;
+  userId: string;
+  name: string;
+  memberType?: string;
+  petType?: string;
+  birthDate?: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BackendMedication {
+  medicationId: string;
+  memberId: string;
+  userId: string;
+  name: string;
+  category?: string;
+  dosageAmount?: string;
+  frequency?: string;
+  stockQuantity?: number;
+  lowStockThreshold?: number;
+  instructions?: string;
+  isActive?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BackendSchedule {
+  scheduleId: string;
+  medicationId: string;
+  userId: string;
+  memberId: string;
+  scheduledTime: string;
+  daysOfWeek?: string[];
+  isEnabled?: boolean;
+  reminderMinutesBefore?: number;
+  createdAt: string;
+}
+
+export interface BackendRecord {
+  recordId: string;
+  userId: string;
+  memberId: string;
+  medicationId: string;
+  scheduleId?: string;
+  takenAt: string;
+  notes?: string;
+  dosageAmount?: string;
+}

--- a/src/data/repositories/MedicationRepositoryImpl.ts
+++ b/src/data/repositories/MedicationRepositoryImpl.ts
@@ -1,0 +1,33 @@
+/**
+ * 薬リポジトリの実装
+ */
+
+import {
+  MedicationRepository,
+  CreateMedicationInput,
+  UpdateMedicationInput,
+} from '../../domain/repositories/MedicationRepository';
+import { Medication } from '../../domain/entities/Medication';
+import { medicationApi } from '../api/medicationApi';
+
+export class MedicationRepositoryImpl implements MedicationRepository {
+  async getMedicationsByMember(memberId: string): Promise<Medication[]> {
+    return medicationApi.getMedicationsByMember(memberId);
+  }
+
+  async getMedicationById(medicationId: string): Promise<Medication | null> {
+    return medicationApi.getMedicationById(medicationId);
+  }
+
+  async createMedication(input: CreateMedicationInput): Promise<Medication> {
+    return medicationApi.createMedication(input);
+  }
+
+  async updateMedication(medicationId: string, input: UpdateMedicationInput): Promise<Medication> {
+    return medicationApi.updateMedication(medicationId, input);
+  }
+
+  async deleteMedication(medicationId: string): Promise<void> {
+    return medicationApi.deleteMedication(medicationId);
+  }
+}

--- a/src/data/repositories/MemberRepositoryImpl.ts
+++ b/src/data/repositories/MemberRepositoryImpl.ts
@@ -1,0 +1,34 @@
+/**
+ * メンバーリポジトリの実装
+ * Domain層のインターフェースを実装
+ */
+
+import {
+  MemberRepository,
+  CreateMemberInput,
+  UpdateMemberInput,
+} from '../../domain/repositories/MemberRepository';
+import { Member } from '../../domain/entities/Member';
+import { memberApi } from '../api/memberApi';
+
+export class MemberRepositoryImpl implements MemberRepository {
+  async getMembers(userId: string): Promise<Member[]> {
+    return memberApi.getMembers(userId);
+  }
+
+  async getMemberById(memberId: string): Promise<Member | null> {
+    return memberApi.getMemberById(memberId);
+  }
+
+  async createMember(input: CreateMemberInput): Promise<Member> {
+    return memberApi.createMember(input);
+  }
+
+  async updateMember(memberId: string, input: UpdateMemberInput): Promise<Member> {
+    return memberApi.updateMember(memberId, input);
+  }
+
+  async deleteMember(memberId: string): Promise<void> {
+    return memberApi.deleteMember(memberId);
+  }
+}

--- a/src/data/repositories/ScheduleRepositoryImpl.ts
+++ b/src/data/repositories/ScheduleRepositoryImpl.ts
@@ -1,0 +1,34 @@
+/**
+ * スケジュールリポジトリの実装
+ * Domain層のインターフェースを実装
+ */
+
+import {
+  ScheduleRepository,
+  TodayScheduleQuery,
+  TodayScheduleItem,
+} from '../../domain/repositories/ScheduleRepository';
+import { Schedule } from '../../domain/entities/Schedule';
+import { scheduleApi } from '../api/scheduleApi';
+
+export class ScheduleRepositoryImpl implements ScheduleRepository {
+  async getTodaySchedules(query: TodayScheduleQuery): Promise<TodayScheduleItem[]> {
+    return await scheduleApi.getTodaySchedules(query.userId, query.date);
+  }
+
+  async createSchedule(schedule: Omit<Schedule, 'id' | 'createdAt'>): Promise<Schedule> {
+    return await scheduleApi.createSchedule(schedule);
+  }
+
+  async updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule> {
+    return await scheduleApi.updateSchedule(id, schedule);
+  }
+
+  async deleteSchedule(id: string): Promise<void> {
+    await scheduleApi.deleteSchedule(id);
+  }
+
+  async markAsCompleted(scheduleId: string, completedAt: Date): Promise<void> {
+    await scheduleApi.markAsCompleted(scheduleId, completedAt);
+  }
+}

--- a/src/domain/entities/Character.ts
+++ b/src/domain/entities/Character.ts
@@ -1,0 +1,119 @@
+export type CharacterType = 'dog' | 'cat' | 'rabbit' | 'bird';
+
+export type CharacterMood =
+  | 'happy'
+  | 'excited'
+  | 'normal'
+  | 'reminding'
+  | 'worried'
+  | 'sad'
+  | 'cheering';
+
+export interface CharacterConfig {
+  type: CharacterType;
+  name: string;
+  sounds: {
+    normal: string;
+    medicationReminder: string;
+    missedMedication: string;
+    medicationComplete: string;
+    exerciseCheer: string;
+  };
+  messages: {
+    medicationReminder: string;
+    missedMedication: string;
+    medicationComplete: string;
+    exerciseCheer: string;
+    lowStock: string;
+    appointmentReminder: string;
+    vaccineReminder: string;
+    checkupReminder: string;
+  };
+}
+
+export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {
+  dog: {
+    type: 'dog',
+    name: 'いぬ',
+    sounds: {
+      normal: '/sounds/dog/bark.mp3',
+      medicationReminder: '/sounds/dog/reminder.mp3',
+      missedMedication: '/sounds/dog/missed.mp3',
+      medicationComplete: '/sounds/dog/complete.mp3',
+      exerciseCheer: '/sounds/dog/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'わんわん！お薬の時間だよ！',
+      missedMedication: 'きゃいんきゃいん！お薬忘れてるよ！',
+      medicationComplete: 'わん！えらい！',
+      exerciseCheer: 'わんわん！すごいね！',
+      lowStock: 'わんわん！お薬が少なくなってるよ！病院に行こう！',
+      appointmentReminder: 'わんわん！病院の日だよ！',
+      vaccineReminder: 'わんわん！注射の日が近いよ！',
+      checkupReminder: 'わんわん！健康診断だよ！',
+    },
+  },
+  cat: {
+    type: 'cat',
+    name: 'ねこ',
+    sounds: {
+      normal: '/sounds/cat/meow.mp3',
+      medicationReminder: '/sounds/cat/reminder.mp3',
+      missedMedication: '/sounds/cat/missed.mp3',
+      medicationComplete: '/sounds/cat/complete.mp3',
+      exerciseCheer: '/sounds/cat/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'にゃいにゃい！お薬の時間にゃ！',
+      missedMedication: 'びゃいびゃい！お薬飲んでにゃ！',
+      medicationComplete: 'にゃ〜ん♪',
+      exerciseCheer: 'にゃいにゃい！頑張ったにゃ！',
+      lowStock: 'にゃいにゃい！お薬少ないにゃ！病院行こうにゃい！',
+      appointmentReminder: 'にゃいにゃい！病院の日だにゃ！',
+      vaccineReminder: 'にゃいにゃい！注射の日が近いにゃ！',
+      checkupReminder: 'にゃいにゃい！健康診断だにゃ！',
+    },
+  },
+  rabbit: {
+    type: 'rabbit',
+    name: 'うさぎ',
+    sounds: {
+      normal: '/sounds/rabbit/squeak.mp3',
+      medicationReminder: '/sounds/rabbit/reminder.mp3',
+      missedMedication: '/sounds/rabbit/missed.mp3',
+      medicationComplete: '/sounds/rabbit/complete.mp3',
+      exerciseCheer: '/sounds/rabbit/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'ぴょんぴょん！お薬の時間だよ！',
+      missedMedication: 'ぶぅぶぅ！お薬忘れてるよ！',
+      medicationComplete: 'ぴょん♪',
+      exerciseCheer: 'ぴょんぴょん！えらいね！',
+      lowStock: 'ぴょんぴょん！お薬少ないよ！病院に行こう！',
+      appointmentReminder: 'ぴょんぴょん！病院の日だよ！',
+      vaccineReminder: 'ぴょんぴょん！注射の日が近いよ！',
+      checkupReminder: 'ぴょんぴょん！健康診断だよ！',
+    },
+  },
+  bird: {
+    type: 'bird',
+    name: 'インコ',
+    sounds: {
+      normal: '/sounds/bird/chirp.mp3',
+      medicationReminder: '/sounds/bird/reminder.mp3',
+      missedMedication: '/sounds/bird/missed.mp3',
+      medicationComplete: '/sounds/bird/complete.mp3',
+      exerciseCheer: '/sounds/bird/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'ぴよぴよ！お薬の時間だよ！',
+      missedMedication: 'ぎゃーぎゃー！お薬飲んで！',
+      medicationComplete: 'ぴー♪',
+      exerciseCheer: 'ぴよぴよ！すごい！',
+      lowStock: 'ぴよぴよ！お薬少ないよ！病院行こう！',
+      appointmentReminder: 'ぴよぴよ！病院の日だよ！',
+      vaccineReminder: 'ぴよぴよ！注射の日が近いよ！',
+      checkupReminder: 'ぴよぴよ！健康診断だよ！',
+    },
+  },
+};

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -1,0 +1,107 @@
+/**
+ * お薬エンティティ
+ */
+
+export type MedicationCategory =
+  | 'regular'
+  | 'supplement'
+  | 'prn'
+  | 'flea_tick'
+  | 'heartworm';
+
+export interface Medication {
+  readonly id: string;
+  readonly memberId: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly category: MedicationCategory;
+  readonly dosage?: string;
+  readonly frequency?: string;
+  readonly stockQuantity?: number;
+  readonly lowStockThreshold?: number;
+  readonly intervalHours?: number;
+  readonly instructions?: string;
+  readonly isActive: boolean;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * お薬のビジネスロジック
+ */
+export class MedicationEntity {
+  constructor(private readonly medication: Medication) {}
+
+  /**
+   * 在庫が少ないかチェック
+   */
+  isLowStock(): boolean {
+    if (
+      this.medication.stockQuantity === undefined ||
+      this.medication.lowStockThreshold === undefined
+    ) {
+      return false;
+    }
+
+    return this.medication.stockQuantity <= this.medication.lowStockThreshold;
+  }
+
+  /**
+   * 在庫を減らす
+   */
+  decreaseStock(amount: number = 1): Medication {
+    if (this.medication.stockQuantity === undefined) {
+      return this.medication;
+    }
+
+    return {
+      ...this.medication,
+      stockQuantity: Math.max(0, this.medication.stockQuantity - amount),
+      updatedAt: new Date(),
+    };
+  }
+
+  /**
+   * 在庫を増やす
+   */
+  increaseStock(amount: number): Medication {
+    if (this.medication.stockQuantity === undefined) {
+      return this.medication;
+    }
+
+    return {
+      ...this.medication,
+      stockQuantity: this.medication.stockQuantity + amount,
+      updatedAt: new Date(),
+    };
+  }
+
+  get id(): string {
+    return this.medication.id;
+  }
+
+  get name(): string {
+    return this.medication.name;
+  }
+
+  get data(): Medication {
+    return this.medication;
+  }
+
+  private static readonly categoryLabels: Record<MedicationCategory, string> = {
+    regular: '常用薬',
+    supplement: 'サプリメント',
+    prn: '頓服薬',
+    flea_tick: 'ノミ・ダニ薬',
+    heartworm: 'フィラリア薬',
+  };
+
+  getDisplayInfo(): { name: string; categoryLabel: string; dosageInfo: string } {
+    const dosageParts = [this.medication.dosage, this.medication.frequency].filter(Boolean);
+    return {
+      name: this.medication.name,
+      categoryLabel: MedicationEntity.categoryLabels[this.medication.category],
+      dosageInfo: dosageParts.join(' / '),
+    };
+  }
+}

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -1,0 +1,94 @@
+/**
+ * メンバー（家族・ペット）エンティティ
+ */
+
+export type MemberType = 'human' | 'pet';
+export type PetType = 'dog' | 'cat' | 'rabbit' | 'bird' | 'other';
+
+export interface Member {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberType: MemberType;
+  readonly name: string;
+  readonly petType?: PetType;
+  readonly photoUrl?: string;
+  readonly birthDate?: Date;
+  readonly notes?: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * メンバーのビジネスロジック
+ */
+export class MemberEntity {
+  constructor(private readonly member: Member) {}
+
+  /**
+   * ペットかどうか
+   */
+  isPet(): boolean {
+    return this.member.memberType === 'pet';
+  }
+
+  /**
+   * 人間かどうか
+   */
+  isHuman(): boolean {
+    return this.member.memberType === 'human';
+  }
+
+  /**
+   * 年齢を計算
+   */
+  getAge(): number | null {
+    if (!this.member.birthDate) {
+      return null;
+    }
+
+    const today = new Date();
+    const birthDate = new Date(this.member.birthDate);
+    let age = today.getFullYear() - birthDate.getFullYear();
+    const monthDiff = today.getMonth() - birthDate.getMonth();
+
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+      age--;
+    }
+
+    return age;
+  }
+
+  /**
+   * アイコン種別を取得（コンポーネント側でMemberIconに渡す用）
+   */
+  getIconType(): { memberType: MemberType; petType?: PetType } {
+    return {
+      memberType: this.member.memberType,
+      petType: this.member.petType,
+    };
+  }
+
+  get id(): string {
+    return this.member.id;
+  }
+
+  get name(): string {
+    return this.member.name;
+  }
+
+  get data(): Member {
+    return this.member;
+  }
+
+  /**
+   * 表示用の情報を取得
+   */
+  getDisplayInfo(): { memberType: MemberType; petType?: PetType; name: string; typeLabel: string } {
+    return {
+      memberType: this.member.memberType,
+      petType: this.member.petType,
+      name: this.member.name,
+      typeLabel: this.isPet() ? 'ペット' : '家族',
+    };
+  }
+}

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -1,0 +1,86 @@
+/**
+ * スケジュールエンティティ
+ * ビジネスロジックの中核となるドメインモデル
+ */
+
+export type DayOfWeek = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+export type ScheduleStatus = 'pending' | 'completed' | 'overdue';
+
+export interface Schedule {
+  readonly id: string;
+  readonly medicationId: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly scheduledTime: string; // HH:mm形式
+  readonly daysOfWeek: readonly DayOfWeek[];
+  readonly isEnabled: boolean;
+  readonly reminderMinutesBefore: number;
+  readonly createdAt: Date;
+}
+
+/**
+ * スケジュールのステータスを計算するドメインロジック
+ */
+export class ScheduleEntity {
+  constructor(private readonly schedule: Schedule) {}
+
+  /**
+   * 現在時刻に基づいてスケジュールのステータスを取得
+   */
+  getStatus(currentTime: Date, isCompleted: boolean): ScheduleStatus {
+    if (isCompleted) {
+      return 'completed';
+    }
+
+    const [hours, minutes] = this.schedule.scheduledTime.split(':').map(Number);
+    const scheduledDateTime = new Date(currentTime);
+    scheduledDateTime.setHours(hours, minutes, 0, 0);
+
+    if (currentTime > scheduledDateTime) {
+      return 'overdue';
+    }
+
+    return 'pending';
+  }
+
+  /**
+   * 指定された曜日にスケジュールが有効かチェック
+   */
+  isActiveOnDay(date: Date): boolean {
+    if (!this.schedule.isEnabled) {
+      return false;
+    }
+
+    const dayMap: Record<number, DayOfWeek> = {
+      0: 'sun',
+      1: 'mon',
+      2: 'tue',
+      3: 'wed',
+      4: 'thu',
+      5: 'fri',
+      6: 'sat',
+    };
+
+    const dayOfWeek = dayMap[date.getDay()];
+    return this.schedule.daysOfWeek.includes(dayOfWeek);
+  }
+
+  /**
+   * リマインダーを送信すべき時刻を取得
+   */
+  getReminderTime(date: Date): Date {
+    const [hours, minutes] = this.schedule.scheduledTime.split(':').map(Number);
+    const reminderTime = new Date(date);
+    reminderTime.setHours(hours, minutes, 0, 0);
+    reminderTime.setMinutes(reminderTime.getMinutes() - this.schedule.reminderMinutesBefore);
+    return reminderTime;
+  }
+
+  get id(): string {
+    return this.schedule.id;
+  }
+
+  get data(): Schedule {
+    return this.schedule;
+  }
+}

--- a/src/domain/repositories/MedicationRepository.ts
+++ b/src/domain/repositories/MedicationRepository.ts
@@ -1,0 +1,35 @@
+/**
+ * 薬リポジトリインターフェース
+ */
+
+import { Medication, MedicationCategory } from '../entities/Medication';
+
+export interface CreateMedicationInput {
+  memberId: string;
+  userId: string;
+  name: string;
+  category: MedicationCategory;
+  dosage?: string;
+  frequency?: string;
+  stockQuantity?: number;
+  lowStockThreshold?: number;
+  instructions?: string;
+}
+
+export interface UpdateMedicationInput {
+  name?: string;
+  dosage?: string;
+  frequency?: string;
+  stockQuantity?: number;
+  lowStockThreshold?: number;
+  instructions?: string;
+  isActive?: boolean;
+}
+
+export interface MedicationRepository {
+  getMedicationsByMember(memberId: string): Promise<Medication[]>;
+  getMedicationById(medicationId: string): Promise<Medication | null>;
+  createMedication(input: CreateMedicationInput): Promise<Medication>;
+  updateMedication(medicationId: string, input: UpdateMedicationInput): Promise<Medication>;
+  deleteMedication(medicationId: string): Promise<void>;
+}

--- a/src/domain/repositories/MemberRepository.ts
+++ b/src/domain/repositories/MemberRepository.ts
@@ -1,0 +1,30 @@
+/**
+ * メンバーリポジトリインターフェース
+ * 依存関係逆転の原則（DIP）に従い、Domain層がData層に依存しない
+ */
+
+import { Member } from '../entities/Member';
+
+export interface CreateMemberInput {
+  userId: string;
+  memberType: 'human' | 'pet';
+  name: string;
+  petType?: 'dog' | 'cat' | 'rabbit' | 'bird' | 'other';
+  birthDate?: Date;
+  notes?: string;
+}
+
+export interface UpdateMemberInput {
+  name?: string;
+  petType?: 'dog' | 'cat' | 'rabbit' | 'bird' | 'other';
+  birthDate?: Date;
+  notes?: string;
+}
+
+export interface MemberRepository {
+  getMembers(userId: string): Promise<Member[]>;
+  getMemberById(memberId: string): Promise<Member | null>;
+  createMember(input: CreateMemberInput): Promise<Member>;
+  updateMember(memberId: string, input: UpdateMemberInput): Promise<Member>;
+  deleteMember(memberId: string): Promise<void>;
+}

--- a/src/domain/repositories/ScheduleRepository.ts
+++ b/src/domain/repositories/ScheduleRepository.ts
@@ -1,0 +1,46 @@
+/**
+ * スケジュールリポジトリインターフェース
+ * 依存関係逆転の原則（DIP）に従い、Domain層がData層に依存しない
+ */
+
+import { Schedule } from '../entities/Schedule';
+
+export interface TodayScheduleQuery {
+  userId: string;
+  date: Date;
+}
+
+export interface TodayScheduleItem {
+  schedule: Schedule;
+  medicationName: string;
+  memberName: string;
+  memberType: 'human' | 'pet';
+  isCompleted: boolean;
+}
+
+export interface ScheduleRepository {
+  /**
+   * 今日のスケジュール一覧を取得
+   */
+  getTodaySchedules(query: TodayScheduleQuery): Promise<TodayScheduleItem[]>;
+
+  /**
+   * スケジュールを作成
+   */
+  createSchedule(schedule: Omit<Schedule, 'id' | 'createdAt'>): Promise<Schedule>;
+
+  /**
+   * スケジュールを更新
+   */
+  updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule>;
+
+  /**
+   * スケジュールを削除
+   */
+  deleteSchedule(id: string): Promise<void>;
+
+  /**
+   * スケジュールを服薬完了にする
+   */
+  markAsCompleted(scheduleId: string, completedAt: Date): Promise<void>;
+}

--- a/src/domain/usecases/GetTodaySchedules.ts
+++ b/src/domain/usecases/GetTodaySchedules.ts
@@ -1,0 +1,75 @@
+/**
+ * 今日のスケジュール取得ユースケース
+ * ビジネスロジックを集約
+ */
+
+import { ScheduleRepository, TodayScheduleItem } from '../repositories/ScheduleRepository';
+import { ScheduleEntity, ScheduleStatus } from '../entities/Schedule';
+
+export interface GetTodaySchedulesInput {
+  userId: string;
+  date?: Date;
+}
+
+export interface TodayScheduleViewModel {
+  scheduleId: string;
+  medicationId: string;
+  medicationName: string;
+  userId: string;
+  memberId: string;
+  memberName: string;
+  memberType: 'human' | 'pet';
+  scheduledTime: string;
+  status: ScheduleStatus;
+  isEnabled: boolean;
+  reminderMinutesBefore: number;
+}
+
+export class GetTodaySchedules {
+  constructor(private readonly scheduleRepository: ScheduleRepository) {}
+
+  /**
+   * ユースケースの実行
+   */
+  async execute(input: GetTodaySchedulesInput): Promise<TodayScheduleViewModel[]> {
+    const date = input.date || new Date();
+
+    // リポジトリから今日のスケジュール取得
+    const items = await this.scheduleRepository.getTodaySchedules({
+      userId: input.userId,
+      date,
+    });
+
+    // ドメインロジックを適用してViewModelに変換
+    const viewModels = items
+      .filter((item) => {
+        const entity = new ScheduleEntity(item.schedule);
+        return entity.isActiveOnDay(date);
+      })
+      .map((item) => this.toViewModel(item, date));
+
+    // 時刻順にソート
+    viewModels.sort((a, b) => a.scheduledTime.localeCompare(b.scheduledTime));
+
+    return viewModels;
+  }
+
+  private toViewModel(item: TodayScheduleItem, currentTime: Date): TodayScheduleViewModel {
+    const entity = new ScheduleEntity(item.schedule);
+    const status = entity.getStatus(currentTime, item.isCompleted);
+
+    return {
+      scheduleId: item.schedule.id,
+      medicationId: item.schedule.medicationId,
+      medicationName: item.medicationName,
+      userId: item.schedule.userId,
+      memberId: item.schedule.memberId,
+      memberName: item.memberName,
+      memberType: item.memberType,
+      scheduledTime: item.schedule.scheduledTime,
+      status,
+      isEnabled: item.schedule.isEnabled,
+      reminderMinutesBefore: item.schedule.reminderMinutesBefore,
+    };
+  }
+}

--- a/src/domain/usecases/ManageMedications.ts
+++ b/src/domain/usecases/ManageMedications.ts
@@ -1,0 +1,54 @@
+/**
+ * 薬管理ユースケース
+ */
+
+import { Medication, MedicationEntity } from '../entities/Medication';
+import {
+  MedicationRepository,
+  CreateMedicationInput,
+} from '../repositories/MedicationRepository';
+
+export interface MedicationViewModel {
+  medication: Medication;
+  isLowStock: boolean;
+  displayInfo: { name: string; categoryLabel: string; dosageInfo: string };
+}
+
+export class GetMedications {
+  constructor(private readonly medicationRepository: MedicationRepository) {}
+
+  async execute(memberId: string): Promise<MedicationViewModel[]> {
+    const medications = await this.medicationRepository.getMedicationsByMember(memberId);
+    return medications.map((med) => {
+      const entity = new MedicationEntity(med);
+      return {
+        medication: med,
+        isLowStock: entity.isLowStock(),
+        displayInfo: entity.getDisplayInfo(),
+      };
+    });
+  }
+}
+
+export class CreateMedication {
+  constructor(private readonly medicationRepository: MedicationRepository) {}
+
+  async execute(input: CreateMedicationInput): Promise<Medication> {
+    if (!input.name.trim()) {
+      throw new Error('薬の名前は必須です');
+    }
+    return this.medicationRepository.createMedication(input);
+  }
+}
+
+export class DeleteMedication {
+  constructor(private readonly medicationRepository: MedicationRepository) {}
+
+  async execute(medicationId: string): Promise<void> {
+    const existing = await this.medicationRepository.getMedicationById(medicationId);
+    if (!existing) {
+      throw new Error('薬が見つかりません');
+    }
+    return this.medicationRepository.deleteMedication(medicationId);
+  }
+}

--- a/src/domain/usecases/ManageMembers.ts
+++ b/src/domain/usecases/ManageMembers.ts
@@ -1,0 +1,69 @@
+/**
+ * メンバー管理ユースケース
+ * メンバーのCRUD操作のビジネスロジックを集約
+ */
+
+import { Member } from '../entities/Member';
+import {
+  MemberRepository,
+  CreateMemberInput,
+  UpdateMemberInput,
+} from '../repositories/MemberRepository';
+
+/**
+ * メンバー一覧取得ユースケース
+ */
+export class GetMembers {
+  constructor(private readonly memberRepository: MemberRepository) {}
+
+  async execute(userId: string): Promise<Member[]> {
+    return this.memberRepository.getMembers(userId);
+  }
+}
+
+/**
+ * メンバー作成ユースケース
+ */
+export class CreateMember {
+  constructor(private readonly memberRepository: MemberRepository) {}
+
+  async execute(input: CreateMemberInput): Promise<Member> {
+    if (!input.name.trim()) {
+      throw new Error('メンバー名は必須です');
+    }
+
+    return this.memberRepository.createMember(input);
+  }
+}
+
+/**
+ * メンバー更新ユースケース
+ */
+export class UpdateMember {
+  constructor(private readonly memberRepository: MemberRepository) {}
+
+  async execute(memberId: string, input: UpdateMemberInput): Promise<Member> {
+    const existing = await this.memberRepository.getMemberById(memberId);
+    if (!existing) {
+      throw new Error('メンバーが見つかりません');
+    }
+
+    return this.memberRepository.updateMember(memberId, input);
+  }
+}
+
+/**
+ * メンバー削除ユースケース
+ */
+export class DeleteMember {
+  constructor(private readonly memberRepository: MemberRepository) {}
+
+  async execute(memberId: string): Promise<void> {
+    const existing = await this.memberRepository.getMemberById(memberId);
+    if (!existing) {
+      throw new Error('メンバーが見つかりません');
+    }
+
+    return this.memberRepository.deleteMember(memberId);
+  }
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+
+export function useAuth() {
+  const { data: session, status } = useSession();
+
+  return {
+    userId: session?.user?.id ?? '',
+    email: session?.user?.email ?? '',
+    isAuthenticated: status === 'authenticated',
+    isLoading: status === 'loading',
+  };
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -1,0 +1,41 @@
+/**
+ * 依存性注入コンテナ
+ * Domain層のリポジトリインターフェースにData層の実装を紐づける
+ */
+
+import { MemberRepository } from '../domain/repositories/MemberRepository';
+import { MedicationRepository } from '../domain/repositories/MedicationRepository';
+import { ScheduleRepository } from '../domain/repositories/ScheduleRepository';
+import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
+import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
+import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
+
+export interface DIContainer {
+  memberRepository: MemberRepository;
+  medicationRepository: MedicationRepository;
+  scheduleRepository: ScheduleRepository;
+}
+
+// シングルトンコンテナ（テスト時にモックに差し替え可能）
+let container: DIContainer | null = null;
+
+export const getDIContainer = (): DIContainer => {
+  if (!container) {
+    container = {
+      memberRepository: new MemberRepositoryImpl(),
+      medicationRepository: new MedicationRepositoryImpl(),
+      scheduleRepository: new ScheduleRepositoryImpl(),
+    };
+  }
+  return container;
+};
+
+// テスト用: DIコンテナを差し替え
+export const setDIContainer = (newContainer: DIContainer): void => {
+  container = newContainer;
+};
+
+// テスト用: DIコンテナをリセット
+export const resetDIContainer = (): void => {
+  container = null;
+};

--- a/src/presentation/hooks/useMedications.ts
+++ b/src/presentation/hooks/useMedications.ts
@@ -1,0 +1,69 @@
+/**
+ * 薬管理カスタムフック（ViewModel）
+ * Presentation層とDomain層を繋ぐ
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { GetMedications, CreateMedication, DeleteMedication, MedicationViewModel } from '../../domain/usecases/ManageMedications';
+import { CreateMedicationInput } from '../../domain/repositories/MedicationRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface UseMedicationsResult {
+  medications: MedicationViewModel[];
+  isLoading: boolean;
+  error: Error | null;
+  createMedication: (input: CreateMedicationInput) => Promise<void>;
+  deleteMedication: (medicationId: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useMedications = (memberId: string): UseMedicationsResult => {
+  const useCases = useMemo(() => {
+    const { medicationRepository } = getDIContainer();
+    return {
+      getMedications: new GetMedications(medicationRepository),
+      createMedication: new CreateMedication(medicationRepository),
+      deleteMedication: new DeleteMedication(medicationRepository),
+    };
+  }, []);
+
+  const [medications, setMedications] = useState<MedicationViewModel[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchMedications = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await useCases.getMedications.execute(memberId);
+      setMedications(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [memberId, useCases]);
+
+  useEffect(() => {
+    fetchMedications();
+  }, [fetchMedications]);
+
+  const handleCreateMedication = async (input: CreateMedicationInput) => {
+    await useCases.createMedication.execute(input);
+    await fetchMedications();
+  };
+
+  const handleDeleteMedication = async (medicationId: string) => {
+    await useCases.deleteMedication.execute(medicationId);
+    await fetchMedications();
+  };
+
+  return {
+    medications,
+    isLoading,
+    error,
+    createMedication: handleCreateMedication,
+    deleteMedication: handleDeleteMedication,
+    refetch: fetchMedications,
+  };
+};

--- a/src/presentation/hooks/useMembers.ts
+++ b/src/presentation/hooks/useMembers.ts
@@ -1,0 +1,70 @@
+/**
+ * メンバー管理カスタムフック（ViewModel）
+ * Presentation層とDomain層を繋ぐ
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Member } from '../../domain/entities/Member';
+import { GetMembers, CreateMember, DeleteMember } from '../../domain/usecases/ManageMembers';
+import { CreateMemberInput } from '../../domain/repositories/MemberRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface UseMembersResult {
+  members: Member[];
+  isLoading: boolean;
+  error: Error | null;
+  createMember: (input: CreateMemberInput) => Promise<void>;
+  deleteMember: (memberId: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useMembers = (userId: string): UseMembersResult => {
+  const useCases = useMemo(() => {
+    const { memberRepository } = getDIContainer();
+    return {
+      getMembers: new GetMembers(memberRepository),
+      createMember: new CreateMember(memberRepository),
+      deleteMember: new DeleteMember(memberRepository),
+    };
+  }, []);
+
+  const [members, setMembers] = useState<Member[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await useCases.getMembers.execute(userId);
+      setMembers(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, useCases]);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  const handleCreateMember = async (input: CreateMemberInput) => {
+    await useCases.createMember.execute(input);
+    await fetchMembers();
+  };
+
+  const handleDeleteMember = async (memberId: string) => {
+    await useCases.deleteMember.execute(memberId);
+    await fetchMembers();
+  };
+
+  return {
+    members,
+    isLoading,
+    error,
+    createMember: handleCreateMember,
+    deleteMember: handleDeleteMember,
+    refetch: fetchMembers,
+  };
+};

--- a/src/presentation/hooks/useScheduleManagement.ts
+++ b/src/presentation/hooks/useScheduleManagement.ts
@@ -1,0 +1,58 @@
+/**
+ * スケジュール管理カスタムフック（ViewModel）
+ * Presentation層とDomain層を繋ぐ
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface CreateScheduleInput {
+  medicationId: string;
+  userId: string;
+  memberId: string;
+  scheduledTime: string;
+  daysOfWeek: DayOfWeek[];
+  reminderMinutesBefore: number;
+}
+
+export interface UseScheduleManagementResult {
+  isCreating: boolean;
+  error: Error | null;
+  createSchedule: (input: CreateScheduleInput) => Promise<void>;
+}
+
+export const useScheduleManagement = (): UseScheduleManagementResult => {
+  const scheduleRepository = useMemo(() => getDIContainer().scheduleRepository, []);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const handleCreateSchedule = useCallback(async (input: CreateScheduleInput) => {
+    try {
+      setIsCreating(true);
+      setError(null);
+
+      const scheduleData: Omit<Schedule, 'id' | 'createdAt'> = {
+        medicationId: input.medicationId,
+        userId: input.userId,
+        memberId: input.memberId,
+        scheduledTime: input.scheduledTime,
+        daysOfWeek: input.daysOfWeek,
+        isEnabled: true,
+        reminderMinutesBefore: input.reminderMinutesBefore,
+      };
+
+      await scheduleRepository.createSchedule(scheduleData);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsCreating(false);
+    }
+  }, [scheduleRepository]);
+
+  return {
+    isCreating,
+    error,
+    createSchedule: handleCreateSchedule,
+  };
+};

--- a/src/presentation/hooks/useTodaySchedules.ts
+++ b/src/presentation/hooks/useTodaySchedules.ts
@@ -1,0 +1,69 @@
+/**
+ * 今日のスケジュール取得カスタムフック（ViewModel）
+ * Presentation層とDomain層を繋ぐ
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { GetTodaySchedules, TodayScheduleViewModel } from '../../domain/usecases/GetTodaySchedules';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface UseTodaySchedulesResult {
+  schedules: TodayScheduleViewModel[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+  markAsCompleted: (scheduleId: string) => Promise<void>;
+}
+
+export const useTodaySchedules = (userId: string): UseTodaySchedulesResult => {
+  const { scheduleRepository, getTodaySchedulesUseCase } = useMemo(() => {
+    const container = getDIContainer();
+    return {
+      scheduleRepository: container.scheduleRepository,
+      getTodaySchedulesUseCase: new GetTodaySchedules(container.scheduleRepository),
+    };
+  }, []);
+
+  const [schedules, setSchedules] = useState<TodayScheduleViewModel[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchSchedules = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const result = await getTodaySchedulesUseCase.execute({
+        userId,
+        date: new Date(),
+      });
+
+      setSchedules(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, getTodaySchedulesUseCase]);
+
+  useEffect(() => {
+    fetchSchedules();
+  }, [fetchSchedules]);
+
+  const markAsCompleted = useCallback(async (scheduleId: string) => {
+    try {
+      await scheduleRepository.markAsCompleted(scheduleId, new Date());
+      await fetchSchedules();
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    }
+  }, [scheduleRepository, fetchSchedules]);
+
+  return {
+    schedules,
+    isLoading,
+    error,
+    refetch: fetchSchedules,
+    markAsCompleted,
+  };
+};

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { CharacterType, CharacterConfig, CHARACTER_CONFIGS } from '../domain/entities/Character';
+
+type MessageKey = keyof CharacterConfig['messages'];
+
+interface CharacterState {
+  selectedCharacter: CharacterType;
+  setCharacter: (character: CharacterType) => void;
+  getConfig: () => CharacterConfig;
+  getMessage: (key: MessageKey) => string;
+}
+
+export const useCharacterStore = create<CharacterState>((set, get) => ({
+  selectedCharacter: 'cat',
+
+  setCharacter: (character: CharacterType) => {
+    set({ selectedCharacter: character });
+  },
+
+  getConfig: () => {
+    return CHARACTER_CONFIGS[get().selectedCharacter];
+  },
+
+  getMessage: (key: MessageKey) => {
+    return CHARACTER_CONFIGS[get().selectedCharacter].messages[key];
+  },
+}));


### PR DESCRIPTION
## Summary

- ドメイン層（entities, repositories, usecases）をそのまま移行
- データ層（apiClient, API modules, mappers, repository impls）を移行し、Cognito認証からcookie認証に切り替え
- 全UIコンポーネント（共有, メンバー, 薬, スケジュール, キャラクター, ダッシュボード）を移行
- 全ページ（ダッシュボード, ログイン, サインアップ, メンバー, 薬管理, 設定）をApp Router形式で作成
- NextAuth対応のuseAuthフック、Providers（SessionProvider + QueryClientProvider）を追加
- react-router-dom → next/link への移行完了

## Test plan

- [ ] `npm run build` でビルド成功を確認
- [ ] 各ページのルーティングが正常に動作すること
- [ ] ログイン・サインアップのフローが動作すること
- [ ] メンバー追加・削除が動作すること
- [ ] 薬の追加・削除・スケジュール設定が動作すること
- [ ] キャラクター選択が動作すること

closes #62