### PR TITLE
クリーンアーキテクチャ改善: 再エクスポート削除とReact.memo最適化

### DIFF
--- a/src/components/appointments/AppointmentList.tsx
+++ b/src/components/appointments/AppointmentList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Calendar, Pencil, Trash2, User, MapPin } from 'lucide-react';
 import { Appointment, AppointmentEntity } from '../../domain/entities/Appointment';
 
@@ -25,6 +25,16 @@ export function getAppointmentCounts(appointments: Appointment[]): { upcoming: n
 }
 
 export const AppointmentList: React.FC<AppointmentListProps> = ({ appointments, isLoading, filter, onEdit, onDelete }) => {
+  const { upcoming, past } = useMemo(() => {
+    const up: Appointment[] = [];
+    const pa: Appointment[] = [];
+    for (const a of appointments) {
+      if (new AppointmentEntity(a).isPast()) pa.push(a);
+      else up.push(a);
+    }
+    return { upcoming: up, past: pa };
+  }, [appointments]);
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center py-8">
@@ -40,9 +50,6 @@ export const AppointmentList: React.FC<AppointmentListProps> = ({ appointments, 
       </div>
     );
   }
-
-  const upcoming = appointments.filter((a) => !new AppointmentEntity(a).isPast());
-  const past = appointments.filter((a) => new AppointmentEntity(a).isPast());
 
   if (filter === 'upcoming') {
     return (
@@ -95,13 +102,13 @@ export const AppointmentList: React.FC<AppointmentListProps> = ({ appointments, 
   );
 };
 
-interface AppointmentCardProps {
+export interface AppointmentCardProps {
   appointment: Appointment;
   onEdit: (appointment: Appointment) => void;
   onDelete: (appointmentId: string) => void;
 }
 
-const AppointmentCard: React.FC<AppointmentCardProps> = ({ appointment, onEdit, onDelete }) => {
+const AppointmentCard: React.FC<AppointmentCardProps> = React.memo(({ appointment, onEdit, onDelete }) => {
   const entity = new AppointmentEntity(appointment);
   const daysUntil = entity.daysUntil();
   const typeLabel = entity.getTypeLabel();
@@ -166,4 +173,6 @@ const AppointmentCard: React.FC<AppointmentCardProps> = ({ appointment, onEdit, 
       </div>
     </div>
   );
-};
+});
+
+AppointmentCard.displayName = 'AppointmentCard';

--- a/src/components/dashboard/AdherenceStatsCard.tsx
+++ b/src/components/dashboard/AdherenceStatsCard.tsx
@@ -21,7 +21,7 @@ const levelBgColors = {
   poor: 'bg-red-100',
 } as const;
 
-export const AdherenceStatsCard: React.FC<AdherenceStatsCardProps> = ({ stats, isLoading }) => {
+export const AdherenceStatsCard: React.FC<AdherenceStatsCardProps> = React.memo(({ stats, isLoading }) => {
   if (isLoading || !stats) return null;
 
   const weeklyLevel = AdherenceStatsEntity.getRateLevel(stats.overall.weeklyRate);
@@ -77,4 +77,6 @@ export const AdherenceStatsCard: React.FC<AdherenceStatsCardProps> = ({ stats, i
       </div>
     </div>
   );
-};
+});
+
+AdherenceStatsCard.displayName = 'AdherenceStatsCard';

--- a/src/components/dashboard/WeeklySummaryCard.tsx
+++ b/src/components/dashboard/WeeklySummaryCard.tsx
@@ -7,7 +7,7 @@ interface WeeklySummaryCardProps {
   isLoading: boolean;
 }
 
-export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = ({ schedules, isLoading }) => {
+export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = React.memo(({ schedules, isLoading }) => {
   if (isLoading) {
     return (
       <div className="bg-white rounded-lg shadow-md p-4 mb-4 border border-gray-200">
@@ -61,4 +61,6 @@ export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = ({ schedules,
       </div>
     </div>
   );
-};
+});
+
+WeeklySummaryCard.displayName = 'WeeklySummaryCard';

--- a/src/components/members/MemberSummaryCard.tsx
+++ b/src/components/members/MemberSummaryCard.tsx
@@ -6,7 +6,7 @@ interface MemberSummaryCardProps {
   summary: MemberSummary;
 }
 
-export const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({ summary }) => {
+export const MemberSummaryCard: React.FC<MemberSummaryCardProps> = React.memo(({ summary }) => {
   const entity = new MemberSummaryEntity(summary);
   const appointmentLabel = entity.getAppointmentLabel();
 
@@ -24,4 +24,6 @@ export const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({ summary })
       )}
     </div>
   );
-};
+});
+
+MemberSummaryCard.displayName = 'MemberSummaryCard';

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -2,8 +2,6 @@
  * 通院予約エンティティ
  */
 
-export { type Hospital } from './Hospital';
-
 import { DAY_LABELS_JP } from '../../lib/constants';
 
 export interface Appointment {


### PR DESCRIPTION
## 概要

Closes #156

アーキテクチャ監査により特定された改善点を修正。

## 変更内容

- Appointment.tsからHospital型の不要な再エクスポートを削除（利用箇所なし）
- AppointmentCard, MemberSummaryCard, WeeklySummaryCard, AdherenceStatsCardにReact.memoを適用
- AppointmentListの予定分類処理をuseMemoで最適化（毎レンダーでのEntity生成を防止）
- AppointmentCardPropsインターフェースをエクスポート

## テスト結果

- 全481テスト通過
- ビルド成功