### PR TITLE
fix: 残りフックのuseCallback追加とリストコンポーネントのメモ化

### DIFF
--- a/src/components/dashboard/StockAlertList.tsx
+++ b/src/components/dashboard/StockAlertList.tsx
@@ -18,29 +18,38 @@ export const StockAlertList: React.FC<StockAlertListProps> = ({ alerts, isLoadin
       </div>
       <div className="space-y-2">
         {alerts.map((alert) => (
-          <div
-            key={alert.medicationId}
-            className={`bg-white rounded-lg shadow-sm p-3 border ${
-              alert.isOverdue ? 'border-red-300 bg-red-50' : 'border-yellow-300 bg-yellow-50'
-            }`}
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium text-gray-800">{alert.medicationName}</p>
-                <p className="text-xs text-gray-500">{alert.memberName}</p>
-              </div>
-              <div className="text-right">
-                {alert.stockQuantity !== null && (
-                  <p className="text-sm font-medium text-gray-700">残り{alert.stockQuantity}日分</p>
-                )}
-                <p className={`text-xs font-medium ${alert.isOverdue ? 'text-red-600' : 'text-yellow-600'}`}>
-                  {alert.isOverdue ? '期限超過' : `あと${alert.daysUntilAlert}日`}
-                </p>
-              </div>
-            </div>
-          </div>
+          <StockAlertItem key={alert.medicationId} alert={alert} />
         ))}
       </div>
     </div>
   );
 };
+
+export interface StockAlertItemProps {
+  alert: StockAlert;
+}
+
+const StockAlertItem: React.FC<StockAlertItemProps> = React.memo(({ alert }) => (
+  <div
+    className={`bg-white rounded-lg shadow-sm p-3 border ${
+      alert.isOverdue ? 'border-red-300 bg-red-50' : 'border-yellow-300 bg-yellow-50'
+    }`}
+  >
+    <div className="flex items-center justify-between">
+      <div>
+        <p className="text-sm font-medium text-gray-800">{alert.medicationName}</p>
+        <p className="text-xs text-gray-500">{alert.memberName}</p>
+      </div>
+      <div className="text-right">
+        {alert.stockQuantity !== null && (
+          <p className="text-sm font-medium text-gray-700">残り{alert.stockQuantity}日分</p>
+        )}
+        <p className={`text-xs font-medium ${alert.isOverdue ? 'text-red-600' : 'text-yellow-600'}`}>
+          {alert.isOverdue ? '期限超過' : `あと${alert.daysUntilAlert}日`}
+        </p>
+      </div>
+    </div>
+  </div>
+));
+
+StockAlertItem.displayName = 'StockAlertItem';

--- a/src/components/dashboard/TodayScheduleList.tsx
+++ b/src/components/dashboard/TodayScheduleList.tsx
@@ -43,7 +43,7 @@ interface ScheduleCardProps {
   onMarkCompleted?: (scheduleId: string) => void;
 }
 
-const ScheduleCard: React.FC<ScheduleCardProps> = ({ schedule, onMarkCompleted }) => {
+const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ schedule, onMarkCompleted }) => {
   return (
     <div
       className="bg-white rounded-lg shadow-md p-4 border border-gray-200 hover:shadow-lg transition-shadow"
@@ -87,13 +87,15 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({ schedule, onMarkCompleted }
       </div>
     </div>
   );
-};
+});
+
+ScheduleCard.displayName = 'ScheduleCard';
 
 interface StatusBadgeProps {
   status: 'pending' | 'completed' | 'overdue';
 }
 
-const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
+const StatusBadge: React.FC<StatusBadgeProps> = React.memo(({ status }) => {
   const styles = {
     pending: {
       bg: 'bg-yellow-100',
@@ -123,4 +125,6 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
       {style.label}
     </span>
   );
-};
+});
+
+StatusBadge.displayName = 'StatusBadge';

--- a/src/presentation/hooks/useMedicationHistory.ts
+++ b/src/presentation/hooks/useMedicationHistory.ts
@@ -3,7 +3,7 @@
  * Presentation層とDomain層を繋ぐ
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { DailyRecordGroup } from '../../domain/entities/MedicationRecord';
 import { GetMedicationHistory, DeleteMedicationRecord } from '../../domain/usecases/ManageMedicationRecords';
 import { getDIContainer } from '../../infrastructure/DIContainer';
@@ -32,10 +32,10 @@ export const useMedicationHistory = (): UseMedicationHistoryResult => {
     [] as DailyRecordGroup[],
   );
 
-  const handleDeleteRecord = async (recordId: string) => {
+  const handleDeleteRecord = useCallback(async (recordId: string) => {
     await useCases.deleteRecord.execute(recordId);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
   return {
     groups,

--- a/src/presentation/hooks/useSchedules.ts
+++ b/src/presentation/hooks/useSchedules.ts
@@ -67,15 +67,15 @@ export const useSchedules = (): UseSchedulesResult => {
     }
   }, [useCases, refetch]);
 
-  const handleUpdateSchedule = async (scheduleId: string, input: Partial<Schedule>) => {
+  const handleUpdateSchedule = useCallback(async (scheduleId: string, input: Partial<Schedule>) => {
     await useCases.updateSchedule.execute(scheduleId, input);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
-  const handleDeleteSchedule = async (scheduleId: string) => {
+  const handleDeleteSchedule = useCallback(async (scheduleId: string) => {
     await useCases.deleteSchedule.execute(scheduleId);
     await refetch();
-  };
+  }, [useCases, refetch]);
 
   return {
     schedules,

--- a/src/presentation/hooks/useUserProfile.ts
+++ b/src/presentation/hooks/useUserProfile.ts
@@ -3,7 +3,7 @@
  * Presentation層とDomain層を繋ぐ
  */
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { UserProfile, UpdateUserProfileInput } from '../../domain/repositories/UserProfileRepository';
 import { GetUserProfile, UpdateUserProfile } from '../../domain/usecases/ManageUserProfile';
 import { getDIContainer } from '../../infrastructure/DIContainer';
@@ -32,11 +32,11 @@ export const useUserProfile = (): UseUserProfileResult => {
     null as UserProfile | null,
   );
 
-  const handleUpdateProfile = async (input: UpdateUserProfileInput): Promise<UserProfile> => {
+  const handleUpdateProfile = useCallback(async (input: UpdateUserProfileInput): Promise<UserProfile> => {
     const updated = await useCases.updateProfile.execute(input);
     await refetch();
     return updated;
-  };
+  }, [useCases, refetch]);
 
   return {
     profile,


### PR DESCRIPTION
## 概要

残りの未最適化フックにuseCallbackを追加し、ダッシュボードリストをメモ化。

Closes #180

## 変更内容

- **useSchedules/useMedicationHistory/useUserProfile**: ハンドラーにuseCallback追加
- **TodayScheduleList**: ScheduleCard/StatusBadgeにReact.memo適用
- **StockAlertList**: StockAlertItemを抽出しReact.memo適用

## テスト

- 645テスト全パス
- ビルド成功確認済み