### PR TITLE
test: Cycle4 Step3 - コンポーネントテストの追加

### DIFF
--- a/src/__tests__/components/appointments/AppointmentList.test.tsx
+++ b/src/__tests__/components/appointments/AppointmentList.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppointmentList, getAppointmentCounts } from '@/components/appointments/AppointmentList';
+import { Appointment } from '@/domain/entities/Appointment';
+
+const futureDate = new Date();
+futureDate.setDate(futureDate.getDate() + 5);
+
+const pastDate = new Date();
+pastDate.setDate(pastDate.getDate() - 5);
+
+const createAppointment = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: 'apt-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  hospitalName: 'テスト病院',
+  appointmentType: 'checkup',
+  appointmentDate: futureDate,
+  reminderEnabled: true,
+  reminderDaysBefore: 1,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+describe('getAppointmentCounts', () => {
+  it('今後と過去の件数を正しく算出する', () => {
+    const appointments = [
+      createAppointment({ id: 'apt-1', appointmentDate: futureDate }),
+      createAppointment({ id: 'apt-2', appointmentDate: pastDate }),
+      createAppointment({ id: 'apt-3', appointmentDate: futureDate }),
+    ];
+    const counts = getAppointmentCounts(appointments);
+    expect(counts.upcoming).toBe(2);
+    expect(counts.past).toBe(1);
+  });
+
+  it('空配列で0を返す', () => {
+    const counts = getAppointmentCounts([]);
+    expect(counts.upcoming).toBe(0);
+    expect(counts.past).toBe(0);
+  });
+});
+
+describe('AppointmentList', () => {
+  const mockOnEdit = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  it('読み込み中を表示する', () => {
+    render(<AppointmentList appointments={[]} isLoading={true} onEdit={mockOnEdit} onDelete={mockOnDelete} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('空状態を表示する', () => {
+    render(<AppointmentList appointments={[]} isLoading={false} onEdit={mockOnEdit} onDelete={mockOnDelete} />);
+    expect(screen.getByText('通院予定がありません')).toBeInTheDocument();
+  });
+
+  it('upcomingフィルターで今後の予定のみ表示する', () => {
+    const appointments = [
+      createAppointment({ id: 'apt-1', appointmentDate: futureDate, memberName: '未来さん' }),
+      createAppointment({ id: 'apt-2', appointmentDate: pastDate, memberName: '過去さん' }),
+    ];
+    render(<AppointmentList appointments={appointments} isLoading={false} filter="upcoming" onEdit={mockOnEdit} onDelete={mockOnDelete} />);
+    expect(screen.getByText('未来さん')).toBeInTheDocument();
+    expect(screen.queryByText('過去さん')).not.toBeInTheDocument();
+  });
+
+  it('pastフィルターで過去の予定のみ表示する', () => {
+    const appointments = [
+      createAppointment({ id: 'apt-1', appointmentDate: futureDate, memberName: '未来さん' }),
+      createAppointment({ id: 'apt-2', appointmentDate: pastDate, memberName: '過去さん' }),
+    ];
+    render(<AppointmentList appointments={appointments} isLoading={false} filter="past" onEdit={mockOnEdit} onDelete={mockOnDelete} />);
+    expect(screen.queryByText('未来さん')).not.toBeInTheDocument();
+    expect(screen.getByText('過去さん')).toBeInTheDocument();
+  });
+
+  it('削除ボタンでonDeleteが呼ばれる', () => {
+    const appointments = [createAppointment()];
+    render(<AppointmentList appointments={appointments} isLoading={false} onEdit={mockOnEdit} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('削除'));
+    expect(mockOnDelete).toHaveBeenCalledWith('apt-1');
+  });
+
+  it('編集ボタンでonEditが呼ばれる', () => {
+    const apt = createAppointment();
+    render(<AppointmentList appointments={[apt]} isLoading={false} onEdit={mockOnEdit} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('編集'));
+    expect(mockOnEdit).toHaveBeenCalledWith(apt);
+  });
+});

--- a/src/__tests__/components/dashboard/UpcomingAppointments.test.tsx
+++ b/src/__tests__/components/dashboard/UpcomingAppointments.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UpcomingAppointments } from '@/components/dashboard/UpcomingAppointments';
+import { Appointment } from '@/domain/entities/Appointment';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const createAppointment = (daysFromNow: number, overrides: Partial<Appointment> = {}): Appointment => {
+  const date = new Date();
+  date.setDate(date.getDate() + daysFromNow);
+  return {
+    id: `apt-${daysFromNow}`,
+    userId: 'user-1',
+    memberId: 'member-1',
+    memberName: 'テスト太郎',
+    appointmentDate: date,
+    reminderEnabled: true,
+    reminderDaysBefore: 1,
+    createdAt: new Date(),
+    ...overrides,
+  };
+};
+
+describe('UpcomingAppointments', () => {
+  it('読み込み中は何も表示しない', () => {
+    const { container } = render(<UpcomingAppointments appointments={[]} isLoading={true} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('予定がない場合何も表示しない', () => {
+    const { container } = render(<UpcomingAppointments appointments={[]} isLoading={false} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('7日以内の予定のみ表示する', () => {
+    const appointments = [
+      createAppointment(3, { id: 'near', memberName: '近い予定' }),
+      createAppointment(10, { id: 'far', memberName: '遠い予定' }),
+    ];
+    render(<UpcomingAppointments appointments={appointments} isLoading={false} />);
+    expect(screen.getByText('近い予定')).toBeInTheDocument();
+    expect(screen.queryByText('遠い予定')).not.toBeInTheDocument();
+  });
+
+  it('過去の予定を除外する', () => {
+    const appointments = [
+      createAppointment(-2, { id: 'past', memberName: '過去の予定' }),
+      createAppointment(2, { id: 'future', memberName: '未来の予定' }),
+    ];
+    render(<UpcomingAppointments appointments={appointments} isLoading={false} />);
+    expect(screen.queryByText('過去の予定')).not.toBeInTheDocument();
+    expect(screen.getByText('未来の予定')).toBeInTheDocument();
+  });
+
+  it('最大3件まで表示する', () => {
+    const appointments = [
+      createAppointment(1, { id: 'a1', memberName: '予定1' }),
+      createAppointment(2, { id: 'a2', memberName: '予定2' }),
+      createAppointment(3, { id: 'a3', memberName: '予定3' }),
+      createAppointment(4, { id: 'a4', memberName: '予定4' }),
+    ];
+    render(<UpcomingAppointments appointments={appointments} isLoading={false} />);
+    expect(screen.getByText('予定1')).toBeInTheDocument();
+    expect(screen.getByText('予定2')).toBeInTheDocument();
+    expect(screen.getByText('予定3')).toBeInTheDocument();
+    expect(screen.queryByText('予定4')).not.toBeInTheDocument();
+  });
+
+  it('すべて見るリンクを表示する', () => {
+    const appointments = [createAppointment(1)];
+    render(<UpcomingAppointments appointments={appointments} isLoading={false} />);
+    expect(screen.getByText('すべて見る')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/members/MemberForm.test.tsx
+++ b/src/__tests__/components/members/MemberForm.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemberForm } from '@/components/members/MemberForm';
+
+describe('MemberForm', () => {
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    mockOnSubmit.mockClear();
+  });
+
+  it('フォームフィールドを表示する', () => {
+    render(<MemberForm onSubmit={mockOnSubmit} />);
+    expect(screen.getByLabelText('名前')).toBeInTheDocument();
+    expect(screen.getByLabelText('タイプ')).toBeInTheDocument();
+    expect(screen.getByLabelText('生年月日')).toBeInTheDocument();
+    expect(screen.getByLabelText('メモ')).toBeInTheDocument();
+  });
+
+  it('名前が空の場合送信しない', () => {
+    render(<MemberForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('名前を入力して送信する', () => {
+    render(<MemberForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('名前'), { target: { value: '太郎' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({ name: '太郎', memberType: 'human' }));
+  });
+
+  it('ペットタイプ選択時にペットの種類が表示される', () => {
+    render(<MemberForm onSubmit={mockOnSubmit} />);
+    expect(screen.queryByLabelText('ペットの種類')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('タイプ'), { target: { value: 'pet' } });
+    expect(screen.getByLabelText('ペットの種類')).toBeInTheDocument();
+  });
+
+  it('ペットタイプで送信するとpetTypeが含まれる', () => {
+    render(<MemberForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('名前'), { target: { value: 'ポチ' } });
+    fireEvent.change(screen.getByLabelText('タイプ'), { target: { value: 'pet' } });
+    fireEvent.change(screen.getByLabelText('ペットの種類'), { target: { value: 'cat' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'ポチ',
+      memberType: 'pet',
+      petType: 'cat',
+    }));
+  });
+
+  it('編集モードでは更新するボタンとタイプ非表示', () => {
+    const initialData = {
+      id: 'member-1',
+      userId: 'user-1',
+      name: '太郎',
+      memberType: 'human' as const,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    render(<MemberForm onSubmit={mockOnSubmit} initialData={initialData} />);
+    expect(screen.getByText('更新する')).toBeInTheDocument();
+    expect(screen.queryByLabelText('タイプ')).not.toBeInTheDocument();
+  });
+
+  it('キャンセルボタンでonCancelが呼ばれる', () => {
+    const mockOnCancel = vi.fn();
+    render(<MemberForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/schedules/ScheduleList.test.tsx
+++ b/src/__tests__/components/schedules/ScheduleList.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ScheduleList } from '@/components/schedules/ScheduleList';
+import { ScheduleWithDetails } from '@/domain/repositories/ScheduleRepository';
+import { Schedule } from '@/domain/entities/Schedule';
+
+const createSchedule = (overrides: Partial<Schedule> = {}): Schedule => ({
+  id: 'sch-1',
+  medicationId: 'med-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  scheduledTime: '08:00',
+  daysOfWeek: ['mon', 'wed', 'fri'],
+  isEnabled: true,
+  reminderMinutesBefore: 10,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+const createItem = (overrides: Partial<Schedule> = {}, details: Partial<ScheduleWithDetails> = {}): ScheduleWithDetails => ({
+  schedule: createSchedule(overrides),
+  medicationName: 'テスト薬',
+  memberName: 'テスト太郎',
+  ...details,
+});
+
+describe('ScheduleList', () => {
+  const mockOnUpdate = vi.fn().mockResolvedValue(undefined);
+  const mockOnDelete = vi.fn();
+
+  it('読み込み中を表示する', () => {
+    render(<ScheduleList schedules={[]} isLoading={true} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('空状態を表示する', () => {
+    render(<ScheduleList schedules={[]} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('スケジュールがありません')).toBeInTheDocument();
+  });
+
+  it('有効なスケジュールを表示する', () => {
+    const schedules = [createItem()];
+    render(<ScheduleList schedules={schedules} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('有効なスケジュール')).toBeInTheDocument();
+    expect(screen.getByText('08:00')).toBeInTheDocument();
+    expect(screen.getByText('月・水・金')).toBeInTheDocument();
+  });
+
+  it('無効なスケジュールを分けて表示する', () => {
+    const schedules = [
+      createItem({ id: 'sch-1', isEnabled: true }),
+      createItem({ id: 'sch-2', isEnabled: false }),
+    ];
+    render(<ScheduleList schedules={schedules} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('有効なスケジュール')).toBeInTheDocument();
+    expect(screen.getByText('無効なスケジュール')).toBeInTheDocument();
+  });
+
+  it('全曜日の場合毎日と表示する', () => {
+    const schedules = [createItem({ daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] })];
+    render(<ScheduleList schedules={schedules} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('毎日')).toBeInTheDocument();
+  });
+
+  it('削除ボタンでonDeleteが呼ばれる', () => {
+    const schedules = [createItem()];
+    render(<ScheduleList schedules={schedules} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('削除'));
+    expect(mockOnDelete).toHaveBeenCalledWith('sch-1');
+  });
+
+  it('有効/無効の切り替えでonUpdateが呼ばれる', () => {
+    const schedules = [createItem()];
+    render(<ScheduleList schedules={schedules} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByText('有効'));
+    expect(mockOnUpdate).toHaveBeenCalledWith('sch-1', { isEnabled: false });
+  });
+});


### PR DESCRIPTION
## 概要
Closes #142

Cycle4 Step3として主要コンポーネントのテストカバレッジを向上。

## 変更内容
- `AppointmentList.test.tsx` (8テスト) - フィルター・件数・コールバック
- `UpcomingAppointments.test.tsx` (6テスト) - 日数フィルター・件数制限
- `ScheduleList.test.tsx` (7テスト) - 有効/無効分離・毎日ラベル
- `MemberForm.test.tsx` (7テスト) - バリデーション・条件表示

## テスト
- 395テスト全パス
- ビルド成功