### PR TITLE
セキュリティ強化: テキストtrim、ID長さ制限、JWTセッション有効期限

### DIFF
--- a/src/__tests__/lib/schemas.test.ts
+++ b/src/__tests__/lib/schemas.test.ts
@@ -354,3 +354,50 @@ describe('文字列フィールドの長さ制約', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('テキストフィールドのtrim処理', () => {
+  it('メンバー名の前後空白が除去される', () => {
+    const result = createMemberSchema.safeParse({ name: '  太郎  ' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.name).toBe('太郎');
+  });
+
+  it('薬名の前後空白が除去される', () => {
+    const result = createMedicationSchema.safeParse({ name: '  頭痛薬  ' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.name).toBe('頭痛薬');
+  });
+
+  it('病院名の前後空白が除去される', () => {
+    const result = createHospitalSchema.safeParse({ name: '  東京病院  ' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.name).toBe('東京病院');
+  });
+
+  it('空白のみの名前は拒否される', () => {
+    expect(createMemberSchema.safeParse({ name: '   ' }).success).toBe(false);
+    expect(createMedicationSchema.safeParse({ name: '   ' }).success).toBe(false);
+    expect(createHospitalSchema.safeParse({ name: '   ' }).success).toBe(false);
+  });
+});
+
+describe('IDフィールドの長さ制約', () => {
+  it('長すぎるIDを拒否する', () => {
+    const longId = 'a'.repeat(51);
+    const result = createScheduleSchema.safeParse({
+      medicationId: longId,
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('適切な長さのIDを受け入れる', () => {
+    const result = createScheduleSchema.safeParse({
+      medicationId: 'med-12345',
+      memberId: 'member-12345',
+      scheduledTime: '08:00',
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -2,7 +2,7 @@ import type { NextAuthConfig } from 'next-auth';
 
 export const authConfig: NextAuthConfig = {
   providers: [],
-  session: { strategy: 'jwt' },
+  session: { strategy: 'jwt', maxAge: 7 * 24 * 60 * 60 },
   pages: {
     signIn: '/login',
   },

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -5,55 +5,58 @@ const dateString = z.string().refine(
   { message: '有効な日付形式で入力してください' },
 );
 
+const idField = z.string().min(1).max(50);
+const optionalIdField = z.string().max(50).optional();
+
 // ===== Users =====
 export const createUserProfileSchema = z.object({
-  displayName: z.string().min(1, '表示名は必須です').max(100),
+  displayName: z.string().trim().min(1, '表示名は必須です').max(100),
 });
 
 export const updateUserProfileSchema = z.object({
-  displayName: z.string().min(1).max(100).optional(),
+  displayName: z.string().trim().min(1).max(100).optional(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
 });
 
 // ===== Members =====
 export const createMemberSchema = z.object({
-  name: z.string({ required_error: '名前は必須です' }).min(1, '名前は必須です').max(100),
+  name: z.string({ required_error: '名前は必須です' }).trim().min(1, '名前は必須です').max(100),
   memberType: z.enum(['human', 'pet']).optional(),
-  petType: z.string().max(50).optional(),
+  petType: z.string().trim().max(50).optional(),
   birthDate: dateString.optional(),
-  notes: z.string().max(500).optional(),
+  notes: z.string().trim().max(500).optional(),
 });
 
 export const updateMemberSchema = z.object({
-  name: z.string().min(1).max(100).optional(),
-  petType: z.string().max(50).optional(),
+  name: z.string().trim().min(1).max(100).optional(),
+  petType: z.string().trim().max(50).optional(),
   birthDate: dateString.optional().nullable(),
-  notes: z.string().max(500).optional().nullable(),
+  notes: z.string().trim().max(500).optional().nullable(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
 });
 
 // ===== Medications =====
 export const createMedicationSchema = z.object({
-  name: z.string({ required_error: '薬の名前は必須です' }).min(1, '薬の名前は必須です').max(200),
-  memberId: z.string().optional(),
-  category: z.string().max(100).optional(),
-  dosageAmount: z.string().max(100).optional(),
-  frequency: z.string().max(100).optional(),
+  name: z.string({ required_error: '薬の名前は必須です' }).trim().min(1, '薬の名前は必須です').max(200),
+  memberId: optionalIdField,
+  category: z.string().trim().max(100).optional(),
+  dosageAmount: z.string().trim().max(100).optional(),
+  frequency: z.string().trim().max(100).optional(),
   stockQuantity: z.number().int().min(0).max(99999).optional(),
   stockAlertDate: dateString.optional(),
-  instructions: z.string().max(1000).optional(),
+  instructions: z.string().trim().max(1000).optional(),
 });
 
 export const updateMedicationSchema = z.object({
-  name: z.string().min(1).max(200).optional(),
-  category: z.string().max(100).optional(),
-  dosageAmount: z.string().max(100).optional().nullable(),
-  frequency: z.string().max(100).optional().nullable(),
+  name: z.string().trim().min(1).max(200).optional(),
+  category: z.string().trim().max(100).optional(),
+  dosageAmount: z.string().trim().max(100).optional().nullable(),
+  frequency: z.string().trim().max(100).optional().nullable(),
   stockQuantity: z.number().int().min(0).max(99999).optional().nullable(),
   stockAlertDate: dateString.optional().nullable(),
-  instructions: z.string().max(1000).optional().nullable(),
+  instructions: z.string().trim().max(1000).optional().nullable(),
   isActive: z.boolean().optional(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
@@ -67,16 +70,16 @@ export const updateStockSchema = z.object({
 const dayOfWeekEnum = z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']);
 
 export const createScheduleSchema = z.object({
-  medicationId: z.string().min(1, '薬IDは必須です'),
-  memberId: z.string().min(1, 'メンバーIDは必須です'),
-  scheduledTime: z.string().min(1, '予定時刻は必須です'),
+  medicationId: idField,
+  memberId: idField,
+  scheduledTime: z.string().min(1, '予定時刻は必須です').max(10),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),
 });
 
 export const updateScheduleSchema = z.object({
-  scheduledTime: z.string().optional(),
+  scheduledTime: z.string().max(10).optional(),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),
@@ -84,50 +87,50 @@ export const updateScheduleSchema = z.object({
 
 // ===== Records =====
 export const createRecordSchema = z.object({
-  memberId: z.string().min(1, 'メンバーIDは必須です'),
-  medicationId: z.string().min(1, '薬IDは必須です'),
-  scheduleId: z.string().optional(),
-  notes: z.string().max(500).optional(),
-  dosageAmount: z.string().max(100).optional(),
+  memberId: idField,
+  medicationId: idField,
+  scheduleId: optionalIdField,
+  notes: z.string().trim().max(500).optional(),
+  dosageAmount: z.string().trim().max(100).optional(),
 });
 
 // ===== Hospitals =====
 export const createHospitalSchema = z.object({
-  name: z.string({ required_error: '病院名は必須です' }).min(1, '病院名は必須です').max(200),
-  address: z.string().max(500).optional(),
-  phone: z.string().max(20).optional(),
-  type: z.string().max(100).optional(),
-  notes: z.string().max(1000).optional(),
-  memberId: z.string().optional(),
+  name: z.string({ required_error: '病院名は必須です' }).trim().min(1, '病院名は必須です').max(200),
+  address: z.string().trim().max(500).optional(),
+  phone: z.string().trim().max(20).optional(),
+  type: z.string().trim().max(100).optional(),
+  notes: z.string().trim().max(1000).optional(),
+  memberId: optionalIdField,
 });
 
 export const updateHospitalSchema = z.object({
-  name: z.string().min(1).max(200).optional(),
-  address: z.string().max(500).optional(),
-  phone: z.string().max(20).optional(),
-  type: z.string().max(100).optional(),
-  notes: z.string().max(1000).optional(),
+  name: z.string().trim().min(1).max(200).optional(),
+  address: z.string().trim().max(500).optional(),
+  phone: z.string().trim().max(20).optional(),
+  type: z.string().trim().max(100).optional(),
+  notes: z.string().trim().max(1000).optional(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
 });
 
 // ===== Appointments =====
 export const createAppointmentSchema = z.object({
-  memberId: z.string().min(1, 'メンバーIDは必須です'),
-  hospitalId: z.string().optional(),
+  memberId: idField,
+  hospitalId: optionalIdField,
   appointmentDate: dateString,
-  appointmentTime: z.string().optional(),
-  type: z.string().max(100).optional(),
-  notes: z.string().max(1000).optional(),
+  appointmentTime: z.string().max(10).optional(),
+  type: z.string().trim().max(100).optional(),
+  notes: z.string().trim().max(1000).optional(),
   reminderEnabled: z.boolean().optional(),
   reminderDaysBefore: z.number().int().min(0).max(365).optional(),
 });
 
 export const updateAppointmentSchema = z.object({
   appointmentDate: z.string().optional(),
-  appointmentTime: z.string().optional(),
-  type: z.string().max(100).optional(),
-  notes: z.string().max(1000).optional(),
+  appointmentTime: z.string().max(10).optional(),
+  type: z.string().trim().max(100).optional(),
+  notes: z.string().trim().max(1000).optional(),
   reminderEnabled: z.boolean().optional(),
   reminderDaysBefore: z.number().int().min(0).max(365).optional(),
 }).refine((data) => Object.keys(data).length > 0, {


### PR DESCRIPTION
## 概要

Closes #168

入力バリデーションとセッション設定のセキュリティ強化。

## 変更内容

- 全テキスト入力フィールドに.trim()追加（空白インジェクション防止）
- IDフィールドにmax(50)制限追加（DoS防止）
- 時刻フィールドにmax(10)制限追加
- JWTセッション有効期限を7日間に明示的設定
- ID定義の共通化（idField/optionalIdField）

## テスト結果

- 全568テスト通過（+6）
- ビルド成功