### PR TITLE
feat: 薬の編集機能の追加

### DIFF
--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -4,6 +4,7 @@ import {
   createMemberSchema,
   updateMemberSchema,
   createMedicationSchema,
+  updateMedicationSchema,
   createScheduleSchema,
   createRecordSchema,
   createHospitalSchema,
@@ -102,6 +103,28 @@ describe('createMedicationSchema', () => {
 
   it('負の在庫数を拒否する', () => {
     const result = createMedicationSchema.safeParse({ name: 'テスト薬', stockQuantity: -1 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateMedicationSchema', () => {
+  it('名前のみの更新を受け入れる', () => {
+    const result = updateMedicationSchema.safeParse({ name: '更新薬名' });
+    expect(result.success).toBe(true);
+  });
+
+  it('空のオブジェクトを拒否する', () => {
+    const result = updateMedicationSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('nullの在庫数を受け入れる', () => {
+    const result = updateMedicationSchema.safeParse({ stockQuantity: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('負の在庫数を拒否する', () => {
+    const result = updateMedicationSchema.safeParse({ stockQuantity: -1 });
     expect(result.success).toBe(false);
   });
 });

--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { updateMedicationSchema } from '@/lib/schemas';
 import { getAuthUserId, success, errorResponse, notFound, unauthorized } from '@/lib/auth-helpers';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
@@ -13,6 +14,41 @@ export async function GET(_request: Request, { params }: { params: Promise<{ med
     return success(medication);
   } catch {
     return errorResponse('取得に失敗しました', 500);
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
+  try {
+    const userId = await getAuthUserId();
+    if (!userId) return unauthorized();
+
+    const { medicationId } = await params;
+    const medication = await prisma.medication.findUnique({ where: { id: medicationId } });
+    if (!medication || medication.userId !== userId) return notFound('お薬');
+
+    const body = await request.json();
+    const parsed = updateMedicationSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const data: Record<string, unknown> = {};
+    if (parsed.data.name !== undefined) data.name = parsed.data.name;
+    if (parsed.data.category !== undefined) data.category = parsed.data.category;
+    if (parsed.data.dosageAmount !== undefined) data.dosageAmount = parsed.data.dosageAmount;
+    if (parsed.data.frequency !== undefined) data.frequency = parsed.data.frequency;
+    if (parsed.data.stockQuantity !== undefined) data.stockQuantity = parsed.data.stockQuantity;
+    if (parsed.data.stockAlertDate !== undefined) {
+      data.stockAlertDate = parsed.data.stockAlertDate ? new Date(parsed.data.stockAlertDate) : null;
+    }
+    if (parsed.data.instructions !== undefined) data.instructions = parsed.data.instructions;
+    if (parsed.data.isActive !== undefined) data.isActive = parsed.data.isActive;
+
+    const updated = await prisma.medication.update({
+      where: { id: medicationId },
+      data,
+    });
+    return success(updated);
+  } catch {
+    return errorResponse('更新に失敗しました', 500);
   }
 }
 

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { MedicationCategory } from '../../domain/entities/Medication';
+import { Medication, MedicationCategory } from '../../domain/entities/Medication';
 
 export interface MedicationFormData {
   name: string;
@@ -13,16 +13,23 @@ export interface MedicationFormData {
 
 interface MedicationFormProps {
   onSubmit: (data: MedicationFormData) => void;
+  initialData?: Medication;
+  onCancel?: () => void;
 }
 
-export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
-  const [name, setName] = useState('');
-  const [category, setCategory] = useState<MedicationCategory>('regular');
-  const [dosage, setDosage] = useState('');
-  const [frequency, setFrequency] = useState('');
-  const [stockQuantity, setStockQuantity] = useState('');
-  const [stockAlertDate, setStockAlertDate] = useState('');
-  const [instructions, setInstructions] = useState('');
+export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initialData, onCancel }) => {
+  const isEditing = !!initialData;
+  const [name, setName] = useState(initialData?.name || '');
+  const [category, setCategory] = useState<MedicationCategory>(initialData?.category || 'regular');
+  const [dosage, setDosage] = useState(initialData?.dosage || '');
+  const [frequency, setFrequency] = useState(initialData?.frequency || '');
+  const [stockQuantity, setStockQuantity] = useState(
+    initialData?.stockQuantity !== undefined ? String(initialData.stockQuantity) : ''
+  );
+  const [stockAlertDate, setStockAlertDate] = useState(
+    initialData?.stockAlertDate ? new Date(initialData.stockAlertDate).toISOString().split('T')[0] : ''
+  );
+  const [instructions, setInstructions] = useState(initialData?.instructions || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,13 +48,15 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
 
     onSubmit(data);
 
-    setName('');
-    setCategory('regular');
-    setDosage('');
-    setFrequency('');
-    setStockQuantity('');
-    setStockAlertDate('');
-    setInstructions('');
+    if (!isEditing) {
+      setName('');
+      setCategory('regular');
+      setDosage('');
+      setFrequency('');
+      setStockQuantity('');
+      setStockAlertDate('');
+      setInstructions('');
+    }
   };
 
   return (
@@ -156,12 +165,23 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit }) => {
         />
       </div>
 
-      <button
-        type="submit"
-        className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
-      >
-        追加する
-      </button>
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {isEditing ? '更新する' : '追加する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
     </form>
   );
 };

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { Pill, Check } from 'lucide-react';
+import { Pill, Check, Pencil } from 'lucide-react';
+import { Medication } from '../../domain/entities/Medication';
 import { MedicationViewModel } from '../../domain/usecases/ManageMedications';
 
 interface MedicationListProps {
@@ -7,9 +8,10 @@ interface MedicationListProps {
   isLoading: boolean;
   onDelete: (medicationId: string) => void;
   onMarkTaken?: (medicationId: string) => Promise<void>;
+  onEdit?: (medication: Medication) => void;
 }
 
-export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete, onMarkTaken }) => {
+export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete, onMarkTaken, onEdit }) => {
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-8">
@@ -29,7 +31,7 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
   return (
     <div className="space-y-3">
       {medications.map((vm) => (
-        <MedicationCard key={vm.medication.id} viewModel={vm} onDelete={onDelete} onMarkTaken={onMarkTaken} />
+        <MedicationCard key={vm.medication.id} viewModel={vm} onDelete={onDelete} onMarkTaken={onMarkTaken} onEdit={onEdit} />
       ))}
     </div>
   );
@@ -39,9 +41,10 @@ interface MedicationCardProps {
   viewModel: MedicationViewModel;
   onDelete: (medicationId: string) => void;
   onMarkTaken?: (medicationId: string) => Promise<void>;
+  onEdit?: (medication: Medication) => void;
 }
 
-const MedicationCard: React.FC<MedicationCardProps> = ({ viewModel, onDelete, onMarkTaken }) => {
+const MedicationCard: React.FC<MedicationCardProps> = ({ viewModel, onDelete, onMarkTaken, onEdit }) => {
   const { medication, isLowStock, displayInfo } = viewModel;
   const [isTaken, setIsTaken] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -82,6 +85,15 @@ const MedicationCard: React.FC<MedicationCardProps> = ({ viewModel, onDelete, on
           </div>
         </div>
         <div className="flex items-center space-x-2">
+          {onEdit && (
+            <button
+              onClick={() => onEdit(medication)}
+              className="text-gray-500 hover:text-gray-700 text-sm px-2 py-1 rounded-md hover:bg-gray-100 transition-colors"
+              aria-label="編集"
+            >
+              <Pencil size={14} />
+            </button>
+          )}
           {onMarkTaken && (
             isTaken ? (
               <span className="flex items-center space-x-1 text-green-600 text-sm font-medium px-3 py-1">

--- a/src/domain/usecases/ManageMedications.ts
+++ b/src/domain/usecases/ManageMedications.ts
@@ -6,6 +6,7 @@ import { Medication, MedicationEntity } from '../entities/Medication';
 import {
   MedicationRepository,
   CreateMedicationInput,
+  UpdateMedicationInput,
 } from '../repositories/MedicationRepository';
 
 export interface MedicationViewModel {
@@ -38,6 +39,18 @@ export class CreateMedication {
       throw new Error('薬の名前は必須です');
     }
     return this.medicationRepository.createMedication(input);
+  }
+}
+
+export class UpdateMedication {
+  constructor(private readonly medicationRepository: MedicationRepository) {}
+
+  async execute(medicationId: string, input: UpdateMedicationInput): Promise<Medication> {
+    const existing = await this.medicationRepository.getMedicationById(medicationId);
+    if (!existing) {
+      throw new Error('薬が見つかりません');
+    }
+    return this.medicationRepository.updateMedication(medicationId, input);
   }
 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -41,6 +41,19 @@ export const createMedicationSchema = z.object({
   instructions: z.string().max(1000).optional(),
 });
 
+export const updateMedicationSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  category: z.string().max(100).optional(),
+  dosageAmount: z.string().max(100).optional().nullable(),
+  frequency: z.string().max(100).optional().nullable(),
+  stockQuantity: z.number().int().min(0).optional().nullable(),
+  stockAlertDate: z.string().optional().nullable(),
+  instructions: z.string().max(1000).optional().nullable(),
+  isActive: z.boolean().optional(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 export const updateStockSchema = z.object({
   stockQuantity: z.number().int().min(0, '在庫数は0以上の数値を指定してください'),
 });

--- a/src/presentation/hooks/useMedications.ts
+++ b/src/presentation/hooks/useMedications.ts
@@ -4,8 +4,8 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { GetMedications, CreateMedication, DeleteMedication, MedicationViewModel } from '../../domain/usecases/ManageMedications';
-import { CreateMedicationInput } from '../../domain/repositories/MedicationRepository';
+import { GetMedications, CreateMedication, UpdateMedication, DeleteMedication, MedicationViewModel } from '../../domain/usecases/ManageMedications';
+import { CreateMedicationInput, UpdateMedicationInput } from '../../domain/repositories/MedicationRepository';
 import { getDIContainer } from '../../infrastructure/DIContainer';
 
 export interface UseMedicationsResult {
@@ -13,6 +13,7 @@ export interface UseMedicationsResult {
   isLoading: boolean;
   error: Error | null;
   createMedication: (input: CreateMedicationInput) => Promise<void>;
+  updateMedication: (medicationId: string, input: UpdateMedicationInput) => Promise<void>;
   deleteMedication: (medicationId: string) => Promise<void>;
   refetch: () => Promise<void>;
 }
@@ -23,6 +24,7 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
     return {
       getMedications: new GetMedications(medicationRepository),
       createMedication: new CreateMedication(medicationRepository),
+      updateMedication: new UpdateMedication(medicationRepository),
       deleteMedication: new DeleteMedication(medicationRepository),
     };
   }, []);
@@ -53,6 +55,11 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
     await fetchMedications();
   };
 
+  const handleUpdateMedication = async (medicationId: string, input: UpdateMedicationInput) => {
+    await useCases.updateMedication.execute(medicationId, input);
+    await fetchMedications();
+  };
+
   const handleDeleteMedication = async (medicationId: string) => {
     await useCases.deleteMedication.execute(medicationId);
     await fetchMedications();
@@ -63,6 +70,7 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
     isLoading,
     error,
     createMedication: handleCreateMedication,
+    updateMedication: handleUpdateMedication,
     deleteMedication: handleDeleteMedication,
     refetch: fetchMedications,
   };


### PR DESCRIPTION
## Summary
- APIルート（PUT /api/medications/[medicationId]）を追加
- updateMedicationSchema（Zod）を追加
- MedicationFormを新規作成・編集の両方に対応
- MedicationListに編集ボタン（Pencilアイコン）を追加
- useMedicationsフックにupdateMedicationを追加
- UpdateMedicationユースケースを追加
- お薬ページでインライン編集UIを実装

closes #112

## Test plan
- [x] updateMedicationSchemaのユニットテスト4件全通過
- [x] npx vitest run 全84テスト通過
- [x] npm run build ビルド成功