### PR TITLE
feat: UIコンポーネント5種を追加

### DIFF
--- a/src/__tests__/components/medications/MedicationCategoryTag.test.tsx
+++ b/src/__tests__/components/medications/MedicationCategoryTag.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MedicationCategoryTag } from '@/components/medications/MedicationCategoryTag';
+
+describe('MedicationCategoryTag', () => {
+  it('カテゴリ名を表示する', () => {
+    render(<MedicationCategoryTag category="処方薬" />);
+    expect(screen.getByText('処方薬')).toBeInTheDocument();
+  });
+
+  it('処方薬のスタイルが適用される', () => {
+    const { container } = render(<MedicationCategoryTag category="処方薬" />);
+    expect(container.querySelector('[class*="blue"]')).toBeInTheDocument();
+  });
+
+  it('市販薬のスタイルが適用される', () => {
+    const { container } = render(<MedicationCategoryTag category="市販薬" />);
+    expect(container.querySelector('[class*="green"]')).toBeInTheDocument();
+  });
+
+  it('サプリメントのスタイルが適用される', () => {
+    const { container } = render(<MedicationCategoryTag category="サプリメント" />);
+    expect(container.querySelector('[class*="purple"]')).toBeInTheDocument();
+  });
+
+  it('未知のカテゴリにはデフォルトスタイルが適用される', () => {
+    const { container } = render(<MedicationCategoryTag category="その他" />);
+    expect(container.querySelector('[class*="gray"]')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/members/MemberAvatarGroup.test.tsx
+++ b/src/__tests__/components/members/MemberAvatarGroup.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemberAvatarGroup } from '@/components/members/MemberAvatarGroup';
+
+describe('MemberAvatarGroup', () => {
+  it('メンバー名のイニシャルを表示する', () => {
+    const members = [
+      { id: '1', name: '太郎', memberType: 'human' as const },
+      { id: '2', name: '花子', memberType: 'human' as const },
+    ];
+    render(<MemberAvatarGroup members={members} />);
+    expect(screen.getByText('太')).toBeInTheDocument();
+    expect(screen.getByText('花')).toBeInTheDocument();
+  });
+
+  it('最大表示数を超えるとカウントを表示する', () => {
+    const members = [
+      { id: '1', name: 'A', memberType: 'human' as const },
+      { id: '2', name: 'B', memberType: 'human' as const },
+      { id: '3', name: 'C', memberType: 'human' as const },
+      { id: '4', name: 'D', memberType: 'human' as const },
+    ];
+    render(<MemberAvatarGroup members={members} max={3} />);
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('メンバーが空の場合は何も表示しない', () => {
+    const { container } = render(<MemberAvatarGroup members={[]} />);
+    expect(container.firstChild?.childNodes.length).toBe(0);
+  });
+
+  it('ペットタイプのメンバーも表示する', () => {
+    const members = [
+      { id: '1', name: 'ポチ', memberType: 'pet' as const },
+    ];
+    render(<MemberAvatarGroup members={members} />);
+    expect(screen.getByText('ポ')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/schedules/WeekdaySelector.test.tsx
+++ b/src/__tests__/components/schedules/WeekdaySelector.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WeekdaySelector } from '@/components/schedules/WeekdaySelector';
+
+describe('WeekdaySelector', () => {
+  it('全曜日のチェックボックスを表示する', () => {
+    render(<WeekdaySelector selectedDays={[]} onChange={vi.fn()} />);
+    expect(screen.getByLabelText('月')).toBeInTheDocument();
+    expect(screen.getByLabelText('火')).toBeInTheDocument();
+    expect(screen.getByLabelText('水')).toBeInTheDocument();
+    expect(screen.getByLabelText('木')).toBeInTheDocument();
+    expect(screen.getByLabelText('金')).toBeInTheDocument();
+    expect(screen.getByLabelText('土')).toBeInTheDocument();
+    expect(screen.getByLabelText('日')).toBeInTheDocument();
+  });
+
+  it('選択された曜日がチェックされる', () => {
+    render(<WeekdaySelector selectedDays={['月', '水', '金']} onChange={vi.fn()} />);
+    expect(screen.getByLabelText('月')).toBeChecked();
+    expect(screen.getByLabelText('水')).toBeChecked();
+    expect(screen.getByLabelText('金')).toBeChecked();
+    expect(screen.getByLabelText('火')).not.toBeChecked();
+  });
+
+  it('チェックボックスをクリックするとonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<WeekdaySelector selectedDays={['月']} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('火'));
+    expect(onChange).toHaveBeenCalledWith(['月', '火']);
+  });
+
+  it('選択済みの曜日をクリックすると解除される', () => {
+    const onChange = vi.fn();
+    render(<WeekdaySelector selectedDays={['月', '水']} onChange={onChange} />);
+    fireEvent.click(screen.getByLabelText('月'));
+    expect(onChange).toHaveBeenCalledWith(['水']);
+  });
+
+  it('無効状態にできる', () => {
+    render(<WeekdaySelector selectedDays={[]} onChange={vi.fn()} disabled />);
+    expect(screen.getByLabelText('月')).toBeDisabled();
+  });
+});

--- a/src/__tests__/components/shared/HealthScoreIndicator.test.tsx
+++ b/src/__tests__/components/shared/HealthScoreIndicator.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { HealthScoreIndicator } from '@/components/shared/HealthScoreIndicator';
+
+describe('HealthScoreIndicator', () => {
+  it('スコアを表示する', () => {
+    render(<HealthScoreIndicator score={85} />);
+    expect(screen.getByText('85')).toBeInTheDocument();
+  });
+
+  it('ラベルを表示する', () => {
+    render(<HealthScoreIndicator score={90} label="服薬率" />);
+    expect(screen.getByText('服薬率')).toBeInTheDocument();
+  });
+
+  it('高スコアの場合は緑色スタイルが適用される', () => {
+    const { container } = render(<HealthScoreIndicator score={80} />);
+    expect(container.querySelector('[class*="green"]')).toBeInTheDocument();
+  });
+
+  it('中スコアの場合は黄色スタイルが適用される', () => {
+    const { container } = render(<HealthScoreIndicator score={55} />);
+    expect(container.querySelector('[class*="yellow"]')).toBeInTheDocument();
+  });
+
+  it('低スコアの場合は赤色スタイルが適用される', () => {
+    const { container } = render(<HealthScoreIndicator score={30} />);
+    expect(container.querySelector('[class*="red"]')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/shared/TimePickerInput.test.tsx
+++ b/src/__tests__/components/shared/TimePickerInput.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TimePickerInput } from '@/components/shared/TimePickerInput';
+
+describe('TimePickerInput', () => {
+  it('ラベルを表示する', () => {
+    render(<TimePickerInput label="服薬時間" value="" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('服薬時間')).toBeInTheDocument();
+  });
+
+  it('初期値を表示する', () => {
+    render(<TimePickerInput label="時間" value="08:30" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('時間')).toHaveValue('08:30');
+  });
+
+  it('値を変更するとonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<TimePickerInput label="時間" value="" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('時間'), { target: { value: '09:00' } });
+    expect(onChange).toHaveBeenCalledWith('09:00');
+  });
+
+  it('エラーメッセージを表示する', () => {
+    render(<TimePickerInput label="時間" value="" onChange={vi.fn()} error="時間を入力してください" />);
+    expect(screen.getByText('時間を入力してください')).toBeInTheDocument();
+  });
+
+  it('無効状態にできる', () => {
+    render(<TimePickerInput label="時間" value="10:00" onChange={vi.fn()} disabled />);
+    expect(screen.getByLabelText('時間')).toBeDisabled();
+  });
+});

--- a/src/components/medications/MedicationCategoryTag.tsx
+++ b/src/components/medications/MedicationCategoryTag.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+interface MedicationCategoryTagProps {
+  category: string;
+}
+
+const categoryStyles: Record<string, string> = {
+  '処方薬': 'bg-blue-100 text-blue-700',
+  '市販薬': 'bg-green-100 text-green-700',
+  'サプリメント': 'bg-purple-100 text-purple-700',
+};
+
+const defaultStyle = 'bg-gray-100 text-gray-700';
+
+export function MedicationCategoryTag({ category }: MedicationCategoryTagProps) {
+  const style = categoryStyles[category] ?? defaultStyle;
+
+  return (
+    <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${style}`}>
+      {category}
+    </span>
+  );
+}

--- a/src/components/members/MemberAvatarGroup.tsx
+++ b/src/components/members/MemberAvatarGroup.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface AvatarMember {
+  id: string;
+  name: string;
+  memberType: 'human' | 'pet';
+}
+
+interface MemberAvatarGroupProps {
+  members: AvatarMember[];
+  max?: number;
+}
+
+export function MemberAvatarGroup({ members, max = 5 }: MemberAvatarGroupProps) {
+  const visible = members.slice(0, max);
+  const remaining = members.length - max;
+
+  return (
+    <div className="flex -space-x-2">
+      {visible.map((member) => (
+        <div
+          key={member.id}
+          className={`flex h-8 w-8 items-center justify-center rounded-full border-2 border-white text-xs font-bold text-white ${
+            member.memberType === 'pet' ? 'bg-amber-500' : 'bg-primary-500'
+          }`}
+          title={member.name}
+        >
+          {member.name.charAt(0)}
+        </div>
+      ))}
+      {remaining > 0 && (
+        <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-gray-400 text-xs font-bold text-white">
+          +{remaining}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/schedules/WeekdaySelector.tsx
+++ b/src/components/schedules/WeekdaySelector.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+const WEEKDAYS = ['月', '火', '水', '木', '金', '土', '日'] as const;
+
+interface WeekdaySelectorProps {
+  selectedDays: string[];
+  onChange: (days: string[]) => void;
+  disabled?: boolean;
+}
+
+export function WeekdaySelector({
+  selectedDays,
+  onChange,
+  disabled = false,
+}: WeekdaySelectorProps) {
+  const handleToggle = (day: string) => {
+    if (selectedDays.includes(day)) {
+      onChange(selectedDays.filter((d) => d !== day));
+    } else {
+      onChange([...selectedDays, day]);
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      {WEEKDAYS.map((day) => (
+        <label
+          key={day}
+          className={`flex cursor-pointer items-center justify-center rounded-md border px-3 py-1.5 text-sm transition-colors ${
+            selectedDays.includes(day)
+              ? 'border-primary-500 bg-primary-50 text-primary-700'
+              : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+          } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        >
+          <input
+            type="checkbox"
+            checked={selectedDays.includes(day)}
+            onChange={() => handleToggle(day)}
+            disabled={disabled}
+            className="sr-only"
+          />
+          {day}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/components/shared/HealthScoreIndicator.tsx
+++ b/src/components/shared/HealthScoreIndicator.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+interface HealthScoreIndicatorProps {
+  score: number;
+  label?: string;
+}
+
+function getScoreStyle(score: number): string {
+  if (score >= 70) return 'text-green-600 bg-green-50 border-green-200';
+  if (score >= 40) return 'text-yellow-600 bg-yellow-50 border-yellow-200';
+  return 'text-red-600 bg-red-50 border-red-200';
+}
+
+export function HealthScoreIndicator({ score, label }: HealthScoreIndicatorProps) {
+  const style = getScoreStyle(score);
+
+  return (
+    <div className={`inline-flex flex-col items-center rounded-lg border px-4 py-2 ${style}`}>
+      <span className="text-2xl font-bold">{score}</span>
+      {label && <span className="text-xs font-medium">{label}</span>}
+    </div>
+  );
+}

--- a/src/components/shared/TimePickerInput.tsx
+++ b/src/components/shared/TimePickerInput.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+interface TimePickerInputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  disabled?: boolean;
+}
+
+export function TimePickerInput({
+  label,
+  value,
+  onChange,
+  error,
+  disabled = false,
+}: TimePickerInputProps) {
+  return (
+    <div>
+      <label htmlFor={`time-${label}`} className="mb-1 block text-sm font-medium text-gray-700">
+        {label}
+      </label>
+      <input
+        id={`time-${label}`}
+        type="time"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="rounded-md border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-100 disabled:text-gray-400"
+      />
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

再利用可能なUIコンポーネントを5種追加。

Closes #178

## 変更内容

- **TimePickerInput**: 時間入力（ラベル、エラー、無効化対応）
- **MemberAvatarGroup**: メンバーアバターグループ（max表示、残りカウント）
- **MedicationCategoryTag**: 薬カテゴリタグ（処方薬/市販薬/サプリメント色分け）
- **WeekdaySelector**: 曜日選択（チェックボックス式、複数選択/解除）
- **HealthScoreIndicator**: 健康スコア表示（70以上緑/40-69黄/39以下赤）

## テスト

- 24テスト追加（合計645テスト全パス）
- ビルド成功確認済み