### PR TITLE
fix: テストカバレッジを拡充

### DIFF
--- a/src/__tests__/components/dashboard/TodayScheduleList.extra.test.tsx
+++ b/src/__tests__/components/dashboard/TodayScheduleList.extra.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
+import { TodayScheduleViewModel } from '@/domain/usecases/GetTodaySchedules';
+
+const createSchedule = (overrides: Partial<TodayScheduleViewModel> = {}): TodayScheduleViewModel => ({
+  scheduleId: 'sch-1',
+  medicationId: 'med-1',
+  medicationName: 'テスト薬',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  scheduledTime: '08:00',
+  status: 'pending',
+  ...overrides,
+});
+
+describe('TodayScheduleList - 追加テスト', () => {
+  it('服薬済みのスケジュールにはステータスバッジが表示される', () => {
+    const schedules = [createSchedule({ status: 'completed' })];
+    render(<TodayScheduleList schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('服薬済み')).toBeInTheDocument();
+  });
+
+  it('時間超過のスケジュールにはステータスバッジが表示される', () => {
+    const schedules = [createSchedule({ status: 'overdue' })];
+    render(<TodayScheduleList schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('時間超過')).toBeInTheDocument();
+  });
+
+  it('未服薬のスケジュールに服薬完了ボタンが表示される', () => {
+    const onMarkCompleted = vi.fn();
+    const schedules = [createSchedule({ scheduleId: 'sch-1', status: 'pending' })];
+    render(<TodayScheduleList schedules={schedules} isLoading={false} onMarkCompleted={onMarkCompleted} />);
+    fireEvent.click(screen.getByLabelText('服薬完了'));
+    expect(onMarkCompleted).toHaveBeenCalledWith('sch-1');
+  });
+
+  it('服薬済みのスケジュールには完了ボタンが表示されない', () => {
+    const schedules = [createSchedule({ status: 'completed' })];
+    render(<TodayScheduleList schedules={schedules} isLoading={false} onMarkCompleted={vi.fn()} />);
+    expect(screen.queryByLabelText('服薬完了')).not.toBeInTheDocument();
+  });
+
+  it('スケジュール時刻とメンバー名を表示する', () => {
+    const schedules = [createSchedule({ scheduledTime: '09:30', memberName: '花子' })];
+    render(<TodayScheduleList schedules={schedules} isLoading={false} />);
+    expect(screen.getByText('09:30')).toBeInTheDocument();
+    expect(screen.getByText('花子')).toBeInTheDocument();
+  });
+
+  it('onMarkCompletedが未指定の場合は完了ボタンが表示されない', () => {
+    const schedules = [createSchedule({ status: 'pending' })];
+    render(<TodayScheduleList schedules={schedules} isLoading={false} />);
+    expect(screen.queryByLabelText('服薬完了')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/members/MemberList.test.tsx
+++ b/src/__tests__/components/members/MemberList.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemberList } from '@/components/members/MemberList';
+import { Member } from '@/domain/entities/Member';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+const createMember = (overrides: Partial<Member> = {}): Member => ({
+  id: 'member-1',
+  userId: 'user-1',
+  memberType: 'human',
+  name: '太郎',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('MemberList', () => {
+  it('読み込み中は読み込みメッセージを表示する', () => {
+    render(<MemberList members={[]} isLoading={true} onDelete={vi.fn()} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('メンバーがない場合は空メッセージを表示する', () => {
+    render(<MemberList members={[]} isLoading={false} onDelete={vi.fn()} />);
+    expect(screen.getByText('メンバーがまだ登録されていません')).toBeInTheDocument();
+  });
+
+  it('メンバー一覧を表示する', () => {
+    const members = [
+      createMember({ id: 'm1', name: '太郎' }),
+      createMember({ id: 'm2', name: '花子' }),
+    ];
+    render(<MemberList members={members} isLoading={false} onDelete={vi.fn()} />);
+    expect(screen.getByText('太郎')).toBeInTheDocument();
+    expect(screen.getByText('花子')).toBeInTheDocument();
+  });
+
+  it('削除ボタンをクリックするとonDeleteが呼ばれる', () => {
+    const onDelete = vi.fn();
+    const members = [createMember({ id: 'm1', name: '太郎' })];
+    render(<MemberList members={members} isLoading={false} onDelete={onDelete} />);
+    fireEvent.click(screen.getByLabelText('削除'));
+    expect(onDelete).toHaveBeenCalledWith('m1');
+  });
+
+  it('編集ボタンをクリックするとonEditが呼ばれる', () => {
+    const onEdit = vi.fn();
+    const member = createMember({ id: 'm1', name: '太郎' });
+    render(<MemberList members={[member]} isLoading={false} onDelete={vi.fn()} onEdit={onEdit} />);
+    fireEvent.click(screen.getByLabelText('編集'));
+    expect(onEdit).toHaveBeenCalledWith(member);
+  });
+
+  it('onEditが未指定の場合は編集ボタンが表示されない', () => {
+    const members = [createMember()];
+    render(<MemberList members={members} isLoading={false} onDelete={vi.fn()} />);
+    expect(screen.queryByLabelText('編集')).not.toBeInTheDocument();
+  });
+
+  it('薬管理リンクが表示される', () => {
+    const members = [createMember({ id: 'm1' })];
+    render(<MemberList members={members} isLoading={false} onDelete={vi.fn()} />);
+    const link = screen.getByLabelText('薬管理');
+    expect(link).toHaveAttribute('href', '/members/m1/medications');
+  });
+});

--- a/src/__tests__/data/api/apiClient.test.ts
+++ b/src/__tests__/data/api/apiClient.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiClient } from '@/data/api/apiClient';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockResponse = (data: unknown, success = true, status = 200) => {
+  return Promise.resolve({
+    status,
+    json: () => Promise.resolve({ success, data, error: success ? undefined : String(data) }),
+  });
+};
+
+describe('apiClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('GETリクエストを送信する', async () => {
+    mockFetch.mockReturnValue(mockResponse({ id: '1' }));
+    const result = await apiClient.get('/members');
+    expect(mockFetch).toHaveBeenCalledWith('/api/members', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('POSTリクエストをボディ付きで送信する', async () => {
+    mockFetch.mockReturnValue(mockResponse({ id: '2' }));
+    const body = { name: 'テスト' };
+    await apiClient.post('/members', body);
+    expect(mockFetch).toHaveBeenCalledWith('/api/members', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  it('PUTリクエストを送信する', async () => {
+    mockFetch.mockReturnValue(mockResponse({ id: '1' }));
+    const body = { name: '更新' };
+    await apiClient.put('/members/1', body);
+    expect(mockFetch).toHaveBeenCalledWith('/api/members/1', {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  it('DELETEリクエストを送信する', async () => {
+    mockFetch.mockReturnValue(mockResponse(null));
+    await apiClient.del('/members/1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/members/1', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  it('APIエラー時にエラーをスローする', async () => {
+    mockFetch.mockReturnValue(mockResponse('バリデーションエラー', false));
+    await expect(apiClient.get('/members')).rejects.toThrow('バリデーションエラー');
+  });
+
+  it('401レスポンス時にログインページへリダイレクトする', async () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+    });
+    mockFetch.mockReturnValue(
+      Promise.resolve({ status: 401, json: () => Promise.resolve({}) }),
+    );
+    await expect(apiClient.get('/members')).rejects.toThrow('認証エラー');
+    expect(window.location.href).toBe('/login');
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+});

--- a/src/__tests__/stores/characterStore.test.ts
+++ b/src/__tests__/stores/characterStore.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCharacterStore } from '@/stores/characterStore';
+import { CHARACTER_CONFIGS } from '@/domain/entities/Character';
+
+describe('characterStore', () => {
+  beforeEach(() => {
+    useCharacterStore.setState({ selectedCharacter: 'cat' });
+  });
+
+  it('デフォルトのキャラクターはcatである', () => {
+    const { selectedCharacter } = useCharacterStore.getState();
+    expect(selectedCharacter).toBe('cat');
+  });
+
+  it('キャラクターを変更できる', () => {
+    useCharacterStore.getState().setCharacter('dog');
+    expect(useCharacterStore.getState().selectedCharacter).toBe('dog');
+  });
+
+  it('選択中のキャラクター設定を取得できる', () => {
+    useCharacterStore.getState().setCharacter('rabbit');
+    const config = useCharacterStore.getState().getConfig();
+    expect(config).toBe(CHARACTER_CONFIGS['rabbit']);
+  });
+
+  it('キャラクターメッセージを取得できる', () => {
+    const message = useCharacterStore.getState().getMessage('medicationReminder');
+    expect(message).toBe(CHARACTER_CONFIGS['cat'].messages.medicationReminder);
+  });
+
+  it('キャラクター変更後にメッセージが変わる', () => {
+    const catMessage = useCharacterStore.getState().getMessage('medicationComplete');
+    useCharacterStore.getState().setCharacter('bird');
+    const birdMessage = useCharacterStore.getState().getMessage('medicationComplete');
+    expect(catMessage).toBe(CHARACTER_CONFIGS['cat'].messages.medicationComplete);
+    expect(birdMessage).toBe(CHARACTER_CONFIGS['bird'].messages.medicationComplete);
+  });
+});


### PR DESCRIPTION
## 概要

未テストだったモジュールにテストを追加してカバレッジを向上。

Closes #174

## 変更内容

- **MemberList** (7テスト): 読み込み、空表示、一覧表示、削除・編集ボタン、薬管理リンク
- **apiClient** (6テスト): GET/POST/PUT/DELETE、APIエラー、401リダイレクト
- **characterStore** (5テスト): デフォルト値、変更、設定取得、メッセージ取得
- **TodayScheduleList追加** (6テスト): ステータスバッジ、服薬完了ボタンの表示制御

## テスト

- 24テスト追加（合計616テスト全パス）
- ビルド成功確認済み