### PR TITLE
fix: Cycle5 Step4 - セキュリティ脆弱性の修正

### DIFF
--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -267,4 +267,49 @@ describe('updateStockSchema', () => {
   it('負の在庫数を拒否する', () => {
     expect(updateStockSchema.safeParse({ stockQuantity: -1 }).success).toBe(false);
   });
+
+  it('上限を超える在庫数を拒否する', () => {
+    expect(updateStockSchema.safeParse({ stockQuantity: 100000 }).success).toBe(false);
+  });
+});
+
+describe('数値フィールドの上限制約', () => {
+  it('在庫数の上限を超える値を拒否する', () => {
+    const result = createMedicationSchema.safeParse({ name: '薬', stockQuantity: 100000 });
+    expect(result.success).toBe(false);
+  });
+
+  it('リマインダー分数の上限を超える値を拒否する', () => {
+    const result = createScheduleSchema.safeParse({
+      medicationId: 'med-1',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+      reminderMinutesBefore: 1441,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('リマインダー日数の上限を超える値を拒否する', () => {
+    const result = createAppointmentSchema.safeParse({
+      memberId: 'member-1',
+      appointmentDate: '2024-06-01',
+      reminderDaysBefore: 366,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('上限内の値を受け入れる', () => {
+    expect(createMedicationSchema.safeParse({ name: '薬', stockQuantity: 99999 }).success).toBe(true);
+    expect(createScheduleSchema.safeParse({
+      medicationId: 'med-1',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+      reminderMinutesBefore: 1440,
+    }).success).toBe(true);
+    expect(createAppointmentSchema.safeParse({
+      memberId: 'member-1',
+      appointmentDate: '2024-06-01',
+      reminderDaysBefore: 365,
+    }).success).toBe(true);
+  });
 });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -41,7 +41,7 @@ export const createMedicationSchema = z.object({
   category: z.string().max(100).optional(),
   dosageAmount: z.string().max(100).optional(),
   frequency: z.string().max(100).optional(),
-  stockQuantity: z.number().int().min(0).optional(),
+  stockQuantity: z.number().int().min(0).max(99999).optional(),
   stockAlertDate: dateString.optional(),
   instructions: z.string().max(1000).optional(),
 });
@@ -51,7 +51,7 @@ export const updateMedicationSchema = z.object({
   category: z.string().max(100).optional(),
   dosageAmount: z.string().max(100).optional().nullable(),
   frequency: z.string().max(100).optional().nullable(),
-  stockQuantity: z.number().int().min(0).optional().nullable(),
+  stockQuantity: z.number().int().min(0).max(99999).optional().nullable(),
   stockAlertDate: dateString.optional().nullable(),
   instructions: z.string().max(1000).optional().nullable(),
   isActive: z.boolean().optional(),
@@ -60,7 +60,7 @@ export const updateMedicationSchema = z.object({
 });
 
 export const updateStockSchema = z.object({
-  stockQuantity: z.number().int().min(0, '在庫数は0以上の数値を指定してください'),
+  stockQuantity: z.number().int().min(0, '在庫数は0以上の数値を指定してください').max(99999),
 });
 
 // ===== Schedules =====
@@ -72,14 +72,14 @@ export const createScheduleSchema = z.object({
   scheduledTime: z.string().min(1, '予定時刻は必須です'),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
-  reminderMinutesBefore: z.number().int().min(0).optional(),
+  reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),
 });
 
 export const updateScheduleSchema = z.object({
   scheduledTime: z.string().optional(),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
-  reminderMinutesBefore: z.number().int().min(0).optional(),
+  reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),
 });
 
 // ===== Records =====
@@ -120,7 +120,7 @@ export const createAppointmentSchema = z.object({
   type: z.string().max(100).optional(),
   notes: z.string().max(1000).optional(),
   reminderEnabled: z.boolean().optional(),
-  reminderDaysBefore: z.number().int().min(0).optional(),
+  reminderDaysBefore: z.number().int().min(0).max(365).optional(),
 });
 
 export const updateAppointmentSchema = z.object({
@@ -129,7 +129,7 @@ export const updateAppointmentSchema = z.object({
   type: z.string().max(100).optional(),
   notes: z.string().max(1000).optional(),
   reminderEnabled: z.boolean().optional(),
-  reminderDaysBefore: z.number().int().min(0).optional(),
+  reminderDaysBefore: z.number().int().min(0).max(365).optional(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
 });


### PR DESCRIPTION
## 概要

Closes #152

セキュリティ監査に基づく3つの脆弱性を修正。

## 変更内容

- パスワードリセットにZodバリデーション追加（コード6桁制限・パスワード複雑性）
- 服用記録作成時のscheduleId所有権チェック追加（IDOR対策）
- 数値フィールドに上限制約追加

## テスト

- 5件追加（合計458件）
- 全テストパス、ビルド成功