### PR TITLE
fix: クエリ制限とパラメータIDバリデーションを追加

### DIFF
--- a/src/app/api/medications/member/[memberId]/route.ts
+++ b/src/app/api/medications/member/[memberId]/route.ts
@@ -1,10 +1,12 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
-import { withAuth } from '@/lib/api-helpers';
+import { withAuth, validateParamId } from '@/lib/api-helpers';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
     const { memberId } = await params;
+    const idError = validateParamId(memberId);
+    if (idError) return idError;
     const medications = await prisma.medication.findMany({ where: { memberId, userId }, take: 200 });
     return success(medications);
   })();

--- a/src/app/api/members/summary/route.ts
+++ b/src/app/api/members/summary/route.ts
@@ -7,15 +7,18 @@ export const GET = withAuth(async (userId) => {
     prisma.member.findMany({
       where: { userId },
       select: { id: true, name: true, memberType: true },
+      take: 100,
     }),
     prisma.medication.findMany({
       where: { userId, isActive: true },
       select: { memberId: true },
+      take: 500,
     }),
     prisma.appointment.findMany({
       where: { userId, appointmentDate: { gte: new Date() } },
       select: { memberId: true, appointmentDate: true },
       orderBy: { appointmentDate: 'asc' },
+      take: 500,
     }),
   ]);
 

--- a/src/app/api/records/member/[memberId]/route.ts
+++ b/src/app/api/records/member/[memberId]/route.ts
@@ -1,10 +1,12 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
-import { withAuth } from '@/lib/api-helpers';
+import { withAuth, validateParamId } from '@/lib/api-helpers';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
     const { memberId } = await params;
+    const idError = validateParamId(memberId);
+    if (idError) return idError;
     const records = await prisma.medicationRecord.findMany({
       where: { memberId, userId },
       orderBy: { takenAt: 'desc' },

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -16,18 +16,22 @@ export const GET = withAuth(async (userId) => {
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: sevenDaysAgo } },
       select: { memberId: true, medicationId: true, takenAt: true },
+      take: 5000,
     }),
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: thirtyDaysAgo } },
       select: { memberId: true, medicationId: true, takenAt: true },
+      take: 5000,
     }),
     prisma.schedule.findMany({
       where: { userId, isEnabled: true },
       select: { memberId: true, medicationId: true, daysOfWeek: true },
+      take: 1000,
     }),
     prisma.member.findMany({
       where: { userId },
       select: { id: true, name: true },
+      take: 100,
     }),
   ]);
 

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -17,10 +17,12 @@ export const GET = withAuth(async (userId) => {
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: fourteenDaysAgo } },
       select: { takenAt: true },
+      take: 5000,
     }),
     prisma.schedule.findMany({
       where: { userId, isEnabled: true },
       select: { daysOfWeek: true },
+      take: 1000,
     }),
   ]);
 


### PR DESCRIPTION
## 概要

無制限クエリの防止と動的ルートパラメータのバリデーションを追加。

Closes #176

## 変更内容

- **records/stats, records/trends, members/summary**: Prismaクエリにtake制限を追加
- **validateParamId**: 共通IDバリデーション関数を追加（min:1, max:50）
- **withOwnershipCheck**: IDバリデーションを統合し全動的ルートを自動保護
- **medications/member, records/member**: 個別にIDバリデーションを追加

## テスト

- 5テスト追加（合計621テスト全パス）
- ビルド成功確認済み