### PR TITLE
feat: Cycle4 Step1 - 5つの新機能を追加

### DIFF
--- a/src/__tests__/components/dashboard/AdherenceTrendCard.test.tsx
+++ b/src/__tests__/components/dashboard/AdherenceTrendCard.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AdherenceTrendCard } from '@/components/dashboard/AdherenceTrendCard';
+import { AdherenceTrend } from '@/domain/entities/AdherenceTrend';
+
+const createTrend = (overrides: Partial<AdherenceTrend> = {}): AdherenceTrend => ({
+  dayOfWeekStats: [
+    { day: 0, dayLabel: '日', count: 1, expected: 2, rate: 50 },
+    { day: 1, dayLabel: '月', count: 2, expected: 2, rate: 100 },
+    { day: 2, dayLabel: '火', count: 2, expected: 2, rate: 100 },
+    { day: 3, dayLabel: '水', count: 1, expected: 2, rate: 50 },
+    { day: 4, dayLabel: '木', count: 2, expected: 2, rate: 100 },
+    { day: 5, dayLabel: '金', count: 2, expected: 2, rate: 100 },
+    { day: 6, dayLabel: '土', count: 1, expected: 2, rate: 50 },
+  ],
+  bestDay: '月',
+  worstDay: '日',
+  previousPeriodRate: 70,
+  currentPeriodRate: 80,
+  rateChange: 10,
+  ...overrides,
+});
+
+describe('AdherenceTrendCard', () => {
+  it('ローディング中はメッセージを表示する', () => {
+    render(<AdherenceTrendCard trend={null} isLoading={true} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('トレンドがnullの場合は何も表示しない', () => {
+    const { container } = render(<AdherenceTrendCard trend={null} isLoading={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('タイトルを表示する', () => {
+    render(<AdherenceTrendCard trend={createTrend()} isLoading={false} />);
+    expect(screen.getByText('服薬トレンド（週間）')).toBeInTheDocument();
+  });
+
+  it('変化率を表示する', () => {
+    render(<AdherenceTrendCard trend={createTrend({ rateChange: 10 })} isLoading={false} />);
+    expect(screen.getByText('+10%')).toBeInTheDocument();
+  });
+
+  it('最高・最低の曜日を表示する', () => {
+    render(<AdherenceTrendCard trend={createTrend({ bestDay: '月', worstDay: '日' })} isLoading={false} />);
+    expect(screen.getByText('最高: 月曜日')).toBeInTheDocument();
+    expect(screen.getByText('最低: 日曜日')).toBeInTheDocument();
+  });
+
+  it('全曜日ラベルを表示する', () => {
+    render(<AdherenceTrendCard trend={createTrend()} isLoading={false} />);
+    expect(screen.getByText('日')).toBeInTheDocument();
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('土')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/dashboard/WeeklySummaryCard.test.tsx
+++ b/src/__tests__/components/dashboard/WeeklySummaryCard.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WeeklySummaryCard } from '@/components/dashboard/WeeklySummaryCard';
+import { TodayScheduleViewModel } from '@/domain/usecases/GetTodaySchedules';
+
+const createSchedule = (status: 'pending' | 'completed' | 'overdue'): TodayScheduleViewModel => ({
+  scheduleId: `s-${Math.random()}`,
+  medicationId: 'med-1',
+  medicationName: 'テスト薬',
+  memberName: '太郎',
+  memberId: 'member-1',
+  scheduledTime: '08:00',
+  status,
+});
+
+describe('WeeklySummaryCard', () => {
+  it('ローディング中はメッセージを表示する', () => {
+    render(<WeeklySummaryCard schedules={[]} isLoading={true} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('スケジュールが空の場合は何も表示しない', () => {
+    const { container } = render(<WeeklySummaryCard schedules={[]} isLoading={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('完了件数を表示する', () => {
+    const schedules = [createSchedule('completed'), createSchedule('completed'), createSchedule('pending')];
+    render(<WeeklySummaryCard schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('2件完了')).toBeInTheDocument();
+  });
+
+  it('予定件数を表示する', () => {
+    const schedules = [createSchedule('pending'), createSchedule('completed')];
+    render(<WeeklySummaryCard schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('1件予定')).toBeInTheDocument();
+  });
+
+  it('超過件数がある場合は表示する', () => {
+    const schedules = [createSchedule('overdue'), createSchedule('completed')];
+    render(<WeeklySummaryCard schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('1件超過')).toBeInTheDocument();
+  });
+
+  it('超過件数がない場合は非表示', () => {
+    const schedules = [createSchedule('completed'), createSchedule('pending')];
+    render(<WeeklySummaryCard schedules={schedules} isLoading={false} />);
+    expect(screen.queryByText(/件超過/)).not.toBeInTheDocument();
+  });
+
+  it('達成率を表示する', () => {
+    const schedules = [createSchedule('completed'), createSchedule('completed'), createSchedule('pending'), createSchedule('pending')];
+    render(<WeeklySummaryCard schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('50%')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/members/MemberSummaryCard.test.tsx
+++ b/src/__tests__/components/members/MemberSummaryCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemberSummaryCard } from '@/components/members/MemberSummaryCard';
+import { MemberSummary } from '@/domain/entities/MemberSummary';
+
+const createSummary = (overrides: Partial<MemberSummary> = {}): MemberSummary => ({
+  memberId: 'member-1',
+  memberName: '太郎',
+  memberType: 'human',
+  medicationCount: 3,
+  nextAppointmentDate: null,
+  ...overrides,
+});
+
+describe('MemberSummaryCard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('薬の種類数を表示する', () => {
+    render(<MemberSummaryCard summary={createSummary({ medicationCount: 5 })} />);
+    expect(screen.getByText('5種類')).toBeInTheDocument();
+  });
+
+  it('予約がない場合は次回通院を表示しない', () => {
+    render(<MemberSummaryCard summary={createSummary()} />);
+    expect(screen.queryByText(/次回通院/)).not.toBeInTheDocument();
+  });
+
+  it('予約がある場合は次回通院を表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T10:00:00Z'));
+    render(<MemberSummaryCard summary={createSummary({ nextAppointmentDate: '2026-03-05T00:00:00Z' })} />);
+    expect(screen.getByText('次回通院: 4日後')).toBeInTheDocument();
+  });
+
+  it('薬が0種類の場合も表示する', () => {
+    render(<MemberSummaryCard summary={createSummary({ medicationCount: 0 })} />);
+    expect(screen.getByText('0種類')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/shared/CategoryFilter.test.tsx
+++ b/src/__tests__/components/shared/CategoryFilter.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CategoryFilter } from '@/components/shared/CategoryFilter';
+
+describe('CategoryFilter', () => {
+  it('すべてボタンとカテゴリボタンを表示する', () => {
+    render(<CategoryFilter selectedCategory={null} onSelect={vi.fn()} />);
+    expect(screen.getByText('すべて')).toBeInTheDocument();
+    expect(screen.getByText('常用薬')).toBeInTheDocument();
+    expect(screen.getByText('サプリメント')).toBeInTheDocument();
+  });
+
+  it('すべてが選択されているときはaria-selected=trueになる', () => {
+    render(<CategoryFilter selectedCategory={null} onSelect={vi.fn()} />);
+    expect(screen.getByText('すべて')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('常用薬')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('カテゴリが選択されているときは該当ボタンがaria-selected=trueになる', () => {
+    render(<CategoryFilter selectedCategory="supplement" onSelect={vi.fn()} />);
+    expect(screen.getByText('すべて')).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('サプリメント')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('すべてボタンをクリックするとnullが渡される', () => {
+    const onSelect = vi.fn();
+    render(<CategoryFilter selectedCategory="regular" onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('すべて'));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('カテゴリボタンをクリックするとカテゴリIDが渡される', () => {
+    const onSelect = vi.fn();
+    render(<CategoryFilter selectedCategory={null} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('頓服薬'));
+    expect(onSelect).toHaveBeenCalledWith('prn');
+  });
+
+  it('availableCategoriesで絞り込める', () => {
+    render(<CategoryFilter selectedCategory={null} onSelect={vi.fn()} availableCategories={['regular', 'supplement']} />);
+    expect(screen.getByText('常用薬')).toBeInTheDocument();
+    expect(screen.getByText('サプリメント')).toBeInTheDocument();
+    expect(screen.queryByText('頓服薬')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/shared/TabSwitch.test.tsx
+++ b/src/__tests__/components/shared/TabSwitch.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TabSwitch } from '@/components/shared/TabSwitch';
+
+describe('TabSwitch', () => {
+  const tabs = [
+    { id: 'upcoming', label: '今後の予定', count: 3 },
+    { id: 'past', label: '過去の予定', count: 5 },
+  ];
+
+  it('全てのタブを表示する', () => {
+    render(<TabSwitch tabs={tabs} activeTab="upcoming" onTabChange={vi.fn()} />);
+    expect(screen.getByText('今後の予定')).toBeInTheDocument();
+    expect(screen.getByText('過去の予定')).toBeInTheDocument();
+  });
+
+  it('カウントを表示する', () => {
+    render(<TabSwitch tabs={tabs} activeTab="upcoming" onTabChange={vi.fn()} />);
+    expect(screen.getByText('(3)')).toBeInTheDocument();
+    expect(screen.getByText('(5)')).toBeInTheDocument();
+  });
+
+  it('アクティブタブにaria-selected=trueが設定される', () => {
+    render(<TabSwitch tabs={tabs} activeTab="upcoming" onTabChange={vi.fn()} />);
+    expect(screen.getByText('今後の予定').closest('button')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('過去の予定').closest('button')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('タブクリックでonTabChangeが呼ばれる', () => {
+    const onTabChange = vi.fn();
+    render(<TabSwitch tabs={tabs} activeTab="upcoming" onTabChange={onTabChange} />);
+    fireEvent.click(screen.getByText('過去の予定'));
+    expect(onTabChange).toHaveBeenCalledWith('past');
+  });
+
+  it('カウントなしのタブも表示できる', () => {
+    const simpleTabs = [
+      { id: 'a', label: 'タブA' },
+      { id: 'b', label: 'タブB' },
+    ];
+    render(<TabSwitch tabs={simpleTabs} activeTab="a" onTabChange={vi.fn()} />);
+    expect(screen.getByText('タブA')).toBeInTheDocument();
+    expect(screen.queryByText('(')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/domain/entities/AdherenceTrend.test.ts
+++ b/src/__tests__/domain/entities/AdherenceTrend.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity, AdherenceTrend } from '@/domain/entities/AdherenceTrend';
+
+const createTrend = (overrides: Partial<AdherenceTrend> = {}): AdherenceTrend => ({
+  dayOfWeekStats: [],
+  bestDay: '月',
+  worstDay: '日',
+  previousPeriodRate: 70,
+  currentPeriodRate: 80,
+  rateChange: 10,
+  ...overrides,
+});
+
+describe('AdherenceTrendEntity', () => {
+  it('改善中の場合isImprovingがtrueを返す', () => {
+    const entity = new AdherenceTrendEntity(createTrend({ rateChange: 5 }));
+    expect(entity.isImproving()).toBe(true);
+    expect(entity.isDeclining()).toBe(false);
+  });
+
+  it('低下中の場合isImprovingがfalseを返す', () => {
+    const entity = new AdherenceTrendEntity(createTrend({ rateChange: -3 }));
+    expect(entity.isImproving()).toBe(false);
+    expect(entity.isDeclining()).toBe(true);
+  });
+
+  it('変化なしの場合両方falseを返す', () => {
+    const entity = new AdherenceTrendEntity(createTrend({ rateChange: 0 }));
+    expect(entity.isImproving()).toBe(false);
+    expect(entity.isDeclining()).toBe(false);
+  });
+
+  it('増加の変化率ラベルに+が付く', () => {
+    const entity = new AdherenceTrendEntity(createTrend({ rateChange: 10 }));
+    expect(entity.getRateChangeLabel()).toBe('+10%');
+  });
+
+  it('減少の変化率ラベルに-が付く', () => {
+    const entity = new AdherenceTrendEntity(createTrend({ rateChange: -5 }));
+    expect(entity.getRateChangeLabel()).toBe('-5%');
+  });
+
+  it('変化なしの場合0%を返す', () => {
+    const entity = new AdherenceTrendEntity(createTrend({ rateChange: 0 }));
+    expect(entity.getRateChangeLabel()).toBe('0%');
+  });
+
+  it('getDayLabelが正しい曜日名を返す', () => {
+    expect(AdherenceTrendEntity.getDayLabel(0)).toBe('日');
+    expect(AdherenceTrendEntity.getDayLabel(1)).toBe('月');
+    expect(AdherenceTrendEntity.getDayLabel(6)).toBe('土');
+  });
+
+  it('dataがトレンドデータを返す', () => {
+    const trend = createTrend({ bestDay: '火' });
+    const entity = new AdherenceTrendEntity(trend);
+    expect(entity.data.bestDay).toBe('火');
+  });
+});

--- a/src/__tests__/domain/entities/MemberSummary.test.ts
+++ b/src/__tests__/domain/entities/MemberSummary.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MemberSummaryEntity, MemberSummary } from '@/domain/entities/MemberSummary';
+
+const createSummary = (overrides: Partial<MemberSummary> = {}): MemberSummary => ({
+  memberId: 'member-1',
+  memberName: '太郎',
+  memberType: 'human',
+  medicationCount: 3,
+  nextAppointmentDate: null,
+  ...overrides,
+});
+
+describe('MemberSummaryEntity', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('予約なしの場合hasUpcomingAppointmentがfalseを返す', () => {
+    const entity = new MemberSummaryEntity(createSummary());
+    expect(entity.hasUpcomingAppointment()).toBe(false);
+  });
+
+  it('予約ありの場合hasUpcomingAppointmentがtrueを返す', () => {
+    const entity = new MemberSummaryEntity(createSummary({ nextAppointmentDate: '2026-12-01T00:00:00Z' }));
+    expect(entity.hasUpcomingAppointment()).toBe(true);
+  });
+
+  it('予約なしの場合getDaysUntilAppointmentがnullを返す', () => {
+    const entity = new MemberSummaryEntity(createSummary());
+    expect(entity.getDaysUntilAppointment()).toBeNull();
+  });
+
+  it('今日の予約の場合getAppointmentLabelが今日を返す', () => {
+    vi.useFakeTimers();
+    const now = new Date(2026, 2, 1, 10, 0, 0); // 2026-03-01 10:00 local
+    vi.setSystemTime(now);
+    const todayStr = new Date(2026, 2, 1, 14, 0, 0).toISOString();
+    const entity = new MemberSummaryEntity(createSummary({ nextAppointmentDate: todayStr }));
+    expect(entity.getAppointmentLabel()).toBe('今日');
+  });
+
+  it('明日の予約の場合getAppointmentLabelが明日を返す', () => {
+    vi.useFakeTimers();
+    const now = new Date(2026, 2, 1, 10, 0, 0);
+    vi.setSystemTime(now);
+    const tomorrowStr = new Date(2026, 2, 2, 14, 0, 0).toISOString();
+    const entity = new MemberSummaryEntity(createSummary({ nextAppointmentDate: tomorrowStr }));
+    expect(entity.getAppointmentLabel()).toBe('明日');
+  });
+
+  it('複数日後の予約の場合日数を返す', () => {
+    vi.useFakeTimers();
+    const now = new Date(2026, 2, 1, 10, 0, 0);
+    vi.setSystemTime(now);
+    const futureStr = new Date(2026, 2, 6, 14, 0, 0).toISOString();
+    const entity = new MemberSummaryEntity(createSummary({ nextAppointmentDate: futureStr }));
+    expect(entity.getAppointmentLabel()).toBe('5日後');
+  });
+
+  it('予約なしの場合getAppointmentLabelが空文字を返す', () => {
+    const entity = new MemberSummaryEntity(createSummary());
+    expect(entity.getAppointmentLabel()).toBe('');
+  });
+
+  it('dataがサマリーデータを返す', () => {
+    const summary = createSummary({ memberName: '花子' });
+    const entity = new MemberSummaryEntity(summary);
+    expect(entity.data.memberName).toBe('花子');
+  });
+});

--- a/src/app/api/members/summary/route.ts
+++ b/src/app/api/members/summary/route.ts
@@ -1,0 +1,36 @@
+import { prisma } from '@/lib/prisma';
+import { success } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+
+export const GET = withAuth(async (userId) => {
+  const [members, medications, appointments] = await Promise.all([
+    prisma.member.findMany({
+      where: { userId },
+      select: { id: true, name: true, memberType: true },
+    }),
+    prisma.medication.findMany({
+      where: { userId, isActive: true },
+      select: { memberId: true },
+    }),
+    prisma.appointment.findMany({
+      where: { userId, appointmentDate: { gte: new Date() } },
+      select: { memberId: true, appointmentDate: true },
+      orderBy: { appointmentDate: 'asc' },
+    }),
+  ]);
+
+  const summary = members.map((member) => {
+    const medicationCount = medications.filter((m) => m.memberId === member.id).length;
+    const nextAppointment = appointments.find((a) => a.memberId === member.id);
+
+    return {
+      memberId: member.id,
+      memberName: member.name,
+      memberType: member.memberType,
+      medicationCount,
+      nextAppointmentDate: nextAppointment?.appointmentDate.toISOString() ?? null,
+    };
+  });
+
+  return success(summary);
+});

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -1,0 +1,83 @@
+import { prisma } from '@/lib/prisma';
+import { success } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+export const GET = withAuth(async (userId) => {
+  const now = new Date();
+  const fourteenDaysAgo = new Date(now);
+  fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14);
+  fourteenDaysAgo.setHours(0, 0, 0, 0);
+
+  const sevenDaysAgo = new Date(now);
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  sevenDaysAgo.setHours(0, 0, 0, 0);
+
+  const [records, schedules] = await Promise.all([
+    prisma.medicationRecord.findMany({
+      where: { userId, takenAt: { gte: fourteenDaysAgo } },
+      select: { takenAt: true },
+    }),
+    prisma.schedule.findMany({
+      where: { userId, isEnabled: true },
+      select: { daysOfWeek: true },
+    }),
+  ]);
+
+  // 曜日別の期待数（スケジュールから）
+  const expectedByDay = new Array(7).fill(0);
+  for (const schedule of schedules) {
+    for (const day of schedule.daysOfWeek) {
+      const dayIndex = DAY_LABELS.indexOf(day);
+      if (dayIndex >= 0) expectedByDay[dayIndex] += 1;
+    }
+  }
+
+  // 直近7日の曜日別実績
+  const currentByDay = new Array(7).fill(0);
+  const previousByDay = new Array(7).fill(0);
+
+  for (const record of records) {
+    const dayOfWeek = record.takenAt.getDay();
+    if (record.takenAt >= sevenDaysAgo) {
+      currentByDay[dayOfWeek]++;
+    } else {
+      previousByDay[dayOfWeek]++;
+    }
+  }
+
+  const dayOfWeekStats = DAY_LABELS.map((label, i) => ({
+    day: i,
+    dayLabel: label,
+    count: currentByDay[i],
+    expected: expectedByDay[i],
+    rate: expectedByDay[i] > 0 ? Math.min(100, Math.round((currentByDay[i] / expectedByDay[i]) * 100)) : 0,
+  }));
+
+  // ベスト/ワーストの曜日（期待値のある曜日のみ）
+  const activeDays = dayOfWeekStats.filter((d) => d.expected > 0);
+  const bestDay = activeDays.length > 0
+    ? activeDays.reduce((a, b) => (a.rate >= b.rate ? a : b)).dayLabel
+    : '-';
+  const worstDay = activeDays.length > 0
+    ? activeDays.reduce((a, b) => (a.rate <= b.rate ? a : b)).dayLabel
+    : '-';
+
+  // 前期間と今期間の全体率
+  const currentTotal = currentByDay.reduce((a, b) => a + b, 0);
+  const previousTotal = previousByDay.reduce((a, b) => a + b, 0);
+  const weeklyExpected = expectedByDay.reduce((a, b) => a + b, 0);
+
+  const currentPeriodRate = weeklyExpected > 0 ? Math.min(100, Math.round((currentTotal / weeklyExpected) * 100)) : 0;
+  const previousPeriodRate = weeklyExpected > 0 ? Math.min(100, Math.round((previousTotal / weeklyExpected) * 100)) : 0;
+
+  return success({
+    dayOfWeekStats,
+    bestDay,
+    worstDay,
+    previousPeriodRate,
+    currentPeriodRate,
+    rateChange: currentPeriodRate - previousPeriodRate,
+  });
+});

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
 import { useHospitals } from '@/presentation/hooks/useHospitals';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
-import { AppointmentList } from '@/components/appointments/AppointmentList';
+import { AppointmentList, AppointmentFilter, getAppointmentCounts } from '@/components/appointments/AppointmentList';
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
+import { TabSwitch } from '@/components/shared/TabSwitch';
 import { Appointment } from '@/domain/entities/Appointment';
 import Link from 'next/link';
 import { Plus, X, MapPin } from 'lucide-react';
@@ -19,6 +20,13 @@ export default function AppointmentsPage() {
   const { hospitals } = useHospitals();
   const [showForm, setShowForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
+  const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
+
+  const counts = useMemo(() => getAppointmentCounts(appointments), [appointments]);
+  const tabs = useMemo(() => [
+    { id: 'upcoming', label: '今後の予定', count: counts.upcoming },
+    { id: 'past', label: '過去の予定', count: counts.past },
+  ], [counts]);
 
   const handleCreate = async (data: AppointmentFormData) => {
     await createAppointment(data);
@@ -104,9 +112,12 @@ export default function AppointmentsPage() {
           </div>
         )}
 
+        <TabSwitch tabs={tabs} activeTab={activeTab} onTabChange={(id) => setActiveTab(id as AppointmentFilter)} />
+
         <AppointmentList
           appointments={appointments}
           isLoading={isLoading}
+          filter={activeTab}
           onEdit={handleEdit}
           onDelete={handleDelete}
         />

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -2,6 +2,7 @@
 
 import { useAuth } from '@/hooks/useAuth';
 import { useMembers } from '@/presentation/hooks/useMembers';
+import { useMemberSummaries } from '@/presentation/hooks/useMemberSummaries';
 import { MemberList } from '@/components/members/MemberList';
 import { MemberForm, MemberFormData } from '@/components/members/MemberForm';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
@@ -12,6 +13,7 @@ import { Plus, X } from 'lucide-react';
 export default function Members() {
   const { userId } = useAuth();
   const { members, isLoading, createMember, updateMember, deleteMember } = useMembers(userId);
+  const { summaries } = useMemberSummaries();
   const [showForm, setShowForm] = useState(false);
   const [editingMember, setEditingMember] = useState<Member | null>(null);
 
@@ -88,6 +90,7 @@ export default function Members() {
           isLoading={isLoading}
           onDelete={deleteMember}
           onEdit={handleEdit}
+          summaries={summaries}
         />
       </main>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,13 +5,16 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTodaySchedules } from '@/presentation/hooks/useTodaySchedules';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
 import { useAdherenceStats } from '@/presentation/hooks/useAdherenceStats';
+import { useAdherenceTrends } from '@/presentation/hooks/useAdherenceTrends';
 import { useStockAlerts } from '@/presentation/hooks/useStockAlerts';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useCharacterStore } from '@/stores/characterStore';
 import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
 import { UpcomingAppointments } from '@/components/dashboard/UpcomingAppointments';
 import { AdherenceStatsCard } from '@/components/dashboard/AdherenceStatsCard';
+import { AdherenceTrendCard } from '@/components/dashboard/AdherenceTrendCard';
 import { StockAlertList } from '@/components/dashboard/StockAlertList';
+import { WeeklySummaryCard } from '@/components/dashboard/WeeklySummaryCard';
 import { MemberFilter } from '@/components/shared/MemberFilter';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { CharacterIcon } from '@/components/shared/CharacterIcon';
@@ -21,6 +24,7 @@ export default function Dashboard() {
   const { schedules, isLoading, markAsCompleted } = useTodaySchedules(userId);
   const { appointments, isLoading: appointmentsLoading } = useAppointments();
   const { stats, isLoading: statsLoading } = useAdherenceStats();
+  const { trend, isLoading: trendLoading } = useAdherenceTrends();
   const { alerts, isLoading: alertsLoading } = useStockAlerts();
   const { members } = useMembers(userId);
   const { getConfig, getMessage } = useCharacterStore();
@@ -56,12 +60,16 @@ export default function Dashboard() {
 
         <AdherenceStatsCard stats={stats} isLoading={statsLoading} />
 
+        <AdherenceTrendCard trend={trend} isLoading={trendLoading} />
+
         <StockAlertList alerts={alerts} isLoading={alertsLoading} />
 
         <UpcomingAppointments
           appointments={appointments}
           isLoading={appointmentsLoading}
         />
+
+        <WeeklySummaryCard schedules={schedules} isLoading={isLoading} />
 
         <h2 className="text-lg font-semibold text-gray-800 mb-3">今日の予定</h2>
         <div className="mb-4">

--- a/src/components/appointments/AppointmentList.tsx
+++ b/src/components/appointments/AppointmentList.tsx
@@ -4,14 +4,27 @@ import React from 'react';
 import { Calendar, Pencil, Trash2, User, MapPin } from 'lucide-react';
 import { Appointment, AppointmentEntity } from '../../domain/entities/Appointment';
 
+export type AppointmentFilter = 'upcoming' | 'past';
+
 interface AppointmentListProps {
   appointments: Appointment[];
   isLoading: boolean;
+  filter?: AppointmentFilter;
   onEdit: (appointment: Appointment) => void;
   onDelete: (appointmentId: string) => void;
 }
 
-export const AppointmentList: React.FC<AppointmentListProps> = ({ appointments, isLoading, onEdit, onDelete }) => {
+export function getAppointmentCounts(appointments: Appointment[]): { upcoming: number; past: number } {
+  let upcoming = 0;
+  let past = 0;
+  for (const a of appointments) {
+    if (new AppointmentEntity(a).isPast()) past++;
+    else upcoming++;
+  }
+  return { upcoming, past };
+}
+
+export const AppointmentList: React.FC<AppointmentListProps> = ({ appointments, isLoading, filter, onEdit, onDelete }) => {
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-8">
@@ -30,6 +43,30 @@ export const AppointmentList: React.FC<AppointmentListProps> = ({ appointments, 
 
   const upcoming = appointments.filter((a) => !new AppointmentEntity(a).isPast());
   const past = appointments.filter((a) => new AppointmentEntity(a).isPast());
+
+  if (filter === 'upcoming') {
+    return (
+      <div className="space-y-2">
+        {upcoming.length > 0 ? upcoming.map((apt) => (
+          <AppointmentCard key={apt.id} appointment={apt} onEdit={onEdit} onDelete={onDelete} />
+        )) : (
+          <p className="text-sm text-gray-500 text-center py-8">今後の予定はありません</p>
+        )}
+      </div>
+    );
+  }
+
+  if (filter === 'past') {
+    return (
+      <div className="space-y-2">
+        {past.length > 0 ? past.map((apt) => (
+          <AppointmentCard key={apt.id} appointment={apt} onEdit={onEdit} onDelete={onDelete} />
+        )) : (
+          <p className="text-sm text-gray-500 text-center py-8">過去の予定はありません</p>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/components/dashboard/AdherenceTrendCard.tsx
+++ b/src/components/dashboard/AdherenceTrendCard.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { AdherenceTrend, AdherenceTrendEntity } from '../../domain/entities/AdherenceTrend';
+
+interface AdherenceTrendCardProps {
+  trend: AdherenceTrend | null;
+  isLoading: boolean;
+}
+
+export const AdherenceTrendCard: React.FC<AdherenceTrendCardProps> = ({ trend, isLoading }) => {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-4 mb-4 border border-gray-200">
+        <p className="text-gray-400 text-sm text-center py-2">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!trend) return null;
+
+  const entity = new AdherenceTrendEntity(trend);
+  const TrendIcon = entity.isImproving() ? TrendingUp : entity.isDeclining() ? TrendingDown : Minus;
+  const trendColor = entity.isImproving() ? 'text-green-600' : entity.isDeclining() ? 'text-red-600' : 'text-gray-500';
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 mb-4 border border-gray-200">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-700">服薬トレンド（週間）</h3>
+        <div className={`flex items-center space-x-1 ${trendColor}`}>
+          <TrendIcon size={16} />
+          <span className="text-sm font-medium">{entity.getRateChangeLabel()}</span>
+        </div>
+      </div>
+
+      <div className="flex justify-between mb-2">
+        {trend.dayOfWeekStats.map((stat) => (
+          <div key={stat.day} className="flex flex-col items-center">
+            <div
+              className="w-6 rounded-t"
+              style={{
+                height: `${Math.max(4, stat.rate * 0.4)}px`,
+                backgroundColor: stat.rate >= 80 ? '#22c55e' : stat.rate >= 50 ? '#f59e0b' : '#ef4444',
+              }}
+            />
+            <span className="text-xs text-gray-500 mt-1">{stat.dayLabel}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-between text-xs text-gray-500 mt-2">
+        <span>最高: {trend.bestDay}曜日</span>
+        <span>最低: {trend.worstDay}曜日</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/WeeklySummaryCard.tsx
+++ b/src/components/dashboard/WeeklySummaryCard.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { CheckCircle2, Clock, AlertCircle } from 'lucide-react';
+import { TodayScheduleViewModel } from '../../domain/usecases/GetTodaySchedules';
+
+interface WeeklySummaryCardProps {
+  schedules: TodayScheduleViewModel[];
+  isLoading: boolean;
+}
+
+export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = ({ schedules, isLoading }) => {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-4 mb-4 border border-gray-200">
+        <p className="text-gray-400 text-sm text-center py-2">読み込み中...</p>
+      </div>
+    );
+  }
+
+  const completed = schedules.filter((s) => s.status === 'completed').length;
+  const pending = schedules.filter((s) => s.status === 'pending').length;
+  const overdue = schedules.filter((s) => s.status === 'overdue').length;
+  const total = schedules.length;
+
+  if (total === 0) return null;
+
+  const completionRate = Math.round((completed / total) * 100);
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 mb-4 border border-gray-200">
+      <h3 className="text-sm font-semibold text-gray-700 mb-3">今日のまとめ</h3>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-1">
+          <CheckCircle2 size={16} className="text-green-500" />
+          <span className="text-sm text-gray-700">{completed}件完了</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <Clock size={16} className="text-yellow-500" />
+          <span className="text-sm text-gray-700">{pending}件予定</span>
+        </div>
+        {overdue > 0 && (
+          <div className="flex items-center space-x-1">
+            <AlertCircle size={16} className="text-red-500" />
+            <span className="text-sm text-gray-700">{overdue}件超過</span>
+          </div>
+        )}
+      </div>
+      <div className="mt-3">
+        <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+          <span>達成率</span>
+          <span>{completionRate}%</span>
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-2">
+          <div
+            className="h-2 rounded-full transition-all"
+            style={{
+              width: `${completionRate}%`,
+              backgroundColor: completionRate >= 80 ? '#22c55e' : completionRate >= 50 ? '#f59e0b' : '#ef4444',
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import Link from 'next/link';
 import { Member, MemberEntity } from '../../domain/entities/Member';
+import { MemberSummary } from '../../domain/entities/MemberSummary';
 import { MemberIcon } from '../shared/MemberIcon';
+import { MemberSummaryCard } from './MemberSummaryCard';
 import { Pill, Pencil } from 'lucide-react';
 
 interface MemberListProps {
@@ -9,9 +11,10 @@ interface MemberListProps {
   isLoading: boolean;
   onDelete: (memberId: string) => void;
   onEdit?: (member: Member) => void;
+  summaries?: MemberSummary[];
 }
 
-export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDelete, onEdit }) => {
+export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDelete, onEdit, summaries }) => {
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-8">
@@ -31,7 +34,7 @@ export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDe
   return (
     <div className="space-y-3">
       {members.map((member) => (
-        <MemberCard key={member.id} member={member} onDelete={onDelete} onEdit={onEdit} />
+        <MemberCard key={member.id} member={member} onDelete={onDelete} onEdit={onEdit} summary={summaries?.find((s) => s.memberId === member.id)} />
       ))}
     </div>
   );
@@ -41,9 +44,10 @@ interface MemberCardProps {
   member: Member;
   onDelete: (memberId: string) => void;
   onEdit?: (member: Member) => void;
+  summary?: MemberSummary;
 }
 
-const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete, onEdit }) => {
+const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete, onEdit, summary }) => {
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
   const age = entity.getAge();
@@ -91,6 +95,7 @@ const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete, onEdit }) => 
           </button>
         </div>
       </div>
+      {summary && <MemberSummaryCard summary={summary} />}
       {member.notes && (
         <p className="mt-2 text-sm text-gray-500">{member.notes}</p>
       )}

--- a/src/components/members/MemberSummaryCard.tsx
+++ b/src/components/members/MemberSummaryCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Pill, Calendar } from 'lucide-react';
+import { MemberSummary, MemberSummaryEntity } from '../../domain/entities/MemberSummary';
+
+interface MemberSummaryCardProps {
+  summary: MemberSummary;
+}
+
+export const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({ summary }) => {
+  const entity = new MemberSummaryEntity(summary);
+  const appointmentLabel = entity.getAppointmentLabel();
+
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div className="flex items-center space-x-2 text-sm text-gray-600">
+        <Pill size={14} />
+        <span>{summary.medicationCount}種類</span>
+      </div>
+      {appointmentLabel && (
+        <div className="flex items-center space-x-1 text-sm text-orange-600">
+          <Calendar size={14} />
+          <span>次回通院: {appointmentLabel}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/shared/CategoryFilter.tsx
+++ b/src/components/shared/CategoryFilter.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { MedicationCategory, MedicationEntity } from '../../domain/entities/Medication';
+
+interface CategoryFilterProps {
+  selectedCategory: MedicationCategory | null;
+  onSelect: (category: MedicationCategory | null) => void;
+  availableCategories?: MedicationCategory[];
+}
+
+export const CategoryFilter: React.FC<CategoryFilterProps> = ({
+  selectedCategory,
+  onSelect,
+  availableCategories,
+}) => {
+  const allCategories = MedicationEntity.getAllCategories();
+  const categories = availableCategories
+    ? allCategories.filter((c) => availableCategories.includes(c.id))
+    : allCategories;
+
+  if (categories.length <= 1) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-3" role="tablist" aria-label="カテゴリフィルター">
+      <button
+        role="tab"
+        aria-selected={selectedCategory === null}
+        onClick={() => onSelect(null)}
+        className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+          selectedCategory === null
+            ? 'bg-primary-600 text-white'
+            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+        }`}
+      >
+        すべて
+      </button>
+      {categories.map((cat) => (
+        <button
+          key={cat.id}
+          role="tab"
+          aria-selected={selectedCategory === cat.id}
+          onClick={() => onSelect(cat.id)}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+            selectedCategory === cat.id
+              ? 'bg-primary-600 text-white'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          {cat.label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/components/shared/TabSwitch.tsx
+++ b/src/components/shared/TabSwitch.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export interface TabOption {
+  id: string;
+  label: string;
+  count?: number;
+}
+
+interface TabSwitchProps {
+  tabs: TabOption[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+}
+
+export const TabSwitch: React.FC<TabSwitchProps> = ({ tabs, activeTab, onTabChange }) => {
+  return (
+    <div className="flex bg-gray-100 rounded-lg p-1 mb-4" role="tablist">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          onClick={() => onTabChange(tab.id)}
+          className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-colors ${
+            activeTab === tab.id
+              ? 'bg-white text-primary-600 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          {tab.label}
+          {tab.count !== undefined && (
+            <span className={`ml-1 text-xs ${activeTab === tab.id ? 'text-primary-400' : 'text-gray-400'}`}>
+              ({tab.count})
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/data/api/memberApi.ts
+++ b/src/data/api/memberApi.ts
@@ -1,4 +1,5 @@
 import { Member } from '../../domain/entities/Member';
+import { MemberSummary } from '../../domain/entities/MemberSummary';
 import { CreateMemberInput, UpdateMemberInput } from '../../domain/repositories/MemberRepository';
 import { apiClient } from './apiClient';
 import { BackendMember } from './types';
@@ -42,5 +43,9 @@ export const memberApi = {
 
   async deleteMember(memberId: string): Promise<void> {
     await apiClient.del(`/members/${memberId}`);
+  },
+
+  async getMemberSummaries(): Promise<MemberSummary[]> {
+    return apiClient.get<MemberSummary[]>('/members/summary');
   },
 };

--- a/src/data/api/recordApi.ts
+++ b/src/data/api/recordApi.ts
@@ -1,5 +1,6 @@
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { AdherenceStats } from '../../domain/entities/AdherenceStats';
+import { AdherenceTrend } from '../../domain/entities/AdherenceTrend';
 import { apiClient } from './apiClient';
 import { toMedicationRecord } from './mappers';
 import { BackendRecord } from './types';
@@ -28,5 +29,9 @@ export const recordApi = {
 
   async getStats(): Promise<AdherenceStats> {
     return apiClient.get<AdherenceStats>('/records/stats');
+  },
+
+  async getTrends(): Promise<AdherenceTrend> {
+    return apiClient.get<AdherenceTrend>('/records/trends');
   },
 };

--- a/src/data/repositories/MedicationRecordRepositoryImpl.ts
+++ b/src/data/repositories/MedicationRecordRepositoryImpl.ts
@@ -8,6 +8,7 @@ import {
 } from '../../domain/repositories/MedicationRecordRepository';
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { AdherenceStats } from '../../domain/entities/AdherenceStats';
+import { AdherenceTrend } from '../../domain/entities/AdherenceTrend';
 import { recordApi } from '../api/recordApi';
 
 export class MedicationRecordRepositoryImpl implements MedicationRecordRepository {
@@ -25,5 +26,9 @@ export class MedicationRecordRepositoryImpl implements MedicationRecordRepositor
 
   async getAdherenceStats(): Promise<AdherenceStats> {
     return recordApi.getStats();
+  }
+
+  async getAdherenceTrends(): Promise<AdherenceTrend> {
+    return recordApi.getTrends();
   }
 }

--- a/src/data/repositories/MemberRepositoryImpl.ts
+++ b/src/data/repositories/MemberRepositoryImpl.ts
@@ -9,6 +9,7 @@ import {
   UpdateMemberInput,
 } from '../../domain/repositories/MemberRepository';
 import { Member } from '../../domain/entities/Member';
+import { MemberSummary } from '../../domain/entities/MemberSummary';
 import { memberApi } from '../api/memberApi';
 
 export class MemberRepositoryImpl implements MemberRepository {
@@ -30,5 +31,9 @@ export class MemberRepositoryImpl implements MemberRepository {
 
   async deleteMember(memberId: string): Promise<void> {
     return memberApi.deleteMember(memberId);
+  }
+
+  async getMemberSummaries(): Promise<MemberSummary[]> {
+    return memberApi.getMemberSummaries();
   }
 }

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -1,0 +1,49 @@
+/**
+ * 服薬トレンドエンティティ
+ */
+
+export interface DayOfWeekStat {
+  readonly day: number; // 0=日, 1=月, ..., 6=土
+  readonly dayLabel: string;
+  readonly count: number;
+  readonly expected: number;
+  readonly rate: number;
+}
+
+export interface AdherenceTrend {
+  readonly dayOfWeekStats: DayOfWeekStat[];
+  readonly bestDay: string;
+  readonly worstDay: string;
+  readonly previousPeriodRate: number;
+  readonly currentPeriodRate: number;
+  readonly rateChange: number;
+}
+
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+export class AdherenceTrendEntity {
+  constructor(private readonly trend: AdherenceTrend) {}
+
+  get data(): AdherenceTrend {
+    return this.trend;
+  }
+
+  isImproving(): boolean {
+    return this.trend.rateChange > 0;
+  }
+
+  isDeclining(): boolean {
+    return this.trend.rateChange < 0;
+  }
+
+  getRateChangeLabel(): string {
+    const change = this.trend.rateChange;
+    if (change > 0) return `+${change}%`;
+    if (change < 0) return `${change}%`;
+    return '0%';
+  }
+
+  static getDayLabel(day: number): string {
+    return DAY_LABELS[day] ?? '';
+  }
+}

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -109,6 +109,17 @@ export class MedicationEntity {
     heartworm: 'フィラリア薬',
   };
 
+  static getCategoryLabel(category: MedicationCategory): string {
+    return MedicationEntity.categoryLabels[category] ?? category;
+  }
+
+  static getAllCategories(): Array<{ id: MedicationCategory; label: string }> {
+    return Object.entries(MedicationEntity.categoryLabels).map(([id, label]) => ({
+      id: id as MedicationCategory,
+      label,
+    }));
+  }
+
   getDisplayInfo(): { name: string; categoryLabel: string; dosageInfo: string } {
     const dosageParts = [this.medication.dosage, this.medication.frequency].filter(Boolean);
     return {

--- a/src/domain/entities/MemberSummary.ts
+++ b/src/domain/entities/MemberSummary.ts
@@ -1,0 +1,40 @@
+/**
+ * メンバーサマリーエンティティ
+ */
+
+export interface MemberSummary {
+  readonly memberId: string;
+  readonly memberName: string;
+  readonly memberType: string;
+  readonly medicationCount: number;
+  readonly nextAppointmentDate: string | null;
+}
+
+export class MemberSummaryEntity {
+  constructor(private readonly summary: MemberSummary) {}
+
+  get data(): MemberSummary {
+    return this.summary;
+  }
+
+  hasUpcomingAppointment(): boolean {
+    return this.summary.nextAppointmentDate !== null;
+  }
+
+  getDaysUntilAppointment(): number | null {
+    if (!this.summary.nextAppointmentDate) return null;
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+    const appointmentDate = new Date(this.summary.nextAppointmentDate);
+    appointmentDate.setHours(0, 0, 0, 0);
+    return Math.ceil((appointmentDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  }
+
+  getAppointmentLabel(): string {
+    const days = this.getDaysUntilAppointment();
+    if (days === null) return '';
+    if (days === 0) return '今日';
+    if (days === 1) return '明日';
+    return `${days}日後`;
+  }
+}

--- a/src/domain/repositories/MedicationRecordRepository.ts
+++ b/src/domain/repositories/MedicationRecordRepository.ts
@@ -4,6 +4,7 @@
 
 import { MedicationRecord } from '../entities/MedicationRecord';
 import { AdherenceStats } from '../entities/AdherenceStats';
+import { AdherenceTrend } from '../entities/AdherenceTrend';
 
 export interface CreateRecordInput {
   memberId: string;
@@ -18,4 +19,5 @@ export interface MedicationRecordRepository {
   createRecord(input: CreateRecordInput): Promise<void>;
   deleteRecord(recordId: string): Promise<void>;
   getAdherenceStats(): Promise<AdherenceStats>;
+  getAdherenceTrends(): Promise<AdherenceTrend>;
 }

--- a/src/domain/repositories/MemberRepository.ts
+++ b/src/domain/repositories/MemberRepository.ts
@@ -4,6 +4,7 @@
  */
 
 import { Member } from '../entities/Member';
+import { MemberSummary } from '../entities/MemberSummary';
 
 export interface CreateMemberInput {
   userId: string;
@@ -27,4 +28,5 @@ export interface MemberRepository {
   createMember(input: CreateMemberInput): Promise<Member>;
   updateMember(memberId: string, input: UpdateMemberInput): Promise<Member>;
   deleteMember(memberId: string): Promise<void>;
+  getMemberSummaries(): Promise<MemberSummary[]>;
 }

--- a/src/domain/usecases/ManageMedicationRecords.ts
+++ b/src/domain/usecases/ManageMedicationRecords.ts
@@ -4,6 +4,7 @@
 
 import { MedicationRecordEntity, DailyRecordGroup } from '../entities/MedicationRecord';
 import { AdherenceStats } from '../entities/AdherenceStats';
+import { AdherenceTrend } from '../entities/AdherenceTrend';
 import {
   MedicationRecordRepository,
   CreateRecordInput,
@@ -48,5 +49,13 @@ export class GetAdherenceStats {
 
   async execute(): Promise<AdherenceStats> {
     return this.recordRepository.getAdherenceStats();
+  }
+}
+
+export class GetAdherenceTrends {
+  constructor(private readonly recordRepository: MedicationRecordRepository) {}
+
+  async execute(): Promise<AdherenceTrend> {
+    return this.recordRepository.getAdherenceTrends();
   }
 }

--- a/src/domain/usecases/ManageMembers.ts
+++ b/src/domain/usecases/ManageMembers.ts
@@ -4,6 +4,7 @@
  */
 
 import { Member } from '../entities/Member';
+import { MemberSummary } from '../entities/MemberSummary';
 import {
   MemberRepository,
   CreateMemberInput,
@@ -65,5 +66,13 @@ export class DeleteMember {
     }
 
     return this.memberRepository.deleteMember(memberId);
+  }
+}
+
+export class GetMemberSummaries {
+  constructor(private readonly memberRepository: MemberRepository) {}
+
+  async execute(): Promise<MemberSummary[]> {
+    return this.memberRepository.getMemberSummaries();
   }
 }

--- a/src/presentation/hooks/useAdherenceTrends.ts
+++ b/src/presentation/hooks/useAdherenceTrends.ts
@@ -1,0 +1,32 @@
+/**
+ * 服薬トレンド取得フック
+ */
+
+import { useMemo } from 'react';
+import { AdherenceTrend } from '../../domain/entities/AdherenceTrend';
+import { GetAdherenceTrends } from '../../domain/usecases/ManageMedicationRecords';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseAdherenceTrendsResult {
+  trend: AdherenceTrend | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const defaultTrend: AdherenceTrend | null = null;
+
+export const useAdherenceTrends = (): UseAdherenceTrendsResult => {
+  const useCase = useMemo(() => {
+    const { medicationRecordRepository } = getDIContainer();
+    return new GetAdherenceTrends(medicationRecordRepository);
+  }, []);
+
+  const { data, isLoading, error } = useFetcher(
+    () => useCase.execute(),
+    [useCase],
+    defaultTrend,
+  );
+
+  return { trend: data, isLoading, error };
+};

--- a/src/presentation/hooks/useMemberSummaries.ts
+++ b/src/presentation/hooks/useMemberSummaries.ts
@@ -1,0 +1,30 @@
+/**
+ * メンバーサマリー取得フック
+ */
+
+import { useMemo } from 'react';
+import { MemberSummary } from '../../domain/entities/MemberSummary';
+import { GetMemberSummaries } from '../../domain/usecases/ManageMembers';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseMemberSummariesResult {
+  summaries: MemberSummary[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export const useMemberSummaries = (): UseMemberSummariesResult => {
+  const useCase = useMemo(() => {
+    const { memberRepository } = getDIContainer();
+    return new GetMemberSummaries(memberRepository);
+  }, []);
+
+  const { data, isLoading, error } = useFetcher(
+    () => useCase.execute(),
+    [useCase],
+    [] as MemberSummary[],
+  );
+
+  return { summaries: data, isLoading, error };
+};


### PR DESCRIPTION
## 概要
Closes #138

Cycle4 Step1として5つの新機能を実装。

## 変更内容
1. **服薬曜日別トレンド分析** - `GET /api/records/trends` + `AdherenceTrendCard` + ドメインエンティティ
2. **通院タブ切り替え** - `TabSwitch`コンポーネント + `AppointmentList`にfilter prop追加
3. **お薬カテゴリフィルター** - `CategoryFilter`コンポーネント + `MedicationEntity`にgetCategoryLabel追加
4. **メンバーサマリー** - `GET /api/members/summary` + `MemberSummaryCard` + ドメインエンティティ
5. **週間サマリーカード** - `WeeklySummaryCard`でダッシュボードに今日の進捗を表示

## テスト
- 363テスト全パス（新規44テスト追加）
- ビルド成功