### PR TITLE
fix: フックのハンドラーにuseCallbackを追加

### DIFF
--- a/src/components/dashboard/UpcomingAppointments.tsx
+++ b/src/components/dashboard/UpcomingAppointments.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { Calendar, User, MapPin } from 'lucide-react';
 import { Appointment, AppointmentEntity } from '../../domain/entities/Appointment';
 
-interface UpcomingAppointmentsProps {
+export interface UpcomingAppointmentsProps {
   appointments: Appointment[];
   isLoading: boolean;
 }

--- a/src/presentation/hooks/useAppointments.ts
+++ b/src/presentation/hooks/useAppointments.ts
@@ -3,7 +3,7 @@
  * Presentation層とDomain層を繋ぐ
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Appointment } from '../../domain/entities/Appointment';
 import { GetAppointments, CreateAppointment, UpdateAppointment, DeleteAppointment } from '../../domain/usecases/ManageAppointments';
 import { CreateAppointmentInput, UpdateAppointmentInput } from '../../domain/repositories/AppointmentRepository';
@@ -40,20 +40,20 @@ export const useAppointments = (): UseAppointmentsResult => {
     [] as Appointment[],
   );
 
-  const handleCreateAppointment = async (input: CreateAppointmentInput) => {
+  const handleCreateAppointment = useCallback(async (input: CreateAppointmentInput) => {
     await useCases.createAppointment.execute(input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleUpdateAppointment = async (appointmentId: string, input: UpdateAppointmentInput) => {
+  const handleUpdateAppointment = useCallback(async (appointmentId: string, input: UpdateAppointmentInput) => {
     await useCases.updateAppointment.execute(appointmentId, input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleDeleteAppointment = async (appointmentId: string) => {
+  const handleDeleteAppointment = useCallback(async (appointmentId: string) => {
     await useCases.deleteAppointment.execute(appointmentId);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
   return {
     appointments,

--- a/src/presentation/hooks/useHospitals.ts
+++ b/src/presentation/hooks/useHospitals.ts
@@ -3,7 +3,7 @@
  * Presentation層とDomain層を繋ぐ
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Hospital } from '../../domain/entities/Hospital';
 import { GetHospitals, CreateHospital, UpdateHospital, DeleteHospital } from '../../domain/usecases/ManageHospitals';
 import { CreateHospitalInput, UpdateHospitalInput } from '../../domain/repositories/HospitalRepository';
@@ -37,20 +37,20 @@ export const useHospitals = (): UseHospitalsResult => {
     [] as Hospital[],
   );
 
-  const handleCreateHospital = async (input: CreateHospitalInput) => {
+  const handleCreateHospital = useCallback(async (input: CreateHospitalInput) => {
     await useCases.createHospital.execute(input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleUpdateHospital = async (hospitalId: string, input: UpdateHospitalInput) => {
+  const handleUpdateHospital = useCallback(async (hospitalId: string, input: UpdateHospitalInput) => {
     await useCases.updateHospital.execute(hospitalId, input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleDeleteHospital = async (hospitalId: string) => {
+  const handleDeleteHospital = useCallback(async (hospitalId: string) => {
     await useCases.deleteHospital.execute(hospitalId);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
   return {
     hospitals,

--- a/src/presentation/hooks/useMedications.ts
+++ b/src/presentation/hooks/useMedications.ts
@@ -3,7 +3,7 @@
  * Presentation層とDomain層を繋ぐ
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { GetMedications, CreateMedication, UpdateMedication, DeleteMedication, MedicationViewModel } from '../../domain/usecases/ManageMedications';
 import { CreateMedicationInput, UpdateMedicationInput } from '../../domain/repositories/MedicationRepository';
 import { getDIContainer } from '../../infrastructure/DIContainer';
@@ -36,20 +36,20 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
     [] as MedicationViewModel[],
   );
 
-  const handleCreateMedication = async (input: CreateMedicationInput) => {
+  const handleCreateMedication = useCallback(async (input: CreateMedicationInput) => {
     await useCases.createMedication.execute(input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleUpdateMedication = async (medicationId: string, input: UpdateMedicationInput) => {
+  const handleUpdateMedication = useCallback(async (medicationId: string, input: UpdateMedicationInput) => {
     await useCases.updateMedication.execute(medicationId, input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleDeleteMedication = async (medicationId: string) => {
+  const handleDeleteMedication = useCallback(async (medicationId: string) => {
     await useCases.deleteMedication.execute(medicationId);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
   return {
     medications,

--- a/src/presentation/hooks/useMembers.ts
+++ b/src/presentation/hooks/useMembers.ts
@@ -3,7 +3,7 @@
  * Presentation層とDomain層を繋ぐ
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Member } from '../../domain/entities/Member';
 import { GetMembers, CreateMember, UpdateMember, DeleteMember } from '../../domain/usecases/ManageMembers';
 import { CreateMemberInput, UpdateMemberInput } from '../../domain/repositories/MemberRepository';
@@ -37,20 +37,20 @@ export const useMembers = (userId: string): UseMembersResult => {
     [] as Member[],
   );
 
-  const handleCreateMember = async (input: CreateMemberInput) => {
+  const handleCreateMember = useCallback(async (input: CreateMemberInput) => {
     await useCases.createMember.execute(input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleUpdateMember = async (memberId: string, input: UpdateMemberInput) => {
+  const handleUpdateMember = useCallback(async (memberId: string, input: UpdateMemberInput) => {
     await useCases.updateMember.execute(memberId, input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleDeleteMember = async (memberId: string) => {
+  const handleDeleteMember = useCallback(async (memberId: string) => {
     await useCases.deleteMember.execute(memberId);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
   return {
     members,


### PR DESCRIPTION
## 概要

CRUD操作フックのハンドラー関数にuseCallbackを追加してパフォーマンスを改善。

Closes #172

## 変更内容

- **useHospitals/useMedications/useMembers/useAppointments**: 全ハンドラーをuseCallbackでメモ化
- **UpcomingAppointmentsProps**: interfaceをexport

## テスト

- 592テスト全パス
- ビルド成功確認済み