### PR TITLE
feat: メンバー編集機能の追加

### DIFF
--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   signUpSchema,
   createMemberSchema,
+  updateMemberSchema,
   createMedicationSchema,
   createScheduleSchema,
   createRecordSchema,
@@ -67,6 +68,23 @@ describe('createMemberSchema', () => {
       birthDate: '2020-01-01',
       notes: 'テストメモ',
     });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('updateMemberSchema', () => {
+  it('名前のみの更新を受け入れる', () => {
+    const result = updateMemberSchema.safeParse({ name: '更新名' });
+    expect(result.success).toBe(true);
+  });
+
+  it('空のオブジェクトを拒否する', () => {
+    const result = updateMemberSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('nullのnotesを受け入れる', () => {
+    const result = updateMemberSchema.safeParse({ notes: null });
     expect(result.success).toBe(true);
   });
 });

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { updateMemberSchema } from '@/lib/schemas';
 import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
@@ -13,6 +14,37 @@ export async function GET(_request: Request, { params }: { params: Promise<{ mem
     return success(member);
   } catch {
     return errorResponse('取得に失敗しました', 500);
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { memberId } = await params;
+    const member = await prisma.member.findUnique({ where: { id: memberId } });
+    if (!member || member.userId !== userId) return notFound('メンバー');
+
+    const body = await request.json();
+    const parsed = updateMemberSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const data: Record<string, unknown> = {};
+    if (parsed.data.name !== undefined) data.name = parsed.data.name;
+    if (parsed.data.petType !== undefined) data.petType = parsed.data.petType;
+    if (parsed.data.birthDate !== undefined) {
+      data.birthDate = parsed.data.birthDate ? new Date(parsed.data.birthDate) : null;
+    }
+    if (parsed.data.notes !== undefined) data.notes = parsed.data.notes;
+
+    const updated = await prisma.member.update({
+      where: { id: memberId },
+      data,
+    });
+    return success(updated);
+  } catch {
+    return errorResponse('更新に失敗しました', 500);
   }
 }
 

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -5,13 +5,15 @@ import { useMembers } from '@/presentation/hooks/useMembers';
 import { MemberList } from '@/components/members/MemberList';
 import { MemberForm, MemberFormData } from '@/components/members/MemberForm';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { Member } from '@/domain/entities/Member';
 import { useState } from 'react';
 import { Plus, X } from 'lucide-react';
 
 export default function Members() {
   const { userId } = useAuth();
-  const { members, isLoading, createMember, deleteMember } = useMembers(userId);
+  const { members, isLoading, createMember, updateMember, deleteMember } = useMembers(userId);
   const [showForm, setShowForm] = useState(false);
+  const [editingMember, setEditingMember] = useState<Member | null>(null);
 
   const handleCreate = async (data: MemberFormData) => {
     await createMember({
@@ -25,13 +27,36 @@ export default function Members() {
     setShowForm(false);
   };
 
+  const handleEdit = (member: Member) => {
+    setEditingMember(member);
+    setShowForm(false);
+  };
+
+  const handleUpdate = async (data: MemberFormData) => {
+    if (!editingMember) return;
+    await updateMember(editingMember.id, {
+      name: data.name,
+      petType: data.petType,
+      birthDate: data.birthDate ? new Date(data.birthDate) : undefined,
+      notes: data.notes,
+    });
+    setEditingMember(null);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingMember(null);
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
           <h1 className="text-xl font-bold text-primary-600">メンバー</h1>
           <button
-            onClick={() => setShowForm(!showForm)}
+            onClick={() => {
+              setShowForm(!showForm);
+              setEditingMember(null);
+            }}
             className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
             aria-label={showForm ? '閉じる' : 'メンバーを追加'}
           >
@@ -47,10 +72,22 @@ export default function Members() {
           </div>
         )}
 
+        {editingMember && (
+          <div className="mb-6 bg-white rounded-lg shadow-md p-4 border border-primary-200">
+            <h2 className="text-sm font-semibold text-gray-700 mb-3">メンバー編集</h2>
+            <MemberForm
+              onSubmit={handleUpdate}
+              initialData={editingMember}
+              onCancel={handleCancelEdit}
+            />
+          </div>
+        )}
+
         <MemberList
           members={members}
           isLoading={isLoading}
           onDelete={deleteMember}
+          onEdit={handleEdit}
         />
       </main>
 

--- a/src/components/members/MemberForm.tsx
+++ b/src/components/members/MemberForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { MemberType, PetType } from '../../domain/entities/Member';
+import { MemberType, PetType, Member } from '../../domain/entities/Member';
 
 export interface MemberFormData {
   name: string;
@@ -11,14 +11,19 @@ export interface MemberFormData {
 
 interface MemberFormProps {
   onSubmit: (data: MemberFormData) => void;
+  initialData?: Member;
+  onCancel?: () => void;
 }
 
-export const MemberForm: React.FC<MemberFormProps> = ({ onSubmit }) => {
-  const [name, setName] = useState('');
-  const [memberType, setMemberType] = useState<MemberType>('human');
-  const [petType, setPetType] = useState<PetType>('dog');
-  const [birthDate, setBirthDate] = useState('');
-  const [notes, setNotes] = useState('');
+export const MemberForm: React.FC<MemberFormProps> = ({ onSubmit, initialData, onCancel }) => {
+  const isEditing = !!initialData;
+  const [name, setName] = useState(initialData?.name || '');
+  const [memberType, setMemberType] = useState<MemberType>(initialData?.memberType || 'human');
+  const [petType, setPetType] = useState<PetType>(initialData?.petType || 'dog');
+  const [birthDate, setBirthDate] = useState(
+    initialData?.birthDate ? new Date(initialData.birthDate).toISOString().split('T')[0] : ''
+  );
+  const [notes, setNotes] = useState(initialData?.notes || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -35,12 +40,13 @@ export const MemberForm: React.FC<MemberFormProps> = ({ onSubmit }) => {
 
     onSubmit(data);
 
-    // フォームリセット
-    setName('');
-    setMemberType('human');
-    setPetType('dog');
-    setBirthDate('');
-    setNotes('');
+    if (!isEditing) {
+      setName('');
+      setMemberType('human');
+      setPetType('dog');
+      setBirthDate('');
+      setNotes('');
+    }
   };
 
   return (
@@ -59,20 +65,22 @@ export const MemberForm: React.FC<MemberFormProps> = ({ onSubmit }) => {
         />
       </div>
 
-      <div>
-        <label htmlFor="member-type" className="block text-sm font-medium text-gray-700 mb-1">
-          タイプ
-        </label>
-        <select
-          id="member-type"
-          value={memberType}
-          onChange={(e) => setMemberType(e.target.value as MemberType)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        >
-          <option value="human">家族</option>
-          <option value="pet">ペット</option>
-        </select>
-      </div>
+      {!isEditing && (
+        <div>
+          <label htmlFor="member-type" className="block text-sm font-medium text-gray-700 mb-1">
+            タイプ
+          </label>
+          <select
+            id="member-type"
+            value={memberType}
+            onChange={(e) => setMemberType(e.target.value as MemberType)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="human">家族</option>
+            <option value="pet">ペット</option>
+          </select>
+        </div>
+      )}
 
       {memberType === 'pet' && (
         <div>
@@ -121,12 +129,23 @@ export const MemberForm: React.FC<MemberFormProps> = ({ onSubmit }) => {
         />
       </div>
 
-      <button
-        type="submit"
-        className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
-      >
-        追加する
-      </button>
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {isEditing ? '更新する' : '追加する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
     </form>
   );
 };

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -2,15 +2,16 @@ import React from 'react';
 import Link from 'next/link';
 import { Member, MemberEntity } from '../../domain/entities/Member';
 import { MemberIcon } from '../shared/MemberIcon';
-import { Pill } from 'lucide-react';
+import { Pill, Pencil } from 'lucide-react';
 
 interface MemberListProps {
   members: Member[];
   isLoading: boolean;
   onDelete: (memberId: string) => void;
+  onEdit?: (member: Member) => void;
 }
 
-export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDelete }) => {
+export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDelete, onEdit }) => {
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-8">
@@ -30,7 +31,7 @@ export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDe
   return (
     <div className="space-y-3">
       {members.map((member) => (
-        <MemberCard key={member.id} member={member} onDelete={onDelete} />
+        <MemberCard key={member.id} member={member} onDelete={onDelete} onEdit={onEdit} />
       ))}
     </div>
   );
@@ -39,9 +40,10 @@ export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDe
 interface MemberCardProps {
   member: Member;
   onDelete: (memberId: string) => void;
+  onEdit?: (member: Member) => void;
 }
 
-const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete }) => {
+const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete, onEdit }) => {
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
   const age = entity.getAge();
@@ -71,6 +73,15 @@ const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete }) => {
             <Pill size={14} />
             <span>薬管理</span>
           </Link>
+          {onEdit && (
+            <button
+              onClick={() => onEdit(member)}
+              className="text-gray-500 hover:text-gray-700 text-sm px-2 py-1 rounded-md hover:bg-gray-100 transition-colors"
+              aria-label="編集"
+            >
+              <Pencil size={14} />
+            </button>
+          )}
           <button
             onClick={() => onDelete(member.id)}
             className="text-red-500 hover:text-red-700 text-sm px-3 py-1 rounded-md hover:bg-red-50 transition-colors"

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -20,6 +20,15 @@ export const createMemberSchema = z.object({
   notes: z.string().max(500).optional(),
 });
 
+export const updateMemberSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  petType: z.string().max(50).optional(),
+  birthDate: z.string().optional().nullable(),
+  notes: z.string().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Medications =====
 export const createMedicationSchema = z.object({
   name: z.string({ required_error: '薬の名前は必須です' }).min(1, '薬の名前は必須です').max(200),

--- a/src/presentation/hooks/useMembers.ts
+++ b/src/presentation/hooks/useMembers.ts
@@ -5,8 +5,8 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Member } from '../../domain/entities/Member';
-import { GetMembers, CreateMember, DeleteMember } from '../../domain/usecases/ManageMembers';
-import { CreateMemberInput } from '../../domain/repositories/MemberRepository';
+import { GetMembers, CreateMember, UpdateMember, DeleteMember } from '../../domain/usecases/ManageMembers';
+import { CreateMemberInput, UpdateMemberInput } from '../../domain/repositories/MemberRepository';
 import { getDIContainer } from '../../infrastructure/DIContainer';
 
 export interface UseMembersResult {
@@ -14,6 +14,7 @@ export interface UseMembersResult {
   isLoading: boolean;
   error: Error | null;
   createMember: (input: CreateMemberInput) => Promise<void>;
+  updateMember: (memberId: string, input: UpdateMemberInput) => Promise<void>;
   deleteMember: (memberId: string) => Promise<void>;
   refetch: () => Promise<void>;
 }
@@ -24,6 +25,7 @@ export const useMembers = (userId: string): UseMembersResult => {
     return {
       getMembers: new GetMembers(memberRepository),
       createMember: new CreateMember(memberRepository),
+      updateMember: new UpdateMember(memberRepository),
       deleteMember: new DeleteMember(memberRepository),
     };
   }, []);
@@ -54,6 +56,11 @@ export const useMembers = (userId: string): UseMembersResult => {
     await fetchMembers();
   };
 
+  const handleUpdateMember = async (memberId: string, input: UpdateMemberInput) => {
+    await useCases.updateMember.execute(memberId, input);
+    await fetchMembers();
+  };
+
   const handleDeleteMember = async (memberId: string) => {
     await useCases.deleteMember.execute(memberId);
     await fetchMembers();
@@ -64,6 +71,7 @@ export const useMembers = (userId: string): UseMembersResult => {
     isLoading,
     error,
     createMember: handleCreateMember,
+    updateMember: handleUpdateMember,
     deleteMember: handleDeleteMember,
     refetch: fetchMembers,
   };


### PR DESCRIPTION
## Summary
- APIルート（PUT /api/members/[memberId]）を追加
- updateMemberSchema（Zod）を追加しテストを実装
- MemberFormを新規作成・編集の両方に対応（initialData, onCancel props）
- MemberListに編集ボタン（Pencilアイコン）を追加
- useMembersフックにupdateMemberを追加
- メンバーページでインライン編集UIを実装

closes #108

## Test plan
- [x] updateMemberSchemaのユニットテスト（名前更新、空オブジェクト拒否、null許容）
- [x] npx vitest run 全68テスト通過
- [x] npm run build ビルド成功