### PR TITLE
メール送信元を本番ドメインに変更・サインアップラベル修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 coverage/
 .claude/
 CLAUDE.md
+.vercel

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -56,7 +56,7 @@ export default function SignUp() {
 
           <div>
             <label htmlFor="displayName" className="block text-sm font-medium text-gray-700 mb-1">
-              表示名
+              ユーザー名
             </label>
             <input
               id="displayName"

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -2,7 +2,7 @@ import { Resend } from 'resend';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-const FROM_EMAIL = 'HealthFamily <onboarding@resend.dev>';
+const FROM_EMAIL = 'HealthFamily <noreply@takushinblog.com>';
 
 export interface SendEmailOptions {
   to: string;


### PR DESCRIPTION
## Summary
- メール送信元を `onboarding@resend.dev` から `noreply@takushinblog.com` に変更（本番メール送信対応）
- サインアップページの「表示名」を「ユーザー名」に変更
- `.gitignore` に `.vercel` を追加

Closes #84