### PR TITLE
refactor: Cycle4 Step2 - クリーンアーキテクチャ改善

### DIFF
--- a/src/__tests__/domain/usecases/ManageHospitals.test.ts
+++ b/src/__tests__/domain/usecases/ManageHospitals.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { GetHospitals, CreateHospital, UpdateHospital, DeleteHospital } from '@/domain/usecases/ManageHospitals';
 import { HospitalRepository } from '@/domain/repositories/HospitalRepository';
-import { Hospital } from '@/domain/entities/Appointment';
+import { Hospital } from '@/domain/entities/Hospital';
 
 const mockHospital: Hospital = {
   id: 'hosp-1',

--- a/src/__tests__/domain/usecases/ManageSchedules.test.ts
+++ b/src/__tests__/domain/usecases/ManageSchedules.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { GetSchedules, UpdateSchedule, DeleteSchedule } from '@/domain/usecases/ManageSchedules';
+import { GetSchedules, CreateSchedule, UpdateSchedule, DeleteSchedule } from '@/domain/usecases/ManageSchedules';
 import { ScheduleRepository, ScheduleWithDetails } from '@/domain/repositories/ScheduleRepository';
 import { Schedule } from '@/domain/entities/Schedule';
 
@@ -49,6 +49,77 @@ describe('GetSchedules', () => {
     const useCase = new GetSchedules(repo);
 
     await expect(useCase.execute()).rejects.toThrow('DB接続エラー');
+  });
+});
+
+describe('CreateSchedule', () => {
+  it('スケジュールを作成する', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateSchedule(repo);
+    const input = {
+      medicationId: 'med-1',
+      userId: 'user-1',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+      daysOfWeek: ['mon', 'wed', 'fri'] as const,
+      isEnabled: true,
+      reminderMinutesBefore: 10,
+    };
+    const result = await useCase.execute(input);
+
+    expect(result).toBe(mockSchedule);
+    expect(repo.createSchedule).toHaveBeenCalledWith(input);
+  });
+
+  it('薬IDが空の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateSchedule(repo);
+
+    await expect(
+      useCase.execute({
+        medicationId: '',
+        userId: 'user-1',
+        memberId: 'member-1',
+        scheduledTime: '08:00',
+        daysOfWeek: ['mon'],
+        isEnabled: true,
+        reminderMinutesBefore: 10,
+      })
+    ).rejects.toThrow('薬IDは必須です');
+  });
+
+  it('メンバーIDが空の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateSchedule(repo);
+
+    await expect(
+      useCase.execute({
+        medicationId: 'med-1',
+        userId: 'user-1',
+        memberId: '',
+        scheduledTime: '08:00',
+        daysOfWeek: ['mon'],
+        isEnabled: true,
+        reminderMinutesBefore: 10,
+      })
+    ).rejects.toThrow('メンバーIDは必須です');
+  });
+
+  it('スケジュール時刻が空の場合エラーを投げる', async () => {
+    const repo = createMockRepository();
+    const useCase = new CreateSchedule(repo);
+
+    await expect(
+      useCase.execute({
+        medicationId: 'med-1',
+        userId: 'user-1',
+        memberId: 'member-1',
+        scheduledTime: '',
+        daysOfWeek: ['mon'],
+        isEnabled: true,
+        reminderMinutesBefore: 10,
+      })
+    ).rejects.toThrow('スケジュール時刻は必須です');
   });
 });
 

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -11,12 +11,13 @@ import { MemberIcon } from '@/components/shared/MemberIcon';
 import { MemberEntity, Member } from '@/domain/entities/Member';
 import { Medication, MedicationCategory } from '@/domain/entities/Medication';
 import { CategoryFilter } from '@/components/shared/CategoryFilter';
-import { recordApi } from '@/data/api/recordApi';
+import { useMedicationRecordActions } from '@/presentation/hooks/useMedicationRecordActions';
 import Link from 'next/link';
 import { Plus, ClipboardList } from 'lucide-react';
 
 function MemberMedications({ member, categoryFilter }: { member: Member; categoryFilter: MedicationCategory | null }) {
   const { medications, isLoading, updateMedication, deleteMedication } = useMedications(member.id);
+  const { markAsTaken } = useMedicationRecordActions();
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
   const [editingMed, setEditingMed] = useState<Medication | null>(null);
@@ -27,11 +28,8 @@ function MemberMedications({ member, categoryFilter }: { member: Member; categor
   );
 
   const handleMarkTaken = useCallback(async (medicationId: string) => {
-    await recordApi.createRecord({
-      memberId: member.id,
-      medicationId,
-    });
-  }, [member.id]);
+    await markAsTaken(member.id, medicationId);
+  }, [member.id, markAsTaken]);
 
   const handleEdit = (medication: Medication) => {
     setEditingMed(medication);

--- a/src/components/appointments/AppointmentForm.tsx
+++ b/src/components/appointments/AppointmentForm.tsx
@@ -2,8 +2,8 @@
 
 import React, { useState } from 'react';
 import { Member, MemberEntity } from '../../domain/entities/Member';
-import { Appointment, Hospital } from '../../domain/entities/Appointment';
-import { AppointmentEntity } from '../../domain/entities/Appointment';
+import { Appointment, AppointmentEntity } from '../../domain/entities/Appointment';
+import { Hospital } from '../../domain/entities/Hospital';
 import { MemberIcon } from '../shared/MemberIcon';
 
 export interface AppointmentFormData {

--- a/src/components/hospitals/HospitalList.tsx
+++ b/src/components/hospitals/HospitalList.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { MapPin, Pencil, Trash2, Phone, Check, X } from 'lucide-react';
-import { Hospital } from '../../domain/entities/Appointment';
+import { Hospital } from '../../domain/entities/Hospital';
 import { UpdateHospitalInput } from '../../domain/repositories/HospitalRepository';
 
 interface HospitalListProps {

--- a/src/data/api/hospitalApi.ts
+++ b/src/data/api/hospitalApi.ts
@@ -1,4 +1,4 @@
-import { Hospital } from '../../domain/entities/Appointment';
+import { Hospital } from '../../domain/entities/Hospital';
 import { CreateHospitalInput, UpdateHospitalInput } from '../../domain/repositories/HospitalRepository';
 import { apiClient } from './apiClient';
 import { toHospital } from './mappers';

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -1,17 +1,23 @@
-import { Appointment, Hospital } from '../../domain/entities/Appointment';
-import { Member, MemberType } from '../../domain/entities/Member';
+import { Appointment } from '../../domain/entities/Appointment';
+import { Hospital } from '../../domain/entities/Hospital';
+import { Member, MemberType, PetType } from '../../domain/entities/Member';
 import { Medication, MedicationCategory } from '../../domain/entities/Medication';
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
 import { BackendAppointment, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule } from './types';
 
+const VALID_MEMBER_TYPES: readonly string[] = ['human', 'pet'];
+const VALID_MEDICATION_CATEGORIES: readonly string[] = ['regular', 'supplement', 'prn', 'inhaler', 'flea_tick', 'heartworm'];
+const VALID_DAYS_OF_WEEK: readonly string[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+const VALID_PET_TYPES: readonly string[] = ['dog', 'cat', 'rabbit', 'bird', 'other'];
+
 export function toMember(b: BackendMember): Member {
   return {
     id: b.id,
     userId: b.userId,
-    memberType: (b.memberType as MemberType) || 'human',
+    memberType: b.memberType && VALID_MEMBER_TYPES.includes(b.memberType) ? (b.memberType as MemberType) : 'human',
     name: b.name,
-    petType: b.petType as Member['petType'],
+    petType: b.petType && VALID_PET_TYPES.includes(b.petType) ? (b.petType as PetType) : undefined,
     birthDate: b.birthDate ? new Date(b.birthDate) : undefined,
     notes: b.notes,
     createdAt: new Date(b.createdAt),
@@ -25,7 +31,7 @@ export function toMedication(b: BackendMedication): Medication {
     memberId: b.memberId,
     userId: b.userId,
     name: b.name,
-    category: (b.category as MedicationCategory) || 'regular',
+    category: b.category && VALID_MEDICATION_CATEGORIES.includes(b.category) ? (b.category as MedicationCategory) : 'regular',
     dosage: b.dosageAmount,
     frequency: b.frequency,
     stockQuantity: b.stockQuantity,
@@ -89,7 +95,7 @@ export function toSchedule(b: BackendSchedule): Schedule {
     userId: b.userId,
     memberId: b.memberId,
     scheduledTime: b.scheduledTime,
-    daysOfWeek: (b.daysOfWeek as DayOfWeek[]) || [],
+    daysOfWeek: (b.daysOfWeek?.filter((d: string) => VALID_DAYS_OF_WEEK.includes(d)) as DayOfWeek[]) ?? [],
     isEnabled: b.isEnabled ?? true,
     reminderMinutesBefore: b.reminderMinutesBefore ?? 10,
     createdAt: new Date(b.createdAt),

--- a/src/data/repositories/HospitalRepositoryImpl.ts
+++ b/src/data/repositories/HospitalRepositoryImpl.ts
@@ -7,7 +7,7 @@ import {
   CreateHospitalInput,
   UpdateHospitalInput,
 } from '../../domain/repositories/HospitalRepository';
-import { Hospital } from '../../domain/entities/Appointment';
+import { Hospital } from '../../domain/entities/Hospital';
 import { hospitalApi } from '../api/hospitalApi';
 
 export class HospitalRepositoryImpl implements HospitalRepository {

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -2,6 +2,8 @@
  * 通院予約エンティティ
  */
 
+export { type Hospital } from './Hospital';
+
 export interface Appointment {
   readonly id: string;
   readonly userId: string;
@@ -14,17 +16,6 @@ export interface Appointment {
   readonly description?: string;
   readonly reminderEnabled: boolean;
   readonly reminderDaysBefore: number;
-  readonly createdAt: Date;
-}
-
-export interface Hospital {
-  readonly id: string;
-  readonly userId: string;
-  readonly name: string;
-  readonly hospitalType?: string;
-  readonly address?: string;
-  readonly phoneNumber?: string;
-  readonly notes?: string;
   readonly createdAt: Date;
 }
 

--- a/src/domain/entities/Hospital.ts
+++ b/src/domain/entities/Hospital.ts
@@ -1,0 +1,14 @@
+/**
+ * 病院エンティティ
+ */
+
+export interface Hospital {
+  readonly id: string;
+  readonly userId: string;
+  readonly name: string;
+  readonly hospitalType?: string;
+  readonly address?: string;
+  readonly phoneNumber?: string;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/HospitalRepository.ts
+++ b/src/domain/repositories/HospitalRepository.ts
@@ -2,7 +2,7 @@
  * 病院リポジトリインターフェース
  */
 
-import { Hospital } from '../entities/Appointment';
+import { Hospital } from '../entities/Hospital';
 
 export interface CreateHospitalInput {
   name: string;

--- a/src/domain/usecases/ManageHospitals.ts
+++ b/src/domain/usecases/ManageHospitals.ts
@@ -2,7 +2,7 @@
  * 病院管理ユースケース
  */
 
-import { Hospital } from '../entities/Appointment';
+import { Hospital } from '../entities/Hospital';
 import {
   HospitalRepository,
   CreateHospitalInput,

--- a/src/domain/usecases/ManageSchedules.ts
+++ b/src/domain/usecases/ManageSchedules.ts
@@ -13,6 +13,23 @@ export class GetSchedules {
   }
 }
 
+export class CreateSchedule {
+  constructor(private readonly scheduleRepository: ScheduleRepository) {}
+
+  async execute(input: Omit<Schedule, 'id' | 'createdAt'>): Promise<Schedule> {
+    if (!input.medicationId) {
+      throw new Error('薬IDは必須です');
+    }
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.scheduledTime) {
+      throw new Error('スケジュール時刻は必須です');
+    }
+    return this.scheduleRepository.createSchedule(input);
+  }
+}
+
 export class UpdateSchedule {
   constructor(private readonly scheduleRepository: ScheduleRepository) {}
 

--- a/src/presentation/hooks/useAdherenceTrends.ts
+++ b/src/presentation/hooks/useAdherenceTrends.ts
@@ -12,6 +12,7 @@ export interface UseAdherenceTrendsResult {
   trend: AdherenceTrend | null;
   isLoading: boolean;
   error: Error | null;
+  refetch: () => void;
 }
 
 const defaultTrend: AdherenceTrend | null = null;
@@ -22,11 +23,11 @@ export const useAdherenceTrends = (): UseAdherenceTrendsResult => {
     return new GetAdherenceTrends(medicationRecordRepository);
   }, []);
 
-  const { data, isLoading, error } = useFetcher(
+  const { data, isLoading, error, refetch } = useFetcher(
     () => useCase.execute(),
     [useCase],
     defaultTrend,
   );
 
-  return { trend: data, isLoading, error };
+  return { trend: data, isLoading, error, refetch };
 };

--- a/src/presentation/hooks/useHospitals.ts
+++ b/src/presentation/hooks/useHospitals.ts
@@ -4,7 +4,7 @@
  */
 
 import { useMemo } from 'react';
-import { Hospital } from '../../domain/entities/Appointment';
+import { Hospital } from '../../domain/entities/Hospital';
 import { GetHospitals, CreateHospital, UpdateHospital, DeleteHospital } from '../../domain/usecases/ManageHospitals';
 import { CreateHospitalInput, UpdateHospitalInput } from '../../domain/repositories/HospitalRepository';
 import { getDIContainer } from '../../infrastructure/DIContainer';

--- a/src/presentation/hooks/useMedicationRecordActions.ts
+++ b/src/presentation/hooks/useMedicationRecordActions.ts
@@ -1,0 +1,21 @@
+/**
+ * 服薬記録アクションフック
+ * 服薬完了記録の作成をPresentation層経由で提供
+ */
+
+import { useCallback, useMemo } from 'react';
+import { CreateMedicationRecord } from '../../domain/usecases/ManageMedicationRecords';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export const useMedicationRecordActions = () => {
+  const useCase = useMemo(() => {
+    const { medicationRecordRepository } = getDIContainer();
+    return new CreateMedicationRecord(medicationRecordRepository);
+  }, []);
+
+  const markAsTaken = useCallback(async (memberId: string, medicationId: string) => {
+    await useCase.execute({ memberId, medicationId });
+  }, [useCase]);
+
+  return { markAsTaken };
+};


### PR DESCRIPTION
## 概要
Closes #140

Cycle4 Step2としてクリーンアーキテクチャの改善を実施。

## 変更内容
1. **Hospitalエンティティ分離** - 独自ファイルに移動、全importを更新
2. **CreateScheduleユースケース** - バリデーション付きのユースケースを追加、hookをリファクタリング
3. **レイヤー違反修正** - `useMedicationRecordActions`フック経由でPresentation層を通過
4. **フックAPI一貫性** - `useAdherenceTrends`に`refetch`追加
5. **型安全性** - マッパーの検証付きキャストに改善

## テスト
- 367テスト全パス（CreateScheduleユースケースのテスト4件追加）
- ビルド成功