### PR TITLE
テスト品質向上: 未テストコンポーネント4件のテスト追加

### DIFF
--- a/src/__tests__/components/schedules/ScheduleForm.test.tsx
+++ b/src/__tests__/components/schedules/ScheduleForm.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ScheduleForm } from '@/components/schedules/ScheduleForm';
+
+describe('ScheduleForm', () => {
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    mockOnSubmit.mockClear();
+  });
+
+  it('フォームフィールドが表示される', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    expect(screen.getByLabelText('服薬時刻')).toBeInTheDocument();
+    expect(screen.getByText('曜日')).toBeInTheDocument();
+    expect(screen.getByLabelText('リマインダー（分前）')).toBeInTheDocument();
+    expect(screen.getByText('スケジュールを追加')).toBeInTheDocument();
+  });
+
+  it('曜日ボタンが全て表示される', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    expect(screen.getByLabelText('月')).toBeInTheDocument();
+    expect(screen.getByLabelText('火')).toBeInTheDocument();
+    expect(screen.getByLabelText('水')).toBeInTheDocument();
+    expect(screen.getByLabelText('木')).toBeInTheDocument();
+    expect(screen.getByLabelText('金')).toBeInTheDocument();
+    expect(screen.getByLabelText('土')).toBeInTheDocument();
+    expect(screen.getByLabelText('日')).toBeInTheDocument();
+  });
+
+  it('曜日を選択せずに送信するとonSubmitが呼ばれない', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByText('スケジュールを追加'));
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('曜日を選択して送信するとonSubmitが正しいデータで呼ばれる', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByLabelText('月'));
+    fireEvent.click(screen.getByLabelText('水'));
+    fireEvent.click(screen.getByText('スケジュールを追加'));
+    expect(mockOnSubmit).toHaveBeenCalledWith({
+      scheduledTime: '08:00',
+      daysOfWeek: ['mon', 'wed'],
+      reminderMinutesBefore: 10,
+    });
+  });
+
+  it('曜日のトグルが正しく動作する', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    const mondayCheckbox = screen.getByLabelText('月');
+    fireEvent.click(mondayCheckbox);
+    expect(mondayCheckbox).toBeChecked();
+    fireEvent.click(mondayCheckbox);
+    expect(mondayCheckbox).not.toBeChecked();
+  });
+
+  it('リマインダーの選択肢が正しい', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    const select = screen.getByLabelText('リマインダー（分前）');
+    expect(select).toHaveValue('10');
+    const options = select.querySelectorAll('option');
+    expect(options).toHaveLength(6);
+  });
+
+  it('送信後にフォームがリセットされる', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByLabelText('金'));
+    fireEvent.click(screen.getByText('スケジュールを追加'));
+    expect(screen.getByLabelText('金')).not.toBeChecked();
+  });
+});

--- a/src/__tests__/components/shared/CharacterIcon.test.tsx
+++ b/src/__tests__/components/shared/CharacterIcon.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { CharacterIcon } from '@/components/shared/CharacterIcon';
+
+describe('CharacterIcon', () => {
+  it('犬アイコンを表示する', () => {
+    const { container } = render(<CharacterIcon type="dog" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('猫アイコンを表示する', () => {
+    const { container } = render(<CharacterIcon type="cat" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('うさぎアイコンを表示する', () => {
+    const { container } = render(<CharacterIcon type="rabbit" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('鳥アイコンを表示する', () => {
+    const { container } = render(<CharacterIcon type="bird" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('デフォルトサイズが32である', () => {
+    const { container } = render(<CharacterIcon type="dog" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('カスタムサイズを指定できる', () => {
+    const { container } = render(<CharacterIcon type="cat" size={48} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '48');
+    expect(svg).toHaveAttribute('height', '48');
+  });
+
+  it('カスタムクラス名を適用できる', () => {
+    const { container } = render(<CharacterIcon type="rabbit" className="text-blue-500" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toContain('text-blue-500');
+  });
+});

--- a/src/__tests__/components/shared/ErrorBoundary.test.tsx
+++ b/src/__tests__/components/shared/ErrorBoundary.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+
+const ThrowingComponent = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) throw new Error('テストエラー');
+  return <div>正常コンテンツ</div>;
+};
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('エラーがない場合は子コンポーネントを表示する', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('正常コンテンツ')).toBeInTheDocument();
+  });
+
+  it('エラー発生時にエラーメッセージを表示する', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+    expect(screen.getByText('テストエラー')).toBeInTheDocument();
+  });
+
+  it('エラー発生時に再読み込みボタンを表示する', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('再読み込み')).toBeInTheDocument();
+  });
+
+  it('再読み込みボタンをクリックするとwindow.location.reloadが呼ばれる', () => {
+    const reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload: reloadMock },
+      writable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    fireEvent.click(screen.getByText('再読み込み'));
+    expect(reloadMock).toHaveBeenCalled();
+  });
+
+  it('エラー発生時にconsole.errorが呼ばれる', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/shared/MemberIcon.test.tsx
+++ b/src/__tests__/components/shared/MemberIcon.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemberIcon } from '@/components/shared/MemberIcon';
+
+describe('MemberIcon', () => {
+  it('人間メンバーにはUserアイコンを表示する', () => {
+    const { container } = render(<MemberIcon memberType="human" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('ペット（犬）にはDogアイコンを表示する', () => {
+    const { container } = render(<MemberIcon memberType="pet" petType="dog" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('ペット（猫）にはCatアイコンを表示する', () => {
+    const { container } = render(<MemberIcon memberType="pet" petType="cat" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('ペット（その他）にはPawPrintアイコンを表示する', () => {
+    const { container } = render(<MemberIcon memberType="pet" petType="other" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('petTypeなしのペットにはPawPrintアイコンを表示する', () => {
+    const { container } = render(<MemberIcon memberType="pet" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('デフォルトサイズが24である', () => {
+    const { container } = render(<MemberIcon memberType="human" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+  });
+
+  it('カスタムサイズを指定できる', () => {
+    const { container } = render(<MemberIcon memberType="pet" petType="rabbit" size={36} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '36');
+    expect(svg).toHaveAttribute('height', '36');
+  });
+
+  it('カスタムクラス名を適用できる', () => {
+    const { container } = render(<MemberIcon memberType="human" className="text-red-500" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toContain('text-red-500');
+  });
+});


### PR DESCRIPTION
## 概要

Closes #158

テストカバレッジが不足していたコンポーネントにテストを追加。

## 追加テスト

- **ScheduleForm** (7テスト): フォームフィールド表示、曜日選択トグル、未選択時バリデーション、送信データ、送信後リセット
- **CharacterIcon** (7テスト): dog/cat/rabbit/birdの各アイコン表示、デフォルト・カスタムサイズ、クラス名
- **ErrorBoundary** (5テスト): 正常時の子コンポーネント表示、エラーキャッチ、エラーメッセージ表示、再読み込みボタン
- **MemberIcon** (8テスト): human/pet各種アイコン、petType未指定時のフォールバック、サイズ、クラス名

## テスト結果

- 全508テスト通過（+27）
- ビルド成功