### PR TITLE
テストカバレッジの向上（Cycle3 Step3）

### DIFF
--- a/src/__tests__/components/dashboard/TodayScheduleList.test.tsx
+++ b/src/__tests__/components/dashboard/TodayScheduleList.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
+import { TodayScheduleViewModel } from '@/domain/usecases/GetTodaySchedules';
+
+const createSchedule = (overrides: Partial<TodayScheduleViewModel> = {}): TodayScheduleViewModel => ({
+  scheduleId: 'schedule-1',
+  medicationId: 'med-1',
+  medicationName: 'アスピリン',
+  memberName: '太郎',
+  scheduledTime: '08:00',
+  status: 'pending' as const,
+  ...overrides,
+});
+
+describe('TodayScheduleList', () => {
+  it('ローディング中は読み込みメッセージを表示する', () => {
+    render(<TodayScheduleList schedules={[]} isLoading={true} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('スケジュールが空の場合はメッセージを表示する', () => {
+    render(<TodayScheduleList schedules={[]} isLoading={false} />);
+    expect(screen.getByText('今日の服薬スケジュールはありません')).toBeInTheDocument();
+  });
+
+  it('スケジュール一覧を表示する', () => {
+    const schedules = [
+      createSchedule({ scheduleId: 's1', medicationName: 'アスピリン', scheduledTime: '08:00' }),
+      createSchedule({ scheduleId: 's2', medicationName: 'ビタミンC', scheduledTime: '12:00', memberName: '花子' }),
+    ];
+    render(<TodayScheduleList schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('アスピリン')).toBeInTheDocument();
+    expect(screen.getByText('ビタミンC')).toBeInTheDocument();
+    expect(screen.getByText('太郎')).toBeInTheDocument();
+    expect(screen.getByText('花子')).toBeInTheDocument();
+  });
+
+  it('未服薬ステータスが表示される', () => {
+    render(<TodayScheduleList schedules={[createSchedule({ status: 'pending' })]} isLoading={false} />);
+    expect(screen.getByText('未服薬')).toBeInTheDocument();
+  });
+
+  it('服薬済みステータスが表示される', () => {
+    render(<TodayScheduleList schedules={[createSchedule({ status: 'completed' })]} isLoading={false} />);
+    expect(screen.getByText('服薬済み')).toBeInTheDocument();
+  });
+
+  it('時間超過ステータスが表示される', () => {
+    render(<TodayScheduleList schedules={[createSchedule({ status: 'overdue' })]} isLoading={false} />);
+    expect(screen.getByText('時間超過')).toBeInTheDocument();
+  });
+
+  it('服薬完了ボタンをクリックするとコールバックが呼ばれる', () => {
+    const onMarkCompleted = vi.fn();
+    render(
+      <TodayScheduleList
+        schedules={[createSchedule({ scheduleId: 's1', status: 'pending' })]}
+        isLoading={false}
+        onMarkCompleted={onMarkCompleted}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('服薬完了'));
+    expect(onMarkCompleted).toHaveBeenCalledWith('s1');
+  });
+
+  it('服薬済みの場合は完了ボタンが表示されない', () => {
+    const onMarkCompleted = vi.fn();
+    render(
+      <TodayScheduleList
+        schedules={[createSchedule({ status: 'completed' })]}
+        isLoading={false}
+        onMarkCompleted={onMarkCompleted}
+      />,
+    );
+    expect(screen.queryByLabelText('服薬完了')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/shared/BottomNavigation.test.tsx
+++ b/src/__tests__/components/shared/BottomNavigation.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+
+describe('BottomNavigation', () => {
+  it('全てのナビゲーションアイテムを表示する', () => {
+    render(<BottomNavigation activePath="/" />);
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('お薬')).toBeInTheDocument();
+    expect(screen.getByText('通院')).toBeInTheDocument();
+    expect(screen.getByText('メンバー')).toBeInTheDocument();
+    expect(screen.getByText('設定')).toBeInTheDocument();
+  });
+
+  it('アクティブなパスのリンクにaria-current="page"が設定される', () => {
+    render(<BottomNavigation activePath="/" />);
+    const homeLink = screen.getByText('ホーム').closest('a');
+    expect(homeLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('非アクティブなパスのリンクにはaria-currentが設定されない', () => {
+    render(<BottomNavigation activePath="/" />);
+    const membersLink = screen.getByText('メンバー').closest('a');
+    expect(membersLink).not.toHaveAttribute('aria-current');
+  });
+
+  it('各リンクが正しいhrefを持つ', () => {
+    render(<BottomNavigation activePath="/" />);
+    expect(screen.getByText('ホーム').closest('a')).toHaveAttribute('href', '/');
+    expect(screen.getByText('お薬').closest('a')).toHaveAttribute('href', '/medications');
+    expect(screen.getByText('通院').closest('a')).toHaveAttribute('href', '/appointments');
+    expect(screen.getByText('メンバー').closest('a')).toHaveAttribute('href', '/members');
+    expect(screen.getByText('設定').closest('a')).toHaveAttribute('href', '/settings');
+  });
+
+  it('お薬ページがアクティブの場合の表示', () => {
+    render(<BottomNavigation activePath="/medications" />);
+    const medicationsLink = screen.getByText('お薬').closest('a');
+    const homeLink = screen.getByText('ホーム').closest('a');
+    expect(medicationsLink).toHaveAttribute('aria-current', 'page');
+    expect(homeLink).not.toHaveAttribute('aria-current');
+  });
+
+  it('navにaria-labelが設定されている', () => {
+    render(<BottomNavigation activePath="/" />);
+    expect(screen.getByRole('navigation', { name: 'メインナビゲーション' })).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/domain/entities/StockAlert.test.ts
+++ b/src/__tests__/domain/entities/StockAlert.test.ts
@@ -29,6 +29,16 @@ describe('StockAlertEntity', () => {
       const entity = new StockAlertEntity(createAlert({ daysUntilAlert: 4 }));
       expect(entity.isUrgent()).toBe(false);
     });
+
+    it('daysUntilAlert=0の場合trueを返す（境界値）', () => {
+      const entity = new StockAlertEntity(createAlert({ daysUntilAlert: 0 }));
+      expect(entity.isUrgent()).toBe(true);
+    });
+
+    it('daysUntilAlert=1の場合trueを返す', () => {
+      const entity = new StockAlertEntity(createAlert({ daysUntilAlert: 1 }));
+      expect(entity.isUrgent()).toBe(true);
+    });
   });
 
   describe('getDaysLabel', () => {
@@ -40,6 +50,16 @@ describe('StockAlertEntity', () => {
     it('期限内の場合「あとN日」を返す', () => {
       const entity = new StockAlertEntity(createAlert({ daysUntilAlert: 7 }));
       expect(entity.getDaysLabel()).toBe('あと7日');
+    });
+
+    it('daysUntilAlert=0の場合「あと0日」を返す', () => {
+      const entity = new StockAlertEntity(createAlert({ daysUntilAlert: 0 }));
+      expect(entity.getDaysLabel()).toBe('あと0日');
+    });
+
+    it('daysUntilAlert=1の場合「あと1日」を返す', () => {
+      const entity = new StockAlertEntity(createAlert({ daysUntilAlert: 1 }));
+      expect(entity.getDaysLabel()).toBe('あと1日');
     });
   });
 

--- a/src/__tests__/lib/auth-helpers.test.ts
+++ b/src/__tests__/lib/auth-helpers.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { success, created, errorResponse, notFound, unauthorized, getAuthUserId } from '@/lib/auth-helpers';
+
+vi.mock('@/lib/auth', () => ({
+  auth: vi.fn(),
+}));
+
+import { auth } from '@/lib/auth';
+
+const mockAuth = vi.mocked(auth);
+
+describe('auth-helpers', () => {
+  describe('success', () => {
+    it('200ステータスでJSONレスポンスを返す', async () => {
+      const response = success({ message: 'ok' });
+      const json = await response.json();
+      expect(response.status).toBe(200);
+      expect(json).toEqual({ success: true, data: { message: 'ok' } });
+    });
+
+    it('カスタムステータスコードを指定できる', async () => {
+      const response = success({ data: 'test' }, 202);
+      expect(response.status).toBe(202);
+    });
+  });
+
+  describe('created', () => {
+    it('201ステータスでJSONレスポンスを返す', async () => {
+      const response = created({ id: '1' });
+      const json = await response.json();
+      expect(response.status).toBe(201);
+      expect(json).toEqual({ success: true, data: { id: '1' } });
+    });
+  });
+
+  describe('errorResponse', () => {
+    it('400ステータスでエラーレスポンスを返す', async () => {
+      const response = errorResponse('入力エラー');
+      const json = await response.json();
+      expect(response.status).toBe(400);
+      expect(json).toEqual({ success: false, error: '入力エラー' });
+    });
+
+    it('カスタムステータスコードを指定できる', async () => {
+      const response = errorResponse('レート制限', 429);
+      expect(response.status).toBe(429);
+    });
+  });
+
+  describe('notFound', () => {
+    it('404ステータスでリソース名入りエラーを返す', async () => {
+      const response = notFound('メンバー');
+      const json = await response.json();
+      expect(response.status).toBe(404);
+      expect(json).toEqual({ success: false, error: 'メンバーが見つかりません' });
+    });
+  });
+
+  describe('unauthorized', () => {
+    it('401ステータスで認証エラーを返す', async () => {
+      const response = unauthorized();
+      const json = await response.json();
+      expect(response.status).toBe(401);
+      expect(json).toEqual({ success: false, error: '認証エラー' });
+    });
+  });
+
+  describe('getAuthUserId', () => {
+    it('セッションからuserIdを取得する', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'user-1', email: 'test@example.com' }, expires: '' } as ReturnType<typeof auth> extends Promise<infer T> ? T : never);
+      const userId = await getAuthUserId();
+      expect(userId).toBe('user-1');
+    });
+
+    it('セッションがない場合nullを返す', async () => {
+      mockAuth.mockResolvedValue(null as ReturnType<typeof auth> extends Promise<infer T> ? T : never);
+      const userId = await getAuthUserId();
+      expect(userId).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/lib/email.test.ts
+++ b/src/__tests__/lib/email.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { emailTemplates, generateVerificationCode } from '@/lib/email';
+
+describe('generateVerificationCode', () => {
+  it('6桁の数字文字列を生成する', () => {
+    const code = generateVerificationCode();
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  it('100000以上999999以下の値を生成する', () => {
+    for (let i = 0; i < 50; i++) {
+      const code = parseInt(generateVerificationCode(), 10);
+      expect(code).toBeGreaterThanOrEqual(100000);
+      expect(code).toBeLessThanOrEqual(999999);
+    }
+  });
+});
+
+describe('emailTemplates', () => {
+  describe('verificationCode', () => {
+    it('確認コードテンプレートを生成する', () => {
+      const result = emailTemplates.verificationCode({ code: '123456' });
+      expect(result.subject).toBe('HealthFamily - メールアドレスの確認');
+      expect(result.html).toContain('123456');
+      expect(result.html).toContain('メールアドレスの確認');
+    });
+
+    it('HTMLエスケープが適用される', () => {
+      const result = emailTemplates.verificationCode({ code: '<script>alert("xss")</script>' });
+      expect(result.html).not.toContain('<script>');
+      expect(result.html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('passwordReset', () => {
+    it('パスワードリセットテンプレートを生成する', () => {
+      const result = emailTemplates.passwordReset({ code: '654321' });
+      expect(result.subject).toBe('HealthFamily - パスワードの再設定');
+      expect(result.html).toContain('654321');
+      expect(result.html).toContain('パスワードの再設定');
+    });
+  });
+
+  describe('medicationReminder', () => {
+    it('服薬リマインダーテンプレートを生成する', () => {
+      const result = emailTemplates.medicationReminder({
+        memberName: '太郎',
+        medicationName: 'アスピリン',
+        scheduledTime: '08:00',
+      });
+      expect(result.subject).toBe('太郎さんのお薬の時間です');
+      expect(result.html).toContain('太郎');
+      expect(result.html).toContain('アスピリン');
+      expect(result.html).toContain('08:00');
+    });
+
+    it('HTMLエスケープが適用される', () => {
+      const result = emailTemplates.medicationReminder({
+        memberName: '<b>太郎</b>',
+        medicationName: 'テスト&薬',
+        scheduledTime: '08:00',
+      });
+      expect(result.html).toContain('&lt;b&gt;太郎&lt;/b&gt;');
+      expect(result.html).toContain('テスト&amp;薬');
+    });
+  });
+
+  describe('missedMedication', () => {
+    it('飲み忘れ通知テンプレートを生成する', () => {
+      const result = emailTemplates.missedMedication({
+        memberName: '花子',
+        medicationName: 'ビタミンC',
+        scheduledTime: '12:00',
+      });
+      expect(result.subject).toBe('花子さんのお薬が飲み忘れています');
+      expect(result.html).toContain('お薬の飲み忘れ');
+      expect(result.html).toContain('花子');
+      expect(result.html).toContain('ビタミンC');
+    });
+  });
+
+  describe('appointmentReminder', () => {
+    it('通院リマインダーテンプレートを生成する', () => {
+      const result = emailTemplates.appointmentReminder({
+        memberName: '太郎',
+        hospitalName: '東京病院',
+        appointmentDate: '2026-03-01',
+      });
+      expect(result.subject).toBe('太郎さんの通院予定があります');
+      expect(result.html).toContain('東京病院');
+      expect(result.html).toContain('2026-03-01');
+    });
+
+    it('descriptionがある場合はHTMLに含まれる', () => {
+      const result = emailTemplates.appointmentReminder({
+        memberName: '太郎',
+        hospitalName: '東京病院',
+        appointmentDate: '2026-03-01',
+        description: '定期検診',
+      });
+      expect(result.html).toContain('定期検診');
+    });
+
+    it('descriptionがない場合はメモ欄を表示しない', () => {
+      const result = emailTemplates.appointmentReminder({
+        memberName: '太郎',
+        hospitalName: '東京病院',
+        appointmentDate: '2026-03-01',
+      });
+      expect(result.html).not.toContain('内容:');
+    });
+  });
+
+  describe('lowStockAlert', () => {
+    it('在庫アラートテンプレートを生成する', () => {
+      const result = emailTemplates.lowStockAlert({
+        memberName: '太郎',
+        medicationName: 'アスピリン',
+        currentStock: 3,
+        alertDate: '2026-03-05',
+        daysUntilAlert: 5,
+      });
+      expect(result.subject).toBe('アスピリンの在庫が2026-03-05までに不足します');
+      expect(result.html).toContain('3日分');
+      expect(result.html).toContain('あと5日');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

テストが不足していた領域にテストを追加し、テストカバレッジを向上させる。

## 変更内容

- `auth-helpers.test.ts`: レスポンスヘルパー（success, created, errorResponse, notFound, unauthorized）+ getAuthUserIdのテスト（9テスト）
- `email.test.ts`: generateVerificationCode + 全6種メールテンプレートのテスト（12テスト）
- `StockAlert.test.ts`: isUrgent/getDaysLabelの境界値テスト追加（4テスト）
- `BottomNavigation.test.tsx`: ナビゲーション表示、aria属性、href確認（6テスト）
- `TodayScheduleList.test.tsx`: ローディング、空状態、一覧表示、ステータス、完了ボタン（8テスト）

## テスト数

277 → 316（+39テスト）

closes #134