### PR TITLE
クリーンアーキテクチャの統一リファクタリング

### DIFF
--- a/src/__tests__/domain/usecases/ManageAppointments.test.ts
+++ b/src/__tests__/domain/usecases/ManageAppointments.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GetAppointments, CreateAppointment, DeleteAppointment } from '@/domain/usecases/ManageAppointments';
+import { AppointmentRepository } from '@/domain/repositories/AppointmentRepository';
+import { Appointment } from '@/domain/entities/Appointment';
+
+const mockAppointment: Appointment = {
+  id: 'apt-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  appointmentDate: new Date('2025-06-01'),
+  reminderEnabled: true,
+  reminderDaysBefore: 1,
+  createdAt: new Date(),
+};
+
+const createMockRepository = (): AppointmentRepository => ({
+  getAppointments: vi.fn().mockResolvedValue([mockAppointment]),
+  createAppointment: vi.fn().mockResolvedValue(mockAppointment),
+  deleteAppointment: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('GetAppointments', () => {
+  it('予約一覧をViewModelとして取得する', async () => {
+    const repo = createMockRepository();
+    const useCase = new GetAppointments(repo);
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].appointment).toBe(mockAppointment);
+    expect(result[0].entity).toBeDefined();
+    expect(repo.getAppointments).toHaveBeenCalled();
+  });
+});
+
+describe('CreateAppointment', () => {
+  it('有効な入力で予約を作成する', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateAppointment(repo);
+    const result = await useCase.execute({
+      memberId: 'member-1',
+      appointmentDate: '2025-06-01',
+    });
+
+    expect(result).toBe(mockAppointment);
+    expect(repo.createAppointment).toHaveBeenCalled();
+  });
+
+  it('メンバーIDが空の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateAppointment(repo);
+
+    await expect(
+      useCase.execute({ memberId: '', appointmentDate: '2025-06-01' })
+    ).rejects.toThrow('メンバーIDは必須です');
+  });
+
+  it('予約日が空の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateAppointment(repo);
+
+    await expect(
+      useCase.execute({ memberId: 'member-1', appointmentDate: '' })
+    ).rejects.toThrow('予約日は必須です');
+  });
+});
+
+describe('DeleteAppointment', () => {
+  it('予約を削除する', async () => {
+    const repo = createMockRepository();
+    const useCase = new DeleteAppointment(repo);
+    await useCase.execute('apt-1');
+
+    expect(repo.deleteAppointment).toHaveBeenCalledWith('apt-1');
+  });
+});

--- a/src/__tests__/domain/usecases/ManageHospitals.test.ts
+++ b/src/__tests__/domain/usecases/ManageHospitals.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GetHospitals, CreateHospital, DeleteHospital } from '@/domain/usecases/ManageHospitals';
+import { HospitalRepository } from '@/domain/repositories/HospitalRepository';
+import { Hospital } from '@/domain/entities/Appointment';
+
+const mockHospital: Hospital = {
+  id: 'hosp-1',
+  userId: 'user-1',
+  name: 'テスト病院',
+  hospitalType: 'checkup',
+  createdAt: new Date(),
+};
+
+const createMockRepository = (): HospitalRepository => ({
+  getHospitals: vi.fn().mockResolvedValue([mockHospital]),
+  createHospital: vi.fn().mockResolvedValue(mockHospital),
+  deleteHospital: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('GetHospitals', () => {
+  it('病院一覧を取得する', async () => {
+    const repo = createMockRepository();
+    const useCase = new GetHospitals(repo);
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(mockHospital);
+    expect(repo.getHospitals).toHaveBeenCalled();
+  });
+});
+
+describe('CreateHospital', () => {
+  it('有効な入力で病院を作成する', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateHospital(repo);
+    const result = await useCase.execute({ name: 'テスト病院' });
+
+    expect(result).toBe(mockHospital);
+    expect(repo.createHospital).toHaveBeenCalled();
+  });
+
+  it('空の病院名の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateHospital(repo);
+
+    await expect(
+      useCase.execute({ name: '' })
+    ).rejects.toThrow('病院名は必須です');
+  });
+
+  it('空白のみの病院名の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateHospital(repo);
+
+    await expect(
+      useCase.execute({ name: '   ' })
+    ).rejects.toThrow('病院名は必須です');
+  });
+});
+
+describe('DeleteHospital', () => {
+  it('病院を削除する', async () => {
+    const repo = createMockRepository();
+    const useCase = new DeleteHospital(repo);
+    await useCase.execute('hosp-1');
+
+    expect(repo.deleteHospital).toHaveBeenCalledWith('hosp-1');
+  });
+});

--- a/src/__tests__/domain/usecases/ManageMedicationRecords.test.ts
+++ b/src/__tests__/domain/usecases/ManageMedicationRecords.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GetMedicationHistory, CreateMedicationRecord } from '@/domain/usecases/ManageMedicationRecords';
+import { MedicationRecordRepository } from '@/domain/repositories/MedicationRecordRepository';
+import { MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const mockRecords: MedicationRecord[] = [
+  {
+    id: 'rec-1',
+    memberId: 'member-1',
+    memberName: 'テスト太郎',
+    medicationId: 'med-1',
+    medicationName: 'テスト薬A',
+    userId: 'user-1',
+    takenAt: new Date('2025-06-15T08:00:00'),
+  },
+  {
+    id: 'rec-2',
+    memberId: 'member-1',
+    memberName: 'テスト太郎',
+    medicationId: 'med-2',
+    medicationName: 'テスト薬B',
+    userId: 'user-1',
+    takenAt: new Date('2025-06-15T12:00:00'),
+  },
+  {
+    id: 'rec-3',
+    memberId: 'member-1',
+    memberName: 'テスト太郎',
+    medicationId: 'med-1',
+    medicationName: 'テスト薬A',
+    userId: 'user-1',
+    takenAt: new Date('2025-06-14T08:00:00'),
+  },
+];
+
+const createMockRepository = (): MedicationRecordRepository => ({
+  getHistory: vi.fn().mockResolvedValue(mockRecords),
+  createRecord: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('GetMedicationHistory', () => {
+  it('服薬履歴を日付グループで取得する', async () => {
+    const repo = createMockRepository();
+    const useCase = new GetMedicationHistory(repo);
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].date).toBe('2025-06-15');
+    expect(result[0].records).toHaveLength(2);
+    expect(result[1].date).toBe('2025-06-14');
+    expect(result[1].records).toHaveLength(1);
+  });
+});
+
+describe('CreateMedicationRecord', () => {
+  it('有効な入力で服薬記録を作成する', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMedicationRecord(repo);
+    await useCase.execute({
+      memberId: 'member-1',
+      medicationId: 'med-1',
+    });
+
+    expect(repo.createRecord).toHaveBeenCalled();
+  });
+
+  it('メンバーIDが空の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMedicationRecord(repo);
+
+    await expect(
+      useCase.execute({ memberId: '', medicationId: 'med-1' })
+    ).rejects.toThrow('メンバーIDは必須です');
+  });
+
+  it('薬IDが空の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMedicationRecord(repo);
+
+    await expect(
+      useCase.execute({ memberId: 'member-1', medicationId: '' })
+    ).rejects.toThrow('薬IDは必須です');
+  });
+});

--- a/src/__tests__/domain/usecases/ManageUserProfile.test.ts
+++ b/src/__tests__/domain/usecases/ManageUserProfile.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GetUserProfile, UpdateUserProfile } from '@/domain/usecases/ManageUserProfile';
+import { UserProfileRepository, UserProfile } from '@/domain/repositories/UserProfileRepository';
+
+const mockProfile: UserProfile = {
+  id: 'user-1',
+  email: 'test@example.com',
+  displayName: 'テストユーザー',
+  characterType: 'dog',
+  characterName: null,
+};
+
+const createMockRepository = (): UserProfileRepository => ({
+  getProfile: vi.fn().mockResolvedValue(mockProfile),
+  updateProfile: vi.fn().mockResolvedValue({ ...mockProfile, displayName: '更新名' }),
+});
+
+describe('GetUserProfile', () => {
+  it('プロフィールを取得する', async () => {
+    const repo = createMockRepository();
+    const useCase = new GetUserProfile(repo);
+    const result = await useCase.execute();
+
+    expect(result).toBe(mockProfile);
+    expect(repo.getProfile).toHaveBeenCalled();
+  });
+});
+
+describe('UpdateUserProfile', () => {
+  it('表示名を更新する', async () => {
+    const repo = createMockRepository();
+    const useCase = new UpdateUserProfile(repo);
+    const result = await useCase.execute({ displayName: '更新名' });
+
+    expect(result.displayName).toBe('更新名');
+    expect(repo.updateProfile).toHaveBeenCalledWith({ displayName: '更新名' });
+  });
+
+  it('空の表示名の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new UpdateUserProfile(repo);
+
+    await expect(
+      useCase.execute({ displayName: '' })
+    ).rejects.toThrow('表示名は空にできません');
+  });
+
+  it('空白のみの表示名の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new UpdateUserProfile(repo);
+
+    await expect(
+      useCase.execute({ displayName: '   ' })
+    ).rejects.toThrow('表示名は空にできません');
+  });
+});

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -1,54 +1,29 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useMembers } from '@/presentation/hooks/useMembers';
+import { useAppointments } from '@/presentation/hooks/useAppointments';
+import { useHospitals } from '@/presentation/hooks/useHospitals';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { AppointmentList } from '@/components/appointments/AppointmentList';
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
-import { Appointment, Hospital } from '@/domain/entities/Appointment';
-import { appointmentApi } from '@/data/api/appointmentApi';
-import { hospitalApi } from '@/data/api/hospitalApi';
 import { Plus, X } from 'lucide-react';
 
 export default function AppointmentsPage() {
   const { userId } = useAuth();
   const { members, isLoading: membersLoading } = useMembers(userId);
-  const [appointments, setAppointments] = useState<Appointment[]>([]);
-  const [hospitals, setHospitals] = useState<Hospital[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { appointments, isLoading, createAppointment, deleteAppointment } = useAppointments();
+  const { hospitals } = useHospitals();
   const [showForm, setShowForm] = useState(false);
 
-  const fetchData = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const [apts, hosps] = await Promise.all([
-        appointmentApi.getAppointments(),
-        hospitalApi.getHospitals(),
-      ]);
-      setAppointments(apts);
-      setHospitals(hosps);
-    } catch {
-      setAppointments([]);
-      setHospitals([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
   const handleCreate = async (data: AppointmentFormData) => {
-    await appointmentApi.createAppointment(data);
+    await createAppointment(data);
     setShowForm(false);
-    await fetchData();
   };
 
   const handleDelete = async (appointmentId: string) => {
-    await appointmentApi.deleteAppointment(appointmentId);
-    await fetchData();
+    await deleteAppointment(appointmentId);
   };
 
   return (

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,30 +1,11 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { MedicationHistoryList } from '@/components/history/MedicationHistoryList';
-import { MedicationRecord, MedicationRecordEntity, DailyRecordGroup } from '@/domain/entities/MedicationRecord';
-import { recordApi } from '@/data/api/recordApi';
+import { useMedicationHistory } from '@/presentation/hooks/useMedicationHistory';
 
 export default function HistoryPage() {
-  const [groups, setGroups] = useState<DailyRecordGroup[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  const fetchHistory = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const records: MedicationRecord[] = await recordApi.getHistory();
-      setGroups(MedicationRecordEntity.groupByDate(records));
-    } catch {
-      setGroups([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchHistory();
-  }, [fetchHistory]);
+  const { groups, isLoading } = useMedicationHistory();
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,50 +1,31 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
+import { useUserProfile } from '@/presentation/hooks/useUserProfile';
 import { CharacterSelector } from '@/components/character/CharacterSelector';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
-import { apiClient } from '@/data/api/apiClient';
 import { signOut } from 'next-auth/react';
 import { LogOut, Pencil, Check, X } from 'lucide-react';
 
-interface UserProfile {
-  id: string;
-  email: string;
-  displayName: string | null;
-  characterType: string;
-  characterName: string | null;
-}
-
 export default function Settings() {
   const { email } = useAuth();
-  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const { profile, updateProfile } = useUserProfile();
   const [isEditingName, setIsEditingName] = useState(false);
   const [displayName, setDisplayName] = useState('');
   const [isSaving, setIsSaving] = useState(false);
 
-  const fetchProfile = useCallback(async () => {
-    try {
-      const data = await apiClient.get<UserProfile>('/users/me');
-      setProfile(data);
-      setDisplayName(data.displayName || '');
-    } catch {
-      // ignore
-    }
-  }, []);
-
   useEffect(() => {
-    fetchProfile();
-  }, [fetchProfile]);
+    if (profile) {
+      setDisplayName(profile.displayName || '');
+    }
+  }, [profile]);
 
   const handleSaveName = async () => {
     if (!displayName.trim()) return;
     setIsSaving(true);
     try {
-      const updated = await apiClient.put<UserProfile>('/users/me', {
-        displayName: displayName.trim(),
-      });
-      setProfile(updated);
+      await updateProfile({ displayName: displayName.trim() });
       setIsEditingName(false);
     } finally {
       setIsSaving(false);

--- a/src/data/repositories/AppointmentRepositoryImpl.ts
+++ b/src/data/repositories/AppointmentRepositoryImpl.ts
@@ -1,0 +1,24 @@
+/**
+ * 通院予約リポジトリの実装
+ */
+
+import {
+  AppointmentRepository,
+  CreateAppointmentInput,
+} from '../../domain/repositories/AppointmentRepository';
+import { Appointment } from '../../domain/entities/Appointment';
+import { appointmentApi } from '../api/appointmentApi';
+
+export class AppointmentRepositoryImpl implements AppointmentRepository {
+  async getAppointments(): Promise<Appointment[]> {
+    return appointmentApi.getAppointments();
+  }
+
+  async createAppointment(input: CreateAppointmentInput): Promise<Appointment> {
+    return appointmentApi.createAppointment(input);
+  }
+
+  async deleteAppointment(appointmentId: string): Promise<void> {
+    return appointmentApi.deleteAppointment(appointmentId);
+  }
+}

--- a/src/data/repositories/HospitalRepositoryImpl.ts
+++ b/src/data/repositories/HospitalRepositoryImpl.ts
@@ -1,0 +1,24 @@
+/**
+ * 病院リポジトリの実装
+ */
+
+import {
+  HospitalRepository,
+  CreateHospitalInput,
+} from '../../domain/repositories/HospitalRepository';
+import { Hospital } from '../../domain/entities/Appointment';
+import { hospitalApi } from '../api/hospitalApi';
+
+export class HospitalRepositoryImpl implements HospitalRepository {
+  async getHospitals(): Promise<Hospital[]> {
+    return hospitalApi.getHospitals();
+  }
+
+  async createHospital(input: CreateHospitalInput): Promise<Hospital> {
+    return hospitalApi.createHospital(input);
+  }
+
+  async deleteHospital(hospitalId: string): Promise<void> {
+    return hospitalApi.deleteHospital(hospitalId);
+  }
+}

--- a/src/data/repositories/MedicationRecordRepositoryImpl.ts
+++ b/src/data/repositories/MedicationRecordRepositoryImpl.ts
@@ -1,0 +1,20 @@
+/**
+ * 服薬記録リポジトリの実装
+ */
+
+import {
+  MedicationRecordRepository,
+  CreateRecordInput,
+} from '../../domain/repositories/MedicationRecordRepository';
+import { MedicationRecord } from '../../domain/entities/MedicationRecord';
+import { recordApi } from '../api/recordApi';
+
+export class MedicationRecordRepositoryImpl implements MedicationRecordRepository {
+  async getHistory(): Promise<MedicationRecord[]> {
+    return recordApi.getHistory();
+  }
+
+  async createRecord(input: CreateRecordInput): Promise<void> {
+    await recordApi.createRecord(input);
+  }
+}

--- a/src/data/repositories/UserProfileRepositoryImpl.ts
+++ b/src/data/repositories/UserProfileRepositoryImpl.ts
@@ -1,0 +1,20 @@
+/**
+ * ユーザープロフィールリポジトリの実装
+ */
+
+import {
+  UserProfileRepository,
+  UserProfile,
+  UpdateUserProfileInput,
+} from '../../domain/repositories/UserProfileRepository';
+import { apiClient } from '../api/apiClient';
+
+export class UserProfileRepositoryImpl implements UserProfileRepository {
+  async getProfile(): Promise<UserProfile> {
+    return apiClient.get<UserProfile>('/users/me');
+  }
+
+  async updateProfile(input: UpdateUserProfileInput): Promise<UserProfile> {
+    return apiClient.put<UserProfile>('/users/me', input);
+  }
+}

--- a/src/domain/repositories/AppointmentRepository.ts
+++ b/src/domain/repositories/AppointmentRepository.ts
@@ -1,0 +1,21 @@
+/**
+ * 通院予約リポジトリインターフェース
+ */
+
+import { Appointment } from '../entities/Appointment';
+
+export interface CreateAppointmentInput {
+  memberId: string;
+  hospitalId?: string;
+  appointmentDate: string;
+  type?: string;
+  notes?: string;
+  reminderEnabled?: boolean;
+  reminderDaysBefore?: number;
+}
+
+export interface AppointmentRepository {
+  getAppointments(): Promise<Appointment[]>;
+  createAppointment(input: CreateAppointmentInput): Promise<Appointment>;
+  deleteAppointment(appointmentId: string): Promise<void>;
+}

--- a/src/domain/repositories/HospitalRepository.ts
+++ b/src/domain/repositories/HospitalRepository.ts
@@ -1,0 +1,19 @@
+/**
+ * 病院リポジトリインターフェース
+ */
+
+import { Hospital } from '../entities/Appointment';
+
+export interface CreateHospitalInput {
+  name: string;
+  type?: string;
+  address?: string;
+  phone?: string;
+  notes?: string;
+}
+
+export interface HospitalRepository {
+  getHospitals(): Promise<Hospital[]>;
+  createHospital(input: CreateHospitalInput): Promise<Hospital>;
+  deleteHospital(hospitalId: string): Promise<void>;
+}

--- a/src/domain/repositories/MedicationRecordRepository.ts
+++ b/src/domain/repositories/MedicationRecordRepository.ts
@@ -1,0 +1,18 @@
+/**
+ * 服薬記録リポジトリインターフェース
+ */
+
+import { MedicationRecord } from '../entities/MedicationRecord';
+
+export interface CreateRecordInput {
+  memberId: string;
+  medicationId: string;
+  scheduleId?: string;
+  notes?: string;
+  dosageAmount?: string;
+}
+
+export interface MedicationRecordRepository {
+  getHistory(): Promise<MedicationRecord[]>;
+  createRecord(input: CreateRecordInput): Promise<void>;
+}

--- a/src/domain/repositories/UserProfileRepository.ts
+++ b/src/domain/repositories/UserProfileRepository.ts
@@ -1,0 +1,20 @@
+/**
+ * ユーザープロフィールリポジトリインターフェース
+ */
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  displayName: string | null;
+  characterType: string;
+  characterName: string | null;
+}
+
+export interface UpdateUserProfileInput {
+  displayName?: string;
+}
+
+export interface UserProfileRepository {
+  getProfile(): Promise<UserProfile>;
+  updateProfile(input: UpdateUserProfileInput): Promise<UserProfile>;
+}

--- a/src/domain/usecases/ManageAppointments.ts
+++ b/src/domain/usecases/ManageAppointments.ts
@@ -1,0 +1,48 @@
+/**
+ * 通院予約管理ユースケース
+ */
+
+import { Appointment, AppointmentEntity } from '../entities/Appointment';
+import {
+  AppointmentRepository,
+  CreateAppointmentInput,
+} from '../repositories/AppointmentRepository';
+
+export interface AppointmentViewModel {
+  appointment: Appointment;
+  entity: AppointmentEntity;
+}
+
+export class GetAppointments {
+  constructor(private readonly appointmentRepository: AppointmentRepository) {}
+
+  async execute(): Promise<AppointmentViewModel[]> {
+    const appointments = await this.appointmentRepository.getAppointments();
+    return appointments.map((apt) => ({
+      appointment: apt,
+      entity: new AppointmentEntity(apt),
+    }));
+  }
+}
+
+export class CreateAppointment {
+  constructor(private readonly appointmentRepository: AppointmentRepository) {}
+
+  async execute(input: CreateAppointmentInput): Promise<Appointment> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.appointmentDate) {
+      throw new Error('予約日は必須です');
+    }
+    return this.appointmentRepository.createAppointment(input);
+  }
+}
+
+export class DeleteAppointment {
+  constructor(private readonly appointmentRepository: AppointmentRepository) {}
+
+  async execute(appointmentId: string): Promise<void> {
+    return this.appointmentRepository.deleteAppointment(appointmentId);
+  }
+}

--- a/src/domain/usecases/ManageHospitals.ts
+++ b/src/domain/usecases/ManageHospitals.ts
@@ -1,0 +1,36 @@
+/**
+ * 病院管理ユースケース
+ */
+
+import { Hospital } from '../entities/Appointment';
+import {
+  HospitalRepository,
+  CreateHospitalInput,
+} from '../repositories/HospitalRepository';
+
+export class GetHospitals {
+  constructor(private readonly hospitalRepository: HospitalRepository) {}
+
+  async execute(): Promise<Hospital[]> {
+    return this.hospitalRepository.getHospitals();
+  }
+}
+
+export class CreateHospital {
+  constructor(private readonly hospitalRepository: HospitalRepository) {}
+
+  async execute(input: CreateHospitalInput): Promise<Hospital> {
+    if (!input.name.trim()) {
+      throw new Error('病院名は必須です');
+    }
+    return this.hospitalRepository.createHospital(input);
+  }
+}
+
+export class DeleteHospital {
+  constructor(private readonly hospitalRepository: HospitalRepository) {}
+
+  async execute(hospitalId: string): Promise<void> {
+    return this.hospitalRepository.deleteHospital(hospitalId);
+  }
+}

--- a/src/domain/usecases/ManageMedicationRecords.ts
+++ b/src/domain/usecases/ManageMedicationRecords.ts
@@ -1,0 +1,32 @@
+/**
+ * 服薬記録管理ユースケース
+ */
+
+import { MedicationRecordEntity, DailyRecordGroup } from '../entities/MedicationRecord';
+import {
+  MedicationRecordRepository,
+  CreateRecordInput,
+} from '../repositories/MedicationRecordRepository';
+
+export class GetMedicationHistory {
+  constructor(private readonly recordRepository: MedicationRecordRepository) {}
+
+  async execute(): Promise<DailyRecordGroup[]> {
+    const records = await this.recordRepository.getHistory();
+    return MedicationRecordEntity.groupByDate(records);
+  }
+}
+
+export class CreateMedicationRecord {
+  constructor(private readonly recordRepository: MedicationRecordRepository) {}
+
+  async execute(input: CreateRecordInput): Promise<void> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.medicationId) {
+      throw new Error('薬IDは必須です');
+    }
+    return this.recordRepository.createRecord(input);
+  }
+}

--- a/src/domain/usecases/ManageUserProfile.ts
+++ b/src/domain/usecases/ManageUserProfile.ts
@@ -1,0 +1,28 @@
+/**
+ * ユーザープロフィール管理ユースケース
+ */
+
+import {
+  UserProfileRepository,
+  UserProfile,
+  UpdateUserProfileInput,
+} from '../repositories/UserProfileRepository';
+
+export class GetUserProfile {
+  constructor(private readonly userProfileRepository: UserProfileRepository) {}
+
+  async execute(): Promise<UserProfile> {
+    return this.userProfileRepository.getProfile();
+  }
+}
+
+export class UpdateUserProfile {
+  constructor(private readonly userProfileRepository: UserProfileRepository) {}
+
+  async execute(input: UpdateUserProfileInput): Promise<UserProfile> {
+    if (input.displayName !== undefined && !input.displayName.trim()) {
+      throw new Error('表示名は空にできません');
+    }
+    return this.userProfileRepository.updateProfile(input);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -6,14 +6,26 @@
 import { MemberRepository } from '../domain/repositories/MemberRepository';
 import { MedicationRepository } from '../domain/repositories/MedicationRepository';
 import { ScheduleRepository } from '../domain/repositories/ScheduleRepository';
+import { AppointmentRepository } from '../domain/repositories/AppointmentRepository';
+import { HospitalRepository } from '../domain/repositories/HospitalRepository';
+import { MedicationRecordRepository } from '../domain/repositories/MedicationRecordRepository';
+import { UserProfileRepository } from '../domain/repositories/UserProfileRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
+import { AppointmentRepositoryImpl } from '../data/repositories/AppointmentRepositoryImpl';
+import { HospitalRepositoryImpl } from '../data/repositories/HospitalRepositoryImpl';
+import { MedicationRecordRepositoryImpl } from '../data/repositories/MedicationRecordRepositoryImpl';
+import { UserProfileRepositoryImpl } from '../data/repositories/UserProfileRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
   medicationRepository: MedicationRepository;
   scheduleRepository: ScheduleRepository;
+  appointmentRepository: AppointmentRepository;
+  hospitalRepository: HospitalRepository;
+  medicationRecordRepository: MedicationRecordRepository;
+  userProfileRepository: UserProfileRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -25,6 +37,10 @@ export const getDIContainer = (): DIContainer => {
       memberRepository: new MemberRepositoryImpl(),
       medicationRepository: new MedicationRepositoryImpl(),
       scheduleRepository: new ScheduleRepositoryImpl(),
+      appointmentRepository: new AppointmentRepositoryImpl(),
+      hospitalRepository: new HospitalRepositoryImpl(),
+      medicationRecordRepository: new MedicationRecordRepositoryImpl(),
+      userProfileRepository: new UserProfileRepositoryImpl(),
     };
   }
   return container;

--- a/src/presentation/hooks/useHospitals.ts
+++ b/src/presentation/hooks/useHospitals.ts
@@ -1,0 +1,70 @@
+/**
+ * 病院管理カスタムフック（ViewModel）
+ * Presentation層とDomain層を繋ぐ
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Hospital } from '../../domain/entities/Appointment';
+import { GetHospitals, CreateHospital, DeleteHospital } from '../../domain/usecases/ManageHospitals';
+import { CreateHospitalInput } from '../../domain/repositories/HospitalRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface UseHospitalsResult {
+  hospitals: Hospital[];
+  isLoading: boolean;
+  error: Error | null;
+  createHospital: (input: CreateHospitalInput) => Promise<void>;
+  deleteHospital: (hospitalId: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useHospitals = (): UseHospitalsResult => {
+  const useCases = useMemo(() => {
+    const { hospitalRepository } = getDIContainer();
+    return {
+      getHospitals: new GetHospitals(hospitalRepository),
+      createHospital: new CreateHospital(hospitalRepository),
+      deleteHospital: new DeleteHospital(hospitalRepository),
+    };
+  }, []);
+
+  const [hospitals, setHospitals] = useState<Hospital[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchHospitals = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await useCases.getHospitals.execute();
+      setHospitals(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [useCases]);
+
+  useEffect(() => {
+    fetchHospitals();
+  }, [fetchHospitals]);
+
+  const handleCreateHospital = async (input: CreateHospitalInput) => {
+    await useCases.createHospital.execute(input);
+    await fetchHospitals();
+  };
+
+  const handleDeleteHospital = async (hospitalId: string) => {
+    await useCases.deleteHospital.execute(hospitalId);
+    await fetchHospitals();
+  };
+
+  return {
+    hospitals,
+    isLoading,
+    error,
+    createHospital: handleCreateHospital,
+    deleteHospital: handleDeleteHospital,
+    refetch: fetchHospitals,
+  };
+};

--- a/src/presentation/hooks/useMedicationHistory.ts
+++ b/src/presentation/hooks/useMedicationHistory.ts
@@ -1,0 +1,53 @@
+/**
+ * 服薬履歴カスタムフック（ViewModel）
+ * Presentation層とDomain層を繋ぐ
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { DailyRecordGroup } from '../../domain/entities/MedicationRecord';
+import { GetMedicationHistory } from '../../domain/usecases/ManageMedicationRecords';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface UseMedicationHistoryResult {
+  groups: DailyRecordGroup[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export const useMedicationHistory = (): UseMedicationHistoryResult => {
+  const useCases = useMemo(() => {
+    const { medicationRecordRepository } = getDIContainer();
+    return {
+      getHistory: new GetMedicationHistory(medicationRecordRepository),
+    };
+  }, []);
+
+  const [groups, setGroups] = useState<DailyRecordGroup[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await useCases.getHistory.execute();
+      setGroups(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [useCases]);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  return {
+    groups,
+    isLoading,
+    error,
+    refetch: fetchHistory,
+  };
+};

--- a/src/presentation/hooks/useUserProfile.ts
+++ b/src/presentation/hooks/useUserProfile.ts
@@ -1,0 +1,62 @@
+/**
+ * ユーザープロフィール管理カスタムフック（ViewModel）
+ * Presentation層とDomain層を繋ぐ
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { UserProfile, UpdateUserProfileInput } from '../../domain/repositories/UserProfileRepository';
+import { GetUserProfile, UpdateUserProfile } from '../../domain/usecases/ManageUserProfile';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface UseUserProfileResult {
+  profile: UserProfile | null;
+  isLoading: boolean;
+  error: Error | null;
+  updateProfile: (input: UpdateUserProfileInput) => Promise<UserProfile>;
+  refetch: () => Promise<void>;
+}
+
+export const useUserProfile = (): UseUserProfileResult => {
+  const useCases = useMemo(() => {
+    const { userProfileRepository } = getDIContainer();
+    return {
+      getProfile: new GetUserProfile(userProfileRepository),
+      updateProfile: new UpdateUserProfile(userProfileRepository),
+    };
+  }, []);
+
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchProfile = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await useCases.getProfile.execute();
+      setProfile(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [useCases]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  const handleUpdateProfile = async (input: UpdateUserProfileInput): Promise<UserProfile> => {
+    const updated = await useCases.updateProfile.execute(input);
+    setProfile(updated);
+    return updated;
+  };
+
+  return {
+    profile,
+    isLoading,
+    error,
+    updateProfile: handleUpdateProfile,
+    refetch: fetchProfile,
+  };
+};


### PR DESCRIPTION
## 概要

Closes #116

通院予約・病院・服薬記録・ユーザープロフィール機能のアーキテクチャを、
メンバー・薬・スケジュール機能と同じクリーンアーキテクチャパターンに統一。

## 変更内容

- リポジトリインターフェース4件追加（Appointment, Hospital, MedicationRecord, UserProfile）
- データリポジトリ実装4件追加
- ユースケース8件追加
- プレゼンテーションフック4件追加（useAppointments, useHospitals, useMedicationHistory, useUserProfile）
- DIContainerに新規リポジトリ4件を登録
- ページ3件のリファクタリング（appointments, history, settings）
- ユースケーステスト18件追加

## アーキテクチャ

全機能で統一された依存関係フロー:
```
Page → Hook → UseCase → Repository Interface → Repository Impl → API
```

## テスト結果
- 102テスト全パス
- ビルド成功