### PR TITLE
feat: 服薬履歴ページの追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationRecordEntity.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordEntity.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MedicationRecord,
+  MedicationRecordEntity,
+} from '@/domain/entities/MedicationRecord';
+
+const createRecord = (overrides: Partial<MedicationRecord> = {}): MedicationRecord => ({
+  id: 'record-1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  medicationId: 'med-1',
+  medicationName: 'テスト薬A',
+  userId: 'user-1',
+  takenAt: new Date('2024-06-15T08:30:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity', () => {
+  describe('groupByDate', () => {
+    it('日付ごとにグループ化する', () => {
+      const records: MedicationRecord[] = [
+        createRecord({ id: 'r1', takenAt: new Date('2024-06-15T08:00:00') }),
+        createRecord({ id: 'r2', takenAt: new Date('2024-06-15T12:00:00') }),
+        createRecord({ id: 'r3', takenAt: new Date('2024-06-14T09:00:00') }),
+      ];
+
+      const groups = MedicationRecordEntity.groupByDate(records);
+
+      expect(groups).toHaveLength(2);
+      expect(groups[0].date).toBe('2024-06-15');
+      expect(groups[0].records).toHaveLength(2);
+      expect(groups[1].date).toBe('2024-06-14');
+      expect(groups[1].records).toHaveLength(1);
+    });
+
+    it('新しい日付が先に来る', () => {
+      const records: MedicationRecord[] = [
+        createRecord({ id: 'r1', takenAt: new Date('2024-06-10T08:00:00') }),
+        createRecord({ id: 'r2', takenAt: new Date('2024-06-15T08:00:00') }),
+        createRecord({ id: 'r3', takenAt: new Date('2024-06-12T08:00:00') }),
+      ];
+
+      const groups = MedicationRecordEntity.groupByDate(records);
+
+      expect(groups[0].date).toBe('2024-06-15');
+      expect(groups[1].date).toBe('2024-06-12');
+      expect(groups[2].date).toBe('2024-06-10');
+    });
+
+    it('空の配列の場合は空を返す', () => {
+      const groups = MedicationRecordEntity.groupByDate([]);
+      expect(groups).toHaveLength(0);
+    });
+  });
+
+  describe('formatDate', () => {
+    it('日本語形式で日付をフォーマットする', () => {
+      const result = MedicationRecordEntity.formatDate('2024-06-15');
+      expect(result).toBe('6月15日(土)');
+    });
+
+    it('曜日が正しく表示される', () => {
+      expect(MedicationRecordEntity.formatDate('2024-06-10')).toContain('月');
+      expect(MedicationRecordEntity.formatDate('2024-06-11')).toContain('火');
+      expect(MedicationRecordEntity.formatDate('2024-06-12')).toContain('水');
+      expect(MedicationRecordEntity.formatDate('2024-06-13')).toContain('木');
+      expect(MedicationRecordEntity.formatDate('2024-06-14')).toContain('金');
+      expect(MedicationRecordEntity.formatDate('2024-06-15')).toContain('土');
+      expect(MedicationRecordEntity.formatDate('2024-06-16')).toContain('日');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('時刻を HH:mm 形式で返す', () => {
+      const result = MedicationRecordEntity.formatTime(new Date('2024-06-15T08:30:00'));
+      expect(result).toBe('08:30');
+    });
+
+    it('午後の時刻も正しく表示する', () => {
+      const result = MedicationRecordEntity.formatTime(new Date('2024-06-15T14:05:00'));
+      expect(result).toBe('14:05');
+    });
+  });
+});

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -10,9 +10,20 @@ export async function GET() {
     const records = await prisma.medicationRecord.findMany({
       where: { userId },
       orderBy: { takenAt: 'desc' },
-      take: 50,
+      take: 100,
+      include: {
+        member: { select: { name: true } },
+        medication: { select: { name: true } },
+      },
     });
-    return success(records);
+    const result = records.map((r) => ({
+      ...r,
+      memberName: r.member.name,
+      medicationName: r.medication.name,
+      member: undefined,
+      medication: undefined,
+    }));
+    return success(result);
   } catch {
     return errorResponse('一覧取得に失敗しました', 500);
   }

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { MedicationHistoryList } from '@/components/history/MedicationHistoryList';
+import { MedicationRecord, MedicationRecordEntity, DailyRecordGroup } from '@/domain/entities/MedicationRecord';
+import { recordApi } from '@/data/api/recordApi';
+
+export default function HistoryPage() {
+  const [groups, setGroups] = useState<DailyRecordGroup[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const records: MedicationRecord[] = await recordApi.getHistory();
+      setGroups(MedicationRecordEntity.groupByDate(records));
+    } catch {
+      setGroups([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-20">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-md mx-auto px-4 py-3">
+          <h1 className="text-xl font-bold text-primary-600">服薬履歴</h1>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4">
+        <MedicationHistoryList groups={groups} isLoading={isLoading} />
+      </main>
+
+      <BottomNavigation activePath="/history" />
+    </div>
+  );
+}

--- a/src/components/history/MedicationHistoryList.tsx
+++ b/src/components/history/MedicationHistoryList.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React from 'react';
+import { Clock, Pill, User } from 'lucide-react';
+import { DailyRecordGroup, MedicationRecordEntity } from '../../domain/entities/MedicationRecord';
+
+interface MedicationHistoryListProps {
+  groups: DailyRecordGroup[];
+  isLoading: boolean;
+}
+
+export const MedicationHistoryList: React.FC<MedicationHistoryListProps> = ({ groups, isLoading }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (groups.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-12">
+        <p className="text-gray-500 text-lg">服薬履歴がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <div key={group.date}>
+          <h3 className="text-sm font-semibold text-gray-600 mb-2 px-1">
+            {MedicationRecordEntity.formatDate(group.date)}
+          </h3>
+          <div className="space-y-2">
+            {group.records.map((record) => (
+              <div
+                key={record.id}
+                className="bg-white rounded-lg shadow-sm p-3 border border-gray-200"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-3 flex-1 min-w-0">
+                    <div className="flex-shrink-0">
+                      <Pill size={18} className="text-primary-600" />
+                    </div>
+                    <div className="min-w-0">
+                      <p className="font-medium text-gray-800 truncate">{record.medicationName}</p>
+                      <div className="flex items-center space-x-2 text-xs text-gray-500 mt-0.5">
+                        <span className="flex items-center space-x-1">
+                          <User size={12} />
+                          <span>{record.memberName}</span>
+                        </span>
+                        {record.dosageAmount && (
+                          <span>{record.dosageAmount}</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-1 text-sm text-gray-500 flex-shrink-0 ml-2">
+                    <Clock size={14} />
+                    <span>{MedicationRecordEntity.formatTime(record.takenAt)}</span>
+                  </div>
+                </div>
+                {record.notes && (
+                  <p className="text-xs text-gray-400 mt-1 pl-8">{record.notes}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/shared/BottomNavigation.tsx
+++ b/src/components/shared/BottomNavigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import { Home, Users, Pill, Settings, type LucideIcon } from 'lucide-react';
+import { Home, Users, Pill, ClipboardList, Settings, type LucideIcon } from 'lucide-react';
 
 interface NavItem {
   path: string;
@@ -12,6 +12,7 @@ const navItems: NavItem[] = [
   { path: '/', icon: Home, label: 'ホーム' },
   { path: '/members', icon: Users, label: 'メンバー' },
   { path: '/medications', icon: Pill, label: 'お薬' },
+  { path: '/history', icon: ClipboardList, label: '履歴' },
   { path: '/settings', icon: Settings, label: '設定' },
 ];
 

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -1,7 +1,8 @@
 import { Member, MemberType } from '../../domain/entities/Member';
 import { Medication, MedicationCategory } from '../../domain/entities/Medication';
+import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
-import { BackendMember, BackendMedication, BackendSchedule } from './types';
+import { BackendMember, BackendMedication, BackendRecord, BackendSchedule } from './types';
 
 export function toMember(b: BackendMember): Member {
   return {
@@ -32,6 +33,21 @@ export function toMedication(b: BackendMedication): Medication {
     isActive: b.isActive ?? true,
     createdAt: new Date(b.createdAt),
     updatedAt: new Date(b.updatedAt),
+  };
+}
+
+export function toMedicationRecord(b: BackendRecord): MedicationRecord {
+  return {
+    id: b.id,
+    memberId: b.memberId,
+    memberName: b.memberName || '',
+    medicationId: b.medicationId,
+    medicationName: b.medicationName || '',
+    userId: b.userId,
+    scheduleId: b.scheduleId,
+    takenAt: new Date(b.takenAt),
+    notes: b.notes,
+    dosageAmount: b.dosageAmount,
   };
 }
 

--- a/src/data/api/recordApi.ts
+++ b/src/data/api/recordApi.ts
@@ -1,4 +1,6 @@
+import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { apiClient } from './apiClient';
+import { toMedicationRecord } from './mappers';
 import { BackendRecord } from './types';
 
 interface CreateRecordInput {
@@ -20,5 +22,10 @@ export const recordApi = {
 
   async getRecordsByMember(memberId: string): Promise<BackendRecord[]> {
     return apiClient.get<BackendRecord[]>(`/records/member/${memberId}`);
+  },
+
+  async getHistory(): Promise<MedicationRecord[]> {
+    const data = await apiClient.get<BackendRecord[]>('/records');
+    return data.map(toMedicationRecord);
   },
 };

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -42,7 +42,9 @@ export interface BackendRecord {
   id: string;
   userId: string;
   memberId: string;
+  memberName?: string;
   medicationId: string;
+  medicationName?: string;
   scheduleId?: string;
   takenAt: string;
   notes?: string;

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -1,0 +1,64 @@
+/**
+ * 服薬記録エンティティ
+ */
+
+export interface MedicationRecord {
+  readonly id: string;
+  readonly memberId: string;
+  readonly memberName: string;
+  readonly medicationId: string;
+  readonly medicationName: string;
+  readonly userId: string;
+  readonly scheduleId?: string;
+  readonly takenAt: Date;
+  readonly notes?: string;
+  readonly dosageAmount?: string;
+}
+
+export interface DailyRecordGroup {
+  date: string;
+  records: MedicationRecord[];
+}
+
+/**
+ * 服薬記録のビジネスロジック
+ */
+export class MedicationRecordEntity {
+  /**
+   * 記録を日付ごとにグループ化（新しい順）
+   */
+  static groupByDate(records: MedicationRecord[]): DailyRecordGroup[] {
+    const groups = new Map<string, MedicationRecord[]>();
+
+    for (const record of records) {
+      const d = record.takenAt;
+      const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      if (!groups.has(dateStr)) {
+        groups.set(dateStr, []);
+      }
+      groups.get(dateStr)!.push(record);
+    }
+
+    return Array.from(groups.entries())
+      .sort(([a], [b]) => b.localeCompare(a))
+      .map(([date, recs]) => ({ date, records: recs }));
+  }
+
+  /**
+   * 日付を日本語形式でフォーマット（例: 6月15日(土)）
+   */
+  static formatDate(dateStr: string): string {
+    const date = new Date(dateStr + 'T00:00:00');
+    const days = ['日', '月', '火', '水', '木', '金', '土'];
+    return `${date.getMonth() + 1}月${date.getDate()}日(${days[date.getDay()]})`;
+  }
+
+  /**
+   * 時刻を HH:mm 形式でフォーマット
+   */
+  static formatTime(date: Date): string {
+    const h = date.getHours().toString().padStart(2, '0');
+    const m = date.getMinutes().toString().padStart(2, '0');
+    return `${h}:${m}`;
+  }
+}


### PR DESCRIPTION
## Summary
- MedicationRecord ドメインエンティティを追加（日付グループ化、日本語日付・時刻フォーマット）
- 服薬記録APIにメンバー名・薬名のリレーション情報を含める
- 履歴ページ（/history）を実装、日付ごとにグループ化して表示
- BottomNavigationに履歴タブを追加

closes #106

## Test plan
- [x] MedicationRecordEntity.groupByDate で日付グループ化が正しく動作する
- [x] MedicationRecordEntity.formatDate で日本語形式の日付フォーマットが正しい
- [x] MedicationRecordEntity.formatTime で時刻フォーマットが正しい
- [x] npx vitest run 全テスト通過
- [x] npm run build ビルド成功