### PR TITLE
feat: 汎用UIコンポーネント5種を追加

### DIFF
--- a/src/__tests__/components/medications/MedicationDosageChip.test.tsx
+++ b/src/__tests__/components/medications/MedicationDosageChip.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MedicationDosageChip } from '@/components/medications/MedicationDosageChip';
+
+describe('MedicationDosageChip', () => {
+  it('薬名と用量を表示する', () => {
+    render(<MedicationDosageChip medicationName="頭痛薬" dosage="1錠" />);
+    expect(screen.getByText('頭痛薬')).toBeInTheDocument();
+    expect(screen.getByText('1錠')).toBeInTheDocument();
+  });
+
+  it('服用済みの場合にチェックマークが表示される', () => {
+    const { container } = render(<MedicationDosageChip medicationName="薬A" dosage="2錠" isTaken={true} />);
+    expect(container.querySelector('[class*="green"]')).toBeInTheDocument();
+  });
+
+  it('在庫少の場合に警告が表示される', () => {
+    render(<MedicationDosageChip medicationName="薬B" dosage="1錠" isLowStock={true} />);
+    expect(screen.getByText(/在庫少/)).toBeInTheDocument();
+  });
+
+  it('削除ボタンをクリックするとonRemoveが呼ばれる', () => {
+    const onRemove = vi.fn();
+    render(<MedicationDosageChip medicationName="薬C" dosage="3錠" onRemove={onRemove} />);
+    fireEvent.click(screen.getByLabelText('削除'));
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  it('onRemoveが未指定の場合は削除ボタンが表示されない', () => {
+    render(<MedicationDosageChip medicationName="薬D" dosage="1錠" />);
+    expect(screen.queryByLabelText('削除')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/shared/ConfirmationDialog.test.tsx
+++ b/src/__tests__/components/shared/ConfirmationDialog.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfirmationDialog } from '@/components/shared/ConfirmationDialog';
+
+describe('ConfirmationDialog', () => {
+  const defaultProps = {
+    title: '削除確認',
+    message: 'この項目を削除しますか？',
+    isOpen: true,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it('開いている場合にタイトルとメッセージが表示される', () => {
+    render(<ConfirmationDialog {...defaultProps} />);
+    expect(screen.getByText('削除確認')).toBeInTheDocument();
+    expect(screen.getByText('この項目を削除しますか？')).toBeInTheDocument();
+  });
+
+  it('閉じている場合は何も表示しない', () => {
+    const { container } = render(<ConfirmationDialog {...defaultProps} isOpen={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('確認ボタンをクリックするとonConfirmが呼ばれる', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmationDialog {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText('確認'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('キャンセルボタンをクリックするとonCancelが呼ばれる', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmationDialog {...defaultProps} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('isDangerousの場合に確認ボタンが赤色スタイルになる', () => {
+    render(<ConfirmationDialog {...defaultProps} isDangerous={true} />);
+    const confirmBtn = screen.getByText('確認');
+    expect(confirmBtn.className).toContain('bg-red');
+  });
+});

--- a/src/__tests__/components/shared/DateRangeSelector.test.tsx
+++ b/src/__tests__/components/shared/DateRangeSelector.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DateRangeSelector } from '@/components/shared/DateRangeSelector';
+
+describe('DateRangeSelector', () => {
+  it('開始日と終了日のラベルが表示される', () => {
+    render(<DateRangeSelector startDate="" endDate="" onStartChange={vi.fn()} onEndChange={vi.fn()} />);
+    expect(screen.getByLabelText('開始日')).toBeInTheDocument();
+    expect(screen.getByLabelText('終了日')).toBeInTheDocument();
+  });
+
+  it('開始日を変更するとonStartChangeが呼ばれる', () => {
+    const onStartChange = vi.fn();
+    render(<DateRangeSelector startDate="" endDate="" onStartChange={onStartChange} onEndChange={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText('開始日'), { target: { value: '2025-06-01' } });
+    expect(onStartChange).toHaveBeenCalledWith('2025-06-01');
+  });
+
+  it('終了日を変更するとonEndChangeが呼ばれる', () => {
+    const onEndChange = vi.fn();
+    render(<DateRangeSelector startDate="" endDate="" onStartChange={vi.fn()} onEndChange={onEndChange} />);
+    fireEvent.change(screen.getByLabelText('終了日'), { target: { value: '2025-06-30' } });
+    expect(onEndChange).toHaveBeenCalledWith('2025-06-30');
+  });
+
+  it('初期値が正しく表示される', () => {
+    render(<DateRangeSelector startDate="2025-01-01" endDate="2025-01-31" onStartChange={vi.fn()} onEndChange={vi.fn()} />);
+    expect(screen.getByLabelText('開始日')).toHaveValue('2025-01-01');
+    expect(screen.getByLabelText('終了日')).toHaveValue('2025-01-31');
+  });
+});

--- a/src/__tests__/components/shared/NotificationToast.test.tsx
+++ b/src/__tests__/components/shared/NotificationToast.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { NotificationToast } from '@/components/shared/NotificationToast';
+
+describe('NotificationToast', () => {
+  it('メッセージを表示する', () => {
+    render(<NotificationToast message="保存しました" type="success" />);
+    expect(screen.getByText('保存しました')).toBeInTheDocument();
+  });
+
+  it('エラータイプのスタイルが適用される', () => {
+    const { container } = render(<NotificationToast message="エラー" type="error" />);
+    const el = container.querySelector('[class*="red"]');
+    expect(el).toBeInTheDocument();
+  });
+
+  it('閉じるボタンをクリックするとonCloseが呼ばれる', () => {
+    const onClose = vi.fn();
+    render(<NotificationToast message="テスト" type="success" onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText('閉じる'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('successタイプのスタイルが適用される', () => {
+    const { container } = render(<NotificationToast message="成功" type="success" />);
+    const el = container.querySelector('[class*="green"]');
+    expect(el).toBeInTheDocument();
+  });
+
+  it('onCloseが未指定の場合は閉じるボタンが表示されない', () => {
+    render(<NotificationToast message="テスト" type="info" />);
+    expect(screen.queryByLabelText('閉じる')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/shared/StatisticsBadge.test.tsx
+++ b/src/__tests__/components/shared/StatisticsBadge.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatisticsBadge } from '@/components/shared/StatisticsBadge';
+
+describe('StatisticsBadge', () => {
+  it('ラベルと値を表示する', () => {
+    render(<StatisticsBadge label="週間" value={85} unit="%" />);
+    expect(screen.getByText('週間')).toBeInTheDocument();
+    expect(screen.getByText(/85/)).toBeInTheDocument();
+    expect(screen.getByText(/%/)).toBeInTheDocument();
+  });
+
+  it('文字列の値を表示する', () => {
+    render(<StatisticsBadge label="残り" value="5日" />);
+    expect(screen.getByText('残り')).toBeInTheDocument();
+    expect(screen.getByText('5日')).toBeInTheDocument();
+  });
+
+  it('warningレベルのスタイルが適用される', () => {
+    const { container } = render(<StatisticsBadge label="テスト" value={40} level="warning" />);
+    expect(container.firstChild?.textContent).toContain('40');
+  });
+
+  it('criticalレベルのスタイルが適用される', () => {
+    const { container } = render(<StatisticsBadge label="テスト" value={10} level="critical" />);
+    const el = container.querySelector('[class*="red"]');
+    expect(el).toBeInTheDocument();
+  });
+
+  it('デフォルトレベルはgoodである', () => {
+    const { container } = render(<StatisticsBadge label="テスト" value={75} />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+});

--- a/src/components/medications/MedicationDosageChip.tsx
+++ b/src/components/medications/MedicationDosageChip.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Check, X, AlertTriangle } from 'lucide-react';
+
+interface MedicationDosageChipProps {
+  medicationName: string;
+  dosage: string;
+  isTaken?: boolean;
+  isLowStock?: boolean;
+  onRemove?: () => void;
+}
+
+export function MedicationDosageChip({
+  medicationName,
+  dosage,
+  isTaken = false,
+  isLowStock = false,
+  onRemove,
+}: MedicationDosageChipProps) {
+  return (
+    <div
+      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 ${
+        isTaken ? 'border-green-300 bg-green-50' : 'border-gray-200 bg-white'
+      }`}
+    >
+      {isTaken && <Check className="h-4 w-4 text-green-600" />}
+      <span className="text-sm font-medium">{medicationName}</span>
+      <span className="text-sm text-gray-500">{dosage}</span>
+      {isLowStock && (
+        <span className="flex items-center gap-1 text-xs text-amber-600">
+          <AlertTriangle className="h-3 w-3" />
+          在庫少
+        </span>
+      )}
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="削除"
+          className="ml-1 rounded-full p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/ConfirmationDialog.tsx
+++ b/src/components/shared/ConfirmationDialog.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+interface ConfirmationDialogProps {
+  title: string;
+  message: string;
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDangerous?: boolean;
+}
+
+export function ConfirmationDialog({
+  title,
+  message,
+  isOpen,
+  onConfirm,
+  onCancel,
+  isDangerous = false,
+}: ConfirmationDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 className="mb-2 text-lg font-bold">{title}</h2>
+        <p className="mb-6 text-gray-600">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-md border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`rounded-md px-4 py-2 text-white ${
+              isDangerous
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-primary-600 hover:bg-primary-700'
+            }`}
+          >
+            確認
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/DateRangeSelector.tsx
+++ b/src/components/shared/DateRangeSelector.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+interface DateRangeSelectorProps {
+  startDate: string;
+  endDate: string;
+  onStartChange: (date: string) => void;
+  onEndChange: (date: string) => void;
+}
+
+export function DateRangeSelector({
+  startDate,
+  endDate,
+  onStartChange,
+  onEndChange,
+}: DateRangeSelectorProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <div>
+        <label htmlFor="start-date" className="mb-1 block text-sm font-medium text-gray-700">
+          開始日
+        </label>
+        <input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(e) => onStartChange(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+      <span className="mt-6 text-gray-400">〜</span>
+      <div>
+        <label htmlFor="end-date" className="mb-1 block text-sm font-medium text-gray-700">
+          終了日
+        </label>
+        <input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(e) => onEndChange(e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/NotificationToast.tsx
+++ b/src/components/shared/NotificationToast.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { CheckCircle, XCircle, Info, X } from 'lucide-react';
+
+type ToastType = 'success' | 'error' | 'info';
+
+interface NotificationToastProps {
+  message: string;
+  type: ToastType;
+  onClose?: () => void;
+}
+
+const typeStyles: Record<ToastType, string> = {
+  success: 'border-green-300 bg-green-50 text-green-800',
+  error: 'border-red-300 bg-red-50 text-red-800',
+  info: 'border-blue-300 bg-blue-50 text-blue-800',
+};
+
+const typeIcons: Record<ToastType, React.ReactNode> = {
+  success: <CheckCircle className="h-5 w-5 text-green-600" />,
+  error: <XCircle className="h-5 w-5 text-red-600" />,
+  info: <Info className="h-5 w-5 text-blue-600" />,
+};
+
+export function NotificationToast({
+  message,
+  type,
+  onClose,
+}: NotificationToastProps) {
+  return (
+    <div className={`flex items-center gap-3 rounded-lg border px-4 py-3 ${typeStyles[type]}`}>
+      {typeIcons[type]}
+      <span className="flex-1 text-sm font-medium">{message}</span>
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="閉じる"
+          className="rounded-full p-1 hover:bg-black/10"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/StatisticsBadge.tsx
+++ b/src/components/shared/StatisticsBadge.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+type Level = 'excellent' | 'good' | 'warning' | 'critical';
+
+interface StatisticsBadgeProps {
+  label: string;
+  value: number | string;
+  unit?: string;
+  level?: Level;
+}
+
+const levelStyles: Record<Level, string> = {
+  excellent: 'bg-blue-50 text-blue-700',
+  good: 'bg-green-50 text-green-700',
+  warning: 'bg-yellow-50 text-yellow-700',
+  critical: 'bg-red-50 text-red-700',
+};
+
+export function StatisticsBadge({
+  label,
+  value,
+  unit,
+  level = 'good',
+}: StatisticsBadgeProps) {
+  return (
+    <div className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 ${levelStyles[level]}`}>
+      <span className="text-sm font-medium">{label}</span>
+      <span className="text-lg font-bold">
+        {value}
+        {unit && <span className="ml-0.5 text-sm">{unit}</span>}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

再利用可能な汎用UIコンポーネントを5種追加。

Closes #170

## 変更内容

- **ConfirmationDialog**: 確認ダイアログ（isDangerousで赤色スタイル切替）
- **StatisticsBadge**: 統計バッジ（4段階のレベル表示対応）
- **MedicationDosageChip**: 薬用量チップ（服用済みチェック、在庫少警告、削除ボタン）
- **DateRangeSelector**: 日付範囲セレクター（開始日・終了日入力）
- **NotificationToast**: 通知トースト（success/error/info、閉じるボタン）

## テスト

- 24テスト追加（全592テストパス）
- ビルド成功確認済み