### PR TITLE
セキュリティ脆弱性の修正（Cycle3 Step4）

### DIFF
--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
 
     const user = await prisma.user.findUnique({ where: { email } });
     if (!user) {
-      return errorResponse('ユーザーが見つかりません', 404);
+      return errorResponse('確認コードが正しくありません');
     }
 
     if (user.emailVerified) {

--- a/src/app/api/medications/search/route.ts
+++ b/src/app/api/medications/search/route.ts
@@ -9,6 +9,9 @@ export async function GET(request: NextRequest) {
     if (!q) {
       return errorResponse('検索キーワードを入力してください');
     }
+    if (q.length > 100) {
+      return errorResponse('検索キーワードは100文字以内で入力してください');
+    }
 
     const medications = await prisma.medication.findMany({
       where: {

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -38,3 +38,23 @@ export async function withOwnershipCheck<T extends { userId: string }>({
   if (!resource || resource.userId !== userId) return notFound(resourceName);
   return handler(resource);
 }
+
+/**
+ * リソースの所有権を検証する
+ * 指定されたリソースが指定ユーザーに属しているか確認する
+ */
+export async function verifyResourceOwnership(
+  userId: string,
+  checks: Array<{
+    finder: () => Promise<{ userId: string } | null>;
+    resourceName: string;
+  }>,
+): Promise<Response | null> {
+  for (const check of checks) {
+    const resource = await check.finder();
+    if (!resource || resource.userId !== userId) {
+      return notFound(check.resourceName);
+    }
+  }
+  return null;
+}

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -5,12 +5,12 @@ import crypto from 'crypto';
  * タイミング攻撃を防ぐために固定時間で比較する
  */
 export function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    // 長さが異なる場合もタイミングを一定にするためダミー比較を行う
-    crypto.timingSafeEqual(Buffer.from(a), Buffer.from(a));
-    return false;
-  }
-  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  const maxLen = Math.max(a.length, b.length);
+  const paddedA = a.padEnd(maxLen, '\0');
+  const paddedB = b.padEnd(maxLen, '\0');
+  const result = crypto.timingSafeEqual(Buffer.from(paddedA), Buffer.from(paddedB));
+  if (a.length !== b.length) return false;
+  return result;
 }
 
 /**


### PR DESCRIPTION
## 概要

セキュリティ監査で発見された脆弱性を修正する。

## 変更内容

- `api-helpers.ts`: `verifyResourceOwnership`ヘルパー関数を追加
- `medications/route.ts`: メンバー所有権検証を追加
- `appointments/route.ts`: メンバー・病院所有権検証を追加
- `records/route.ts`: メンバー・薬所有権検証を追加
- `schedules/route.ts`: メンバー・薬所有権検証を追加
- `security.ts`: timingSafeEqualのパディング方式修正
- `auth/verify/route.ts`: ユーザー列挙防止
- `auth/resend-code/route.ts`: ユーザー列挙防止
- `medications/search/route.ts`: クエリ長100文字制限
- `api-helpers.test.ts`: verifyResourceOwnershipのテスト追加（3テスト）

## テスト数

316 → 319（+3テスト）

closes #136