### PR TITLE
feat: テスト追加 + CI更新 + README更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,44 +7,21 @@ on:
     branches: [main]
 
 jobs:
-  frontend:
-    name: Frontend CI
+  ci:
+    name: Lint, Type Check & Build
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - name: TypeScript check
         run: npx tsc --noEmit
       - name: Lint
         run: npm run lint
-      - name: Test with coverage
+      - name: Test
         run: npx vitest run --coverage
-
-  backend:
-    name: Backend CI
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: backend/package-lock.json
-      - run: npm ci
-      - name: TypeScript check
-        run: npx tsc --noEmit
-      - name: Lint
-        run: npm run lint
-      - name: Test with coverage
-        run: npx vitest run --coverage
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 ## 目次
 
 - [概要](#概要)
+- [技術スタック](#技術スタック)
+- [セットアップ](#セットアップ)
 - [ターゲットユーザー](#ターゲットユーザー)
 - [主要機能一覧](#主要機能一覧)
 - [キャラクターシステム](#キャラクターシステム)
@@ -20,6 +22,77 @@
 **「今お薬飲んでよ通知アプリ」** は、自分だけでなく家族やペットの服薬を一括管理できるヘルスケアアプリケーションです。
 
 設定したアテンドキャラクター（犬・猫・うさぎ・インコ）が服薬時間を可愛くお知らせし、飲み忘れ防止をサポートします。
+
+---
+
+## 技術スタック
+
+| カテゴリ | 技術 |
+|---------|------|
+| フレームワーク | Next.js 15 (App Router) |
+| 言語 | TypeScript |
+| データベース | PostgreSQL |
+| ORM | Prisma |
+| 認証 | NextAuth.js v5 (Auth.js) - Credentials Provider |
+| スタイリング | Tailwind CSS |
+| アイコン | lucide-react |
+| 状態管理 | Zustand（キャラクター選択） |
+| バリデーション | Zod |
+| テスト | Vitest + React Testing Library |
+| デプロイ | Vercel |
+| CI | GitHub Actions |
+
+### アーキテクチャ
+
+クリーンアーキテクチャを採用し、以下のレイヤーに分離しています。
+
+```
+src/
+├── domain/          # エンティティ、リポジトリインターフェース、ユースケース
+├── data/            # APIクライアント、リポジトリ実装
+├── presentation/    # カスタムフック（ViewModel）
+├── components/      # UIコンポーネント
+├── app/             # Next.js App Router（ページ、APIルート）
+├── lib/             # Prisma、NextAuth設定、Zodスキーマ
+├── stores/          # Zustandストア
+├── hooks/           # 共通フック
+└── infrastructure/  # DIコンテナ
+```
+
+---
+
+## セットアップ
+
+### 前提条件
+
+- Node.js 20以上
+- PostgreSQL
+
+### インストール
+
+```bash
+# 依存関係インストール
+npm install
+
+# 環境変数設定
+cp .env.local.example .env.local
+# .env.local を編集してデータベースURLとシークレットを設定
+
+# データベース作成・マイグレーション
+npx prisma migrate dev
+
+# 開発サーバー起動
+npm run dev
+```
+
+### 開発コマンド
+
+```bash
+npm run dev       # 開発サーバー起動
+npm run build     # 本番ビルド
+npm run lint      # リント実行
+npx vitest run    # テスト実行
+```
 
 ---
 

--- a/src/__tests__/domain/entities/Character.test.ts
+++ b/src/__tests__/domain/entities/Character.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { CHARACTER_CONFIGS, CharacterType } from '@/domain/entities/Character';
+
+describe('CHARACTER_CONFIGS', () => {
+  const characterTypes: CharacterType[] = ['dog', 'cat', 'rabbit', 'bird'];
+
+  it.each(characterTypes)('%s の設定が存在する', (type) => {
+    const config = CHARACTER_CONFIGS[type];
+    expect(config).toBeDefined();
+    expect(config.type).toBe(type);
+    expect(config.name).toBeTruthy();
+  });
+
+  it.each(characterTypes)('%s のメッセージが全て定義されている', (type) => {
+    const config = CHARACTER_CONFIGS[type];
+    const requiredMessages = [
+      'medicationReminder',
+      'missedMedication',
+      'medicationComplete',
+      'exerciseCheer',
+      'lowStock',
+      'appointmentReminder',
+      'vaccineReminder',
+      'checkupReminder',
+    ] as const;
+
+    for (const key of requiredMessages) {
+      expect(config.messages[key]).toBeTruthy();
+    }
+  });
+
+  it.each(characterTypes)('%s のサウンドパスが全て定義されている', (type) => {
+    const config = CHARACTER_CONFIGS[type];
+    expect(config.sounds.normal).toBeTruthy();
+    expect(config.sounds.medicationReminder).toBeTruthy();
+    expect(config.sounds.missedMedication).toBeTruthy();
+    expect(config.sounds.medicationComplete).toBeTruthy();
+    expect(config.sounds.exerciseCheer).toBeTruthy();
+  });
+});

--- a/src/__tests__/domain/entities/MedicationEntity.test.ts
+++ b/src/__tests__/domain/entities/MedicationEntity.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity, Medication } from '@/domain/entities/Medication';
+
+const createMedication = (overrides: Partial<Medication> = {}): Medication => ({
+  id: 'med-1',
+  memberId: 'member-1',
+  userId: 'user-1',
+  name: 'テスト薬',
+  category: 'regular',
+  isActive: true,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+  ...overrides,
+});
+
+describe('MedicationEntity', () => {
+  describe('isLowStock', () => {
+    it('在庫数が閾値以下の場合 true を返す', () => {
+      const entity = new MedicationEntity(
+        createMedication({ stockQuantity: 3, lowStockThreshold: 5 })
+      );
+      expect(entity.isLowStock()).toBe(true);
+    });
+
+    it('在庫数が閾値より多い場合 false を返す', () => {
+      const entity = new MedicationEntity(
+        createMedication({ stockQuantity: 10, lowStockThreshold: 5 })
+      );
+      expect(entity.isLowStock()).toBe(false);
+    });
+
+    it('在庫数が未設定の場合 false を返す', () => {
+      const entity = new MedicationEntity(createMedication());
+      expect(entity.isLowStock()).toBe(false);
+    });
+
+    it('在庫数と閾値が等しい場合 true を返す', () => {
+      const entity = new MedicationEntity(
+        createMedication({ stockQuantity: 5, lowStockThreshold: 5 })
+      );
+      expect(entity.isLowStock()).toBe(true);
+    });
+  });
+
+  describe('decreaseStock', () => {
+    it('在庫を1減らす', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 10 }));
+      const result = entity.decreaseStock();
+      expect(result.stockQuantity).toBe(9);
+    });
+
+    it('指定数量分を減らす', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 10 }));
+      const result = entity.decreaseStock(3);
+      expect(result.stockQuantity).toBe(7);
+    });
+
+    it('0未満にはならない', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 1 }));
+      const result = entity.decreaseStock(5);
+      expect(result.stockQuantity).toBe(0);
+    });
+
+    it('在庫数が未設定の場合はそのまま返す', () => {
+      const med = createMedication();
+      const entity = new MedicationEntity(med);
+      const result = entity.decreaseStock();
+      expect(result).toBe(med);
+    });
+  });
+
+  describe('increaseStock', () => {
+    it('在庫を増やす', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 5 }));
+      const result = entity.increaseStock(10);
+      expect(result.stockQuantity).toBe(15);
+    });
+
+    it('在庫数が未設定の場合はそのまま返す', () => {
+      const med = createMedication();
+      const entity = new MedicationEntity(med);
+      const result = entity.increaseStock(5);
+      expect(result).toBe(med);
+    });
+  });
+
+  describe('getDisplayInfo', () => {
+    it('カテゴリラベルを日本語で返す', () => {
+      const entity = new MedicationEntity(createMedication({ category: 'regular' }));
+      expect(entity.getDisplayInfo().categoryLabel).toBe('常用薬');
+    });
+
+    it('用量と頻度を結合して返す', () => {
+      const entity = new MedicationEntity(
+        createMedication({ dosage: '1錠', frequency: '1日2回' })
+      );
+      expect(entity.getDisplayInfo().dosageInfo).toBe('1錠 / 1日2回');
+    });
+
+    it('用量のみの場合はそのまま返す', () => {
+      const entity = new MedicationEntity(createMedication({ dosage: '1錠' }));
+      expect(entity.getDisplayInfo().dosageInfo).toBe('1錠');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberEntity.test.ts
+++ b/src/__tests__/domain/entities/MemberEntity.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity, Member } from '@/domain/entities/Member';
+
+const createMember = (overrides: Partial<Member> = {}): Member => ({
+  id: 'member-1',
+  userId: 'user-1',
+  memberType: 'human',
+  name: 'テスト太郎',
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+  ...overrides,
+});
+
+describe('MemberEntity', () => {
+  describe('isPet / isHuman', () => {
+    it('人間メンバーの場合 isHuman が true を返す', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'human' }));
+      expect(entity.isHuman()).toBe(true);
+      expect(entity.isPet()).toBe(false);
+    });
+
+    it('ペットメンバーの場合 isPet が true を返す', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'pet', petType: 'dog' }));
+      expect(entity.isPet()).toBe(true);
+      expect(entity.isHuman()).toBe(false);
+    });
+  });
+
+  describe('getAge', () => {
+    it('生年月日がない場合 null を返す', () => {
+      const entity = new MemberEntity(createMember());
+      expect(entity.getAge()).toBeNull();
+    });
+
+    it('生年月日がある場合、年齢を計算する', () => {
+      const birthDate = new Date();
+      birthDate.setFullYear(birthDate.getFullYear() - 5);
+      birthDate.setMonth(birthDate.getMonth() - 1);
+      const entity = new MemberEntity(createMember({ birthDate }));
+      expect(entity.getAge()).toBe(5);
+    });
+  });
+
+  describe('getDisplayInfo', () => {
+    it('人間メンバーの表示情報を返す', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'human', name: '太郎' }));
+      const info = entity.getDisplayInfo();
+      expect(info.name).toBe('太郎');
+      expect(info.typeLabel).toBe('家族');
+    });
+
+    it('ペットメンバーの表示情報を返す', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'pet', name: 'ポチ', petType: 'dog' }));
+      const info = entity.getDisplayInfo();
+      expect(info.name).toBe('ポチ');
+      expect(info.typeLabel).toBe('ペット');
+      expect(info.petType).toBe('dog');
+    });
+  });
+
+  describe('id / name / data', () => {
+    it('プロパティにアクセスできる', () => {
+      const member = createMember({ id: 'abc', name: '花子' });
+      const entity = new MemberEntity(member);
+      expect(entity.id).toBe('abc');
+      expect(entity.name).toBe('花子');
+      expect(entity.data).toBe(member);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleEntity.test.ts
+++ b/src/__tests__/domain/entities/ScheduleEntity.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity, Schedule } from '@/domain/entities/Schedule';
+
+const createSchedule = (overrides: Partial<Schedule> = {}): Schedule => ({
+  id: 'sched-1',
+  medicationId: 'med-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  scheduledTime: '08:00',
+  daysOfWeek: ['mon', 'wed', 'fri'],
+  isEnabled: true,
+  reminderMinutesBefore: 10,
+  createdAt: new Date('2024-01-01'),
+  ...overrides,
+});
+
+describe('ScheduleEntity', () => {
+  describe('getStatus', () => {
+    it('服薬完了の場合 completed を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '08:00' }));
+      const now = new Date('2024-06-01T09:00:00');
+      expect(entity.getStatus(now, true)).toBe('completed');
+    });
+
+    it('予定時刻を過ぎていて未完了の場合 overdue を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '08:00' }));
+      const now = new Date('2024-06-01T09:00:00');
+      expect(entity.getStatus(now, false)).toBe('overdue');
+    });
+
+    it('予定時刻前の場合 pending を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '14:00' }));
+      const now = new Date('2024-06-01T09:00:00');
+      expect(entity.getStatus(now, false)).toBe('pending');
+    });
+  });
+
+  describe('isActiveOnDay', () => {
+    it('スケジュールが有効な曜日の場合 true を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ daysOfWeek: ['mon', 'wed', 'fri'] }));
+      // 2024-06-03は月曜日
+      const monday = new Date('2024-06-03');
+      expect(entity.isActiveOnDay(monday)).toBe(true);
+    });
+
+    it('スケジュールが無効な曜日の場合 false を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ daysOfWeek: ['mon', 'wed', 'fri'] }));
+      // 2024-06-04は火曜日
+      const tuesday = new Date('2024-06-04');
+      expect(entity.isActiveOnDay(tuesday)).toBe(false);
+    });
+
+    it('スケジュールが無効化されている場合 false を返す', () => {
+      const entity = new ScheduleEntity(
+        createSchedule({ daysOfWeek: ['mon', 'wed', 'fri'], isEnabled: false })
+      );
+      const monday = new Date('2024-06-03');
+      expect(entity.isActiveOnDay(monday)).toBe(false);
+    });
+  });
+
+  describe('getReminderTime', () => {
+    it('リマインダー時刻を正しく計算する', () => {
+      const entity = new ScheduleEntity(
+        createSchedule({ scheduledTime: '08:00', reminderMinutesBefore: 10 })
+      );
+      const date = new Date('2024-06-01T00:00:00');
+      const reminderTime = entity.getReminderTime(date);
+      expect(reminderTime.getHours()).toBe(7);
+      expect(reminderTime.getMinutes()).toBe(50);
+    });
+  });
+
+  describe('id / data', () => {
+    it('プロパティにアクセスできる', () => {
+      const schedule = createSchedule({ id: 'sched-abc' });
+      const entity = new ScheduleEntity(schedule);
+      expect(entity.id).toBe('sched-abc');
+      expect(entity.data).toBe(schedule);
+    });
+  });
+});

--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  signUpSchema,
+  createMemberSchema,
+  createMedicationSchema,
+  createScheduleSchema,
+  createRecordSchema,
+  createHospitalSchema,
+  createAppointmentSchema,
+  updateStockSchema,
+} from '@/lib/schemas';
+
+describe('signUpSchema', () => {
+  it('有効なデータを受け入れる', () => {
+    const result = signUpSchema.safeParse({
+      email: 'test@example.com',
+      password: '12345678',
+      displayName: 'テストユーザー',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('無効なメールアドレスを拒否する', () => {
+    const result = signUpSchema.safeParse({
+      email: 'invalid-email',
+      password: '12345678',
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('短すぎるパスワードを拒否する', () => {
+    const result = signUpSchema.safeParse({
+      email: 'test@example.com',
+      password: '1234567',
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('空の表示名を拒否する', () => {
+    const result = signUpSchema.safeParse({
+      email: 'test@example.com',
+      password: '12345678',
+      displayName: '',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('createMemberSchema', () => {
+  it('名前のみで有効', () => {
+    const result = createMemberSchema.safeParse({ name: 'テスト太郎' });
+    expect(result.success).toBe(true);
+  });
+
+  it('空の名前を拒否する', () => {
+    const result = createMemberSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('全フィールドを受け入れる', () => {
+    const result = createMemberSchema.safeParse({
+      name: 'ポチ',
+      memberType: 'pet',
+      petType: 'dog',
+      birthDate: '2020-01-01',
+      notes: 'テストメモ',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('createMedicationSchema', () => {
+  it('名前のみで有効', () => {
+    const result = createMedicationSchema.safeParse({ name: 'テスト薬' });
+    expect(result.success).toBe(true);
+  });
+
+  it('空の名前を拒否する', () => {
+    const result = createMedicationSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('負の在庫数を拒否する', () => {
+    const result = createMedicationSchema.safeParse({ name: 'テスト薬', stockQuantity: -1 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('createScheduleSchema', () => {
+  it('有効なスケジュールを受け入れる', () => {
+    const result = createScheduleSchema.safeParse({
+      medicationId: 'med-1',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('薬IDがない場合を拒否する', () => {
+    const result = createScheduleSchema.safeParse({
+      medicationId: '',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('createRecordSchema', () => {
+  it('有効な記録を受け入れる', () => {
+    const result = createRecordSchema.safeParse({
+      memberId: 'member-1',
+      medicationId: 'med-1',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('createHospitalSchema', () => {
+  it('病院名のみで有効', () => {
+    const result = createHospitalSchema.safeParse({ name: 'テスト病院' });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('createAppointmentSchema', () => {
+  it('有効な予約を受け入れる', () => {
+    const result = createAppointmentSchema.safeParse({
+      memberId: 'member-1',
+      appointmentDate: '2024-06-01',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('updateStockSchema', () => {
+  it('0以上の在庫数を受け入れる', () => {
+    expect(updateStockSchema.safeParse({ stockQuantity: 0 }).success).toBe(true);
+    expect(updateStockSchema.safeParse({ stockQuantity: 10 }).success).toBe(true);
+  });
+
+  it('負の在庫数を拒否する', () => {
+    expect(updateStockSchema.safeParse({ stockQuantity: -1 }).success).toBe(false);
+  });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary

- ドメインエンティティのユニットテスト追加（MemberEntity, MedicationEntity, ScheduleEntity, Character）- 全57テストパス
- Zodバリデーションスキーマのテスト追加（signUp, member, medication, schedule, record, hospital, appointment, stock）
- CIワークフローをNext.js単一ジョブに更新（旧frontend/backend分離構成を統合）
- READMEに技術スタック表、アーキテクチャ構成図、セットアップ手順を追加

## Test plan

- [ ] `npx vitest run` で全57テストがパスすること
- [ ] `npm run build` でビルド成功すること
- [ ] CIワークフローが正常に動作すること

closes #63