### PR TITLE
飲んだボタンをダッシュボードからお薬ページに移動

### DIFF
--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useMedications } from '@/presentation/hooks/useMedications';
@@ -7,6 +8,7 @@ import { MedicationList } from '@/components/medications/MedicationList';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { MemberIcon } from '@/components/shared/MemberIcon';
 import { MemberEntity, Member } from '@/domain/entities/Member';
+import { recordApi } from '@/data/api/recordApi';
 import Link from 'next/link';
 import { Plus } from 'lucide-react';
 
@@ -14,6 +16,13 @@ function MemberMedications({ member }: { member: Member }) {
   const { medications, isLoading, deleteMedication } = useMedications(member.id);
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
+
+  const handleMarkTaken = useCallback(async (medicationId: string) => {
+    await recordApi.createRecord({
+      memberId: member.id,
+      medicationId,
+    });
+  }, [member.id]);
 
   return (
     <section className="mb-6">
@@ -39,6 +48,7 @@ function MemberMedications({ member }: { member: Member }) {
         medications={medications}
         isLoading={isLoading}
         onDelete={deleteMedication}
+        onMarkTaken={handleMarkTaken}
       />
     </section>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { CharacterIcon } from '@/components/shared/CharacterIcon';
 
 export default function Dashboard() {
   const { userId } = useAuth();
-  const { schedules, isLoading, markAsCompleted } = useTodaySchedules(userId);
+  const { schedules, isLoading } = useTodaySchedules(userId);
   const { getConfig, getMessage } = useCharacterStore();
   const characterConfig = getConfig();
 
@@ -34,7 +34,6 @@ export default function Dashboard() {
         <TodayScheduleList
           schedules={schedules}
           isLoading={isLoading}
-          onMarkCompleted={markAsCompleted}
         />
       </main>
 

--- a/src/components/dashboard/TodayScheduleList.tsx
+++ b/src/components/dashboard/TodayScheduleList.tsx
@@ -4,10 +4,9 @@ import { TodayScheduleViewModel } from '../../domain/usecases/GetTodaySchedules'
 interface TodayScheduleListProps {
   schedules: TodayScheduleViewModel[];
   isLoading: boolean;
-  onMarkCompleted?: (scheduleId: string) => void;
 }
 
-export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules, isLoading, onMarkCompleted }) => {
+export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules, isLoading }) => {
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-8">
@@ -30,7 +29,6 @@ export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules,
         <ScheduleCard
           key={schedule.scheduleId}
           schedule={schedule}
-          onMarkCompleted={onMarkCompleted}
         />
       ))}
     </div>
@@ -39,10 +37,9 @@ export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules,
 
 interface ScheduleCardProps {
   schedule: TodayScheduleViewModel;
-  onMarkCompleted?: (scheduleId: string) => void;
 }
 
-const ScheduleCard: React.FC<ScheduleCardProps> = ({ schedule, onMarkCompleted }) => {
+const ScheduleCard: React.FC<ScheduleCardProps> = ({ schedule }) => {
   return (
     <div
       className="bg-white rounded-lg shadow-md p-4 border border-gray-200 hover:shadow-lg transition-shadow"
@@ -72,19 +69,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({ schedule, onMarkCompleted }
         </div>
 
         <div className="flex items-center space-x-2">
-          {schedule.status === 'completed' ? (
-            <StatusBadge status="completed" />
-          ) : onMarkCompleted ? (
-            <button
-              onClick={() => onMarkCompleted(schedule.scheduleId)}
-              className="bg-green-500 text-white px-3 py-1 rounded-full text-sm font-medium hover:bg-green-600 transition-colors"
-              aria-label="飲んだ"
-            >
-              飲んだ
-            </button>
-          ) : (
-            <StatusBadge status={schedule.status} />
-          )}
+          <StatusBadge status={schedule.status} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- ダッシュボードの服薬スケジュールカードから「飲んだ」ボタンを削除し、ステータスバッジのみ表示
- お薬ページ（/medications）の各薬カードに「飲んだ」ボタンを追加
- ボタン押下で`recordApi.createRecord`を呼び出し服薬記録を登録、「記録済み」表示に切り替え

Closes #98