### PR TITLE
feat: Cycle3 Step1 - 5つの新機能を追加

### DIFF
--- a/src/__tests__/components/dashboard/AdherenceStatsCard.test.tsx
+++ b/src/__tests__/components/dashboard/AdherenceStatsCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AdherenceStatsCard } from '@/components/dashboard/AdherenceStatsCard';
+
+describe('AdherenceStatsCard', () => {
+  const stats = {
+    overall: { weeklyRate: 85, monthlyRate: 72, weeklyCount: 12, monthlyCount: 45 },
+    members: [
+      { memberId: 'm1', memberName: '太郎', weeklyRate: 90, monthlyRate: 80, weeklyCount: 6, monthlyCount: 25 },
+      { memberId: 'm2', memberName: '花子', weeklyRate: 60, monthlyRate: 55, weeklyCount: 6, monthlyCount: 20 },
+    ],
+  };
+
+  it('ローディング中は何も表示しない', () => {
+    const { container } = render(<AdherenceStatsCard stats={null} isLoading={true} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('statsがnullの場合は何も表示しない', () => {
+    const { container } = render(<AdherenceStatsCard stats={null} isLoading={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('週間・月間のアドヒアランス率を表示する', () => {
+    render(<AdherenceStatsCard stats={stats} isLoading={false} />);
+    expect(screen.getByText('85%')).toBeInTheDocument();
+    expect(screen.getByText('72%')).toBeInTheDocument();
+  });
+
+  it('レベルラベルを表示する', () => {
+    render(<AdherenceStatsCard stats={stats} isLoading={false} />);
+    const labels = screen.getAllByText('良好'); // 85% and 72% are both 良好
+    expect(labels.length).toBe(2);
+  });
+
+  it('メンバー別の統計を表示する', () => {
+    render(<AdherenceStatsCard stats={stats} isLoading={false} />);
+    expect(screen.getByText('太郎')).toBeInTheDocument();
+    expect(screen.getByText('花子')).toBeInTheDocument();
+    expect(screen.getByText('90%')).toBeInTheDocument();
+    expect(screen.getByText('60%')).toBeInTheDocument();
+  });
+
+  it('メンバーがいない場合はメンバー別セクションを表示しない', () => {
+    const noMemberStats = { ...stats, members: [] };
+    render(<AdherenceStatsCard stats={noMemberStats} isLoading={false} />);
+    expect(screen.queryByText('メンバー別')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/dashboard/StockAlertList.test.tsx
+++ b/src/__tests__/components/dashboard/StockAlertList.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StockAlertList } from '@/components/dashboard/StockAlertList';
+
+describe('StockAlertList', () => {
+  const alerts = [
+    {
+      medicationId: 'm1',
+      medicationName: 'アスピリン',
+      memberId: 'mem1',
+      memberName: '太郎',
+      stockQuantity: 5,
+      stockAlertDate: '2026-03-05T00:00:00.000Z',
+      daysUntilAlert: 5,
+      isOverdue: false,
+    },
+    {
+      medicationId: 'm2',
+      medicationName: 'ビタミンC',
+      memberId: 'mem2',
+      memberName: '花子',
+      stockQuantity: 0,
+      stockAlertDate: '2026-02-25T00:00:00.000Z',
+      daysUntilAlert: -3,
+      isOverdue: true,
+    },
+  ];
+
+  it('ローディング中は何も表示しない', () => {
+    const { container } = render(<StockAlertList alerts={[]} isLoading={true} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('アラートが空の場合は何も表示しない', () => {
+    const { container } = render(<StockAlertList alerts={[]} isLoading={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('アラート一覧を表示する', () => {
+    render(<StockAlertList alerts={alerts} isLoading={false} />);
+    expect(screen.getByText('在庫アラート')).toBeInTheDocument();
+    expect(screen.getByText('アスピリン')).toBeInTheDocument();
+    expect(screen.getByText('ビタミンC')).toBeInTheDocument();
+  });
+
+  it('メンバー名を表示する', () => {
+    render(<StockAlertList alerts={alerts} isLoading={false} />);
+    expect(screen.getByText('太郎')).toBeInTheDocument();
+    expect(screen.getByText('花子')).toBeInTheDocument();
+  });
+
+  it('残り日数を表示する', () => {
+    render(<StockAlertList alerts={alerts} isLoading={false} />);
+    expect(screen.getByText('残り5日分')).toBeInTheDocument();
+    expect(screen.getByText('あと5日')).toBeInTheDocument();
+  });
+
+  it('期限超過のアラートには期限超過を表示する', () => {
+    render(<StockAlertList alerts={alerts} isLoading={false} />);
+    expect(screen.getByText('期限超過')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/medications/MedicationSearch.test.tsx
+++ b/src/__tests__/components/medications/MedicationSearch.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MedicationSearch } from '@/components/medications/MedicationSearch';
+import { medicationApi } from '@/data/api/medicationApi';
+
+vi.mock('@/data/api/medicationApi', () => ({
+  medicationApi: {
+    searchMedications: vi.fn(),
+  },
+}));
+
+const mockSearch = vi.mocked(medicationApi.searchMedications);
+
+describe('MedicationSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('検索入力欄と検索ボタンを表示する', () => {
+    render(<MedicationSearch />);
+    expect(screen.getByPlaceholderText('お薬名で検索...')).toBeInTheDocument();
+    expect(screen.getByText('検索')).toBeInTheDocument();
+  });
+
+  it('空の入力では検索ボタンが無効になる', () => {
+    render(<MedicationSearch />);
+    expect(screen.getByText('検索')).toBeDisabled();
+  });
+
+  it('検索結果を表示する', async () => {
+    mockSearch.mockResolvedValue([
+      { id: '1', name: 'アスピリン', category: 'regular', memberId: 'm1', memberName: '太郎' },
+    ]);
+
+    render(<MedicationSearch />);
+    fireEvent.change(screen.getByPlaceholderText('お薬名で検索...'), { target: { value: 'アスピリン' } });
+    fireEvent.click(screen.getByText('検索'));
+
+    await waitFor(() => {
+      expect(screen.getByText('アスピリン')).toBeInTheDocument();
+      expect(screen.getByText('(太郎)')).toBeInTheDocument();
+    });
+  });
+
+  it('結果がない場合はメッセージを表示する', async () => {
+    mockSearch.mockResolvedValue([]);
+
+    render(<MedicationSearch />);
+    fireEvent.change(screen.getByPlaceholderText('お薬名で検索...'), { target: { value: 'なし' } });
+    fireEvent.click(screen.getByText('検索'));
+
+    await waitFor(() => {
+      expect(screen.getByText('該当するお薬が見つかりません')).toBeInTheDocument();
+    });
+  });
+
+  it('Enterキーで検索できる', async () => {
+    mockSearch.mockResolvedValue([]);
+
+    render(<MedicationSearch />);
+    const input = screen.getByPlaceholderText('お薬名で検索...');
+    fireEvent.change(input, { target: { value: 'テスト' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith('テスト');
+    });
+  });
+
+  it('結果をクリックするとonSelectResultが呼ばれる', async () => {
+    const result = { id: '1', name: 'アスピリン', category: 'regular', memberId: 'm1', memberName: '太郎' };
+    mockSearch.mockResolvedValue([result]);
+    const onSelect = vi.fn();
+
+    render(<MedicationSearch onSelectResult={onSelect} />);
+    fireEvent.change(screen.getByPlaceholderText('お薬名で検索...'), { target: { value: 'アスピリン' } });
+    fireEvent.click(screen.getByText('検索'));
+
+    await waitFor(() => {
+      expect(screen.getByText('アスピリン')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('アスピリン'));
+    expect(onSelect).toHaveBeenCalledWith(result);
+  });
+});

--- a/src/__tests__/components/shared/MemberFilter.test.tsx
+++ b/src/__tests__/components/shared/MemberFilter.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemberFilter } from '@/components/shared/MemberFilter';
+
+describe('MemberFilter', () => {
+  const members = [
+    { id: 'member-1', name: '太郎' },
+    { id: 'member-2', name: '花子' },
+  ];
+
+  it('全員ボタンとメンバーボタンを表示する', () => {
+    render(<MemberFilter members={members} selectedMemberId={null} onSelect={vi.fn()} />);
+    expect(screen.getByText('全員')).toBeInTheDocument();
+    expect(screen.getByText('太郎')).toBeInTheDocument();
+    expect(screen.getByText('花子')).toBeInTheDocument();
+  });
+
+  it('メンバーが空の場合は何も表示しない', () => {
+    const { container } = render(<MemberFilter members={[]} selectedMemberId={null} onSelect={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('全員が選択されているときは全員ボタンがaria-selected=trueになる', () => {
+    render(<MemberFilter members={members} selectedMemberId={null} onSelect={vi.fn()} />);
+    expect(screen.getByText('全員')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('太郎')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('メンバーが選択されているときは該当ボタンがaria-selected=trueになる', () => {
+    render(<MemberFilter members={members} selectedMemberId="member-1" onSelect={vi.fn()} />);
+    expect(screen.getByText('全員')).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('太郎')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('全員ボタンをクリックするとnullが渡される', () => {
+    const onSelect = vi.fn();
+    render(<MemberFilter members={members} selectedMemberId="member-1" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('全員'));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('メンバーボタンをクリックするとメンバーIDが渡される', () => {
+    const onSelect = vi.fn();
+    render(<MemberFilter members={members} selectedMemberId={null} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('花子'));
+    expect(onSelect).toHaveBeenCalledWith('member-2');
+  });
+});

--- a/src/__tests__/domain/entities/AdherenceStats.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStats.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity', () => {
+  describe('getRateLevel', () => {
+    it('90%以上はexcellentを返す', () => {
+      expect(AdherenceStatsEntity.getRateLevel(100)).toBe('excellent');
+      expect(AdherenceStatsEntity.getRateLevel(90)).toBe('excellent');
+    });
+
+    it('70-89%はgoodを返す', () => {
+      expect(AdherenceStatsEntity.getRateLevel(89)).toBe('good');
+      expect(AdherenceStatsEntity.getRateLevel(70)).toBe('good');
+    });
+
+    it('50-69%はwarningを返す', () => {
+      expect(AdherenceStatsEntity.getRateLevel(69)).toBe('warning');
+      expect(AdherenceStatsEntity.getRateLevel(50)).toBe('warning');
+    });
+
+    it('50%未満はpoorを返す', () => {
+      expect(AdherenceStatsEntity.getRateLevel(49)).toBe('poor');
+      expect(AdherenceStatsEntity.getRateLevel(0)).toBe('poor');
+    });
+  });
+
+  describe('getRateLabel', () => {
+    it('全レベルのラベルが正しい', () => {
+      expect(AdherenceStatsEntity.getRateLabel(95)).toBe('優秀');
+      expect(AdherenceStatsEntity.getRateLabel(75)).toBe('良好');
+      expect(AdherenceStatsEntity.getRateLabel(55)).toBe('注意');
+      expect(AdherenceStatsEntity.getRateLabel(30)).toBe('要改善');
+    });
+  });
+
+  describe('data', () => {
+    it('統計データにアクセスできる', () => {
+      const stats = {
+        overall: { weeklyRate: 85, monthlyRate: 78, weeklyCount: 12, monthlyCount: 45 },
+        members: [],
+      };
+      const entity = new AdherenceStatsEntity(stats);
+      expect(entity.data).toBe(stats);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleEntity.test.ts
+++ b/src/__tests__/domain/entities/ScheduleEntity.test.ts
@@ -107,6 +107,38 @@ describe('ScheduleEntity', () => {
     });
   });
 
+  describe('hasOverlap', () => {
+    it('同じ薬・同じ時刻・曜日重複がある場合trueを返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '08:00', daysOfWeek: ['mon', 'wed'] }));
+      const other = createSchedule({ scheduledTime: '08:00', daysOfWeek: ['wed', 'fri'] });
+      expect(entity.hasOverlap(other)).toBe(true);
+    });
+
+    it('同じ薬・同じ時刻でも曜日が重複しない場合falseを返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '08:00', daysOfWeek: ['mon', 'wed'] }));
+      const other = createSchedule({ scheduledTime: '08:00', daysOfWeek: ['thu', 'fri'] });
+      expect(entity.hasOverlap(other)).toBe(false);
+    });
+
+    it('時刻が異なる場合falseを返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '08:00', daysOfWeek: ['mon'] }));
+      const other = createSchedule({ scheduledTime: '09:00', daysOfWeek: ['mon'] });
+      expect(entity.hasOverlap(other)).toBe(false);
+    });
+
+    it('薬が異なる場合falseを返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ medicationId: 'med-1', scheduledTime: '08:00' }));
+      const other = createSchedule({ medicationId: 'med-2', scheduledTime: '08:00' });
+      expect(entity.hasOverlap(other)).toBe(false);
+    });
+
+    it('曜日が空（毎日）の場合は常に重複する', () => {
+      const entity = new ScheduleEntity(createSchedule({ scheduledTime: '08:00', daysOfWeek: [] }));
+      const other = createSchedule({ scheduledTime: '08:00', daysOfWeek: ['mon'] });
+      expect(entity.hasOverlap(other)).toBe(true);
+    });
+  });
+
   describe('id / data', () => {
     it('プロパティにアクセスできる', () => {
       const schedule = createSchedule({ id: 'sched-abc' });

--- a/src/app/api/medications/alerts/route.ts
+++ b/src/app/api/medications/alerts/route.ts
@@ -1,0 +1,39 @@
+import { prisma } from '@/lib/prisma';
+import { success } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+
+export const GET = withAuth(async (userId) => {
+  const now = new Date();
+
+  const medications = await prisma.medication.findMany({
+    where: {
+      userId,
+      isActive: true,
+      stockAlertDate: { not: null },
+    },
+    include: { member: { select: { id: true, name: true } } },
+    orderBy: { stockAlertDate: 'asc' },
+  });
+
+  const alerts = medications
+    .filter((med) => {
+      if (!med.stockAlertDate) return false;
+      const daysUntil = Math.ceil((med.stockAlertDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+      return daysUntil <= 14;
+    })
+    .map((med) => {
+      const daysUntil = Math.ceil((med.stockAlertDate!.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+      return {
+        medicationId: med.id,
+        medicationName: med.name,
+        memberId: med.memberId,
+        memberName: med.member.name,
+        stockQuantity: med.stockQuantity,
+        stockAlertDate: med.stockAlertDate!.toISOString(),
+        daysUntilAlert: daysUntil,
+        isOverdue: daysUntil <= 0,
+      };
+    });
+
+  return success(alerts);
+});

--- a/src/app/api/medications/search/route.ts
+++ b/src/app/api/medications/search/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+
+export async function GET(request: NextRequest) {
+  return withAuth(async (userId) => {
+    const q = request.nextUrl.searchParams.get('q')?.trim() ?? '';
+    if (!q) {
+      return errorResponse('検索キーワードを入力してください');
+    }
+
+    const medications = await prisma.medication.findMany({
+      where: {
+        userId,
+        isActive: true,
+        name: { contains: q, mode: 'insensitive' },
+      },
+      include: { member: { select: { id: true, name: true } } },
+      orderBy: { name: 'asc' },
+      take: 20,
+    });
+
+    const results = medications.map((med) => ({
+      id: med.id,
+      name: med.name,
+      category: med.category,
+      memberId: med.memberId,
+      memberName: med.member.name,
+      dosageAmount: med.dosageAmount,
+      frequency: med.frequency,
+      stockQuantity: med.stockQuantity,
+    }));
+
+    return success(results);
+  })();
+}

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -1,0 +1,71 @@
+import { prisma } from '@/lib/prisma';
+import { success } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+
+export const GET = withAuth(async (userId) => {
+  const now = new Date();
+  const sevenDaysAgo = new Date(now);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  sevenDaysAgo.setHours(0, 0, 0, 0);
+
+  const thirtyDaysAgo = new Date(now);
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  thirtyDaysAgo.setHours(0, 0, 0, 0);
+
+  const [weeklyRecords, monthlyRecords, schedules, members] = await Promise.all([
+    prisma.medicationRecord.findMany({
+      where: { userId, takenAt: { gte: sevenDaysAgo } },
+      select: { memberId: true, medicationId: true, takenAt: true },
+    }),
+    prisma.medicationRecord.findMany({
+      where: { userId, takenAt: { gte: thirtyDaysAgo } },
+      select: { memberId: true, medicationId: true, takenAt: true },
+    }),
+    prisma.schedule.findMany({
+      where: { userId, isEnabled: true },
+      select: { memberId: true, medicationId: true, daysOfWeek: true },
+    }),
+    prisma.member.findMany({
+      where: { userId },
+      select: { id: true, name: true },
+    }),
+  ]);
+
+  // 1週間のスケジュール数を計算（各スケジュールの有効曜日数）
+  const weeklyExpected = schedules.reduce((sum, s) => sum + Math.min(s.daysOfWeek.length, 7), 0);
+  const monthlyExpected = schedules.reduce((sum, s) => {
+    const daysPerWeek = s.daysOfWeek.length;
+    return sum + Math.round(daysPerWeek * (30 / 7));
+  }, 0);
+
+  // メンバー別の統計
+  const memberStats = members.map((member) => {
+    const memberSchedules = schedules.filter((s) => s.memberId === member.id);
+    const memberWeekly = weeklyRecords.filter((r) => r.memberId === member.id);
+    const memberMonthly = monthlyRecords.filter((r) => r.memberId === member.id);
+
+    const expected7 = memberSchedules.reduce((sum, s) => sum + Math.min(s.daysOfWeek.length, 7), 0);
+    const expected30 = memberSchedules.reduce((sum, s) => {
+      return sum + Math.round(s.daysOfWeek.length * (30 / 7));
+    }, 0);
+
+    return {
+      memberId: member.id,
+      memberName: member.name,
+      weeklyRate: expected7 > 0 ? Math.min(100, Math.round((memberWeekly.length / expected7) * 100)) : 0,
+      monthlyRate: expected30 > 0 ? Math.min(100, Math.round((memberMonthly.length / expected30) * 100)) : 0,
+      weeklyCount: memberWeekly.length,
+      monthlyCount: memberMonthly.length,
+    };
+  });
+
+  return success({
+    overall: {
+      weeklyRate: weeklyExpected > 0 ? Math.min(100, Math.round((weeklyRecords.length / weeklyExpected) * 100)) : 0,
+      monthlyRate: monthlyExpected > 0 ? Math.min(100, Math.round((monthlyRecords.length / monthlyExpected) * 100)) : 0,
+      weeklyCount: weeklyRecords.length,
+      monthlyCount: monthlyRecords.length,
+    },
+    members: memberStats,
+  });
+});

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -14,13 +14,33 @@ export async function POST(request: Request) {
     const parsed = createScheduleSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
+    // 重複チェック: 同じ薬・同じ時刻・曜日が重複するスケジュール
+    const daysOfWeek = parsed.data.daysOfWeek ?? [];
+    const existing = await prisma.schedule.findFirst({
+      where: {
+        userId,
+        medicationId: parsed.data.medicationId,
+        scheduledTime: parsed.data.scheduledTime,
+        isEnabled: true,
+      },
+    });
+
+    if (existing && daysOfWeek.length > 0) {
+      const overlapping = daysOfWeek.some((day) => existing.daysOfWeek.includes(day));
+      if (overlapping) {
+        return errorResponse('同じ薬の同じ時刻に既にスケジュールが存在します');
+      }
+    } else if (existing && daysOfWeek.length === 0) {
+      return errorResponse('同じ薬の同じ時刻に既にスケジュールが存在します');
+    }
+
     const schedule = await prisma.schedule.create({
       data: {
         userId,
         medicationId: parsed.data.medicationId,
         memberId: parsed.data.memberId,
         scheduledTime: parsed.data.scheduledTime,
-        daysOfWeek: parsed.data.daysOfWeek ?? [],
+        daysOfWeek,
         isEnabled: parsed.data.isEnabled ?? true,
         reminderMinutesBefore: parsed.data.reminderMinutesBefore ?? 5,
       },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,18 @@
 'use client';
 
+import { useState, useMemo } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useTodaySchedules } from '@/presentation/hooks/useTodaySchedules';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
+import { useAdherenceStats } from '@/presentation/hooks/useAdherenceStats';
+import { useStockAlerts } from '@/presentation/hooks/useStockAlerts';
+import { useMembers } from '@/presentation/hooks/useMembers';
 import { useCharacterStore } from '@/stores/characterStore';
 import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
 import { UpcomingAppointments } from '@/components/dashboard/UpcomingAppointments';
+import { AdherenceStatsCard } from '@/components/dashboard/AdherenceStatsCard';
+import { StockAlertList } from '@/components/dashboard/StockAlertList';
+import { MemberFilter } from '@/components/shared/MemberFilter';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { CharacterIcon } from '@/components/shared/CharacterIcon';
 
@@ -13,8 +20,22 @@ export default function Dashboard() {
   const { userId } = useAuth();
   const { schedules, isLoading, markAsCompleted } = useTodaySchedules(userId);
   const { appointments, isLoading: appointmentsLoading } = useAppointments();
+  const { stats, isLoading: statsLoading } = useAdherenceStats();
+  const { alerts, isLoading: alertsLoading } = useStockAlerts();
+  const { members } = useMembers(userId);
   const { getConfig, getMessage } = useCharacterStore();
   const characterConfig = getConfig();
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+
+  const filteredSchedules = useMemo(
+    () => selectedMemberId ? schedules.filter((s) => s.memberId === selectedMemberId) : schedules,
+    [schedules, selectedMemberId],
+  );
+
+  const memberOptions = useMemo(
+    () => members.map((m) => ({ id: m.id, name: m.name })),
+    [members],
+  );
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -33,14 +54,25 @@ export default function Dashboard() {
           </div>
         </div>
 
+        <AdherenceStatsCard stats={stats} isLoading={statsLoading} />
+
+        <StockAlertList alerts={alerts} isLoading={alertsLoading} />
+
         <UpcomingAppointments
           appointments={appointments}
           isLoading={appointmentsLoading}
         />
 
-        <h2 className="text-lg font-semibold text-gray-800 mb-4">今日の予定</h2>
+        <h2 className="text-lg font-semibold text-gray-800 mb-3">今日の予定</h2>
+        <div className="mb-4">
+          <MemberFilter
+            members={memberOptions}
+            selectedMemberId={selectedMemberId}
+            onSelect={setSelectedMemberId}
+          />
+        </div>
         <TodayScheduleList
-          schedules={schedules}
+          schedules={filteredSchedules}
           isLoading={isLoading}
           onMarkCompleted={markAsCompleted}
         />

--- a/src/components/dashboard/AdherenceStatsCard.tsx
+++ b/src/components/dashboard/AdherenceStatsCard.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { TrendingUp } from 'lucide-react';
+import { AdherenceStats, AdherenceStatsEntity } from '../../domain/entities/AdherenceStats';
+
+interface AdherenceStatsCardProps {
+  stats: AdherenceStats | null;
+  isLoading: boolean;
+}
+
+const levelColors = {
+  excellent: 'text-green-600',
+  good: 'text-blue-600',
+  warning: 'text-yellow-600',
+  poor: 'text-red-600',
+} as const;
+
+const levelBgColors = {
+  excellent: 'bg-green-100',
+  good: 'bg-blue-100',
+  warning: 'bg-yellow-100',
+  poor: 'bg-red-100',
+} as const;
+
+export const AdherenceStatsCard: React.FC<AdherenceStatsCardProps> = ({ stats, isLoading }) => {
+  if (isLoading || !stats) return null;
+
+  const weeklyLevel = AdherenceStatsEntity.getRateLevel(stats.overall.weeklyRate);
+  const monthlyLevel = AdherenceStatsEntity.getRateLevel(stats.overall.monthlyRate);
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center space-x-2 mb-3">
+        <TrendingUp size={18} className="text-primary-600" />
+        <h2 className="text-lg font-semibold text-gray-800">服薬アドヒアランス</h2>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-sm p-4 border border-gray-200">
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <div className="text-center">
+            <p className="text-xs text-gray-500 mb-1">週間</p>
+            <p className={`text-2xl font-bold ${levelColors[weeklyLevel]}`}>
+              {stats.overall.weeklyRate}%
+            </p>
+            <span className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${levelBgColors[weeklyLevel]} ${levelColors[weeklyLevel]}`}>
+              {AdherenceStatsEntity.getRateLabel(stats.overall.weeklyRate)}
+            </span>
+          </div>
+          <div className="text-center">
+            <p className="text-xs text-gray-500 mb-1">月間</p>
+            <p className={`text-2xl font-bold ${levelColors[monthlyLevel]}`}>
+              {stats.overall.monthlyRate}%
+            </p>
+            <span className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${levelBgColors[monthlyLevel]} ${levelColors[monthlyLevel]}`}>
+              {AdherenceStatsEntity.getRateLabel(stats.overall.monthlyRate)}
+            </span>
+          </div>
+        </div>
+
+        {stats.members.length > 0 && (
+          <div className="border-t border-gray-100 pt-3">
+            <p className="text-xs text-gray-500 mb-2">メンバー別</p>
+            <div className="space-y-2">
+              {stats.members.map((member) => {
+                const memberLevel = AdherenceStatsEntity.getRateLevel(member.weeklyRate);
+                return (
+                  <div key={member.memberId} className="flex items-center justify-between">
+                    <span className="text-sm text-gray-700">{member.memberName}</span>
+                    <span className={`text-sm font-medium ${levelColors[memberLevel]}`}>
+                      {member.weeklyRate}%
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/StockAlertList.tsx
+++ b/src/components/dashboard/StockAlertList.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { StockAlert } from '../../data/api/medicationApi';
+
+interface StockAlertListProps {
+  alerts: StockAlert[];
+  isLoading: boolean;
+}
+
+export const StockAlertList: React.FC<StockAlertListProps> = ({ alerts, isLoading }) => {
+  if (isLoading || alerts.length === 0) return null;
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center space-x-2 mb-3">
+        <AlertTriangle size={18} className="text-yellow-600" />
+        <h2 className="text-lg font-semibold text-gray-800">在庫アラート</h2>
+      </div>
+      <div className="space-y-2">
+        {alerts.map((alert) => (
+          <div
+            key={alert.medicationId}
+            className={`bg-white rounded-lg shadow-sm p-3 border ${
+              alert.isOverdue ? 'border-red-300 bg-red-50' : 'border-yellow-300 bg-yellow-50'
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-800">{alert.medicationName}</p>
+                <p className="text-xs text-gray-500">{alert.memberName}</p>
+              </div>
+              <div className="text-right">
+                {alert.stockQuantity !== null && (
+                  <p className="text-sm font-medium text-gray-700">残り{alert.stockQuantity}日分</p>
+                )}
+                <p className={`text-xs font-medium ${alert.isOverdue ? 'text-red-600' : 'text-yellow-600'}`}>
+                  {alert.isOverdue ? '期限超過' : `あと${alert.daysUntilAlert}日`}
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/medications/MedicationSearch.tsx
+++ b/src/components/medications/MedicationSearch.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useCallback } from 'react';
+import { Search, Pill } from 'lucide-react';
+import { MedicationSearchResult, medicationApi } from '../../data/api/medicationApi';
+
+interface MedicationSearchProps {
+  onSelectResult?: (result: MedicationSearchResult) => void;
+}
+
+export const MedicationSearch: React.FC<MedicationSearchProps> = ({ onSelectResult }) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<MedicationSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  const handleSearch = useCallback(async () => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+
+    setIsSearching(true);
+    try {
+      const data = await medicationApi.searchMedications(trimmed);
+      setResults(data);
+      setHasSearched(true);
+    } catch {
+      setResults([]);
+      setHasSearched(true);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [query]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch();
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex space-x-2 mb-3">
+        <div className="flex-1 relative">
+          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="お薬名で検索..."
+            className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            aria-label="お薬検索"
+          />
+        </div>
+        <button
+          onClick={handleSearch}
+          disabled={isSearching || !query.trim()}
+          className="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+        >
+          {isSearching ? '検索中...' : '検索'}
+        </button>
+      </div>
+
+      {hasSearched && results.length === 0 && (
+        <p className="text-sm text-gray-500 text-center py-4">該当するお薬が見つかりません</p>
+      )}
+
+      {results.length > 0 && (
+        <div className="space-y-2">
+          {results.map((result) => (
+            <div
+              key={result.id}
+              className="bg-white rounded-lg p-3 border border-gray-200 hover:border-primary-300 transition-colors cursor-pointer"
+              onClick={() => onSelectResult?.(result)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => { if (e.key === 'Enter') onSelectResult?.(result); }}
+            >
+              <div className="flex items-center space-x-2">
+                <Pill size={16} className="text-primary-600" />
+                <span className="text-sm font-medium text-gray-800">{result.name}</span>
+                <span className="text-xs text-gray-500">({result.memberName})</span>
+              </div>
+              {result.dosageAmount && (
+                <p className="text-xs text-gray-500 mt-1 ml-6">{result.dosageAmount}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/shared/MemberFilter.tsx
+++ b/src/components/shared/MemberFilter.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+export interface MemberOption {
+  id: string;
+  name: string;
+}
+
+interface MemberFilterProps {
+  members: MemberOption[];
+  selectedMemberId: string | null;
+  onSelect: (memberId: string | null) => void;
+}
+
+export const MemberFilter: React.FC<MemberFilterProps> = ({ members, selectedMemberId, onSelect }) => {
+  if (members.length === 0) return null;
+
+  return (
+    <div className="flex space-x-2 overflow-x-auto pb-2" role="tablist" aria-label="メンバーフィルター">
+      <button
+        onClick={() => onSelect(null)}
+        className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
+          selectedMemberId === null
+            ? 'bg-primary-600 text-white'
+            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+        }`}
+        role="tab"
+        aria-selected={selectedMemberId === null}
+      >
+        全員
+      </button>
+      {members.map((member) => (
+        <button
+          key={member.id}
+          onClick={() => onSelect(member.id)}
+          className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
+            selectedMemberId === member.id
+              ? 'bg-primary-600 text-white'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+          role="tab"
+          aria-selected={selectedMemberId === member.id}
+        >
+          {member.name}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/data/api/medicationApi.ts
+++ b/src/data/api/medicationApi.ts
@@ -50,4 +50,34 @@ export const medicationApi = {
   async deleteMedication(medicationId: string): Promise<void> {
     await apiClient.del(`/medications/${medicationId}`);
   },
+
+  async searchMedications(query: string): Promise<MedicationSearchResult[]> {
+    return apiClient.get<MedicationSearchResult[]>(`/medications/search?q=${encodeURIComponent(query)}`);
+  },
+
+  async getStockAlerts(): Promise<StockAlert[]> {
+    return apiClient.get<StockAlert[]>('/medications/alerts');
+  },
 };
+
+export interface StockAlert {
+  medicationId: string;
+  medicationName: string;
+  memberId: string;
+  memberName: string;
+  stockQuantity: number | null;
+  stockAlertDate: string;
+  daysUntilAlert: number;
+  isOverdue: boolean;
+}
+
+export interface MedicationSearchResult {
+  id: string;
+  name: string;
+  category: string;
+  memberId: string;
+  memberName: string;
+  dosageAmount?: string;
+  frequency?: string;
+  stockQuantity?: number;
+}

--- a/src/data/api/recordApi.ts
+++ b/src/data/api/recordApi.ts
@@ -1,4 +1,5 @@
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
+import { AdherenceStats } from '../../domain/entities/AdherenceStats';
 import { apiClient } from './apiClient';
 import { toMedicationRecord } from './mappers';
 import { BackendRecord } from './types';
@@ -31,5 +32,9 @@ export const recordApi = {
 
   async deleteRecord(recordId: string): Promise<void> {
     await apiClient.del(`/records/${recordId}`);
+  },
+
+  async getStats(): Promise<AdherenceStats> {
+    return apiClient.get<AdherenceStats>('/records/stats');
   },
 };

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -1,0 +1,57 @@
+/**
+ * 服薬アドヒアランス統計エンティティ
+ */
+
+export interface MemberAdherenceStats {
+  readonly memberId: string;
+  readonly memberName: string;
+  readonly weeklyRate: number;
+  readonly monthlyRate: number;
+  readonly weeklyCount: number;
+  readonly monthlyCount: number;
+}
+
+export interface AdherenceStats {
+  readonly overall: {
+    readonly weeklyRate: number;
+    readonly monthlyRate: number;
+    readonly weeklyCount: number;
+    readonly monthlyCount: number;
+  };
+  readonly members: MemberAdherenceStats[];
+}
+
+/**
+ * アドヒアランス率のビジネスロジック
+ */
+export class AdherenceStatsEntity {
+  constructor(private readonly stats: AdherenceStats) {}
+
+  /**
+   * アドヒアランス率のレベルを返す
+   */
+  static getRateLevel(rate: number): 'excellent' | 'good' | 'warning' | 'poor' {
+    if (rate >= 90) return 'excellent';
+    if (rate >= 70) return 'good';
+    if (rate >= 50) return 'warning';
+    return 'poor';
+  }
+
+  /**
+   * アドヒアランス率のラベルを返す
+   */
+  static getRateLabel(rate: number): string {
+    const level = AdherenceStatsEntity.getRateLevel(rate);
+    const labels: Record<string, string> = {
+      excellent: '優秀',
+      good: '良好',
+      warning: '注意',
+      poor: '要改善',
+    };
+    return labels[level];
+  }
+
+  get data(): AdherenceStats {
+    return this.stats;
+  }
+}

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -76,6 +76,21 @@ export class ScheduleEntity {
     return reminderTime;
   }
 
+  /**
+   * 他のスケジュールと時刻・曜日が重複しているかチェック
+   */
+  hasOverlap(other: Schedule): boolean {
+    if (this.schedule.medicationId !== other.medicationId) return false;
+    if (this.schedule.scheduledTime !== other.scheduledTime) return false;
+
+    // 曜日が空（毎日）の場合は常に重複
+    if (this.schedule.daysOfWeek.length === 0 || other.daysOfWeek.length === 0) {
+      return true;
+    }
+
+    return this.schedule.daysOfWeek.some((day) => other.daysOfWeek.includes(day));
+  }
+
   get id(): string {
     return this.schedule.id;
   }

--- a/src/presentation/hooks/useAdherenceStats.ts
+++ b/src/presentation/hooks/useAdherenceStats.ts
@@ -1,0 +1,34 @@
+/**
+ * 服薬アドヒアランス統計取得フック
+ */
+
+import { AdherenceStats } from '../../domain/entities/AdherenceStats';
+import { recordApi } from '../../data/api/recordApi';
+import { useFetcher } from './useFetcher';
+
+export interface UseAdherenceStatsResult {
+  stats: AdherenceStats | null;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+const defaultStats: AdherenceStats = {
+  overall: { weeklyRate: 0, monthlyRate: 0, weeklyCount: 0, monthlyCount: 0 },
+  members: [],
+};
+
+export const useAdherenceStats = (): UseAdherenceStatsResult => {
+  const { data, isLoading, error, refetch } = useFetcher(
+    () => recordApi.getStats(),
+    [],
+    defaultStats,
+  );
+
+  return {
+    stats: data,
+    isLoading,
+    error,
+    refetch,
+  };
+};

--- a/src/presentation/hooks/useStockAlerts.ts
+++ b/src/presentation/hooks/useStockAlerts.ts
@@ -1,0 +1,23 @@
+/**
+ * 在庫アラート取得フック
+ */
+
+import { StockAlert, medicationApi } from '../../data/api/medicationApi';
+import { useFetcher } from './useFetcher';
+
+export interface UseStockAlertsResult {
+  alerts: StockAlert[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export const useStockAlerts = (): UseStockAlertsResult => {
+  const { data, isLoading, error, refetch } = useFetcher(
+    () => medicationApi.getStockAlerts(),
+    [],
+    [] as StockAlert[],
+  );
+
+  return { alerts: data, isLoading, error, refetch };
+};


### PR DESCRIPTION
## 概要
Closes #130

Cycle3 Step1として5つの新機能を実装。

## 変更内容
1. **服薬アドヒアランス統計API** - `GET /api/records/stats` で週間/月間の服薬率を算出、ダッシュボードにカード表示
2. **メンバーフィルターUI** - 再利用可能な`MemberFilter`コンポーネント、ダッシュボードのスケジュールをメンバーで絞り込み
3. **お薬検索機能** - `GET /api/medications/search?q=` 横断検索API + `MedicationSearch`コンポーネント
4. **在庫アラート一覧表示** - `GET /api/medications/alerts` で14日以内の在庫不足警告、ダッシュボードに表示
5. **スケジュール重複チェック** - `ScheduleEntity.hasOverlap()` + API側で重複検出

## 新規ファイル
- `src/app/api/records/stats/route.ts` - アドヒアランス統計API
- `src/app/api/medications/search/route.ts` - お薬検索API
- `src/app/api/medications/alerts/route.ts` - 在庫アラートAPI
- `src/domain/entities/AdherenceStats.ts` - アドヒアランスエンティティ
- `src/components/dashboard/AdherenceStatsCard.tsx` - 統計カード
- `src/components/dashboard/StockAlertList.tsx` - 在庫アラートリスト
- `src/components/medications/MedicationSearch.tsx` - 検索コンポーネント
- `src/components/shared/MemberFilter.tsx` - メンバーフィルター
- `src/presentation/hooks/useAdherenceStats.ts` - 統計フック
- `src/presentation/hooks/useStockAlerts.ts` - アラートフック

## テスト
- 228 → 263テスト（35追加）
- 全テスト通過、ビルド成功