### PR TITLE
feat: 通院管理ページの追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentEntity.test.ts
+++ b/src/__tests__/domain/entities/AppointmentEntity.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity, Appointment } from '@/domain/entities/Appointment';
+
+const createAppointment = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: 'apt-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  appointmentDate: new Date('2024-06-15'),
+  reminderEnabled: true,
+  reminderDaysBefore: 1,
+  createdAt: new Date('2024-01-01'),
+  ...overrides,
+});
+
+describe('AppointmentEntity', () => {
+  describe('isToday', () => {
+    it('今日の予約の場合 true を返す', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: new Date() })
+      );
+      expect(entity.isToday()).toBe(true);
+    });
+
+    it('明日の予約の場合 false を返す', () => {
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: tomorrow })
+      );
+      expect(entity.isToday()).toBe(false);
+    });
+  });
+
+  describe('isPast', () => {
+    it('過去の予約の場合 true を返す', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 3);
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: pastDate })
+      );
+      expect(entity.isPast()).toBe(true);
+    });
+
+    it('今日の予約の場合 false を返す', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: new Date() })
+      );
+      expect(entity.isPast()).toBe(false);
+    });
+
+    it('未来の予約の場合 false を返す', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 5);
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: futureDate })
+      );
+      expect(entity.isPast()).toBe(false);
+    });
+  });
+
+  describe('daysUntil', () => {
+    it('未来の予約の場合、正の日数を返す', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 5);
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: futureDate })
+      );
+      expect(entity.daysUntil()).toBe(5);
+    });
+
+    it('今日の予約の場合 0 を返す', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: new Date() })
+      );
+      expect(entity.daysUntil()).toBe(0);
+    });
+
+    it('過去の予約の場合、負の日数を返す', () => {
+      const pastDate = new Date();
+      pastDate.setDate(pastDate.getDate() - 3);
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: pastDate })
+      );
+      expect(entity.daysUntil()).toBe(-3);
+    });
+  });
+
+  describe('getFormattedDate', () => {
+    it('日本語の日付フォーマットで返す', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: new Date('2024-06-15T00:00:00') })
+      );
+      const result = entity.getFormattedDate();
+      expect(result).toBe('2024年6月15日(土)');
+    });
+  });
+
+  describe('getTypeLabel', () => {
+    it('種別ラベルを日本語で返す', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentType: 'checkup' })
+      );
+      expect(entity.getTypeLabel()).toBe('定期検診');
+    });
+
+    it('未知の種別はそのまま返す', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentType: 'custom' })
+      );
+      expect(entity.getTypeLabel()).toBe('custom');
+    });
+
+    it('種別が未設定の場合は空文字を返す', () => {
+      const entity = new AppointmentEntity(createAppointment());
+      expect(entity.getTypeLabel()).toBe('');
+    });
+  });
+});

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -10,8 +10,19 @@ export async function GET() {
     const appointments = await prisma.appointment.findMany({
       where: { userId },
       orderBy: { appointmentDate: 'asc' },
+      include: {
+        member: { select: { name: true } },
+        hospital: { select: { name: true } },
+      },
     });
-    return success(appointments);
+    const result = appointments.map((a) => ({
+      ...a,
+      memberName: a.member.name,
+      hospitalName: a.hospital?.name,
+      member: undefined,
+      hospital: undefined,
+    }));
+    return success(result);
   } catch {
     return errorResponse('一覧取得に失敗しました', 500);
   }

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { useMembers } from '@/presentation/hooks/useMembers';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { AppointmentList } from '@/components/appointments/AppointmentList';
+import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
+import { Appointment, Hospital } from '@/domain/entities/Appointment';
+import { appointmentApi } from '@/data/api/appointmentApi';
+import { hospitalApi } from '@/data/api/hospitalApi';
+import { Plus, X } from 'lucide-react';
+
+export default function AppointmentsPage() {
+  const { userId } = useAuth();
+  const { members, isLoading: membersLoading } = useMembers(userId);
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [hospitals, setHospitals] = useState<Hospital[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const [apts, hosps] = await Promise.all([
+        appointmentApi.getAppointments(),
+        hospitalApi.getHospitals(),
+      ]);
+      setAppointments(apts);
+      setHospitals(hosps);
+    } catch {
+      setAppointments([]);
+      setHospitals([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleCreate = async (data: AppointmentFormData) => {
+    await appointmentApi.createAppointment(data);
+    setShowForm(false);
+    await fetchData();
+  };
+
+  const handleDelete = async (appointmentId: string) => {
+    await appointmentApi.deleteAppointment(appointmentId);
+    await fetchData();
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-20">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
+          <h1 className="text-xl font-bold text-primary-600">通院管理</h1>
+          <button
+            onClick={() => setShowForm(!showForm)}
+            className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
+            aria-label={showForm ? '閉じる' : '予約を追加'}
+          >
+            {showForm ? <X size={20} /> : <Plus size={20} />}
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4">
+        {showForm && !membersLoading && members.length > 0 && (
+          <div className="mb-6 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+            <h2 className="text-sm font-semibold text-gray-700 mb-3">通院予約の追加</h2>
+            <AppointmentForm
+              members={members}
+              hospitals={hospitals}
+              onSubmit={handleCreate}
+            />
+          </div>
+        )}
+
+        {showForm && !membersLoading && members.length === 0 && (
+          <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+            先にメンバーを登録してください。
+          </div>
+        )}
+
+        <AppointmentList
+          appointments={appointments}
+          isLoading={isLoading}
+          onDelete={handleDelete}
+        />
+      </main>
+
+      <BottomNavigation activePath="/appointments" />
+    </div>
+  );
+}

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -10,7 +10,7 @@ import { MemberIcon } from '@/components/shared/MemberIcon';
 import { MemberEntity, Member } from '@/domain/entities/Member';
 import { recordApi } from '@/data/api/recordApi';
 import Link from 'next/link';
-import { Plus } from 'lucide-react';
+import { Plus, ClipboardList } from 'lucide-react';
 
 function MemberMedications({ member }: { member: Member }) {
   const { medications, isLoading, deleteMedication } = useMedications(member.id);
@@ -61,8 +61,15 @@ export default function Medications() {
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
       <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-md mx-auto px-4 py-3">
+        <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
           <h1 className="text-xl font-bold text-primary-600">お薬</h1>
+          <Link
+            href="/history"
+            className="flex items-center space-x-1 text-sm text-gray-500 hover:text-primary-600 transition-colors"
+          >
+            <ClipboardList size={16} />
+            <span>履歴</span>
+          </Link>
         </div>
       </header>
 

--- a/src/components/appointments/AppointmentForm.tsx
+++ b/src/components/appointments/AppointmentForm.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member, MemberEntity } from '../../domain/entities/Member';
+import { Hospital } from '../../domain/entities/Appointment';
+import { AppointmentEntity } from '../../domain/entities/Appointment';
+import { MemberIcon } from '../shared/MemberIcon';
+
+export interface AppointmentFormData {
+  memberId: string;
+  hospitalId?: string;
+  appointmentDate: string;
+  type?: string;
+  notes?: string;
+}
+
+interface AppointmentFormProps {
+  members: Member[];
+  hospitals: Hospital[];
+  onSubmit: (data: AppointmentFormData) => void;
+}
+
+export const AppointmentForm: React.FC<AppointmentFormProps> = ({ members, hospitals, onSubmit }) => {
+  const [memberId, setMemberId] = useState(members[0]?.id || '');
+  const [hospitalId, setHospitalId] = useState('');
+  const [appointmentDate, setAppointmentDate] = useState('');
+  const [type, setType] = useState('');
+  const [notes, setNotes] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !appointmentDate) return;
+
+    onSubmit({
+      memberId,
+      hospitalId: hospitalId || undefined,
+      appointmentDate,
+      type: type || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    setAppointmentDate('');
+    setType('');
+    setNotes('');
+  };
+
+  const typeOptions = Object.entries(AppointmentEntity.typeLabels);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="apt-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <div className="space-y-1">
+          {members.map((m) => {
+            const entity = new MemberEntity(m);
+            const info = entity.getDisplayInfo();
+            const isSelected = memberId === m.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setMemberId(m.id)}
+                className={`w-full flex items-center space-x-2 px-3 py-2 rounded-lg border text-left transition-colors ${
+                  isSelected
+                    ? 'border-primary-500 bg-primary-50'
+                    : 'border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                <MemberIcon memberType={info.memberType} petType={info.petType} size={16} className="text-gray-600" />
+                <span className="text-sm">{info.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="apt-date" className="block text-sm font-medium text-gray-700 mb-1">
+          予約日
+        </label>
+        <input
+          id="apt-date"
+          type="date"
+          value={appointmentDate}
+          onChange={(e) => setAppointmentDate(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        />
+      </div>
+
+      {hospitals.length > 0 && (
+        <div>
+          <label htmlFor="apt-hospital" className="block text-sm font-medium text-gray-700 mb-1">
+            病院（任意）
+          </label>
+          <select
+            id="apt-hospital"
+            value={hospitalId}
+            onChange={(e) => setHospitalId(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          >
+            <option value="">選択しない</option>
+            {hospitals.map((h) => (
+              <option key={h.id} value={h.id}>{h.name}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="apt-type" className="block text-sm font-medium text-gray-700 mb-1">
+          種別（任意）
+        </label>
+        <select
+          id="apt-type"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        >
+          <option value="">選択しない</option>
+          {typeOptions.map(([key, label]) => (
+            <option key={key} value={key}>{label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="apt-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="apt-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="メモを入力"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+      >
+        追加する
+      </button>
+    </form>
+  );
+};

--- a/src/components/appointments/AppointmentList.tsx
+++ b/src/components/appointments/AppointmentList.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import React from 'react';
+import { Calendar, Trash2, User, MapPin } from 'lucide-react';
+import { Appointment, AppointmentEntity } from '../../domain/entities/Appointment';
+
+interface AppointmentListProps {
+  appointments: Appointment[];
+  isLoading: boolean;
+  onDelete: (appointmentId: string) => void;
+}
+
+export const AppointmentList: React.FC<AppointmentListProps> = ({ appointments, isLoading, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (appointments.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-12">
+        <p className="text-gray-500 text-lg">通院予定がありません</p>
+      </div>
+    );
+  }
+
+  const upcoming = appointments.filter((a) => !new AppointmentEntity(a).isPast());
+  const past = appointments.filter((a) => new AppointmentEntity(a).isPast());
+
+  return (
+    <div className="space-y-6">
+      {upcoming.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-600 mb-2 px-1">今後の予定</h3>
+          <div className="space-y-2">
+            {upcoming.map((apt) => (
+              <AppointmentCard key={apt.id} appointment={apt} onDelete={onDelete} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {past.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-gray-400 mb-2 px-1">過去の予定</h3>
+          <div className="space-y-2 opacity-60">
+            {past.map((apt) => (
+              <AppointmentCard key={apt.id} appointment={apt} onDelete={onDelete} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface AppointmentCardProps {
+  appointment: Appointment;
+  onDelete: (appointmentId: string) => void;
+}
+
+const AppointmentCard: React.FC<AppointmentCardProps> = ({ appointment, onDelete }) => {
+  const entity = new AppointmentEntity(appointment);
+  const daysUntil = entity.daysUntil();
+  const typeLabel = entity.getTypeLabel();
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex items-start space-x-3 flex-1 min-w-0">
+          <div className="flex-shrink-0 mt-0.5">
+            <Calendar size={18} className={entity.isToday() ? 'text-red-500' : 'text-primary-600'} />
+          </div>
+          <div className="min-w-0">
+            <p className="font-medium text-gray-800 text-sm">
+              {entity.getFormattedDate()}
+              {entity.isToday() && (
+                <span className="ml-2 px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-medium">
+                  今日
+                </span>
+              )}
+              {!entity.isPast() && !entity.isToday() && daysUntil <= 7 && (
+                <span className="ml-2 text-xs text-orange-600 font-medium">
+                  あと{daysUntil}日
+                </span>
+              )}
+            </p>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 mt-1">
+              {appointment.memberName && (
+                <span className="flex items-center space-x-1">
+                  <User size={12} />
+                  <span>{appointment.memberName}</span>
+                </span>
+              )}
+              {appointment.hospitalName && (
+                <span className="flex items-center space-x-1">
+                  <MapPin size={12} />
+                  <span>{appointment.hospitalName}</span>
+                </span>
+              )}
+              {typeLabel && <span>{typeLabel}</span>}
+            </div>
+            {appointment.description && (
+              <p className="text-xs text-gray-400 mt-1">{appointment.description}</p>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={() => onDelete(appointment.id)}
+          className="text-gray-400 hover:text-red-500 p-1 transition-colors flex-shrink-0"
+          aria-label="削除"
+        >
+          <Trash2 size={14} />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/shared/BottomNavigation.tsx
+++ b/src/components/shared/BottomNavigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import { Home, Users, Pill, ClipboardList, Settings, type LucideIcon } from 'lucide-react';
+import { Home, Users, Pill, Calendar, Settings, type LucideIcon } from 'lucide-react';
 
 interface NavItem {
   path: string;
@@ -10,9 +10,9 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { path: '/', icon: Home, label: 'ホーム' },
-  { path: '/members', icon: Users, label: 'メンバー' },
   { path: '/medications', icon: Pill, label: 'お薬' },
-  { path: '/history', icon: ClipboardList, label: '履歴' },
+  { path: '/appointments', icon: Calendar, label: '通院' },
+  { path: '/members', icon: Users, label: 'メンバー' },
   { path: '/settings', icon: Settings, label: '設定' },
 ];
 

--- a/src/data/api/appointmentApi.ts
+++ b/src/data/api/appointmentApi.ts
@@ -1,0 +1,30 @@
+import { Appointment } from '../../domain/entities/Appointment';
+import { apiClient } from './apiClient';
+import { toAppointment } from './mappers';
+import { BackendAppointment } from './types';
+
+export interface CreateAppointmentInput {
+  memberId: string;
+  hospitalId?: string;
+  appointmentDate: string;
+  type?: string;
+  notes?: string;
+  reminderEnabled?: boolean;
+  reminderDaysBefore?: number;
+}
+
+export const appointmentApi = {
+  async getAppointments(): Promise<Appointment[]> {
+    const data = await apiClient.get<BackendAppointment[]>('/appointments');
+    return data.map(toAppointment);
+  },
+
+  async createAppointment(input: CreateAppointmentInput): Promise<Appointment> {
+    const data = await apiClient.post<BackendAppointment>('/appointments', input);
+    return toAppointment(data);
+  },
+
+  async deleteAppointment(appointmentId: string): Promise<void> {
+    await apiClient.del(`/appointments/${appointmentId}`);
+  },
+};

--- a/src/data/api/hospitalApi.ts
+++ b/src/data/api/hospitalApi.ts
@@ -1,0 +1,28 @@
+import { Hospital } from '../../domain/entities/Appointment';
+import { apiClient } from './apiClient';
+import { toHospital } from './mappers';
+import { BackendHospital } from './types';
+
+export interface CreateHospitalInput {
+  name: string;
+  type?: string;
+  address?: string;
+  phone?: string;
+  notes?: string;
+}
+
+export const hospitalApi = {
+  async getHospitals(): Promise<Hospital[]> {
+    const data = await apiClient.get<BackendHospital[]>('/hospitals');
+    return data.map(toHospital);
+  },
+
+  async createHospital(input: CreateHospitalInput): Promise<Hospital> {
+    const data = await apiClient.post<BackendHospital>('/hospitals', input);
+    return toHospital(data);
+  },
+
+  async deleteHospital(hospitalId: string): Promise<void> {
+    await apiClient.del(`/hospitals/${hospitalId}`);
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -1,8 +1,9 @@
+import { Appointment, Hospital } from '../../domain/entities/Appointment';
 import { Member, MemberType } from '../../domain/entities/Member';
 import { Medication, MedicationCategory } from '../../domain/entities/Medication';
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
-import { BackendMember, BackendMedication, BackendRecord, BackendSchedule } from './types';
+import { BackendAppointment, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule } from './types';
 
 export function toMember(b: BackendMember): Member {
   return {
@@ -48,6 +49,36 @@ export function toMedicationRecord(b: BackendRecord): MedicationRecord {
     takenAt: new Date(b.takenAt),
     notes: b.notes,
     dosageAmount: b.dosageAmount,
+  };
+}
+
+export function toHospital(b: BackendHospital): Hospital {
+  return {
+    id: b.id,
+    userId: b.userId,
+    name: b.name,
+    hospitalType: b.hospitalType,
+    address: b.address,
+    phoneNumber: b.phoneNumber,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toAppointment(b: BackendAppointment): Appointment {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    hospitalId: b.hospitalId,
+    hospitalName: b.hospitalName,
+    appointmentType: b.appointmentType,
+    appointmentDate: new Date(b.appointmentDate),
+    description: b.description,
+    reminderEnabled: b.reminderEnabled ?? true,
+    reminderDaysBefore: b.reminderDaysBefore ?? 1,
+    createdAt: new Date(b.createdAt),
   };
 }
 

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -38,6 +38,32 @@ export interface BackendSchedule {
   createdAt: string;
 }
 
+export interface BackendHospital {
+  id: string;
+  userId: string;
+  name: string;
+  hospitalType?: string;
+  address?: string;
+  phoneNumber?: string;
+  notes?: string;
+  createdAt: string;
+}
+
+export interface BackendAppointment {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  hospitalId?: string;
+  hospitalName?: string;
+  appointmentType?: string;
+  appointmentDate: string;
+  description?: string;
+  reminderEnabled?: boolean;
+  reminderDaysBefore?: number;
+  createdAt: string;
+}
+
 export interface BackendRecord {
   id: string;
   userId: string;

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -1,0 +1,103 @@
+/**
+ * 通院予約エンティティ
+ */
+
+export interface Appointment {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly hospitalId?: string;
+  readonly hospitalName?: string;
+  readonly appointmentType?: string;
+  readonly appointmentDate: Date;
+  readonly description?: string;
+  readonly reminderEnabled: boolean;
+  readonly reminderDaysBefore: number;
+  readonly createdAt: Date;
+}
+
+export interface Hospital {
+  readonly id: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly hospitalType?: string;
+  readonly address?: string;
+  readonly phoneNumber?: string;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}
+
+/**
+ * 通院予約のビジネスロジック
+ */
+export class AppointmentEntity {
+  constructor(private readonly appointment: Appointment) {}
+
+  /**
+   * 予約が今日かどうか
+   */
+  isToday(): boolean {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const date = new Date(this.appointment.appointmentDate);
+    date.setHours(0, 0, 0, 0);
+    return today.getTime() === date.getTime();
+  }
+
+  /**
+   * 予約が過去かどうか
+   */
+  isPast(): boolean {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const date = new Date(this.appointment.appointmentDate);
+    date.setHours(0, 0, 0, 0);
+    return date.getTime() < today.getTime();
+  }
+
+  /**
+   * 予約日までの残り日数
+   */
+  daysUntil(): number {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const date = new Date(this.appointment.appointmentDate);
+    date.setHours(0, 0, 0, 0);
+    return Math.ceil((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+  }
+
+  /**
+   * 日本語のフォーマット済み日付
+   */
+  getFormattedDate(): string {
+    const d = new Date(this.appointment.appointmentDate);
+    const days = ['日', '月', '火', '水', '木', '金', '土'];
+    return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日(${days[d.getDay()]})`;
+  }
+
+  /**
+   * 種別ラベル
+   */
+  static readonly typeLabels: Record<string, string> = {
+    checkup: '定期検診',
+    treatment: '治療',
+    vaccination: '予防接種',
+    surgery: '手術',
+    consultation: '相談',
+    other: 'その他',
+  };
+
+  getTypeLabel(): string {
+    if (!this.appointment.appointmentType) return '';
+    return AppointmentEntity.typeLabels[this.appointment.appointmentType] || this.appointment.appointmentType;
+  }
+
+  get id(): string {
+    return this.appointment.id;
+  }
+
+  get data(): Appointment {
+    return this.appointment;
+  }
+}


### PR DESCRIPTION
## Summary
- Appointment/Hospital ドメインエンティティを追加
- AppointmentEntity テスト12件（isToday, isPast, daysUntil, formatDate, getTypeLabel）
- hospitalApi/appointmentApi クライアントを追加
- 通院管理ページ（/appointments）を実装（予約追加フォーム + 一覧表示）
- 通院予約APIにメンバー名・病院名のリレーション情報を含める
- BottomNavigationを再構成（ホーム、お薬、通院、メンバー、設定）
- お薬ページに履歴ページへのリンクを追加

closes #110

## Test plan
- [x] AppointmentEntity のユニットテスト12件全通過
- [x] npx vitest run 全80テスト通過
- [x] npm run build ビルド成功