### PR TITLE
テスト品質向上: 未テストコンポーネント3件+エンティティ1件のテスト追加

### DIFF
--- a/src/__tests__/components/appointments/AppointmentForm.test.tsx
+++ b/src/__tests__/components/appointments/AppointmentForm.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppointmentForm } from '@/components/appointments/AppointmentForm';
+import { Member } from '@/domain/entities/Member';
+import { Hospital } from '@/domain/entities/Hospital';
+
+const mockMembers: Member[] = [
+  { id: 'm1', userId: 'u1', memberType: 'human', name: '太郎', isActive: true, createdAt: new Date(), updatedAt: new Date() },
+  { id: 'm2', userId: 'u1', memberType: 'pet', petType: 'dog', name: 'ポチ', isActive: true, createdAt: new Date(), updatedAt: new Date() },
+];
+
+const mockHospitals: Hospital[] = [
+  { id: 'h1', userId: 'u1', name: '東京病院', createdAt: new Date() },
+];
+
+describe('AppointmentForm', () => {
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    mockOnSubmit.mockClear();
+  });
+
+  it('フォームフィールドが表示される', () => {
+    render(<AppointmentForm members={mockMembers} hospitals={mockHospitals} onSubmit={mockOnSubmit} />);
+    expect(screen.getByText('メンバー')).toBeInTheDocument();
+    expect(screen.getByLabelText('予約日')).toBeInTheDocument();
+    expect(screen.getByLabelText(/種別/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/メモ/)).toBeInTheDocument();
+  });
+
+  it('メンバー一覧が表示される', () => {
+    render(<AppointmentForm members={mockMembers} hospitals={mockHospitals} onSubmit={mockOnSubmit} />);
+    expect(screen.getByText('太郎')).toBeInTheDocument();
+    expect(screen.getByText('ポチ')).toBeInTheDocument();
+  });
+
+  it('病院が選択肢に表示される', () => {
+    render(<AppointmentForm members={mockMembers} hospitals={mockHospitals} onSubmit={mockOnSubmit} />);
+    expect(screen.getByText('東京病院')).toBeInTheDocument();
+  });
+
+  it('日付未入力で送信できない', () => {
+    render(<AppointmentForm members={mockMembers} hospitals={mockHospitals} onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('正しいデータで送信される', () => {
+    render(<AppointmentForm members={mockMembers} hospitals={mockHospitals} onSubmit={mockOnSubmit} />);
+    fireEvent.change(screen.getByLabelText('予約日'), { target: { value: '2025-06-01' } });
+    fireEvent.click(screen.getByText('追加する'));
+    expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      memberId: 'm1',
+      appointmentDate: '2025-06-01',
+    }));
+  });
+
+  it('編集モードで更新ボタンが表示される', () => {
+    const initialData = {
+      id: 'a1', userId: 'u1', memberId: 'm1', appointmentDate: new Date('2025-06-01'),
+      reminderEnabled: false, reminderDaysBefore: 0, createdAt: new Date(),
+    };
+    render(<AppointmentForm members={mockMembers} hospitals={mockHospitals} onSubmit={mockOnSubmit} initialData={initialData} />);
+    expect(screen.getByText('更新する')).toBeInTheDocument();
+  });
+
+  it('キャンセルボタンが編集モードで表示される', () => {
+    const onCancel = vi.fn();
+    const initialData = {
+      id: 'a1', userId: 'u1', memberId: 'm1', appointmentDate: new Date('2025-06-01'),
+      reminderEnabled: false, reminderDaysBefore: 0, createdAt: new Date(),
+    };
+    render(<AppointmentForm members={mockMembers} hospitals={mockHospitals} onSubmit={mockOnSubmit} initialData={initialData} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/character/CharacterSelector.test.tsx
+++ b/src/__tests__/components/character/CharacterSelector.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CharacterSelector } from '@/components/character/CharacterSelector';
+import { useCharacterStore } from '@/stores/characterStore';
+
+describe('CharacterSelector', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ selectedCharacter: 'cat' });
+  });
+
+  it('全キャラクターオプションが表示される', () => {
+    render(<CharacterSelector />);
+    expect(screen.getByText('いぬ')).toBeInTheDocument();
+    expect(screen.getByText('ねこ')).toBeInTheDocument();
+    expect(screen.getByText('うさぎ')).toBeInTheDocument();
+    expect(screen.getByText('インコ')).toBeInTheDocument();
+  });
+
+  it('選択中のキャラクターがハイライトされる', () => {
+    render(<CharacterSelector />);
+    const catButton = screen.getByText('ねこ').closest('button');
+    expect(catButton?.className).toContain('border-blue-500');
+  });
+
+  it('キャラクターをクリックすると選択が変更される', () => {
+    render(<CharacterSelector />);
+    fireEvent.click(screen.getByText('いぬ'));
+    expect(useCharacterStore.getState().selectedCharacter).toBe('dog');
+  });
+
+  it('SVGアイコンが4つ表示される', () => {
+    const { container } = render(<CharacterSelector />);
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length).toBe(4);
+  });
+});

--- a/src/__tests__/components/history/MedicationHistoryList.test.tsx
+++ b/src/__tests__/components/history/MedicationHistoryList.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MedicationHistoryList } from '@/components/history/MedicationHistoryList';
+import { DailyRecordGroup } from '@/domain/entities/MedicationRecord';
+
+const mockGroups: DailyRecordGroup[] = [
+  {
+    date: '2025-06-15',
+    records: [
+      {
+        id: 'r1', memberId: 'm1', memberName: '太郎', medicationId: 'med1',
+        medicationName: '頭痛薬', userId: 'u1', takenAt: new Date('2025-06-15T08:30:00'),
+        dosageAmount: '1錠',
+      },
+      {
+        id: 'r2', memberId: 'm1', memberName: '太郎', medicationId: 'med2',
+        medicationName: '胃薬', userId: 'u1', takenAt: new Date('2025-06-15T12:00:00'),
+        notes: '食後に服用',
+      },
+    ],
+  },
+];
+
+describe('MedicationHistoryList', () => {
+  it('読み込み中の表示', () => {
+    render(<MedicationHistoryList groups={[]} isLoading={true} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('空の場合のメッセージ表示', () => {
+    render(<MedicationHistoryList groups={[]} isLoading={false} />);
+    expect(screen.getByText('服薬履歴がありません')).toBeInTheDocument();
+  });
+
+  it('薬名が表示される', () => {
+    render(<MedicationHistoryList groups={mockGroups} isLoading={false} />);
+    expect(screen.getByText('頭痛薬')).toBeInTheDocument();
+    expect(screen.getByText('胃薬')).toBeInTheDocument();
+  });
+
+  it('メンバー名が表示される', () => {
+    render(<MedicationHistoryList groups={mockGroups} isLoading={false} />);
+    expect(screen.getAllByText('太郎').length).toBeGreaterThan(0);
+  });
+
+  it('服用量が表示される', () => {
+    render(<MedicationHistoryList groups={mockGroups} isLoading={false} />);
+    expect(screen.getByText('1錠')).toBeInTheDocument();
+  });
+
+  it('メモが表示される', () => {
+    render(<MedicationHistoryList groups={mockGroups} isLoading={false} />);
+    expect(screen.getByText('食後に服用')).toBeInTheDocument();
+  });
+
+  it('削除ボタンをクリックするとonDeleteが呼ばれる', () => {
+    const onDelete = vi.fn();
+    render(<MedicationHistoryList groups={mockGroups} isLoading={false} onDelete={onDelete} />);
+    const deleteButtons = screen.getAllByLabelText('削除');
+    fireEvent.click(deleteButtons[0]);
+    expect(onDelete).toHaveBeenCalledWith('r1');
+  });
+
+  it('onDeleteが未指定の場合は削除ボタンが表示されない', () => {
+    render(<MedicationHistoryList groups={mockGroups} isLoading={false} />);
+    expect(screen.queryByLabelText('削除')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/domain/entities/MedicationRecord.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecord.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (overrides: Partial<MedicationRecord> = {}): MedicationRecord => ({
+  id: 'r1',
+  memberId: 'm1',
+  memberName: '太郎',
+  medicationId: 'med1',
+  medicationName: '頭痛薬',
+  userId: 'u1',
+  takenAt: new Date('2025-06-15T08:30:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity', () => {
+  describe('groupByDate', () => {
+    it('記録を日付ごとにグループ化する', () => {
+      const records = [
+        createRecord({ id: 'r1', takenAt: new Date('2025-06-15T08:00:00') }),
+        createRecord({ id: 'r2', takenAt: new Date('2025-06-15T12:00:00') }),
+        createRecord({ id: 'r3', takenAt: new Date('2025-06-14T09:00:00') }),
+      ];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups).toHaveLength(2);
+      expect(groups[0].date).toBe('2025-06-15');
+      expect(groups[0].records).toHaveLength(2);
+      expect(groups[1].date).toBe('2025-06-14');
+      expect(groups[1].records).toHaveLength(1);
+    });
+
+    it('新しい日付が先に来る', () => {
+      const records = [
+        createRecord({ id: 'r1', takenAt: new Date('2025-06-10T08:00:00') }),
+        createRecord({ id: 'r2', takenAt: new Date('2025-06-20T08:00:00') }),
+      ];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups[0].date).toBe('2025-06-20');
+      expect(groups[1].date).toBe('2025-06-10');
+    });
+
+    it('空の配列の場合は空を返す', () => {
+      const groups = MedicationRecordEntity.groupByDate([]);
+      expect(groups).toHaveLength(0);
+    });
+  });
+
+  describe('formatDate', () => {
+    it('日本語形式でフォーマットする', () => {
+      const result = MedicationRecordEntity.formatDate('2025-06-15');
+      expect(result).toContain('6月15日');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('HH:mm形式でフォーマットする', () => {
+      const result = MedicationRecordEntity.formatTime(new Date('2025-06-15T08:30:00'));
+      expect(result).toBe('08:30');
+    });
+
+    it('0埋めが正しく動作する', () => {
+      const result = MedicationRecordEntity.formatTime(new Date('2025-06-15T01:05:00'));
+      expect(result).toBe('01:05');
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Closes #166

テストカバレッジが不足していた4ファイルにテストを追加。

## 追加テスト

- **AppointmentForm** (7テスト): フォームUI、メンバー/病院選択、バリデーション、送信、編集/キャンセル
- **MedicationHistoryList** (8テスト): 状態表示、記録データ表示、削除機能
- **CharacterSelector** (4テスト): Zustandストア連携、全キャラクター表示、選択切替
- **MedicationRecordEntity** (6テスト): groupByDate、formatDate、formatTime

## テスト結果

- 全562テスト通過（+25）
- ビルド成功