### PR TITLE
fix: Cycle4 Step4 - セキュリティ脆弱性の修正

### DIFF
--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -16,7 +16,7 @@ describe('signUpSchema', () => {
   it('有効なデータを受け入れる', () => {
     const result = signUpSchema.safeParse({
       email: 'test@example.com',
-      password: '12345678',
+      password: 'Test1234',
       displayName: 'テストユーザー',
     });
     expect(result.success).toBe(true);
@@ -25,7 +25,7 @@ describe('signUpSchema', () => {
   it('無効なメールアドレスを拒否する', () => {
     const result = signUpSchema.safeParse({
       email: 'invalid-email',
-      password: '12345678',
+      password: 'Test1234',
       displayName: 'テスト',
     });
     expect(result.success).toBe(false);
@@ -34,7 +34,25 @@ describe('signUpSchema', () => {
   it('短すぎるパスワードを拒否する', () => {
     const result = signUpSchema.safeParse({
       email: 'test@example.com',
-      password: '1234567',
+      password: 'Ab1',
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('英字のみのパスワードを拒否する', () => {
+    const result = signUpSchema.safeParse({
+      email: 'test@example.com',
+      password: 'abcdefgh',
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('数字のみのパスワードを拒否する', () => {
+    const result = signUpSchema.safeParse({
+      email: 'test@example.com',
+      password: '12345678',
       displayName: 'テスト',
     });
     expect(result.success).toBe(false);
@@ -43,7 +61,7 @@ describe('signUpSchema', () => {
   it('空の表示名を拒否する', () => {
     const result = signUpSchema.safeParse({
       email: 'test@example.com',
-      password: '12345678',
+      password: 'Test1234',
       displayName: '',
     });
     expect(result.success).toBe(false);
@@ -52,7 +70,7 @@ describe('signUpSchema', () => {
   it('メールアドレスを小文字に正規化する', () => {
     const result = signUpSchema.safeParse({
       email: 'Test@Example.COM',
-      password: '12345678',
+      password: 'Test1234',
       displayName: 'テスト',
     });
     expect(result.success).toBe(true);
@@ -64,7 +82,7 @@ describe('signUpSchema', () => {
   it('メールアドレスの前後の空白を除去する', () => {
     const result = signUpSchema.safeParse({
       email: '  test@example.com  ',
-      password: '12345678',
+      password: 'Test1234',
       displayName: 'テスト',
     });
     expect(result.success).toBe(true);
@@ -76,7 +94,7 @@ describe('signUpSchema', () => {
   it('表示名の前後の空白を除去する', () => {
     const result = signUpSchema.safeParse({
       email: 'test@example.com',
-      password: '12345678',
+      password: 'Test1234',
       displayName: '  テスト  ',
     });
     expect(result.success).toBe(true);
@@ -183,6 +201,26 @@ describe('createScheduleSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('無効な曜日を拒否する', () => {
+    const result = createScheduleSchema.safeParse({
+      medicationId: 'med-1',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+      daysOfWeek: ['INVALID'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('有効な曜日を受け入れる', () => {
+    const result = createScheduleSchema.safeParse({
+      medicationId: 'med-1',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+      daysOfWeek: ['mon', 'wed', 'fri'],
+    });
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('createRecordSchema', () => {
@@ -209,6 +247,14 @@ describe('createAppointmentSchema', () => {
       appointmentDate: '2024-06-01',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('無効な日付形式を拒否する', () => {
+    const result = createAppointmentSchema.safeParse({
+      memberId: 'member-1',
+      appointmentDate: 'not-a-date',
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -7,6 +7,7 @@ export const GET = withAuth(async (userId) => {
   const appointments = await prisma.appointment.findMany({
     where: { userId },
     orderBy: { appointmentDate: 'asc' },
+    take: 200,
     include: {
       member: { select: { name: true } },
       hospital: { select: { name: true } },

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -4,7 +4,7 @@ import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
-  const hospitals = await prisma.hospital.findMany({ where: { userId } });
+  const hospitals = await prisma.hospital.findMany({ where: { userId }, take: 100 });
   return success(hospitals);
 });
 

--- a/src/app/api/medications/member/[memberId]/route.ts
+++ b/src/app/api/medications/member/[memberId]/route.ts
@@ -5,7 +5,7 @@ import { withAuth } from '@/lib/api-helpers';
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
     const { memberId } = await params;
-    const medications = await prisma.medication.findMany({ where: { memberId, userId } });
+    const medications = await prisma.medication.findMany({ where: { memberId, userId }, take: 200 });
     return success(medications);
   })();
 }

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -4,7 +4,7 @@ import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
-  const members = await prisma.member.findMany({ where: { userId } });
+  const members = await prisma.member.findMany({ where: { userId }, take: 100 });
   return success(members);
 });
 

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -4,7 +4,7 @@ import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
-  const schedules = await prisma.schedule.findMany({ where: { userId } });
+  const schedules = await prisma.schedule.findMany({ where: { userId }, take: 200 });
   return success(schedules);
 });
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { Resend } from 'resend';
 import { escapeHtml } from './security';
 
@@ -34,7 +35,9 @@ export async function sendEmail({ to, subject, html }: SendEmailOptions) {
 }
 
 export function generateVerificationCode(): string {
-  return Math.floor(100000 + Math.random() * 900000).toString();
+  const bytes = crypto.randomBytes(4);
+  const num = bytes.readUInt32BE(0);
+  return (100000 + (num % 900000)).toString();
 }
 
 export const emailTemplates = {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+const dateString = z.string().refine(
+  (val) => !isNaN(Date.parse(val)),
+  { message: '有効な日付形式で入力してください' },
+);
+
 // ===== Users =====
 export const createUserProfileSchema = z.object({
   displayName: z.string().min(1, '表示名は必須です').max(100),
@@ -16,14 +21,14 @@ export const createMemberSchema = z.object({
   name: z.string({ required_error: '名前は必須です' }).min(1, '名前は必須です').max(100),
   memberType: z.enum(['human', 'pet']).optional(),
   petType: z.string().max(50).optional(),
-  birthDate: z.string().optional(),
+  birthDate: dateString.optional(),
   notes: z.string().max(500).optional(),
 });
 
 export const updateMemberSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   petType: z.string().max(50).optional(),
-  birthDate: z.string().optional().nullable(),
+  birthDate: dateString.optional().nullable(),
   notes: z.string().max(500).optional().nullable(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
@@ -37,7 +42,7 @@ export const createMedicationSchema = z.object({
   dosageAmount: z.string().max(100).optional(),
   frequency: z.string().max(100).optional(),
   stockQuantity: z.number().int().min(0).optional(),
-  stockAlertDate: z.string().optional(),
+  stockAlertDate: dateString.optional(),
   instructions: z.string().max(1000).optional(),
 });
 
@@ -47,7 +52,7 @@ export const updateMedicationSchema = z.object({
   dosageAmount: z.string().max(100).optional().nullable(),
   frequency: z.string().max(100).optional().nullable(),
   stockQuantity: z.number().int().min(0).optional().nullable(),
-  stockAlertDate: z.string().optional().nullable(),
+  stockAlertDate: dateString.optional().nullable(),
   instructions: z.string().max(1000).optional().nullable(),
   isActive: z.boolean().optional(),
 }).refine((data) => Object.keys(data).length > 0, {
@@ -59,18 +64,20 @@ export const updateStockSchema = z.object({
 });
 
 // ===== Schedules =====
+const dayOfWeekEnum = z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']);
+
 export const createScheduleSchema = z.object({
   medicationId: z.string().min(1, '薬IDは必須です'),
   memberId: z.string().min(1, 'メンバーIDは必須です'),
   scheduledTime: z.string().min(1, '予定時刻は必須です'),
-  daysOfWeek: z.array(z.string()).optional(),
+  daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).optional(),
 });
 
 export const updateScheduleSchema = z.object({
   scheduledTime: z.string().optional(),
-  daysOfWeek: z.array(z.string()).optional(),
+  daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).optional(),
 });
@@ -108,7 +115,7 @@ export const updateHospitalSchema = z.object({
 export const createAppointmentSchema = z.object({
   memberId: z.string().min(1, 'メンバーIDは必須です'),
   hospitalId: z.string().optional(),
-  appointmentDate: z.string().min(1, '予約日は必須です'),
+  appointmentDate: dateString,
   appointmentTime: z.string().optional(),
   type: z.string().max(100).optional(),
   notes: z.string().max(1000).optional(),
@@ -130,6 +137,9 @@ export const updateAppointmentSchema = z.object({
 // ===== Auth =====
 export const signUpSchema = z.object({
   email: z.string().trim().toLowerCase().email('有効なメールアドレスを入力してください'),
-  password: z.string().min(8, 'パスワードは8文字以上で入力してください'),
+  password: z.string()
+    .min(8, 'パスワードは8文字以上で入力してください')
+    .regex(/[a-zA-Z]/, 'パスワードには英字を含めてください')
+    .regex(/[0-9]/, 'パスワードには数字を含めてください'),
   displayName: z.string().trim().min(1, '表示名は必須です').max(100),
 });


### PR DESCRIPTION
## 概要
Closes #144

Cycle4 Step4としてセキュリティ脆弱性を修正。

## 変更内容
1. **crypto.randomBytes()** - 確認コードの暗号論的安全な生成
2. **ページネーション制限** - 全リストAPIに`take`制限追加
3. **パスワード複雑性** - 英字+数字の必須要件
4. **曜日enum検証** - 無効な曜日値を拒否
5. **日付形式検証** - `Date.parse`による検証

## テスト
- 400テスト全パス
- ビルド成功