### PR TITLE
fix: PrismaレスポンスのIDフィールド名不一致を修正

### DIFF
--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -10,11 +10,12 @@ export async function POST(request: Request) {
     const body = await request.json();
     const parsed = createMedicationSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+    if (!parsed.data.memberId) return errorResponse('メンバーIDは必須です');
 
     const medication = await prisma.medication.create({
       data: {
         userId,
-        memberId: parsed.data.memberId!,
+        memberId: parsed.data.memberId,
         name: parsed.data.name,
         category: parsed.data.category ?? 'regular',
         dosageAmount: parsed.data.dosageAmount,
@@ -26,7 +27,8 @@ export async function POST(request: Request) {
       },
     });
     return created(medication);
-  } catch {
+  } catch (error) {
+    console.error('Medication creation error:', error);
     return errorResponse('登録に失敗しました', 500);
   }
 }

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -5,7 +5,7 @@ import { BackendMember, BackendMedication, BackendSchedule } from './types';
 
 export function toMember(b: BackendMember): Member {
   return {
-    id: b.memberId,
+    id: b.id,
     userId: b.userId,
     memberType: (b.memberType as MemberType) || 'human',
     name: b.name,
@@ -19,7 +19,7 @@ export function toMember(b: BackendMember): Member {
 
 export function toMedication(b: BackendMedication): Medication {
   return {
-    id: b.medicationId,
+    id: b.id,
     memberId: b.memberId,
     userId: b.userId,
     name: b.name,
@@ -37,7 +37,7 @@ export function toMedication(b: BackendMedication): Medication {
 
 export function toSchedule(b: BackendSchedule): Schedule {
   return {
-    id: b.scheduleId,
+    id: b.id,
     medicationId: b.medicationId,
     userId: b.userId,
     memberId: b.memberId,

--- a/src/data/api/scheduleApi.ts
+++ b/src/data/api/scheduleApi.ts
@@ -12,7 +12,7 @@ export const scheduleApi = {
       apiClient.get<BackendRecord[]>('/records'),
     ]);
 
-    const memberMap = new Map(members.map((m) => [m.memberId, m]));
+    const memberMap = new Map(members.map((m) => [m.id, m]));
     const todayStr = new Date().toISOString().slice(0, 10);
     const todayRecordScheduleIds = new Set(
       records
@@ -28,7 +28,7 @@ export const scheduleApi = {
       )
     );
     const medMap = new Map(
-      medications.filter(Boolean).map((m) => [m!.medicationId, m!])
+      medications.filter(Boolean).map((m) => [m!.id, m!])
     );
 
     return schedules
@@ -41,7 +41,7 @@ export const scheduleApi = {
           medicationName: med?.name || '',
           memberName: member?.name || '',
           memberType: (member?.memberType as 'human' | 'pet') || 'human',
-          isCompleted: todayRecordScheduleIds.has(s.scheduleId),
+          isCompleted: todayRecordScheduleIds.has(s.id),
         };
       });
   },

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -1,5 +1,5 @@
 export interface BackendMember {
-  memberId: string;
+  id: string;
   userId: string;
   name: string;
   memberType?: string;
@@ -11,7 +11,7 @@ export interface BackendMember {
 }
 
 export interface BackendMedication {
-  medicationId: string;
+  id: string;
   memberId: string;
   userId: string;
   name: string;
@@ -27,7 +27,7 @@ export interface BackendMedication {
 }
 
 export interface BackendSchedule {
-  scheduleId: string;
+  id: string;
   medicationId: string;
   userId: string;
   memberId: string;
@@ -39,7 +39,7 @@ export interface BackendSchedule {
 }
 
 export interface BackendRecord {
-  recordId: string;
+  id: string;
   userId: string;
   memberId: string;
   medicationId: string;


### PR DESCRIPTION
## Summary
- Backend型定義のIDフィールドを`memberId`等から`id`に統一（Prisma形式）
- マッパーの`b.memberId`/`b.medicationId`/`b.scheduleId`を`b.id`に修正
- scheduleApiの旧フィールド名参照を修正
- medications APIルートにmemberId必須チェックとエラーログを追加

Closes #80