### PR TITLE
在庫警告を日付ベースの複合条件に変更

### DIFF
--- a/prisma/migrations/20260228_replace_low_stock_threshold_with_alert_date/migration.sql
+++ b/prisma/migrations/20260228_replace_low_stock_threshold_with_alert_date/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Medication" DROP COLUMN "lowStockThreshold",
+ADD COLUMN "stockAlertDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,7 +60,7 @@ model Medication {
   dosageAmount      String?
   frequency         String?
   stockQuantity     Int?
-  lowStockThreshold Int?
+  stockAlertDate    DateTime?
   intervalHours     Int?
   instructions      String?
   isActive          Boolean  @default(true)

--- a/src/__tests__/domain/entities/MedicationEntity.test.ts
+++ b/src/__tests__/domain/entities/MedicationEntity.test.ts
@@ -15,16 +15,20 @@ const createMedication = (overrides: Partial<Medication> = {}): Medication => ({
 
 describe('MedicationEntity', () => {
   describe('isLowStock', () => {
-    it('在庫数が閾値以下の場合 true を返す', () => {
+    it('在庫数が警告日までの日数より少ない場合 true を返す', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 10);
       const entity = new MedicationEntity(
-        createMedication({ stockQuantity: 3, lowStockThreshold: 5 })
+        createMedication({ stockQuantity: 5, stockAlertDate: futureDate })
       );
       expect(entity.isLowStock()).toBe(true);
     });
 
-    it('在庫数が閾値より多い場合 false を返す', () => {
+    it('在庫数が警告日までの日数以上の場合 false を返す', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 5);
       const entity = new MedicationEntity(
-        createMedication({ stockQuantity: 10, lowStockThreshold: 5 })
+        createMedication({ stockQuantity: 10, stockAlertDate: futureDate })
       );
       expect(entity.isLowStock()).toBe(false);
     });
@@ -34,11 +38,20 @@ describe('MedicationEntity', () => {
       expect(entity.isLowStock()).toBe(false);
     });
 
-    it('在庫数と閾値が等しい場合 true を返す', () => {
+    it('警告日が過去の場合 false を返す', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 5);
       const entity = new MedicationEntity(
-        createMedication({ stockQuantity: 5, lowStockThreshold: 5 })
+        createMedication({ stockQuantity: 3, stockAlertDate: pastDate })
       );
-      expect(entity.isLowStock()).toBe(true);
+      expect(entity.isLowStock()).toBe(false);
+    });
+
+    it('警告日が未設定の場合 false を返す', () => {
+      const entity = new MedicationEntity(
+        createMedication({ stockQuantity: 3 })
+      );
+      expect(entity.isLowStock()).toBe(false);
     });
   });
 

--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
         dosageAmount: parsed.data.dosageAmount,
         frequency: parsed.data.frequency,
         stockQuantity: parsed.data.stockQuantity,
-        lowStockThreshold: parsed.data.lowStockThreshold,
+        stockAlertDate: parsed.data.stockAlertDate ? new Date(parsed.data.stockAlertDate) : undefined,
         instructions: parsed.data.instructions,
         isActive: true,
       },

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -92,11 +92,20 @@ export async function POST(request: NextRequest) {
         if (!medication) {
           return errorResponse('Medication not found', 404);
         }
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const alertDate = medication.stockAlertDate
+          ? new Date(medication.stockAlertDate).toLocaleDateString('ja-JP')
+          : '未設定';
+        const daysUntilAlert = medication.stockAlertDate
+          ? Math.ceil((new Date(medication.stockAlertDate).getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+          : 0;
         const template = emailTemplates.lowStockAlert({
           memberName: member.name,
           medicationName: medication.name,
           currentStock: medication.stockQuantity ?? 0,
-          threshold: medication.lowStockThreshold ?? 5,
+          alertDate,
+          daysUntilAlert,
         });
         await sendEmail({ to: user.email, ...template });
         break;

--- a/src/app/members/[memberId]/medications/page.tsx
+++ b/src/app/members/[memberId]/medications/page.tsx
@@ -31,7 +31,7 @@ export default function Medications() {
       dosage: data.dosage,
       frequency: data.frequency,
       stockQuantity: data.stockQuantity,
-      lowStockThreshold: data.lowStockThreshold,
+      stockAlertDate: data.stockAlertDate,
       instructions: data.instructions,
     });
     setShowMedForm(false);

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -7,7 +7,7 @@ export interface MedicationFormData {
   dosage: string;
   frequency: string;
   stockQuantity?: number;
-  lowStockThreshold?: number;
+  stockAlertDate?: string;
   instructions?: string;
 }
 
@@ -21,7 +21,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
   const [dosage, setDosage] = useState('');
   const [frequency, setFrequency] = useState('');
   const [stockQuantity, setStockQuantity] = useState('');
-  const [lowStockThreshold, setLowStockThreshold] = useState('');
+  const [stockAlertDate, setStockAlertDate] = useState('');
   const [instructions, setInstructions] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -35,7 +35,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
       dosage: dosage.trim(),
       frequency: frequency.trim(),
       ...(stockQuantity ? { stockQuantity: parseInt(stockQuantity, 10) } : {}),
-      ...(lowStockThreshold ? { lowStockThreshold: parseInt(lowStockThreshold, 10) } : {}),
+      ...(stockAlertDate ? { stockAlertDate } : {}),
       ...(instructions.trim() ? { instructions: instructions.trim() } : {}),
     };
 
@@ -46,7 +46,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
     setDosage('');
     setFrequency('');
     setStockQuantity('');
-    setLowStockThreshold('');
+    setStockAlertDate('');
     setInstructions('');
   };
 
@@ -114,35 +114,32 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label htmlFor="med-stock" className="block text-sm font-medium text-gray-700 mb-1">
-            在庫数(何日分)
-          </label>
-          <input
-            id="med-stock"
-            type="number"
-            min="0"
-            value={stockQuantity}
-            onChange={(e) => setStockQuantity(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
-            placeholder="例: 30"
-          />
-        </div>
-        <div>
-          <label htmlFor="med-threshold" className="block text-sm font-medium text-gray-700 mb-1">
-            在庫警告(残量お知らせ)
-          </label>
-          <input
-            id="med-threshold"
-            type="number"
-            min="0"
-            value={lowStockThreshold}
-            onChange={(e) => setLowStockThreshold(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
-            placeholder="例: 7"
-          />
-        </div>
+      <div>
+        <label htmlFor="med-stock" className="block text-sm font-medium text-gray-700 mb-1">
+          在庫数(何日分)
+        </label>
+        <input
+          id="med-stock"
+          type="number"
+          min="0"
+          value={stockQuantity}
+          onChange={(e) => setStockQuantity(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+          placeholder="例: 30"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="med-alert-date" className="block text-sm font-medium text-gray-700 mb-1">
+          在庫警告日(この日までに在庫が不足する場合に通知)
+        </label>
+        <input
+          id="med-alert-date"
+          type="date"
+          value={stockAlertDate}
+          onChange={(e) => setStockAlertDate(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
+        />
       </div>
 
       <div>

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -74,7 +74,10 @@ const MedicationCard: React.FC<MedicationCardProps> = ({ viewModel, onDelete, on
             <p>{displayInfo.categoryLabel}</p>
             {displayInfo.dosageInfo && <p>{displayInfo.dosageInfo}</p>}
             {medication.stockQuantity !== undefined && (
-              <p>在庫: {medication.stockQuantity}個</p>
+              <p>在庫: {medication.stockQuantity}日分</p>
+            )}
+            {medication.stockAlertDate && (
+              <p>警告日: {new Date(medication.stockAlertDate).toLocaleDateString('ja-JP')}</p>
             )}
           </div>
         </div>

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -27,7 +27,7 @@ export function toMedication(b: BackendMedication): Medication {
     dosage: b.dosageAmount,
     frequency: b.frequency,
     stockQuantity: b.stockQuantity,
-    lowStockThreshold: b.lowStockThreshold,
+    stockAlertDate: b.stockAlertDate ? new Date(b.stockAlertDate) : undefined,
     instructions: b.instructions,
     isActive: b.isActive ?? true,
     createdAt: new Date(b.createdAt),

--- a/src/data/api/medicationApi.ts
+++ b/src/data/api/medicationApi.ts
@@ -27,7 +27,7 @@ export const medicationApi = {
       dosageAmount: input.dosage,
       frequency: input.frequency,
       stockQuantity: input.stockQuantity,
-      lowStockThreshold: input.lowStockThreshold,
+      stockAlertDate: input.stockAlertDate,
       instructions: input.instructions,
     });
     return toMedication(data);
@@ -39,7 +39,7 @@ export const medicationApi = {
     if (input.name !== undefined) body.name = input.name;
     if (input.dosage !== undefined) body.dosageAmount = input.dosage;
     if (input.frequency !== undefined) body.frequency = input.frequency;
-    if (input.lowStockThreshold !== undefined) body.lowStockThreshold = input.lowStockThreshold;
+    if (input.stockAlertDate !== undefined) body.stockAlertDate = input.stockAlertDate;
     if (input.instructions !== undefined) body.instructions = input.instructions;
     if (input.isActive !== undefined) body.isActive = input.isActive;
 

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -19,7 +19,7 @@ export interface BackendMedication {
   dosageAmount?: string;
   frequency?: string;
   stockQuantity?: number;
-  lowStockThreshold?: number;
+  stockAlertDate?: string;
   instructions?: string;
   isActive?: boolean;
   createdAt: string;

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -19,7 +19,7 @@ export interface Medication {
   readonly dosage?: string;
   readonly frequency?: string;
   readonly stockQuantity?: number;
-  readonly lowStockThreshold?: number;
+  readonly stockAlertDate?: Date;
   readonly intervalHours?: number;
   readonly instructions?: string;
   readonly isActive: boolean;
@@ -39,12 +39,23 @@ export class MedicationEntity {
   isLowStock(): boolean {
     if (
       this.medication.stockQuantity === undefined ||
-      this.medication.lowStockThreshold === undefined
+      this.medication.stockAlertDate === undefined
     ) {
       return false;
     }
 
-    return this.medication.stockQuantity <= this.medication.lowStockThreshold;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const alertDate = new Date(this.medication.stockAlertDate);
+    alertDate.setHours(0, 0, 0, 0);
+
+    const daysUntilAlert = Math.ceil(
+      (alertDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    if (daysUntilAlert <= 0) return false;
+
+    return this.medication.stockQuantity < daysUntilAlert;
   }
 
   /**

--- a/src/domain/repositories/MedicationRepository.ts
+++ b/src/domain/repositories/MedicationRepository.ts
@@ -12,7 +12,7 @@ export interface CreateMedicationInput {
   dosage?: string;
   frequency?: string;
   stockQuantity?: number;
-  lowStockThreshold?: number;
+  stockAlertDate?: string;
   instructions?: string;
 }
 
@@ -21,7 +21,7 @@ export interface UpdateMedicationInput {
   dosage?: string;
   frequency?: string;
   stockQuantity?: number;
-  lowStockThreshold?: number;
+  stockAlertDate?: string;
   instructions?: string;
   isActive?: boolean;
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -155,24 +155,27 @@ export const emailTemplates = {
     memberName,
     medicationName,
     currentStock,
-    threshold,
+    alertDate,
+    daysUntilAlert,
   }: {
     memberName: string;
     medicationName: string;
     currentStock: number;
-    threshold: number;
+    alertDate: string;
+    daysUntilAlert: number;
   }) {
     return {
-      subject: `${medicationName}の残数が少なくなっています`,
+      subject: `${medicationName}の在庫が${alertDate}までに不足します`,
       html: `
         <div style="font-family: 'Helvetica Neue', Arial, sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
-          <h2 style="color: #d97706; margin-bottom: 16px;">お薬の残数アラート</h2>
+          <h2 style="color: #d97706; margin-bottom: 16px;">お薬の在庫アラート</h2>
           <div style="background: #fffbeb; border-radius: 8px; padding: 16px; margin-bottom: 16px;">
             <p style="margin: 0 0 8px 0; font-size: 16px;"><strong>${memberName}</strong>さん</p>
             <p style="margin: 0 0 8px 0; font-size: 14px; color: #374151;">お薬: <strong>${medicationName}</strong></p>
-            <p style="margin: 0 0 8px 0; font-size: 14px; color: #374151;">残数: <strong style="color: #dc2626;">${currentStock}</strong> / 閾値: ${threshold}</p>
+            <p style="margin: 0 0 8px 0; font-size: 14px; color: #374151;">現在の在庫: <strong style="color: #dc2626;">${currentStock}日分</strong></p>
+            <p style="margin: 0 0 8px 0; font-size: 14px; color: #374151;">警告日: <strong>${alertDate}</strong>(あと${daysUntilAlert}日)</p>
           </div>
-          <p style="font-size: 14px; color: #374151;">早めにかかりつけ医に相談し、処方を受けてください。</p>
+          <p style="font-size: 14px; color: #374151;">在庫が警告日までに不足する見込みです。早めにかかりつけ医に相談し、処方を受けてください。</p>
           <p style="font-size: 13px; color: #6b7280;">HealthFamily - 今お薬飲んでよ通知アプリ</p>
         </div>
       `,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -28,7 +28,7 @@ export const createMedicationSchema = z.object({
   dosageAmount: z.string().max(100).optional(),
   frequency: z.string().max(100).optional(),
   stockQuantity: z.number().int().min(0).optional(),
-  lowStockThreshold: z.number().int().min(0).optional(),
+  stockAlertDate: z.string().optional(),
   instructions: z.string().max(1000).optional(),
 });
 


### PR DESCRIPTION
## Summary

- `lowStockThreshold`(数値閾値)を`stockAlertDate`(日付)に置き換え
- フォームの在庫警告入力をカレンダー日付ピッカーに変更
- 判定ロジック: 在庫数(何日分) < 警告日までの残日数 の場合に「在庫少」バッジ表示
- メールアラートを日付ベースの内容に更新
- 薬カードに警告日と在庫を「日分」表示
- Prismaマイグレーション + テスト更新済み

Closes #102