### PR TITLE
テストカバレッジの改善（102→152テスト）

### DIFF
--- a/src/__tests__/data/api/mappers.test.ts
+++ b/src/__tests__/data/api/mappers.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toMember,
+  toMedication,
+  toMedicationRecord,
+  toHospital,
+  toAppointment,
+  toSchedule,
+} from '@/data/api/mappers';
+import { BackendMember, BackendMedication, BackendRecord, BackendHospital, BackendAppointment, BackendSchedule } from '@/data/api/types';
+
+describe('toMember', () => {
+  const validBackend: BackendMember = {
+    id: 'mem-1',
+    userId: 'user-1',
+    name: 'テスト太郎',
+    memberType: 'human',
+    petType: undefined,
+    birthDate: '1990-05-15',
+    notes: 'メモ',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-02T00:00:00Z',
+  };
+
+  it('完全なデータを正しく変換する', () => {
+    const result = toMember(validBackend);
+    expect(result.id).toBe('mem-1');
+    expect(result.userId).toBe('user-1');
+    expect(result.name).toBe('テスト太郎');
+    expect(result.memberType).toBe('human');
+    expect(result.birthDate).toBeInstanceOf(Date);
+    expect(result.notes).toBe('メモ');
+    expect(result.createdAt).toBeInstanceOf(Date);
+    expect(result.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('birthDateがない場合undefinedを返す', () => {
+    const result = toMember({ ...validBackend, birthDate: undefined });
+    expect(result.birthDate).toBeUndefined();
+  });
+
+  it('memberTypeがない場合humanをデフォルトにする', () => {
+    const result = toMember({ ...validBackend, memberType: undefined });
+    expect(result.memberType).toBe('human');
+  });
+
+  it('ペットタイプを正しく変換する', () => {
+    const result = toMember({ ...validBackend, memberType: 'pet', petType: 'dog' });
+    expect(result.memberType).toBe('pet');
+    expect(result.petType).toBe('dog');
+  });
+});
+
+describe('toMedication', () => {
+  const validBackend: BackendMedication = {
+    id: 'med-1',
+    memberId: 'mem-1',
+    userId: 'user-1',
+    name: 'テスト薬',
+    category: 'regular',
+    dosageAmount: '1錠',
+    frequency: '1日3回',
+    stockQuantity: 30,
+    stockAlertDate: '2025-06-01',
+    instructions: '食後に服用',
+    isActive: true,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-02T00:00:00Z',
+  };
+
+  it('完全なデータを正しく変換する', () => {
+    const result = toMedication(validBackend);
+    expect(result.id).toBe('med-1');
+    expect(result.name).toBe('テスト薬');
+    expect(result.category).toBe('regular');
+    expect(result.dosage).toBe('1錠');
+    expect(result.frequency).toBe('1日3回');
+    expect(result.stockQuantity).toBe(30);
+    expect(result.stockAlertDate).toBeInstanceOf(Date);
+    expect(result.instructions).toBe('食後に服用');
+    expect(result.isActive).toBe(true);
+  });
+
+  it('categoryがない場合regularをデフォルトにする', () => {
+    const result = toMedication({ ...validBackend, category: undefined });
+    expect(result.category).toBe('regular');
+  });
+
+  it('isActiveがundefinedの場合trueをデフォルトにする', () => {
+    const result = toMedication({ ...validBackend, isActive: undefined });
+    expect(result.isActive).toBe(true);
+  });
+
+  it('stockAlertDateがない場合undefinedを返す', () => {
+    const result = toMedication({ ...validBackend, stockAlertDate: undefined });
+    expect(result.stockAlertDate).toBeUndefined();
+  });
+
+  it('オプショナルフィールドがすべてundefinedでも変換できる', () => {
+    const result = toMedication({
+      ...validBackend,
+      dosageAmount: undefined,
+      frequency: undefined,
+      stockQuantity: undefined,
+      instructions: undefined,
+    });
+    expect(result.dosage).toBeUndefined();
+    expect(result.frequency).toBeUndefined();
+    expect(result.stockQuantity).toBeUndefined();
+    expect(result.instructions).toBeUndefined();
+  });
+});
+
+describe('toMedicationRecord', () => {
+  const validBackend: BackendRecord = {
+    id: 'rec-1',
+    userId: 'user-1',
+    memberId: 'mem-1',
+    memberName: 'テスト太郎',
+    medicationId: 'med-1',
+    medicationName: 'テスト薬',
+    scheduleId: 'sched-1',
+    takenAt: '2025-06-15T08:00:00Z',
+    notes: '服用メモ',
+    dosageAmount: '1錠',
+  };
+
+  it('完全なデータを正しく変換する', () => {
+    const result = toMedicationRecord(validBackend);
+    expect(result.id).toBe('rec-1');
+    expect(result.memberName).toBe('テスト太郎');
+    expect(result.medicationName).toBe('テスト薬');
+    expect(result.takenAt).toBeInstanceOf(Date);
+    expect(result.notes).toBe('服用メモ');
+    expect(result.dosageAmount).toBe('1錠');
+  });
+
+  it('memberNameがundefinedの場合空文字を返す', () => {
+    const result = toMedicationRecord({ ...validBackend, memberName: undefined });
+    expect(result.memberName).toBe('');
+  });
+
+  it('medicationNameがundefinedの場合空文字を返す', () => {
+    const result = toMedicationRecord({ ...validBackend, medicationName: undefined });
+    expect(result.medicationName).toBe('');
+  });
+
+  it('オプショナルフィールドを正しく処理する', () => {
+    const result = toMedicationRecord({
+      ...validBackend,
+      scheduleId: undefined,
+      notes: undefined,
+      dosageAmount: undefined,
+    });
+    expect(result.scheduleId).toBeUndefined();
+    expect(result.notes).toBeUndefined();
+    expect(result.dosageAmount).toBeUndefined();
+  });
+});
+
+describe('toHospital', () => {
+  const validBackend: BackendHospital = {
+    id: 'hosp-1',
+    userId: 'user-1',
+    name: 'テスト病院',
+    hospitalType: 'checkup',
+    address: '東京都渋谷区',
+    phoneNumber: '03-1234-5678',
+    notes: '備考',
+    createdAt: '2025-01-01T00:00:00Z',
+  };
+
+  it('完全なデータを正しく変換する', () => {
+    const result = toHospital(validBackend);
+    expect(result.id).toBe('hosp-1');
+    expect(result.name).toBe('テスト病院');
+    expect(result.hospitalType).toBe('checkup');
+    expect(result.address).toBe('東京都渋谷区');
+    expect(result.phoneNumber).toBe('03-1234-5678');
+    expect(result.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('オプショナルフィールドがundefinedでも変換できる', () => {
+    const result = toHospital({
+      ...validBackend,
+      hospitalType: undefined,
+      address: undefined,
+      phoneNumber: undefined,
+      notes: undefined,
+    });
+    expect(result.hospitalType).toBeUndefined();
+    expect(result.address).toBeUndefined();
+    expect(result.phoneNumber).toBeUndefined();
+    expect(result.notes).toBeUndefined();
+  });
+});
+
+describe('toAppointment', () => {
+  const validBackend: BackendAppointment = {
+    id: 'apt-1',
+    userId: 'user-1',
+    memberId: 'mem-1',
+    memberName: 'テスト太郎',
+    hospitalId: 'hosp-1',
+    hospitalName: 'テスト病院',
+    appointmentType: 'checkup',
+    appointmentDate: '2025-06-01T00:00:00Z',
+    description: '定期検診',
+    reminderEnabled: true,
+    reminderDaysBefore: 3,
+    createdAt: '2025-01-01T00:00:00Z',
+  };
+
+  it('完全なデータを正しく変換する', () => {
+    const result = toAppointment(validBackend);
+    expect(result.id).toBe('apt-1');
+    expect(result.memberName).toBe('テスト太郎');
+    expect(result.hospitalName).toBe('テスト病院');
+    expect(result.appointmentType).toBe('checkup');
+    expect(result.appointmentDate).toBeInstanceOf(Date);
+    expect(result.reminderEnabled).toBe(true);
+    expect(result.reminderDaysBefore).toBe(3);
+  });
+
+  it('reminderEnabledがundefinedの場合trueをデフォルトにする', () => {
+    const result = toAppointment({ ...validBackend, reminderEnabled: undefined });
+    expect(result.reminderEnabled).toBe(true);
+  });
+
+  it('reminderDaysBeforeがundefinedの場合1をデフォルトにする', () => {
+    const result = toAppointment({ ...validBackend, reminderDaysBefore: undefined });
+    expect(result.reminderDaysBefore).toBe(1);
+  });
+
+  it('オプショナルフィールドがundefinedでも変換できる', () => {
+    const result = toAppointment({
+      ...validBackend,
+      memberName: undefined,
+      hospitalId: undefined,
+      hospitalName: undefined,
+      appointmentType: undefined,
+      description: undefined,
+    });
+    expect(result.memberName).toBeUndefined();
+    expect(result.hospitalId).toBeUndefined();
+    expect(result.hospitalName).toBeUndefined();
+    expect(result.appointmentType).toBeUndefined();
+    expect(result.description).toBeUndefined();
+  });
+});
+
+describe('toSchedule', () => {
+  const validBackend: BackendSchedule = {
+    id: 'sched-1',
+    medicationId: 'med-1',
+    userId: 'user-1',
+    memberId: 'mem-1',
+    scheduledTime: '08:00',
+    daysOfWeek: ['mon', 'wed', 'fri'],
+    isEnabled: true,
+    reminderMinutesBefore: 15,
+    createdAt: '2025-01-01T00:00:00Z',
+  };
+
+  it('完全なデータを正しく変換する', () => {
+    const result = toSchedule(validBackend);
+    expect(result.id).toBe('sched-1');
+    expect(result.medicationId).toBe('med-1');
+    expect(result.scheduledTime).toBe('08:00');
+    expect(result.daysOfWeek).toEqual(['mon', 'wed', 'fri']);
+    expect(result.isEnabled).toBe(true);
+    expect(result.reminderMinutesBefore).toBe(15);
+    expect(result.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('daysOfWeekがundefinedの場合空配列をデフォルトにする', () => {
+    const result = toSchedule({ ...validBackend, daysOfWeek: undefined });
+    expect(result.daysOfWeek).toEqual([]);
+  });
+
+  it('isEnabledがundefinedの場合trueをデフォルトにする', () => {
+    const result = toSchedule({ ...validBackend, isEnabled: undefined });
+    expect(result.isEnabled).toBe(true);
+  });
+
+  it('reminderMinutesBeforeがundefinedの場合10をデフォルトにする', () => {
+    const result = toSchedule({ ...validBackend, reminderMinutesBefore: undefined });
+    expect(result.reminderMinutesBefore).toBe(10);
+  });
+});

--- a/src/__tests__/domain/usecases/GetTodaySchedules.test.ts
+++ b/src/__tests__/domain/usecases/GetTodaySchedules.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GetTodaySchedules } from '@/domain/usecases/GetTodaySchedules';
+import { ScheduleRepository, TodayScheduleItem } from '@/domain/repositories/ScheduleRepository';
+import { Schedule } from '@/domain/entities/Schedule';
+
+const createSchedule = (overrides: Partial<Schedule> = {}): Schedule => ({
+  id: 'sched-1',
+  medicationId: 'med-1',
+  userId: 'user-1',
+  memberId: 'mem-1',
+  scheduledTime: '08:00',
+  daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+  isEnabled: true,
+  reminderMinutesBefore: 10,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+const createScheduleItem = (overrides: Partial<TodayScheduleItem> = {}): TodayScheduleItem => ({
+  schedule: createSchedule(),
+  medicationName: 'テスト薬',
+  memberName: 'テスト太郎',
+  memberType: 'human',
+  isCompleted: false,
+  ...overrides,
+});
+
+const createMockRepository = (items: TodayScheduleItem[] = []): ScheduleRepository => ({
+  getTodaySchedules: vi.fn().mockResolvedValue(items),
+  createSchedule: vi.fn(),
+  updateSchedule: vi.fn(),
+  deleteSchedule: vi.fn(),
+  markAsCompleted: vi.fn(),
+});
+
+describe('GetTodaySchedules', () => {
+  it('アクティブなスケジュールをViewModelとして返す', async () => {
+    const items = [createScheduleItem()];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    // 月曜日を指定
+    const monday = new Date('2025-06-02T10:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].scheduleId).toBe('sched-1');
+    expect(result[0].medicationName).toBe('テスト薬');
+    expect(result[0].memberName).toBe('テスト太郎');
+    expect(result[0].scheduledTime).toBe('08:00');
+  });
+
+  it('無効なスケジュールをフィルタリングする', async () => {
+    const items = [
+      createScheduleItem({
+        schedule: createSchedule({ isEnabled: false }),
+      }),
+    ];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    const monday = new Date('2025-06-02T10:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('曜日が一致しないスケジュールをフィルタリングする', async () => {
+    const items = [
+      createScheduleItem({
+        schedule: createSchedule({ daysOfWeek: ['sat', 'sun'] }),
+      }),
+    ];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    // 月曜日を指定（sat, sunのみ有効なスケジュール）
+    const monday = new Date('2025-06-02T10:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('時刻順にソートする', async () => {
+    const items = [
+      createScheduleItem({
+        schedule: createSchedule({ id: 'sched-2', scheduledTime: '20:00' }),
+      }),
+      createScheduleItem({
+        schedule: createSchedule({ id: 'sched-1', scheduledTime: '08:00' }),
+      }),
+      createScheduleItem({
+        schedule: createSchedule({ id: 'sched-3', scheduledTime: '12:00' }),
+      }),
+    ];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    const monday = new Date('2025-06-02T07:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result[0].scheduledTime).toBe('08:00');
+    expect(result[1].scheduledTime).toBe('12:00');
+    expect(result[2].scheduledTime).toBe('20:00');
+  });
+
+  it('完了したスケジュールのステータスをcompletedにする', async () => {
+    const items = [
+      createScheduleItem({ isCompleted: true }),
+    ];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    const monday = new Date('2025-06-02T10:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result[0].status).toBe('completed');
+  });
+
+  it('予定時刻を過ぎた未完了スケジュールのステータスをoverdueにする', async () => {
+    const items = [
+      createScheduleItem({
+        schedule: createSchedule({ scheduledTime: '08:00' }),
+        isCompleted: false,
+      }),
+    ];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    // 10:00に確認（08:00は過ぎている）
+    const monday = new Date('2025-06-02T10:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result[0].status).toBe('overdue');
+  });
+
+  it('予定時刻前の未完了スケジュールのステータスをpendingにする', async () => {
+    const items = [
+      createScheduleItem({
+        schedule: createSchedule({ scheduledTime: '14:00' }),
+        isCompleted: false,
+      }),
+    ];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    // 10:00に確認（14:00はまだ来ていない）
+    const monday = new Date('2025-06-02T10:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result[0].status).toBe('pending');
+  });
+
+  it('空のスケジュール一覧を正しく処理する', async () => {
+    const repo = createMockRepository([]);
+    const useCase = new GetTodaySchedules(repo);
+
+    const result = await useCase.execute({ userId: 'user-1' });
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/__tests__/domain/usecases/ManageMedications.test.ts
+++ b/src/__tests__/domain/usecases/ManageMedications.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GetMedications, CreateMedication, UpdateMedication, DeleteMedication } from '@/domain/usecases/ManageMedications';
+import { MedicationRepository } from '@/domain/repositories/MedicationRepository';
+import { Medication } from '@/domain/entities/Medication';
+
+const mockMedication: Medication = {
+  id: 'med-1',
+  memberId: 'mem-1',
+  userId: 'user-1',
+  name: 'テスト薬',
+  category: 'regular',
+  dosage: '1錠',
+  frequency: '1日3回',
+  stockQuantity: 30,
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const createMockRepository = (): MedicationRepository => ({
+  getMedicationsByMember: vi.fn().mockResolvedValue([mockMedication]),
+  getMedicationById: vi.fn().mockResolvedValue(mockMedication),
+  createMedication: vi.fn().mockResolvedValue(mockMedication),
+  updateMedication: vi.fn().mockResolvedValue({ ...mockMedication, name: '更新薬' }),
+  deleteMedication: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('GetMedications', () => {
+  it('薬一覧をViewModelとして取得する', async () => {
+    const repo = createMockRepository();
+    const useCase = new GetMedications(repo);
+    const result = await useCase.execute('mem-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].medication.name).toBe('テスト薬');
+    expect(result[0].displayInfo).toBeDefined();
+    expect(result[0].displayInfo.name).toBe('テスト薬');
+    expect(typeof result[0].isLowStock).toBe('boolean');
+  });
+
+  it('在庫少の薬をisLowStock=trueで返す', async () => {
+    const repo = createMockRepository();
+    // stockAlertDateが10日後で在庫が2日分 → 在庫少
+    const lowStockMed: Medication = {
+      ...mockMedication,
+      stockQuantity: 2,
+      stockAlertDate: new Date(Date.now() + 10 * 86400000),
+    };
+    (repo.getMedicationsByMember as ReturnType<typeof vi.fn>).mockResolvedValue([lowStockMed]);
+    const useCase = new GetMedications(repo);
+    const result = await useCase.execute('mem-1');
+
+    expect(result[0].isLowStock).toBe(true);
+  });
+
+  it('空の配列を返す場合もエラーにならない', async () => {
+    const repo = createMockRepository();
+    (repo.getMedicationsByMember as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const useCase = new GetMedications(repo);
+    const result = await useCase.execute('mem-1');
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('CreateMedication', () => {
+  it('有効な入力で薬を作成する', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMedication(repo);
+    const result = await useCase.execute({
+      memberId: 'mem-1',
+      userId: 'user-1',
+      name: 'テスト薬',
+      category: 'regular',
+    });
+
+    expect(result.name).toBe('テスト薬');
+    expect(repo.createMedication).toHaveBeenCalled();
+  });
+
+  it('空の名前の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMedication(repo);
+
+    await expect(
+      useCase.execute({
+        memberId: 'mem-1',
+        userId: 'user-1',
+        name: '',
+        category: 'regular',
+      })
+    ).rejects.toThrow('薬の名前は必須です');
+  });
+
+  it('空白のみの名前の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMedication(repo);
+
+    await expect(
+      useCase.execute({
+        memberId: 'mem-1',
+        userId: 'user-1',
+        name: '   ',
+        category: 'regular',
+      })
+    ).rejects.toThrow('薬の名前は必須です');
+  });
+});
+
+describe('UpdateMedication', () => {
+  it('存在する薬を更新する', async () => {
+    const repo = createMockRepository();
+    const useCase = new UpdateMedication(repo);
+    const result = await useCase.execute('med-1', { name: '更新薬' });
+
+    expect(result.name).toBe('更新薬');
+    expect(repo.getMedicationById).toHaveBeenCalledWith('med-1');
+    expect(repo.updateMedication).toHaveBeenCalledWith('med-1', { name: '更新薬' });
+  });
+
+  it('存在しない薬の更新でエラーを投げる', async () => {
+    const repo = createMockRepository();
+    (repo.getMedicationById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const useCase = new UpdateMedication(repo);
+
+    await expect(
+      useCase.execute('nonexistent', { name: '更新' })
+    ).rejects.toThrow('薬が見つかりません');
+  });
+});
+
+describe('DeleteMedication', () => {
+  it('存在する薬を削除する', async () => {
+    const repo = createMockRepository();
+    const useCase = new DeleteMedication(repo);
+    await useCase.execute('med-1');
+
+    expect(repo.getMedicationById).toHaveBeenCalledWith('med-1');
+    expect(repo.deleteMedication).toHaveBeenCalledWith('med-1');
+  });
+
+  it('存在しない薬の削除でエラーを投げる', async () => {
+    const repo = createMockRepository();
+    (repo.getMedicationById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const useCase = new DeleteMedication(repo);
+
+    await expect(
+      useCase.execute('nonexistent')
+    ).rejects.toThrow('薬が見つかりません');
+  });
+});

--- a/src/__tests__/domain/usecases/ManageMembers.test.ts
+++ b/src/__tests__/domain/usecases/ManageMembers.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GetMembers, CreateMember, UpdateMember, DeleteMember } from '@/domain/usecases/ManageMembers';
+import { MemberRepository } from '@/domain/repositories/MemberRepository';
+import { Member } from '@/domain/entities/Member';
+
+const mockMember: Member = {
+  id: 'mem-1',
+  userId: 'user-1',
+  memberType: 'human',
+  name: 'テスト太郎',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const createMockRepository = (): MemberRepository => ({
+  getMembers: vi.fn().mockResolvedValue([mockMember]),
+  getMemberById: vi.fn().mockResolvedValue(mockMember),
+  createMember: vi.fn().mockResolvedValue(mockMember),
+  updateMember: vi.fn().mockResolvedValue({ ...mockMember, name: '更新太郎' }),
+  deleteMember: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('GetMembers', () => {
+  it('メンバー一覧を取得する', async () => {
+    const repo = createMockRepository();
+    const useCase = new GetMembers(repo);
+    const result = await useCase.execute('user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('テスト太郎');
+    expect(repo.getMembers).toHaveBeenCalledWith('user-1');
+  });
+
+  it('空の配列を返す場合もエラーにならない', async () => {
+    const repo = createMockRepository();
+    (repo.getMembers as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const useCase = new GetMembers(repo);
+    const result = await useCase.execute('user-1');
+
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('CreateMember', () => {
+  it('有効な入力でメンバーを作成する', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMember(repo);
+    const result = await useCase.execute({
+      userId: 'user-1',
+      memberType: 'human',
+      name: 'テスト太郎',
+    });
+
+    expect(result.name).toBe('テスト太郎');
+    expect(repo.createMember).toHaveBeenCalled();
+  });
+
+  it('空の名前の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMember(repo);
+
+    await expect(
+      useCase.execute({ userId: 'user-1', memberType: 'human', name: '' })
+    ).rejects.toThrow('メンバー名は必須です');
+  });
+
+  it('空白のみの名前の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateMember(repo);
+
+    await expect(
+      useCase.execute({ userId: 'user-1', memberType: 'human', name: '   ' })
+    ).rejects.toThrow('メンバー名は必須です');
+  });
+});
+
+describe('UpdateMember', () => {
+  it('存在するメンバーを更新する', async () => {
+    const repo = createMockRepository();
+    const useCase = new UpdateMember(repo);
+    const result = await useCase.execute('mem-1', { name: '更新太郎' });
+
+    expect(result.name).toBe('更新太郎');
+    expect(repo.getMemberById).toHaveBeenCalledWith('mem-1');
+    expect(repo.updateMember).toHaveBeenCalledWith('mem-1', { name: '更新太郎' });
+  });
+
+  it('存在しないメンバーの更新でエラーを投げる', async () => {
+    const repo = createMockRepository();
+    (repo.getMemberById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const useCase = new UpdateMember(repo);
+
+    await expect(
+      useCase.execute('nonexistent', { name: '更新' })
+    ).rejects.toThrow('メンバーが見つかりません');
+  });
+});
+
+describe('DeleteMember', () => {
+  it('存在するメンバーを削除する', async () => {
+    const repo = createMockRepository();
+    const useCase = new DeleteMember(repo);
+    await useCase.execute('mem-1');
+
+    expect(repo.getMemberById).toHaveBeenCalledWith('mem-1');
+    expect(repo.deleteMember).toHaveBeenCalledWith('mem-1');
+  });
+
+  it('存在しないメンバーの削除でエラーを投げる', async () => {
+    const repo = createMockRepository();
+    (repo.getMemberById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const useCase = new DeleteMember(repo);
+
+    await expect(
+      useCase.execute('nonexistent')
+    ).rejects.toThrow('メンバーが見つかりません');
+  });
+});


### PR DESCRIPTION
## 概要

Closes #118

マッパー層とユースケース層のテストカバレッジを大幅に拡充。

## 変更内容

- マッパーテスト23件追加（toMember, toMedication, toMedicationRecord, toHospital, toAppointment, toSchedule）
- GetTodaySchedulesテスト8件追加（フィルタリング、ソート、ステータス計算）
- ManageMembersテスト9件追加（CRUD + バリデーション + 存在チェック）
- ManageMedicationsテスト10件追加（CRUD + ViewModel生成 + 在庫判定）

## テスト結果
- 102件 → 152件（+50件）
- 全テストパス
- ビルド成功