### PR TITLE
メール認証・在庫警告メール・吸入薬カテゴリを追加

### DIFF
--- a/prisma/migrations/20260228053123_add_email_verification/migration.sql
+++ b/prisma/migrations/20260228053123_add_email_verification/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "verificationCode" TEXT,
+ADD COLUMN     "verificationExpiry" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,14 +9,17 @@ datasource db {
 }
 
 model User {
-  id            String   @id @default(cuid())
-  email         String   @unique
-  password      String
-  displayName   String?
-  characterType String   @default("cat")
-  characterName String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id                String    @id @default(cuid())
+  email             String    @unique
+  password          String
+  displayName       String?
+  characterType     String    @default("cat")
+  characterName     String?
+  emailVerified     Boolean   @default(false)
+  verificationCode  String?
+  verificationExpiry DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 
   members      Member[]
   schedules    Schedule[]

--- a/src/app/api/auth/resend-code/route.ts
+++ b/src/app/api/auth/resend-code/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { sendEmail, emailTemplates, generateVerificationCode } from '@/lib/email';
+import { success, errorResponse } from '@/lib/auth-helpers';
+
+const resendSchema = z.object({
+  email: z.string().email(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = resendSchema.safeParse(body);
+    if (!parsed.success) {
+      return errorResponse('有効なメールアドレスを入力してください');
+    }
+
+    const { email } = parsed.data;
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return errorResponse('ユーザーが見つかりません', 404);
+    }
+
+    if (user.emailVerified) {
+      return success({ message: '既に認証済みです' });
+    }
+
+    const code = generateVerificationCode();
+    const expiry = new Date(Date.now() + 10 * 60 * 1000);
+
+    await prisma.user.update({
+      where: { email },
+      data: { verificationCode: code, verificationExpiry: expiry },
+    });
+
+    const template = emailTemplates.verificationCode({ code });
+    await sendEmail({ to: email, ...template });
+
+    return success({ message: '確認コードを再送信しました' });
+  } catch (error) {
+    console.error('Resend code error:', error);
+    return errorResponse('再送信に失敗しました', 500);
+  }
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { signUpSchema } from '@/lib/schemas';
+import { sendEmail, emailTemplates, generateVerificationCode } from '@/lib/email';
 import { created, errorResponse } from '@/lib/auth-helpers';
 
 export async function POST(request: NextRequest) {
@@ -16,21 +17,51 @@ export async function POST(request: NextRequest) {
 
     const existing = await prisma.user.findUnique({ where: { email } });
     if (existing) {
-      return errorResponse('このメールアドレスは既に登録されています');
+      if (existing.emailVerified) {
+        return errorResponse('このメールアドレスは既に登録されています');
+      }
+      // 未認証ユーザーが再登録 → コードを再生成
+      const code = generateVerificationCode();
+      const expiry = new Date(Date.now() + 10 * 60 * 1000);
+      const hashedPassword = await bcrypt.hash(password, 12);
+
+      await prisma.user.update({
+        where: { email },
+        data: {
+          password: hashedPassword,
+          displayName,
+          verificationCode: code,
+          verificationExpiry: expiry,
+        },
+      });
+
+      const template = emailTemplates.verificationCode({ code });
+      await sendEmail({ to: email, ...template });
+
+      return created({ email, requiresVerification: true });
     }
 
     const hashedPassword = await bcrypt.hash(password, 12);
+    const code = generateVerificationCode();
+    const expiry = new Date(Date.now() + 10 * 60 * 1000);
 
-    const user = await prisma.user.create({
-      data: { email, password: hashedPassword, displayName },
+    await prisma.user.create({
+      data: {
+        email,
+        password: hashedPassword,
+        displayName,
+        emailVerified: false,
+        verificationCode: code,
+        verificationExpiry: expiry,
+      },
     });
 
-    return created({
-      id: user.id,
-      email: user.email,
-      displayName: user.displayName,
-    });
-  } catch {
+    const template = emailTemplates.verificationCode({ code });
+    await sendEmail({ to: email, ...template });
+
+    return created({ email, requiresVerification: true });
+  } catch (error) {
+    console.error('Signup error:', error);
     return errorResponse('登録に失敗しました', 500);
   }
 }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { success, errorResponse } from '@/lib/auth-helpers';
+
+const verifySchema = z.object({
+  email: z.string().email(),
+  code: z.string().length(6),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = verifySchema.safeParse(body);
+    if (!parsed.success) {
+      return errorResponse('確認コードは6桁の数字です');
+    }
+
+    const { email, code } = parsed.data;
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return errorResponse('ユーザーが見つかりません', 404);
+    }
+
+    if (user.emailVerified) {
+      return success({ message: '既に認証済みです' });
+    }
+
+    if (!user.verificationCode || !user.verificationExpiry) {
+      return errorResponse('確認コードが発行されていません');
+    }
+
+    if (new Date() > user.verificationExpiry) {
+      return errorResponse('確認コードの有効期限が切れています。再送信してください。');
+    }
+
+    if (user.verificationCode !== code) {
+      return errorResponse('確認コードが正しくありません');
+    }
+
+    await prisma.user.update({
+      where: { email },
+      data: {
+        emailVerified: true,
+        verificationCode: null,
+        verificationExpiry: null,
+      },
+    });
+
+    return success({ message: 'メールアドレスが確認されました' });
+  } catch (error) {
+    console.error('Verify error:', error);
+    return errorResponse('認証に失敗しました', 500);
+  }
+}

--- a/src/app/api/medications/[medicationId]/stock/route.ts
+++ b/src/app/api/medications/[medicationId]/stock/route.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { updateStockSchema } from '@/lib/schemas';
+import { sendEmail, emailTemplates } from '@/lib/email';
 import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
 
 export async function PUT(request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
@@ -8,7 +9,10 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
     if (!userId) return unauthorized();
 
     const { medicationId } = await params;
-    const medication = await prisma.medication.findUnique({ where: { id: medicationId } });
+    const medication = await prisma.medication.findUnique({
+      where: { id: medicationId },
+      include: { member: true },
+    });
     if (!medication || medication.userId !== userId) return notFound('お薬');
 
     const body = await request.json();
@@ -19,8 +23,30 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
       where: { id: medicationId },
       data: { stockQuantity: parsed.data.stockQuantity },
     });
+
+    // 在庫が閾値以下になったらメール送信
+    if (
+      updated.lowStockThreshold !== null &&
+      updated.stockQuantity !== null &&
+      updated.stockQuantity <= updated.lowStockThreshold
+    ) {
+      const user = await prisma.user.findUnique({ where: { id: userId } });
+      if (user) {
+        const template = emailTemplates.lowStockAlert({
+          memberName: medication.member.name,
+          medicationName: medication.name,
+          currentStock: updated.stockQuantity,
+          threshold: updated.lowStockThreshold,
+        });
+        sendEmail({ to: user.email, ...template }).catch((err) => {
+          console.error('Low stock email failed:', err);
+        });
+      }
+    }
+
     return success(updated);
-  } catch {
+  } catch (error) {
+    console.error('Stock update error:', error);
     return errorResponse('更新に失敗しました', 500);
   }
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 
@@ -32,17 +31,7 @@ export default function SignUp() {
         return;
       }
 
-      const result = await signIn('credentials', {
-        email,
-        password,
-        redirect: false,
-      });
-
-      if (result?.error) {
-        setErrorMessage('登録は完了しましたが、ログインに失敗しました。ログイン画面からお試しください。');
-      } else {
-        router.push('/');
-      }
+      router.push(`/verify?email=${encodeURIComponent(email)}&p=${encodeURIComponent(password)}`);
     } catch {
       setErrorMessage('登録に失敗しました');
     } finally {

--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+
+function VerifyContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const emailParam = searchParams.get('email') ?? '';
+  const passwordParam = searchParams.get('p') ?? '';
+
+  const [email] = useState(emailParam);
+  const [code, setCode] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+
+  useEffect(() => {
+    if (!emailParam) {
+      router.push('/signup');
+    }
+  }, [emailParam, router]);
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage('');
+    setSuccessMessage('');
+    setIsSubmitting(true);
+
+    try {
+      const res = await fetch('/api/auth/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, code }),
+      });
+
+      const data = await res.json();
+
+      if (!data.success) {
+        setErrorMessage(data.error || '認証に失敗しました');
+        return;
+      }
+
+      if (passwordParam) {
+        const result = await signIn('credentials', {
+          email,
+          password: passwordParam,
+          redirect: false,
+        });
+
+        if (result?.error) {
+          setSuccessMessage('メール認証が完了しました。ログイン画面からログインしてください。');
+        } else {
+          router.push('/');
+        }
+      } else {
+        setSuccessMessage('メール認証が完了しました。');
+        setTimeout(() => router.push('/login'), 2000);
+      }
+    } catch {
+      setErrorMessage('認証に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleResend = async () => {
+    setErrorMessage('');
+    setSuccessMessage('');
+    setIsResending(true);
+
+    try {
+      const res = await fetch('/api/auth/resend-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await res.json();
+
+      if (data.success) {
+        setSuccessMessage('確認コードを再送信しました');
+      } else {
+        setErrorMessage(data.error || '再送信に失敗しました');
+      }
+    } catch {
+      setErrorMessage('再送信に失敗しました');
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
+          <p className="mt-2 text-gray-500">メールアドレスの確認</p>
+        </div>
+
+        <form onSubmit={handleVerify} className="bg-white shadow-md rounded-lg p-6 space-y-4">
+          <p className="text-sm text-gray-600">
+            <strong>{email}</strong> に送信された6桁の確認コードを入力してください。
+          </p>
+
+          {errorMessage && (
+            <div className="bg-red-50 text-red-700 p-3 rounded-md text-sm" role="alert">
+              {errorMessage}
+            </div>
+          )}
+
+          {successMessage && (
+            <div className="bg-green-50 text-green-700 p-3 rounded-md text-sm" role="alert">
+              {successMessage}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="code" className="block text-sm font-medium text-gray-700 mb-1">
+              確認コード
+            </label>
+            <input
+              id="code"
+              type="text"
+              required
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
+              className="w-full px-3 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 text-center text-2xl tracking-widest"
+              placeholder="000000"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || code.length !== 6}
+            className="w-full bg-primary-600 text-white py-2 rounded-md font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? '確認中...' : '確認する'}
+          </button>
+
+          <div className="text-center">
+            <button
+              type="button"
+              onClick={handleResend}
+              disabled={isResending}
+              className="text-sm text-primary-600 hover:underline disabled:opacity-50"
+            >
+              {isResending ? '送信中...' : '確認コードを再送信'}
+            </button>
+          </div>
+
+          <p className="text-center text-sm text-gray-500">
+            <Link href="/signup" className="text-primary-600 hover:underline">
+              登録画面に戻る
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function Verify() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    }>
+      <VerifyContent />
+    </Suspense>
+  );
+}

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -79,6 +79,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
           <option value="regular">常用薬</option>
           <option value="supplement">サプリメント</option>
           <option value="prn">頓服薬</option>
+          <option value="inhaler">吸入薬</option>
           <option value="flea_tick">ノミ・ダニ薬</option>
           <option value="heartworm">フィラリア薬</option>
         </select>

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -6,6 +6,7 @@ export type MedicationCategory =
   | 'regular'
   | 'supplement'
   | 'prn'
+  | 'inhaler'
   | 'flea_tick'
   | 'heartworm';
 
@@ -92,6 +93,7 @@ export class MedicationEntity {
     regular: '常用薬',
     supplement: 'サプリメント',
     prn: '頓服薬',
+    inhaler: '吸入薬',
     flea_tick: 'ノミ・ダニ薬',
     heartworm: 'フィラリア薬',
   };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -29,6 +29,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         if (!isValid) return null;
 
+        if (!user.emailVerified) return null;
+
         return {
           id: user.id,
           email: user.email,

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -25,7 +25,28 @@ export async function sendEmail({ to, subject, html }: SendEmailOptions) {
   return data;
 }
 
+export function generateVerificationCode(): string {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
 export const emailTemplates = {
+  verificationCode({ code }: { code: string }) {
+    return {
+      subject: 'HealthFamily - メールアドレスの確認',
+      html: `
+        <div style="font-family: 'Helvetica Neue', Arial, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
+          <h2 style="color: #16a34a; margin-bottom: 16px;">メールアドレスの確認</h2>
+          <p style="font-size: 14px; color: #374151; margin-bottom: 16px;">HealthFamilyへのご登録ありがとうございます。以下の確認コードを入力してください。</p>
+          <div style="background: #f0fdf4; border-radius: 8px; padding: 24px; margin-bottom: 16px; text-align: center;">
+            <p style="margin: 0; font-size: 32px; font-weight: bold; letter-spacing: 8px; color: #16a34a;">${code}</p>
+          </div>
+          <p style="font-size: 13px; color: #6b7280;">このコードは10分間有効です。</p>
+          <p style="font-size: 13px; color: #6b7280;">HealthFamily - 今お薬飲んでよ通知アプリ</p>
+        </div>
+      `,
+    };
+  },
+
   medicationReminder({
     memberName,
     medicationName,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,5 +4,5 @@ import { authConfig } from '@/lib/auth.config';
 export const { auth: middleware } = NextAuth(authConfig);
 
 export const config = {
-  matcher: ['/((?!login|signup|api/auth|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!login|signup|verify|api/auth|_next/static|_next/image|favicon.ico).*)'],
 };


### PR DESCRIPTION
## Summary
- 薬カテゴリに「吸入薬（inhaler）」を追加
- サインアップ時のメール認証フロー（6桁確認コード → /verify ページ → 認証完了 → 自動ログイン）を実装
- 在庫更新時に在庫数が閾値以下になった場合、登録メールへ警告メールを自動送信する機能を実装

Closes #82