### PR TITLE
test: Cycle5 Step3 - コンポーネントテストの追加

### DIFF
--- a/src/__tests__/components/hospitals/HospitalForm.test.tsx
+++ b/src/__tests__/components/hospitals/HospitalForm.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HospitalForm } from '@/components/hospitals/HospitalForm';
+
+describe('HospitalForm', () => {
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    mockOnSubmit.mockClear();
+  });
+
+  it('フォームフィールドを表示する', () => {
+    render(<HospitalForm onSubmit={mockOnSubmit} />);
+    expect(screen.getByLabelText('病院名')).toBeInTheDocument();
+    expect(screen.getByLabelText('住所（任意）')).toBeInTheDocument();
+    expect(screen.getByLabelText('電話番号（任意）')).toBeInTheDocument();
+    expect(screen.getByLabelText('メモ（任意）')).toBeInTheDocument();
+  });
+
+  it('病院名が空の場合送信しない', () => {
+    render(<HospitalForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('病院名のみで送信する', () => {
+    render(<HospitalForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('病院名'), { target: { value: '東京病院' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith({
+      name: '東京病院',
+      address: undefined,
+      phone: undefined,
+      notes: undefined,
+    });
+  });
+
+  it('全フィールドを入力して送信する', () => {
+    render(<HospitalForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('病院名'), { target: { value: '渋谷クリニック' } });
+    fireEvent.change(screen.getByLabelText('住所（任意）'), { target: { value: '東京都渋谷区1-1' } });
+    fireEvent.change(screen.getByLabelText('電話番号（任意）'), { target: { value: '03-1234-5678' } });
+    fireEvent.change(screen.getByLabelText('メモ（任意）'), { target: { value: '予約制' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith({
+      name: '渋谷クリニック',
+      address: '東京都渋谷区1-1',
+      phone: '03-1234-5678',
+      notes: '予約制',
+    });
+  });
+
+  it('送信後にフォームがリセットされる', () => {
+    render(<HospitalForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('病院名'), { target: { value: '病院名' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(screen.getByLabelText('病院名')).toHaveValue('');
+  });
+
+  it('空白のみの任意フィールドはundefinedで送信する', () => {
+    render(<HospitalForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('病院名'), { target: { value: 'テスト病院' } });
+    fireEvent.change(screen.getByLabelText('住所（任意）'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'テスト病院',
+      address: undefined,
+    }));
+  });
+});

--- a/src/__tests__/components/hospitals/HospitalList.test.tsx
+++ b/src/__tests__/components/hospitals/HospitalList.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { HospitalList } from '@/components/hospitals/HospitalList';
+import { Hospital } from '@/domain/entities/Hospital';
+
+const createHospital = (overrides: Partial<Hospital> = {}): Hospital => ({
+  id: 'hosp-1',
+  userId: 'user-1',
+  name: 'テスト病院',
+  hospitalType: 'general',
+  address: '東京都渋谷区1-1-1',
+  phoneNumber: '03-1234-5678',
+  notes: '駐車場あり',
+  createdAt: new Date(),
+  ...overrides,
+});
+
+describe('HospitalList', () => {
+  const mockOnUpdate = vi.fn().mockResolvedValue(undefined);
+  const mockOnDelete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('読み込み中を表示する', () => {
+    render(<HospitalList hospitals={[]} isLoading={true} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('空状態を表示する', () => {
+    render(<HospitalList hospitals={[]} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('病院が登録されていません')).toBeInTheDocument();
+  });
+
+  it('病院情報を表示する', () => {
+    const hospital = createHospital();
+    render(<HospitalList hospitals={[hospital]} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    expect(screen.getByText('テスト病院')).toBeInTheDocument();
+    expect(screen.getByText('東京都渋谷区1-1-1')).toBeInTheDocument();
+    expect(screen.getByText('03-1234-5678')).toBeInTheDocument();
+    expect(screen.getByText('駐車場あり')).toBeInTheDocument();
+  });
+
+  it('削除ボタンでonDeleteが呼ばれる', () => {
+    const hospital = createHospital();
+    render(<HospitalList hospitals={[hospital]} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('削除'));
+    expect(mockOnDelete).toHaveBeenCalledWith('hosp-1');
+  });
+
+  it('編集ボタンで編集モードに切り替わる', () => {
+    const hospital = createHospital();
+    render(<HospitalList hospitals={[hospital]} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('編集'));
+    expect(screen.getByDisplayValue('テスト病院')).toBeInTheDocument();
+    expect(screen.getByText('保存')).toBeInTheDocument();
+    expect(screen.getByText('キャンセル')).toBeInTheDocument();
+  });
+
+  it('編集キャンセルで元の表示に戻る', () => {
+    const hospital = createHospital();
+    render(<HospitalList hospitals={[hospital]} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('編集'));
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(screen.getByText('テスト病院')).toBeInTheDocument();
+    expect(screen.queryByText('保存')).not.toBeInTheDocument();
+  });
+
+  it('編集保存でonUpdateが呼ばれる', async () => {
+    const hospital = createHospital();
+    render(<HospitalList hospitals={[hospital]} isLoading={false} onUpdate={mockOnUpdate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('編集'));
+    fireEvent.change(screen.getByDisplayValue('テスト病院'), { target: { value: '新しい病院名' } });
+    fireEvent.click(screen.getByText('保存'));
+    await waitFor(() => {
+      expect(mockOnUpdate).toHaveBeenCalledWith('hosp-1', expect.objectContaining({ name: '新しい病院名' }));
+    });
+  });
+});

--- a/src/__tests__/components/medications/MedicationForm.test.tsx
+++ b/src/__tests__/components/medications/MedicationForm.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MedicationForm } from '@/components/medications/MedicationForm';
+
+describe('MedicationForm', () => {
+  const mockOnSubmit = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('フォームフィールドを表示する', () => {
+    render(<MedicationForm onSubmit={mockOnSubmit} />);
+    expect(screen.getByLabelText('薬の名前')).toBeInTheDocument();
+    expect(screen.getByLabelText('カテゴリ')).toBeInTheDocument();
+    expect(screen.getByLabelText('用量')).toBeInTheDocument();
+    expect(screen.getByLabelText('頻度')).toBeInTheDocument();
+  });
+
+  it('名前が空の場合送信しない', () => {
+    render(<MedicationForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('名前を入力して送信する', () => {
+    render(<MedicationForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('薬の名前'), { target: { value: 'ロキソニン' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'ロキソニン',
+      category: 'regular',
+    }));
+  });
+
+  it('カテゴリを変更して送信する', () => {
+    render(<MedicationForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('薬の名前'), { target: { value: 'ビタミンC' } });
+    fireEvent.change(screen.getByLabelText('カテゴリ'), { target: { value: 'supplement' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'ビタミンC',
+      category: 'supplement',
+    }));
+  });
+
+  it('編集モードでは更新するボタンを表示', () => {
+    const initialData = {
+      id: 'med-1',
+      memberId: 'member-1',
+      userId: 'user-1',
+      name: 'テスト薬',
+      category: 'regular' as const,
+      dosage: '1錠',
+      frequency: '1日1回',
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    render(<MedicationForm onSubmit={mockOnSubmit} initialData={initialData} />);
+    expect(screen.getByText('更新する')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('テスト薬')).toBeInTheDocument();
+  });
+
+  it('キャンセルボタンでonCancelが呼ばれる', () => {
+    render(<MedicationForm onSubmit={mockOnSubmit} onCancel={mockOnCancel} />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it('在庫数を含めて送信する', () => {
+    render(<MedicationForm onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('薬の名前'), { target: { value: '薬A' } });
+    fireEvent.change(screen.getByLabelText('在庫数(何日分)'), { target: { value: '30' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      name: '薬A',
+      stockQuantity: 30,
+    }));
+  });
+});

--- a/src/__tests__/components/medications/MedicationList.test.tsx
+++ b/src/__tests__/components/medications/MedicationList.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MedicationList } from '@/components/medications/MedicationList';
+import { MedicationViewModel } from '@/domain/usecases/ManageMedications';
+
+const createViewModel = (overrides: Partial<MedicationViewModel> = {}): MedicationViewModel => ({
+  medication: {
+    id: 'med-1',
+    memberId: 'member-1',
+    userId: 'user-1',
+    name: 'テスト薬',
+    category: 'regular',
+    dosage: '1錠',
+    frequency: '1日1回',
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  isLowStock: false,
+  displayInfo: { name: 'テスト薬', categoryLabel: '常用薬', dosageInfo: '1錠 / 1日1回' },
+  ...overrides,
+});
+
+describe('MedicationList', () => {
+  const mockOnDelete = vi.fn();
+  const mockOnMarkTaken = vi.fn().mockResolvedValue(undefined);
+  const mockOnEdit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('読み込み中を表示する', () => {
+    render(<MedicationList medications={[]} isLoading={true} onDelete={mockOnDelete} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('空状態を表示する', () => {
+    render(<MedicationList medications={[]} isLoading={false} onDelete={mockOnDelete} />);
+    expect(screen.getByText('薬がまだ登録されていません')).toBeInTheDocument();
+  });
+
+  it('薬の情報を表示する', () => {
+    const vm = createViewModel();
+    render(<MedicationList medications={[vm]} isLoading={false} onDelete={mockOnDelete} />);
+    expect(screen.getByText('テスト薬')).toBeInTheDocument();
+    expect(screen.getByText('常用薬')).toBeInTheDocument();
+  });
+
+  it('在庫少バッジを表示する', () => {
+    const vm = createViewModel({ isLowStock: true });
+    render(<MedicationList medications={[vm]} isLoading={false} onDelete={mockOnDelete} />);
+    expect(screen.getByText('在庫少')).toBeInTheDocument();
+  });
+
+  it('削除ボタンでonDeleteが呼ばれる', () => {
+    const vm = createViewModel();
+    render(<MedicationList medications={[vm]} isLoading={false} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText('削除'));
+    expect(mockOnDelete).toHaveBeenCalledWith('med-1');
+  });
+
+  it('飲んだボタンで記録済みに変わる', async () => {
+    const vm = createViewModel();
+    render(<MedicationList medications={[vm]} isLoading={false} onDelete={mockOnDelete} onMarkTaken={mockOnMarkTaken} />);
+    fireEvent.click(screen.getByLabelText('飲んだ'));
+    await waitFor(() => {
+      expect(screen.getByText('記録済み')).toBeInTheDocument();
+    });
+    expect(mockOnMarkTaken).toHaveBeenCalledWith('med-1');
+  });
+
+  it('編集ボタンでonEditが呼ばれる', () => {
+    const vm = createViewModel();
+    render(<MedicationList medications={[vm]} isLoading={false} onDelete={mockOnDelete} onEdit={mockOnEdit} />);
+    fireEvent.click(screen.getByLabelText('編集'));
+    expect(mockOnEdit).toHaveBeenCalledWith(vm.medication);
+  });
+
+  it('在庫数を表示する', () => {
+    const vm = createViewModel({
+      medication: {
+        ...createViewModel().medication,
+        stockQuantity: 30,
+      },
+    });
+    render(<MedicationList medications={[vm]} isLoading={false} onDelete={mockOnDelete} />);
+    expect(screen.getByText('在庫: 30日分')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

Closes #150

未テストのコンポーネントにテストを追加。

## 変更内容

- MedicationListテスト追加（8件）
- MedicationFormテスト追加（7件）
- HospitalListテスト追加（7件）
- HospitalFormテスト追加（6件）

## テスト

- 28件追加（合計453件）
- 全テストパス、ビルド成功