### PR TITLE
アーキテクチャ改善: React.memo適用とPropsエクスポート

### DIFF
--- a/src/components/hospitals/HospitalList.tsx
+++ b/src/components/hospitals/HospitalList.tsx
@@ -38,13 +38,13 @@ export const HospitalList: React.FC<HospitalListProps> = ({ hospitals, isLoading
   );
 };
 
-interface HospitalCardProps {
+export interface HospitalCardProps {
   hospital: Hospital;
   onUpdate: (hospitalId: string, input: UpdateHospitalInput) => Promise<void>;
   onDelete: (hospitalId: string) => void;
 }
 
-const HospitalCard: React.FC<HospitalCardProps> = ({ hospital, onUpdate, onDelete }) => {
+const HospitalCard: React.FC<HospitalCardProps> = React.memo(({ hospital, onUpdate, onDelete }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(hospital.name);
   const [editAddress, setEditAddress] = useState(hospital.address || '');
@@ -174,4 +174,6 @@ const HospitalCard: React.FC<HospitalCardProps> = ({ hospital, onUpdate, onDelet
       </div>
     </div>
   );
-};
+});
+
+HospitalCard.displayName = 'HospitalCard';

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -37,14 +37,14 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
   );
 };
 
-interface MedicationCardProps {
+export interface MedicationCardProps {
   viewModel: MedicationViewModel;
   onDelete: (medicationId: string) => void;
   onMarkTaken?: (medicationId: string) => Promise<void>;
   onEdit?: (medication: Medication) => void;
 }
 
-const MedicationCard: React.FC<MedicationCardProps> = ({ viewModel, onDelete, onMarkTaken, onEdit }) => {
+const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, onDelete, onMarkTaken, onEdit }) => {
   const { medication, isLowStock, displayInfo } = viewModel;
   const [isTaken, setIsTaken] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -122,4 +122,6 @@ const MedicationCard: React.FC<MedicationCardProps> = ({ viewModel, onDelete, on
       </div>
     </div>
   );
-};
+});
+
+MedicationCard.displayName = 'MedicationCard';

--- a/src/components/members/MemberList.tsx
+++ b/src/components/members/MemberList.tsx
@@ -40,14 +40,14 @@ export const MemberList: React.FC<MemberListProps> = ({ members, isLoading, onDe
   );
 };
 
-interface MemberCardProps {
+export interface MemberCardProps {
   member: Member;
   onDelete: (memberId: string) => void;
   onEdit?: (member: Member) => void;
   summary?: MemberSummary;
 }
 
-const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete, onEdit, summary }) => {
+const MemberCard: React.FC<MemberCardProps> = React.memo(({ member, onDelete, onEdit, summary }) => {
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
   const age = entity.getAge();
@@ -101,4 +101,6 @@ const MemberCard: React.FC<MemberCardProps> = ({ member, onDelete, onEdit, summa
       )}
     </div>
   );
-};
+});
+
+MemberCard.displayName = 'MemberCard';

--- a/src/components/schedules/ScheduleList.tsx
+++ b/src/components/schedules/ScheduleList.tsx
@@ -71,13 +71,13 @@ export const ScheduleList: React.FC<ScheduleListProps> = ({ schedules, isLoading
   );
 };
 
-interface ScheduleCardProps {
+export interface ScheduleCardProps {
   item: ScheduleWithDetails;
   onUpdate: (scheduleId: string, input: Partial<Schedule>) => Promise<void>;
   onDelete: (scheduleId: string) => void;
 }
 
-const ScheduleCard: React.FC<ScheduleCardProps> = ({ item, onUpdate, onDelete }) => {
+const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, onDelete }) => {
   const { schedule, medicationName, memberName } = item;
   const [isEditing, setIsEditing] = useState(false);
   const [editTime, setEditTime] = useState(schedule.scheduledTime);
@@ -215,4 +215,6 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({ item, onUpdate, onDelete })
       </div>
     </div>
   );
-};
+});
+
+ScheduleCard.displayName = 'ScheduleCard';

--- a/src/presentation/hooks/useMedicationRecordActions.ts
+++ b/src/presentation/hooks/useMedicationRecordActions.ts
@@ -3,19 +3,38 @@
  * 服薬完了記録の作成をPresentation層経由で提供
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { CreateMedicationRecord } from '../../domain/usecases/ManageMedicationRecords';
 import { getDIContainer } from '../../infrastructure/DIContainer';
 
-export const useMedicationRecordActions = () => {
+export interface UseMedicationRecordActionsResult {
+  markAsTaken: (memberId: string, medicationId: string, notes?: string) => Promise<void>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export const useMedicationRecordActions = (): UseMedicationRecordActionsResult => {
   const useCase = useMemo(() => {
     const { medicationRecordRepository } = getDIContainer();
     return new CreateMedicationRecord(medicationRecordRepository);
   }, []);
 
-  const markAsTaken = useCallback(async (memberId: string, medicationId: string) => {
-    await useCase.execute({ memberId, medicationId });
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const markAsTaken = useCallback(async (memberId: string, medicationId: string, notes?: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await useCase.execute({ memberId, medicationId, notes });
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error('記録に失敗しました');
+      setError(e);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
   }, [useCase]);
 
-  return { markAsTaken };
+  return { markAsTaken, isLoading, error };
 };


### PR DESCRIPTION
## 概要

Closes #164

リスト内カードコンポーネントのパフォーマンス最適化とインターフェース改善。

## 変更内容

- MedicationCard, MemberCard, ScheduleCard, HospitalCardにReact.memo + displayName適用
- 全カードのPropsインターフェースをexportして再利用可能に
- useMedicationRecordActionsにisLoading/error/notes対応を追加

## テスト結果

- 全537テスト通過
- ビルド成功