### PR TITLE
テスト品質の改善（181→216テスト）

### DIFF
--- a/src/__tests__/domain/entities/AppointmentEntity.test.ts
+++ b/src/__tests__/domain/entities/AppointmentEntity.test.ts
@@ -114,5 +114,30 @@ describe('AppointmentEntity', () => {
       const entity = new AppointmentEntity(createAppointment());
       expect(entity.getTypeLabel()).toBe('');
     });
+
+    it('全種別のラベルが正しい', () => {
+      const cases: [string, string][] = [
+        ['treatment', '治療'],
+        ['vaccination', '予防接種'],
+        ['surgery', '手術'],
+        ['consultation', '相談'],
+        ['other', 'その他'],
+      ];
+      for (const [type, label] of cases) {
+        const entity = new AppointmentEntity(
+          createAppointment({ appointmentType: type })
+        );
+        expect(entity.getTypeLabel()).toBe(label);
+      }
+    });
+  });
+
+  describe('id / data', () => {
+    it('プロパティにアクセスできる', () => {
+      const appointment = createAppointment({ id: 'apt-xyz' });
+      const entity = new AppointmentEntity(appointment);
+      expect(entity.id).toBe('apt-xyz');
+      expect(entity.data).toBe(appointment);
+    });
   });
 });

--- a/src/__tests__/domain/entities/MedicationEntity.test.ts
+++ b/src/__tests__/domain/entities/MedicationEntity.test.ts
@@ -114,5 +114,56 @@ describe('MedicationEntity', () => {
       const entity = new MedicationEntity(createMedication({ dosage: '1錠' }));
       expect(entity.getDisplayInfo().dosageInfo).toBe('1錠');
     });
+
+    it('頻度のみの場合はそのまま返す', () => {
+      const entity = new MedicationEntity(createMedication({ frequency: '1日3回' }));
+      expect(entity.getDisplayInfo().dosageInfo).toBe('1日3回');
+    });
+
+    it('用量・頻度どちらもない場合は空文字を返す', () => {
+      const entity = new MedicationEntity(createMedication());
+      expect(entity.getDisplayInfo().dosageInfo).toBe('');
+    });
+
+    it('全カテゴリのラベルが正しい', () => {
+      const cases: [Medication['category'], string][] = [
+        ['regular', '常用薬'],
+        ['supplement', 'サプリメント'],
+        ['prn', '頓服薬'],
+        ['inhaler', '吸入薬'],
+        ['flea_tick', 'ノミ・ダニ薬'],
+        ['heartworm', 'フィラリア薬'],
+      ];
+      for (const [category, label] of cases) {
+        const entity = new MedicationEntity(createMedication({ category }));
+        expect(entity.getDisplayInfo().categoryLabel).toBe(label);
+      }
+    });
+
+    it('名前が正しく返される', () => {
+      const entity = new MedicationEntity(createMedication({ name: 'ロキソニン' }));
+      expect(entity.getDisplayInfo().name).toBe('ロキソニン');
+    });
+  });
+
+  describe('isLowStock (境界値)', () => {
+    it('在庫数が警告日までの日数と等しい場合 false を返す', () => {
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 5);
+      const entity = new MedicationEntity(
+        createMedication({ stockQuantity: 5, stockAlertDate: futureDate })
+      );
+      expect(entity.isLowStock()).toBe(false);
+    });
+  });
+
+  describe('id / name / data', () => {
+    it('プロパティにアクセスできる', () => {
+      const med = createMedication({ id: 'med-xyz', name: 'アスピリン' });
+      const entity = new MedicationEntity(med);
+      expect(entity.id).toBe('med-xyz');
+      expect(entity.name).toBe('アスピリン');
+      expect(entity.data).toBe(med);
+    });
   });
 });

--- a/src/__tests__/domain/entities/MedicationRecordEntity.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordEntity.test.ts
@@ -80,5 +80,19 @@ describe('MedicationRecordEntity', () => {
       const result = MedicationRecordEntity.formatTime(new Date('2024-06-15T14:05:00'));
       expect(result).toBe('14:05');
     });
+
+    it('深夜0時を 00:00 で返す', () => {
+      const result = MedicationRecordEntity.formatTime(new Date('2024-06-15T00:00:00'));
+      expect(result).toBe('00:00');
+    });
+  });
+
+  describe('groupByDate (エッジケース)', () => {
+    it('1件のみの場合もグループ化できる', () => {
+      const records = [createRecord({ id: 'r1' })];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].records).toHaveLength(1);
+    });
   });
 });

--- a/src/__tests__/domain/entities/MemberEntity.test.ts
+++ b/src/__tests__/domain/entities/MemberEntity.test.ts
@@ -58,6 +58,35 @@ describe('MemberEntity', () => {
     });
   });
 
+  describe('getAge (境界値)', () => {
+    it('今日が誕生日の場合、正しい年齢を返す', () => {
+      const birthDate = new Date();
+      birthDate.setFullYear(birthDate.getFullYear() - 3);
+      const entity = new MemberEntity(createMember({ birthDate }));
+      expect(entity.getAge()).toBe(3);
+    });
+
+    it('誕生日が来月の場合、1歳少ない年齢を返す', () => {
+      const birthDate = new Date();
+      birthDate.setFullYear(birthDate.getFullYear() - 10);
+      birthDate.setMonth(birthDate.getMonth() + 1);
+      const entity = new MemberEntity(createMember({ birthDate }));
+      expect(entity.getAge()).toBe(9);
+    });
+  });
+
+  describe('getIconType', () => {
+    it('人間メンバーのアイコン種別を返す', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'human' }));
+      expect(entity.getIconType()).toEqual({ memberType: 'human', petType: undefined });
+    });
+
+    it('ペットメンバーのアイコン種別を返す', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'pet', petType: 'cat' }));
+      expect(entity.getIconType()).toEqual({ memberType: 'pet', petType: 'cat' });
+    });
+  });
+
   describe('id / name / data', () => {
     it('プロパティにアクセスできる', () => {
       const member = createMember({ id: 'abc', name: '花子' });

--- a/src/__tests__/domain/entities/ScheduleEntity.test.ts
+++ b/src/__tests__/domain/entities/ScheduleEntity.test.ts
@@ -59,6 +59,32 @@ describe('ScheduleEntity', () => {
     });
   });
 
+  describe('getStatus (境界値)', () => {
+    it('予定時刻ちょうどの場合 pending を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '08:00' }));
+      const now = new Date('2024-06-01T08:00:00');
+      expect(entity.getStatus(now, false)).toBe('pending');
+    });
+
+    it('完了済みなら時刻に関係なく completed を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '14:00' }));
+      const now = new Date('2024-06-01T09:00:00');
+      expect(entity.getStatus(now, true)).toBe('completed');
+    });
+  });
+
+  describe('isActiveOnDay (全曜日)', () => {
+    it('全曜日が有効な場合、全ての日で true を返す', () => {
+      const entity = new ScheduleEntity(
+        createSchedule({ daysOfWeek: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] })
+      );
+      // 2024-06-02(日) ~ 2024-06-08(土)
+      for (let i = 2; i <= 8; i++) {
+        expect(entity.isActiveOnDay(new Date(`2024-06-0${i}`))).toBe(true);
+      }
+    });
+  });
+
   describe('getReminderTime', () => {
     it('リマインダー時刻を正しく計算する', () => {
       const entity = new ScheduleEntity(
@@ -68,6 +94,16 @@ describe('ScheduleEntity', () => {
       const reminderTime = entity.getReminderTime(date);
       expect(reminderTime.getHours()).toBe(7);
       expect(reminderTime.getMinutes()).toBe(50);
+    });
+
+    it('リマインダー0分前の場合、予定時刻と同じを返す', () => {
+      const entity = new ScheduleEntity(
+        createSchedule({ scheduledTime: '12:30', reminderMinutesBefore: 0 })
+      );
+      const date = new Date('2024-06-01T00:00:00');
+      const reminderTime = entity.getReminderTime(date);
+      expect(reminderTime.getHours()).toBe(12);
+      expect(reminderTime.getMinutes()).toBe(30);
     });
   });
 

--- a/src/__tests__/domain/usecases/GetTodaySchedules.test.ts
+++ b/src/__tests__/domain/usecases/GetTodaySchedules.test.ts
@@ -160,4 +160,28 @@ describe('GetTodaySchedules', () => {
 
     expect(result).toHaveLength(0);
   });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository([]);
+    (repo.getTodaySchedules as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB接続エラー'));
+    const useCase = new GetTodaySchedules(repo);
+
+    await expect(
+      useCase.execute({ userId: 'user-1', date: new Date() })
+    ).rejects.toThrow('DB接続エラー');
+  });
+
+  it('ペットメンバーのスケジュールも正しくViewModelに変換する', async () => {
+    const items = [
+      createScheduleItem({ memberType: 'pet' }),
+    ];
+    const repo = createMockRepository(items);
+    const useCase = new GetTodaySchedules(repo);
+
+    const monday = new Date('2025-06-02T10:00:00');
+    const result = await useCase.execute({ userId: 'user-1', date: monday });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].memberType).toBe('pet');
+  });
 });

--- a/src/__tests__/domain/usecases/ManageAppointments.test.ts
+++ b/src/__tests__/domain/usecases/ManageAppointments.test.ts
@@ -32,6 +32,23 @@ describe('GetAppointments', () => {
     expect(result[0].entity).toBeDefined();
     expect(repo.getAppointments).toHaveBeenCalled();
   });
+
+  it('空の配列を返す場合もエラーにならない', async () => {
+    const repo = createMockRepository();
+    (repo.getAppointments as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const useCase = new GetAppointments(repo);
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.getAppointments as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB接続エラー'));
+    const useCase = new GetAppointments(repo);
+
+    await expect(useCase.execute()).rejects.toThrow('DB接続エラー');
+  });
 });
 
 describe('CreateAppointment', () => {
@@ -110,5 +127,13 @@ describe('DeleteAppointment', () => {
     await useCase.execute('apt-1');
 
     expect(repo.deleteAppointment).toHaveBeenCalledWith('apt-1');
+  });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.deleteAppointment as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('削除失敗'));
+    const useCase = new DeleteAppointment(repo);
+
+    await expect(useCase.execute('apt-1')).rejects.toThrow('削除失敗');
   });
 });

--- a/src/__tests__/domain/usecases/ManageHospitals.test.ts
+++ b/src/__tests__/domain/usecases/ManageHospitals.test.ts
@@ -28,6 +28,14 @@ describe('GetHospitals', () => {
     expect(result[0]).toBe(mockHospital);
     expect(repo.getHospitals).toHaveBeenCalled();
   });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.getHospitals as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB接続エラー'));
+    const useCase = new GetHospitals(repo);
+
+    await expect(useCase.execute()).rejects.toThrow('DB接続エラー');
+  });
 });
 
 describe('CreateHospital', () => {

--- a/src/__tests__/domain/usecases/ManageMedicationRecords.test.ts
+++ b/src/__tests__/domain/usecases/ManageMedicationRecords.test.ts
@@ -51,6 +51,23 @@ describe('GetMedicationHistory', () => {
     expect(result[1].date).toBe('2025-06-14');
     expect(result[1].records).toHaveLength(1);
   });
+
+  it('空の履歴を正しく処理する', async () => {
+    const repo = createMockRepository();
+    (repo.getHistory as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const useCase = new GetMedicationHistory(repo);
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.getHistory as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB接続エラー'));
+    const useCase = new GetMedicationHistory(repo);
+
+    await expect(useCase.execute()).rejects.toThrow('DB接続エラー');
+  });
 });
 
 describe('CreateMedicationRecord', () => {

--- a/src/__tests__/domain/usecases/ManageMedications.test.ts
+++ b/src/__tests__/domain/usecases/ManageMedications.test.ts
@@ -61,6 +61,14 @@ describe('GetMedications', () => {
 
     expect(result).toHaveLength(0);
   });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.getMedicationsByMember as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB接続エラー'));
+    const useCase = new GetMedications(repo);
+
+    await expect(useCase.execute('mem-1')).rejects.toThrow('DB接続エラー');
+  });
 });
 
 describe('CreateMedication', () => {

--- a/src/__tests__/domain/usecases/ManageMembers.test.ts
+++ b/src/__tests__/domain/usecases/ManageMembers.test.ts
@@ -39,6 +39,14 @@ describe('GetMembers', () => {
 
     expect(result).toHaveLength(0);
   });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.getMembers as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB接続エラー'));
+    const useCase = new GetMembers(repo);
+
+    await expect(useCase.execute('user-1')).rejects.toThrow('DB接続エラー');
+  });
 });
 
 describe('CreateMember', () => {
@@ -71,6 +79,16 @@ describe('CreateMember', () => {
     await expect(
       useCase.execute({ userId: 'user-1', memberType: 'human', name: '   ' })
     ).rejects.toThrow('メンバー名は必須です');
+  });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.createMember as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('作成失敗'));
+    const useCase = new CreateMember(repo);
+
+    await expect(
+      useCase.execute({ userId: 'user-1', memberType: 'human', name: 'テスト' })
+    ).rejects.toThrow('作成失敗');
   });
 });
 

--- a/src/__tests__/domain/usecases/ManageSchedules.test.ts
+++ b/src/__tests__/domain/usecases/ManageSchedules.test.ts
@@ -42,6 +42,14 @@ describe('GetSchedules', () => {
     expect(result[0].memberName).toBe('テスト太郎');
     expect(repo.getSchedules).toHaveBeenCalled();
   });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.getSchedules as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB接続エラー'));
+    const useCase = new GetSchedules(repo);
+
+    await expect(useCase.execute()).rejects.toThrow('DB接続エラー');
+  });
 });
 
 describe('UpdateSchedule', () => {

--- a/src/__tests__/domain/usecases/ManageUserProfile.test.ts
+++ b/src/__tests__/domain/usecases/ManageUserProfile.test.ts
@@ -24,6 +24,14 @@ describe('GetUserProfile', () => {
     expect(result).toBe(mockProfile);
     expect(repo.getProfile).toHaveBeenCalled();
   });
+
+  it('リポジトリがエラーを投げた場合そのまま伝搬する', async () => {
+    const repo = createMockRepository();
+    (repo.getProfile as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('認証エラー'));
+    const useCase = new GetUserProfile(repo);
+
+    await expect(useCase.execute()).rejects.toThrow('認証エラー');
+  });
 });
 
 describe('UpdateUserProfile', () => {

--- a/src/__tests__/infrastructure/DIContainer.test.ts
+++ b/src/__tests__/infrastructure/DIContainer.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getDIContainer, setDIContainer, resetDIContainer, DIContainer } from '@/infrastructure/DIContainer';
+
+beforeEach(() => {
+  resetDIContainer();
+});
+
+describe('DIContainer', () => {
+  describe('getDIContainer', () => {
+    it('全てのリポジトリを含むコンテナを返す', () => {
+      const container = getDIContainer();
+
+      expect(container.memberRepository).toBeDefined();
+      expect(container.medicationRepository).toBeDefined();
+      expect(container.scheduleRepository).toBeDefined();
+      expect(container.appointmentRepository).toBeDefined();
+      expect(container.hospitalRepository).toBeDefined();
+      expect(container.medicationRecordRepository).toBeDefined();
+      expect(container.userProfileRepository).toBeDefined();
+    });
+
+    it('シングルトンとして同じインスタンスを返す', () => {
+      const container1 = getDIContainer();
+      const container2 = getDIContainer();
+
+      expect(container1).toBe(container2);
+    });
+  });
+
+  describe('setDIContainer', () => {
+    it('コンテナを差し替えできる', () => {
+      const mockContainer = {
+        memberRepository: {} as DIContainer['memberRepository'],
+        medicationRepository: {} as DIContainer['medicationRepository'],
+        scheduleRepository: {} as DIContainer['scheduleRepository'],
+        appointmentRepository: {} as DIContainer['appointmentRepository'],
+        hospitalRepository: {} as DIContainer['hospitalRepository'],
+        medicationRecordRepository: {} as DIContainer['medicationRecordRepository'],
+        userProfileRepository: {} as DIContainer['userProfileRepository'],
+      };
+
+      setDIContainer(mockContainer);
+      const container = getDIContainer();
+
+      expect(container).toBe(mockContainer);
+    });
+  });
+
+  describe('resetDIContainer', () => {
+    it('リセット後に新しいインスタンスが作成される', () => {
+      const container1 = getDIContainer();
+      resetDIContainer();
+      const container2 = getDIContainer();
+
+      expect(container1).not.toBe(container2);
+    });
+  });
+});

--- a/src/presentation/hooks/useFetcher.ts
+++ b/src/presentation/hooks/useFetcher.ts
@@ -21,7 +21,6 @@ export function useFetcher<T>(
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchData = useCallback(async () => {
     try {
       setIsLoading(true);


### PR DESCRIPTION
## 概要
- エンティティのエッジケーステスト追加（全カテゴリラベル検証、境界値テスト、アクセサテスト）
- ユースケースのリポジトリエラー伝搬テスト追加（全8ユースケース）
- DIコンテナのシングルトン・差し替え・リセットテスト追加
- useFetcherの不要なESLintディレクティブ削除

## テスト計画
- [x] 全216テストパス
- [x] ビルド成功
- [x] ESLint警告なし

Closes #126