### PR TITLE
feat: Cycle5 Step1 - 5つの新機能を追加

### DIFF
--- a/src/__tests__/components/appointments/MiniCalendar.test.tsx
+++ b/src/__tests__/components/appointments/MiniCalendar.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MiniCalendar } from '@/components/appointments/MiniCalendar';
+
+describe('MiniCalendar', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('月名を表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15));
+    render(<MiniCalendar appointmentDates={[]} />);
+    expect(screen.getByText('2026年3月')).toBeInTheDocument();
+  });
+
+  it('曜日ヘッダーを表示する', () => {
+    render(<MiniCalendar appointmentDates={[]} />);
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('日')).toBeInTheDocument();
+  });
+
+  it('予約のある日にマーカーを表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15));
+    const dates = [new Date(2026, 2, 20)];
+    render(<MiniCalendar appointmentDates={dates} />);
+    const day20 = screen.getByText('20');
+    expect(day20.closest('button')?.querySelector('[data-testid="dot-marker"]')).toBeTruthy();
+  });
+
+  it('前月・次月ボタンで月が変わる', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15));
+    render(<MiniCalendar appointmentDates={[]} />);
+    expect(screen.getByText('2026年3月')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('次の月'));
+    expect(screen.getByText('2026年4月')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('前の月'));
+    expect(screen.getByText('2026年3月')).toBeInTheDocument();
+  });
+
+  it('今日の日付がハイライトされる', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 15));
+    render(<MiniCalendar appointmentDates={[]} />);
+    const today = screen.getByText('15');
+    expect(today.closest('button')?.className).toContain('bg-primary');
+  });
+});

--- a/src/__tests__/components/dashboard/GreetingCard.test.tsx
+++ b/src/__tests__/components/dashboard/GreetingCard.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GreetingCard } from '@/components/dashboard/GreetingCard';
+
+vi.mock('@/stores/characterStore', () => ({
+  useCharacterStore: () => ({
+    getConfig: () => ({ type: 'cat', name: 'ねこ' }),
+  }),
+}));
+
+vi.mock('@/components/shared/CharacterIcon', () => ({
+  CharacterIcon: ({ type }: { type: string }) => <span data-testid="char-icon">{type}</span>,
+}));
+
+describe('GreetingCard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('朝の時間帯で「おはよう」を表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 1, 7, 0, 0));
+    render(<GreetingCard displayName="太郎" />);
+    expect(screen.getByText(/おはよう/)).toBeInTheDocument();
+  });
+
+  it('昼の時間帯で「こんにちは」を表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 1, 13, 0, 0));
+    render(<GreetingCard displayName="太郎" />);
+    expect(screen.getByText(/こんにちは/)).toBeInTheDocument();
+  });
+
+  it('夜の時間帯で「こんばんは」を表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 1, 20, 0, 0));
+    render(<GreetingCard displayName="太郎" />);
+    expect(screen.getByText(/こんばんは/)).toBeInTheDocument();
+  });
+
+  it('ユーザー名を表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 1, 10, 0, 0));
+    render(<GreetingCard displayName="花子" />);
+    expect(screen.getByText(/花子/)).toBeInTheDocument();
+  });
+
+  it('キャラクターアイコンを表示する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 1, 10, 0, 0));
+    render(<GreetingCard displayName="太郎" />);
+    expect(screen.getByTestId('char-icon')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/medications/StockRefillButton.test.tsx
+++ b/src/__tests__/components/medications/StockRefillButton.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { StockRefillButton } from '@/components/medications/StockRefillButton';
+
+describe('StockRefillButton', () => {
+  it('補充ボタンを表示する', () => {
+    render(<StockRefillButton medicationId="med-1" currentStock={5} onRefill={vi.fn()} />);
+    expect(screen.getByLabelText('在庫補充')).toBeInTheDocument();
+  });
+
+  it('クリックで入力フォームを表示する', () => {
+    render(<StockRefillButton medicationId="med-1" currentStock={5} onRefill={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText('在庫補充'));
+    expect(screen.getByLabelText('補充数')).toBeInTheDocument();
+  });
+
+  it('補充を実行する', async () => {
+    const mockOnRefill = vi.fn().mockResolvedValue(undefined);
+    render(<StockRefillButton medicationId="med-1" currentStock={5} onRefill={mockOnRefill} />);
+    fireEvent.click(screen.getByLabelText('在庫補充'));
+    fireEvent.change(screen.getByLabelText('補充数'), { target: { value: '30' } });
+    fireEvent.click(screen.getByText('補充'));
+    await waitFor(() => {
+      expect(mockOnRefill).toHaveBeenCalledWith('med-1', 35);
+    });
+  });
+
+  it('キャンセルでフォームを閉じる', () => {
+    render(<StockRefillButton medicationId="med-1" currentStock={5} onRefill={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText('在庫補充'));
+    expect(screen.getByLabelText('補充数')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('キャンセル'));
+    expect(screen.queryByLabelText('補充数')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/medications/TakeWithNotesButton.test.tsx
+++ b/src/__tests__/components/medications/TakeWithNotesButton.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TakeWithNotesButton } from '@/components/medications/TakeWithNotesButton';
+
+describe('TakeWithNotesButton', () => {
+  const mockOnTake = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    mockOnTake.mockClear();
+  });
+
+  it('飲んだボタンを表示する', () => {
+    render(<TakeWithNotesButton medicationId="med-1" memberId="member-1" onTake={mockOnTake} />);
+    expect(screen.getByText('飲んだ')).toBeInTheDocument();
+  });
+
+  it('長押しでメモ入力欄を表示する', () => {
+    render(<TakeWithNotesButton medicationId="med-1" memberId="member-1" onTake={mockOnTake} />);
+    fireEvent.click(screen.getByLabelText('メモ付きで記録'));
+    expect(screen.getByPlaceholderText('メモ（任意）')).toBeInTheDocument();
+  });
+
+  it('メモなしで飲んだを記録する', async () => {
+    render(<TakeWithNotesButton medicationId="med-1" memberId="member-1" onTake={mockOnTake} />);
+    fireEvent.click(screen.getByText('飲んだ'));
+    await waitFor(() => {
+      expect(mockOnTake).toHaveBeenCalledWith('member-1', 'med-1', undefined);
+    });
+  });
+
+  it('メモ付きで飲んだを記録する', async () => {
+    render(<TakeWithNotesButton medicationId="med-1" memberId="member-1" onTake={mockOnTake} />);
+    fireEvent.click(screen.getByLabelText('メモ付きで記録'));
+    fireEvent.change(screen.getByPlaceholderText('メモ（任意）'), { target: { value: '食後に服用' } });
+    fireEvent.click(screen.getByText('記録'));
+    await waitFor(() => {
+      expect(mockOnTake).toHaveBeenCalledWith('member-1', 'med-1', '食後に服用');
+    });
+  });
+
+  it('記録後に記録済みを表示する', async () => {
+    render(<TakeWithNotesButton medicationId="med-1" memberId="member-1" onTake={mockOnTake} />);
+    fireEvent.click(screen.getByText('飲んだ'));
+    await waitFor(() => {
+      expect(screen.getByText('記録済み')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberProfile.test.ts
+++ b/src/__tests__/domain/entities/MemberProfile.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { MemberProfileEntity, MemberProfile } from '@/domain/entities/MemberProfile';
+
+const createProfile = (overrides: Partial<MemberProfile> = {}): MemberProfile => ({
+  member: {
+    id: 'member-1',
+    userId: 'user-1',
+    name: '太郎',
+    memberType: 'human',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  medicationCount: 3,
+  activeScheduleCount: 5,
+  upcomingAppointmentCount: 2,
+  recentAdherenceRate: 85,
+  ...overrides,
+});
+
+describe('MemberProfileEntity', () => {
+  it('dataがプロフィールデータを返す', () => {
+    const profile = createProfile();
+    const entity = new MemberProfileEntity(profile);
+    expect(entity.data.member.name).toBe('太郎');
+  });
+
+  it('服薬率が高い場合getAdherenceLabelが良好を返す', () => {
+    const entity = new MemberProfileEntity(createProfile({ recentAdherenceRate: 90 }));
+    expect(entity.getAdherenceLabel()).toBe('良好');
+  });
+
+  it('服薬率が中程度の場合getAdherenceLabelが注意を返す', () => {
+    const entity = new MemberProfileEntity(createProfile({ recentAdherenceRate: 60 }));
+    expect(entity.getAdherenceLabel()).toBe('注意');
+  });
+
+  it('服薬率が低い場合getAdherenceLabelが要改善を返す', () => {
+    const entity = new MemberProfileEntity(createProfile({ recentAdherenceRate: 40 }));
+    expect(entity.getAdherenceLabel()).toBe('要改善');
+  });
+
+  it('服薬率がnullの場合getAdherenceLabelが空文字を返す', () => {
+    const entity = new MemberProfileEntity(createProfile({ recentAdherenceRate: null }));
+    expect(entity.getAdherenceLabel()).toBe('');
+  });
+
+  it('hasMedicationsが正しく動作する', () => {
+    expect(new MemberProfileEntity(createProfile({ medicationCount: 3 })).hasMedications()).toBe(true);
+    expect(new MemberProfileEntity(createProfile({ medicationCount: 0 })).hasMedications()).toBe(false);
+  });
+});

--- a/src/app/api/members/[memberId]/profile/route.ts
+++ b/src/app/api/members/[memberId]/profile/route.ts
@@ -1,0 +1,41 @@
+import { prisma } from '@/lib/prisma';
+import { success, notFound } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  return withAuth(async (userId) => {
+    const { memberId } = await params;
+
+    const member = await prisma.member.findUnique({ where: { id: memberId } });
+    if (!member || member.userId !== userId) return notFound('メンバー');
+
+    const [medicationCount, activeScheduleCount, upcomingAppointmentCount] = await Promise.all([
+      prisma.medication.count({ where: { memberId, userId, isActive: true } }),
+      prisma.schedule.count({ where: { memberId, userId, isEnabled: true } }),
+      prisma.appointment.count({
+        where: { memberId, userId, appointmentDate: { gte: new Date() } },
+      }),
+    ]);
+
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const [recordCount, scheduleCount] = await Promise.all([
+      prisma.medicationRecord.count({ where: { memberId, userId, takenAt: { gte: sevenDaysAgo } } }),
+      prisma.schedule.count({ where: { memberId, userId, isEnabled: true } }),
+    ]);
+
+    const expectedRecords = scheduleCount * 7;
+    const recentAdherenceRate = expectedRecords > 0
+      ? Math.round((recordCount / expectedRecords) * 100)
+      : null;
+
+    return success({
+      member,
+      medicationCount,
+      activeScheduleCount,
+      upcomingAppointmentCount,
+      recentAdherenceRate,
+    });
+  })();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -10,6 +10,7 @@ import { AppointmentList, AppointmentFilter, getAppointmentCounts } from '@/comp
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
 import { TabSwitch } from '@/components/shared/TabSwitch';
 import { Appointment } from '@/domain/entities/Appointment';
+import { MiniCalendar } from '@/components/appointments/MiniCalendar';
 import Link from 'next/link';
 import { Plus, X, MapPin } from 'lucide-react';
 
@@ -22,6 +23,7 @@ export default function AppointmentsPage() {
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
 
+  const appointmentDates = useMemo(() => appointments.map((a) => new Date(a.appointmentDate)), [appointments]);
   const counts = useMemo(() => getAppointmentCounts(appointments), [appointments]);
   const tabs = useMemo(() => [
     { id: 'upcoming', label: '今後の予定', count: counts.upcoming },
@@ -111,6 +113,8 @@ export default function AppointmentsPage() {
             />
           </div>
         )}
+
+        <MiniCalendar appointmentDates={appointmentDates} />
 
         <TabSwitch tabs={tabs} activeTab={activeTab} onTabChange={(id) => setActiveTab(id as AppointmentFilter)} />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,16 +8,16 @@ import { useAdherenceStats } from '@/presentation/hooks/useAdherenceStats';
 import { useAdherenceTrends } from '@/presentation/hooks/useAdherenceTrends';
 import { useStockAlerts } from '@/presentation/hooks/useStockAlerts';
 import { useMembers } from '@/presentation/hooks/useMembers';
-import { useCharacterStore } from '@/stores/characterStore';
+import { useUserProfile } from '@/presentation/hooks/useUserProfile';
 import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
 import { UpcomingAppointments } from '@/components/dashboard/UpcomingAppointments';
 import { AdherenceStatsCard } from '@/components/dashboard/AdherenceStatsCard';
 import { AdherenceTrendCard } from '@/components/dashboard/AdherenceTrendCard';
 import { StockAlertList } from '@/components/dashboard/StockAlertList';
 import { WeeklySummaryCard } from '@/components/dashboard/WeeklySummaryCard';
+import { GreetingCard } from '@/components/dashboard/GreetingCard';
 import { MemberFilter } from '@/components/shared/MemberFilter';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
-import { CharacterIcon } from '@/components/shared/CharacterIcon';
 
 export default function Dashboard() {
   const { userId } = useAuth();
@@ -27,8 +27,7 @@ export default function Dashboard() {
   const { trend, isLoading: trendLoading } = useAdherenceTrends();
   const { alerts, isLoading: alertsLoading } = useStockAlerts();
   const { members } = useMembers(userId);
-  const { getConfig, getMessage } = useCharacterStore();
-  const characterConfig = getConfig();
+  const { profile } = useUserProfile();
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
 
   const filteredSchedules = useMemo(
@@ -50,13 +49,7 @@ export default function Dashboard() {
       </header>
 
       <main className="max-w-md mx-auto px-4 py-4">
-        <div className="bg-primary-50 rounded-lg p-4 mb-6 flex items-center space-x-3">
-          <CharacterIcon type={characterConfig.type} size={40} />
-          <div>
-            <p className="text-sm font-medium text-primary-800">{characterConfig.name}</p>
-            <p className="text-sm text-primary-700">{getMessage('medicationReminder')}</p>
-          </div>
-        </div>
+        <GreetingCard displayName={profile?.displayName || ''} />
 
         <AdherenceStatsCard stats={stats} isLoading={statsLoading} />
 

--- a/src/components/appointments/MiniCalendar.tsx
+++ b/src/components/appointments/MiniCalendar.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React, { useState } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface MiniCalendarProps {
+  appointmentDates: Date[];
+}
+
+const DAY_HEADERS = ['月', '火', '水', '木', '金', '土', '日'];
+
+function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+export const MiniCalendar: React.FC<MiniCalendarProps> = ({ appointmentDates }) => {
+  const today = new Date();
+  const [viewMonth, setViewMonth] = useState(today.getMonth());
+  const [viewYear, setViewYear] = useState(today.getFullYear());
+
+  const firstDay = new Date(viewYear, viewMonth, 1);
+  const lastDay = new Date(viewYear, viewMonth + 1, 0);
+  const startDow = (firstDay.getDay() + 6) % 7; // Monday = 0
+
+  const days: (number | null)[] = [];
+  for (let i = 0; i < startDow; i++) days.push(null);
+  for (let d = 1; d <= lastDay.getDate(); d++) days.push(d);
+
+  const hasAppointment = (day: number) =>
+    appointmentDates.some((d) => isSameDay(d, new Date(viewYear, viewMonth, day)));
+
+  const isToday = (day: number) =>
+    isSameDay(today, new Date(viewYear, viewMonth, day));
+
+  const prevMonth = () => {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear(viewYear - 1);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  };
+
+  const nextMonth = () => {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear(viewYear + 1);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200 mb-4">
+      <div className="flex items-center justify-between mb-2">
+        <button onClick={prevMonth} className="p-1 text-gray-500 hover:text-gray-700" aria-label="前の月">
+          <ChevronLeft size={16} />
+        </button>
+        <span className="text-sm font-semibold text-gray-700">{viewYear}年{viewMonth + 1}月</span>
+        <button onClick={nextMonth} className="p-1 text-gray-500 hover:text-gray-700" aria-label="次の月">
+          <ChevronRight size={16} />
+        </button>
+      </div>
+      <div className="grid grid-cols-7 gap-0.5 text-center">
+        {DAY_HEADERS.map((d) => (
+          <div key={d} className="text-xs text-gray-400 py-1">{d}</div>
+        ))}
+        {days.map((day, i) => (
+          <button
+            key={i}
+            disabled={day === null}
+            className={`relative text-xs py-1 rounded ${
+              day !== null && isToday(day)
+                ? 'bg-primary-600 text-white font-bold'
+                : day !== null
+                  ? 'text-gray-700 hover:bg-gray-100'
+                  : ''
+            }`}
+          >
+            {day ?? ''}
+            {day !== null && hasAppointment(day) && (
+              <span
+                data-testid="dot-marker"
+                className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 bg-red-500 rounded-full"
+              />
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/GreetingCard.tsx
+++ b/src/components/dashboard/GreetingCard.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useCharacterStore } from '../../stores/characterStore';
+import { CharacterIcon } from '../shared/CharacterIcon';
+
+interface GreetingCardProps {
+  displayName: string;
+}
+
+function getTimeGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour >= 5 && hour < 12) return 'おはよう';
+  if (hour >= 12 && hour < 18) return 'こんにちは';
+  return 'こんばんは';
+}
+
+export const GreetingCard: React.FC<GreetingCardProps> = ({ displayName }) => {
+  const { getConfig } = useCharacterStore();
+  const config = getConfig();
+  const greeting = getTimeGreeting();
+
+  return (
+    <div className="bg-primary-50 rounded-lg p-4 mb-6 flex items-center space-x-3">
+      <CharacterIcon type={config.type} size={40} />
+      <div>
+        <p className="text-sm font-medium text-primary-800">
+          {greeting}、{displayName}さん
+        </p>
+        <p className="text-xs text-primary-600">{config.name}より</p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/medications/StockRefillButton.tsx
+++ b/src/components/medications/StockRefillButton.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React, { useState } from 'react';
+import { PackagePlus, X } from 'lucide-react';
+
+interface StockRefillButtonProps {
+  medicationId: string;
+  currentStock: number;
+  onRefill: (medicationId: string, newQuantity: number) => Promise<void>;
+}
+
+export const StockRefillButton: React.FC<StockRefillButtonProps> = ({ medicationId, currentStock, onRefill }) => {
+  const [showInput, setShowInput] = useState(false);
+  const [amount, setAmount] = useState('30');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleRefill = async () => {
+    const num = parseInt(amount, 10);
+    if (isNaN(num) || num <= 0) return;
+    setIsSubmitting(true);
+    try {
+      await onRefill(medicationId, currentStock + num);
+      setShowInput(false);
+      setAmount('30');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (showInput) {
+    return (
+      <div className="flex items-center space-x-1">
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-16 px-2 py-1 text-sm border border-gray-300 rounded"
+          min="1"
+          aria-label="補充数"
+        />
+        <button
+          onClick={handleRefill}
+          disabled={isSubmitting}
+          className="px-2 py-1 bg-blue-600 text-white text-xs rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          補充
+        </button>
+        <button
+          onClick={() => setShowInput(false)}
+          className="p-1 text-gray-400 hover:text-gray-600"
+          aria-label="キャンセル"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setShowInput(true)}
+      className="p-1 text-blue-500 hover:text-blue-700 transition-colors"
+      aria-label="在庫補充"
+    >
+      <PackagePlus size={16} />
+    </button>
+  );
+};

--- a/src/components/medications/TakeWithNotesButton.tsx
+++ b/src/components/medications/TakeWithNotesButton.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Check, MessageSquarePlus } from 'lucide-react';
+
+interface TakeWithNotesButtonProps {
+  medicationId: string;
+  memberId: string;
+  onTake: (memberId: string, medicationId: string, notes?: string) => Promise<void>;
+}
+
+export const TakeWithNotesButton: React.FC<TakeWithNotesButtonProps> = ({ medicationId, memberId, onTake }) => {
+  const [showNotes, setShowNotes] = useState(false);
+  const [notes, setNotes] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [recorded, setRecorded] = useState(false);
+
+  const handleTake = async (withNotes: boolean) => {
+    setIsSubmitting(true);
+    try {
+      await onTake(memberId, medicationId, withNotes && notes ? notes : undefined);
+      setRecorded(true);
+      setShowNotes(false);
+      setNotes('');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (recorded) {
+    return (
+      <span className="inline-flex items-center text-sm text-green-600">
+        <Check size={16} className="mr-1" />
+        記録済み
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex items-center space-x-1">
+      {showNotes ? (
+        <div className="flex items-center space-x-1">
+          <input
+            type="text"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="メモ（任意）"
+            className="w-32 px-2 py-1 text-sm border border-gray-300 rounded"
+          />
+          <button
+            onClick={() => handleTake(true)}
+            disabled={isSubmitting}
+            className="px-2 py-1 bg-green-600 text-white text-xs rounded hover:bg-green-700 disabled:opacity-50"
+          >
+            記録
+          </button>
+        </div>
+      ) : (
+        <>
+          <button
+            onClick={() => handleTake(false)}
+            disabled={isSubmitting}
+            className="px-3 py-1 bg-green-600 text-white text-sm rounded hover:bg-green-700 disabled:opacity-50"
+          >
+            飲んだ
+          </button>
+          <button
+            onClick={() => setShowNotes(true)}
+            className="p-1 text-gray-400 hover:text-gray-600"
+            aria-label="メモ付きで記録"
+          >
+            <MessageSquarePlus size={16} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/domain/entities/MemberProfile.ts
+++ b/src/domain/entities/MemberProfile.ts
@@ -1,0 +1,33 @@
+/**
+ * メンバープロフィールエンティティ
+ * メンバーの詳細情報と統計をまとめたビューモデル
+ */
+
+import { Member } from './Member';
+
+export interface MemberProfile {
+  readonly member: Member;
+  readonly medicationCount: number;
+  readonly activeScheduleCount: number;
+  readonly upcomingAppointmentCount: number;
+  readonly recentAdherenceRate: number | null;
+}
+
+export class MemberProfileEntity {
+  constructor(private readonly profile: MemberProfile) {}
+
+  get data(): MemberProfile {
+    return this.profile;
+  }
+
+  hasMedications(): boolean {
+    return this.profile.medicationCount > 0;
+  }
+
+  getAdherenceLabel(): string {
+    if (this.profile.recentAdherenceRate === null) return '';
+    if (this.profile.recentAdherenceRate >= 80) return '良好';
+    if (this.profile.recentAdherenceRate >= 50) return '注意';
+    return '要改善';
+  }
+}


### PR DESCRIPTION
## 概要

Closes #146

Cycle5の新機能実装として5つの機能を追加。

## 変更内容

- 時間帯別挨拶カード（GreetingCard）をダッシュボードに統合
- 通院ミニカレンダー（MiniCalendar）を通院管理ページに統合
- 在庫補充ボタン（StockRefillButton）コンポーネント追加
- メモ付き服用記録（TakeWithNotesButton）コンポーネント追加
- メンバープロフィール（MemberProfile）エンティティとAPIエンドポイント追加

## テスト

- 25件のテストを追加（合計425件）
- 全テストパス、ビルド成功