### PR TITLE
セキュリティ強化: パスワード/メール長さ制限とクエリ上限追加

### DIFF
--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -313,3 +313,44 @@ describe('数値フィールドの上限制約', () => {
     }).success).toBe(true);
   });
 });
+
+describe('文字列フィールドの長さ制約', () => {
+  it('パスワードが128文字を超える場合を拒否する', () => {
+    const longPassword = 'Aa1' + 'x'.repeat(126);
+    const result = signUpSchema.safeParse({
+      email: 'test@example.com',
+      password: longPassword,
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('パスワードが128文字以内の場合を受け入れる', () => {
+    const validPassword = 'Aa1' + 'x'.repeat(125);
+    const result = signUpSchema.safeParse({
+      email: 'test@example.com',
+      password: validPassword,
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('メールアドレスが254文字を超える場合を拒否する', () => {
+    const longEmail = 'a'.repeat(246) + '@test.com';
+    const result = signUpSchema.safeParse({
+      email: longEmail,
+      password: 'Test1234',
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('メールアドレスが254文字以内の場合を受け入れる', () => {
+    const result = signUpSchema.safeParse({
+      email: 'normal@example.com',
+      password: 'Test1234',
+      displayName: 'テスト',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -6,10 +6,11 @@ import { success, errorResponse } from '@/lib/auth-helpers';
 import { timingSafeEqual, checkRateLimit } from '@/lib/security';
 
 const resetPasswordSchema = z.object({
-  email: z.string().trim().toLowerCase().email('有効なメールアドレスを入力してください'),
+  email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),
   code: z.string().length(6, 'リセットコードは6桁で入力してください'),
   newPassword: z.string()
     .min(8, 'パスワードは8文字以上で入力してください')
+    .max(128, 'パスワードは128文字以内で入力してください')
     .regex(/[a-zA-Z]/, 'パスワードには英字を含めてください')
     .regex(/[0-9]/, 'パスワードには数字を含めてください'),
 });

--- a/src/app/api/medications/alerts/route.ts
+++ b/src/app/api/medications/alerts/route.ts
@@ -13,6 +13,7 @@ export const GET = withAuth(async (userId) => {
     },
     include: { member: { select: { id: true, name: true } } },
     orderBy: { stockAlertDate: 'asc' },
+    take: 500,
   });
 
   const alerts = medications

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -136,9 +136,10 @@ export const updateAppointmentSchema = z.object({
 
 // ===== Auth =====
 export const signUpSchema = z.object({
-  email: z.string().trim().toLowerCase().email('有効なメールアドレスを入力してください'),
+  email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),
   password: z.string()
     .min(8, 'パスワードは8文字以上で入力してください')
+    .max(128, 'パスワードは128文字以内で入力してください')
     .regex(/[a-zA-Z]/, 'パスワードには英字を含めてください')
     .regex(/[0-9]/, 'パスワードには数字を含めてください'),
   displayName: z.string().trim().min(1, '表示名は必須です').max(100),


### PR DESCRIPTION
## 概要

Closes #160

セキュリティ監査により特定された脆弱性を修正。

## 変更内容

- signUpSchema/resetPasswordSchemaにパスワード上限128文字を追加（bcrypt DoS防止）
- signUpSchema/resetPasswordSchemaにメールアドレス上限254文字を追加（RFC 5321準拠）
- medications alertsエンドポイントにtake:500のクエリ上限を追加
- 長さ制約の検証テスト4件追加

## テスト結果

- 全512テスト通過（+4）
- ビルド成功