### PR TITLE
fix: データ層とフックのテストカバレッジを拡充

### DIFF
--- a/src/__tests__/data/api/medicationApi.test.ts
+++ b/src/__tests__/data/api/medicationApi.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { medicationApi } from '@/data/api/medicationApi';
+import { apiClient } from '@/data/api/apiClient';
+import { BackendMedication } from '@/data/api/types';
+
+vi.mock('@/data/api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+const mockMedication: BackendMedication = {
+  id: 'med-1',
+  memberId: 'member-1',
+  userId: 'user-1',
+  name: '頭痛薬',
+  category: 'regular',
+  dosageAmount: '1錠',
+  frequency: '1日3回',
+  stockQuantity: 10,
+  isActive: true,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+describe('medicationApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getMedicationsByMemberでメンバーの薬一覧を取得する', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue([mockMedication]);
+    const result = await medicationApi.getMedicationsByMember('member-1');
+    expect(apiClient.get).toHaveBeenCalledWith('/medications/member/member-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('頭痛薬');
+  });
+
+  it('getMedicationByIdで単一の薬を取得する', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(mockMedication);
+    const result = await medicationApi.getMedicationById('med-1');
+    expect(result?.name).toBe('頭痛薬');
+  });
+
+  it('getMedicationByIdでエラー時にnullを返す', async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new Error('Not found'));
+    const result = await medicationApi.getMedicationById('invalid');
+    expect(result).toBeNull();
+  });
+
+  it('createMedicationで薬を作成する', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(mockMedication);
+    const result = await medicationApi.createMedication({
+      name: '頭痛薬',
+      memberId: 'member-1',
+      category: 'regular',
+      dosage: '1錠',
+      frequency: '1日3回',
+    });
+    expect(apiClient.post).toHaveBeenCalledWith('/medications', expect.objectContaining({ name: '頭痛薬' }));
+    expect(result.name).toBe('頭痛薬');
+  });
+
+  it('updateMedicationで薬を更新する', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({ ...mockMedication, stockQuantity: 20 });
+    const result = await medicationApi.updateMedication('med-1', { stockQuantity: 20 });
+    expect(apiClient.put).toHaveBeenCalledWith('/medications/med-1', { stockQuantity: 20 });
+    expect(result.stockQuantity).toBe(20);
+  });
+
+  it('deleteMedicationで薬を削除する', async () => {
+    vi.mocked(apiClient.del).mockResolvedValue(undefined);
+    await medicationApi.deleteMedication('med-1');
+    expect(apiClient.del).toHaveBeenCalledWith('/medications/med-1');
+  });
+
+  it('searchMedicationsで薬を検索する', async () => {
+    const results = [{ id: 'med-1', name: '頭痛薬', category: 'regular', memberId: 'member-1', memberName: '太郎' }];
+    vi.mocked(apiClient.get).mockResolvedValue(results);
+    const result = await medicationApi.searchMedications('頭痛');
+    expect(apiClient.get).toHaveBeenCalledWith('/medications/search?q=%E9%A0%AD%E7%97%9B');
+    expect(result).toEqual(results);
+  });
+
+  it('getStockAlertsで在庫アラートを取得する', async () => {
+    const alerts = [{ medicationId: 'med-1', medicationName: '頭痛薬' }];
+    vi.mocked(apiClient.get).mockResolvedValue(alerts);
+    const result = await medicationApi.getStockAlerts();
+    expect(apiClient.get).toHaveBeenCalledWith('/medications/alerts');
+    expect(result).toEqual(alerts);
+  });
+});

--- a/src/__tests__/data/api/memberApi.test.ts
+++ b/src/__tests__/data/api/memberApi.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { memberApi } from '@/data/api/memberApi';
+import { apiClient } from '@/data/api/apiClient';
+import { BackendMember } from '@/data/api/types';
+
+vi.mock('@/data/api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+const mockMember: BackendMember = {
+  id: 'member-1',
+  userId: 'user-1',
+  name: '太郎',
+  memberType: 'human',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+describe('memberApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getMembersでメンバー一覧を取得する', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue([mockMember]);
+    const result = await memberApi.getMembers('user-1');
+    expect(apiClient.get).toHaveBeenCalledWith('/members');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('太郎');
+    expect(result[0].memberType).toBe('human');
+  });
+
+  it('getMemberByIdで単一メンバーを取得する', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(mockMember);
+    const result = await memberApi.getMemberById('member-1');
+    expect(apiClient.get).toHaveBeenCalledWith('/members/member-1');
+    expect(result?.name).toBe('太郎');
+  });
+
+  it('getMemberByIdでエラー時にnullを返す', async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new Error('Not found'));
+    const result = await memberApi.getMemberById('invalid');
+    expect(result).toBeNull();
+  });
+
+  it('createMemberでメンバーを作成する', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(mockMember);
+    const result = await memberApi.createMember({
+      name: '太郎',
+      memberType: 'human',
+      userId: 'user-1',
+    });
+    expect(apiClient.post).toHaveBeenCalledWith('/members', expect.objectContaining({ name: '太郎' }));
+    expect(result.name).toBe('太郎');
+  });
+
+  it('updateMemberでメンバーを更新する', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({ ...mockMember, name: '花子' });
+    const result = await memberApi.updateMember('member-1', { name: '花子' });
+    expect(apiClient.put).toHaveBeenCalledWith('/members/member-1', expect.objectContaining({ name: '花子' }));
+    expect(result.name).toBe('花子');
+  });
+
+  it('deleteMemberでメンバーを削除する', async () => {
+    vi.mocked(apiClient.del).mockResolvedValue(undefined);
+    await memberApi.deleteMember('member-1');
+    expect(apiClient.del).toHaveBeenCalledWith('/members/member-1');
+  });
+
+  it('getMemberSummariesでサマリーを取得する', async () => {
+    const summaries = [{ memberId: 'member-1', memberName: '太郎', medicationCount: 3 }];
+    vi.mocked(apiClient.get).mockResolvedValue(summaries);
+    const result = await memberApi.getMemberSummaries();
+    expect(apiClient.get).toHaveBeenCalledWith('/members/summary');
+    expect(result).toEqual(summaries);
+  });
+});

--- a/src/__tests__/data/api/scheduleApi.test.ts
+++ b/src/__tests__/data/api/scheduleApi.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { scheduleApi } from '@/data/api/scheduleApi';
+import { apiClient } from '@/data/api/apiClient';
+import { BackendSchedule, BackendMember, BackendMedication } from '@/data/api/types';
+
+vi.mock('@/data/api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+const mockSchedule: BackendSchedule = {
+  id: 'sch-1',
+  medicationId: 'med-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  scheduledTime: '08:00',
+  daysOfWeek: ['mon', 'wed', 'fri'],
+  isEnabled: true,
+  reminderMinutesBefore: 10,
+  createdAt: '2025-01-01T00:00:00.000Z',
+};
+
+const mockMember: BackendMember = {
+  id: 'member-1',
+  userId: 'user-1',
+  name: '太郎',
+  memberType: 'human',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+const mockMedication: BackendMedication = {
+  id: 'med-1',
+  memberId: 'member-1',
+  userId: 'user-1',
+  name: '頭痛薬',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+};
+
+describe('scheduleApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getSchedulesでスケジュール一覧を詳細付きで取得する', async () => {
+    vi.mocked(apiClient.get)
+      .mockResolvedValueOnce([mockSchedule])
+      .mockResolvedValueOnce([mockMember])
+      .mockResolvedValueOnce(mockMedication);
+
+    const result = await scheduleApi.getSchedules();
+    expect(result).toHaveLength(1);
+    expect(result[0].medicationName).toBe('頭痛薬');
+    expect(result[0].memberName).toBe('太郎');
+    expect(result[0].schedule.scheduledTime).toBe('08:00');
+  });
+
+  it('getSchedulesで薬が見つからないスケジュールを除外する', async () => {
+    vi.mocked(apiClient.get)
+      .mockResolvedValueOnce([mockSchedule])
+      .mockResolvedValueOnce([mockMember])
+      .mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await scheduleApi.getSchedules();
+    expect(result).toHaveLength(0);
+  });
+
+  it('createScheduleでスケジュールを作成する', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue(mockSchedule);
+    const result = await scheduleApi.createSchedule({
+      medicationId: 'med-1',
+      userId: 'user-1',
+      memberId: 'member-1',
+      scheduledTime: '08:00',
+      daysOfWeek: ['mon', 'wed', 'fri'],
+      isEnabled: true,
+      reminderMinutesBefore: 10,
+    });
+    expect(apiClient.post).toHaveBeenCalledWith('/schedules', expect.objectContaining({ scheduledTime: '08:00' }));
+    expect(result.scheduledTime).toBe('08:00');
+  });
+
+  it('updateScheduleでスケジュールを更新する', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({ ...mockSchedule, scheduledTime: '09:00' });
+    const result = await scheduleApi.updateSchedule('sch-1', { scheduledTime: '09:00' });
+    expect(apiClient.put).toHaveBeenCalledWith('/schedules/sch-1', { scheduledTime: '09:00' });
+    expect(result.scheduledTime).toBe('09:00');
+  });
+
+  it('deleteScheduleでスケジュールを削除する', async () => {
+    vi.mocked(apiClient.del).mockResolvedValue(undefined);
+    await scheduleApi.deleteSchedule('sch-1');
+    expect(apiClient.del).toHaveBeenCalledWith('/schedules/sch-1');
+  });
+
+  it('markAsCompletedで服薬記録を作成する', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(mockSchedule);
+    vi.mocked(apiClient.post).mockResolvedValue({});
+    await scheduleApi.markAsCompleted('sch-1', new Date());
+    expect(apiClient.post).toHaveBeenCalledWith('/records', {
+      memberId: 'member-1',
+      medicationId: 'med-1',
+      scheduleId: 'sch-1',
+    });
+  });
+
+  it('markAsCompletedでスケジュールが見つからない場合は何もしない', async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new Error('Not found'));
+    await scheduleApi.markAsCompleted('invalid', new Date());
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/hooks/useAuth.test.ts
+++ b/src/__tests__/hooks/useAuth.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAuth } from '@/hooks/useAuth';
+
+vi.mock('next-auth/react', () => ({
+  useSession: vi.fn(),
+}));
+
+import { useSession } from 'next-auth/react';
+
+describe('useAuth', () => {
+  it('認証済みの場合にユーザー情報を返す', () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { id: 'user-1', email: 'test@example.com' }, expires: '' },
+      status: 'authenticated',
+      update: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.userId).toBe('user-1');
+    expect(result.current.email).toBe('test@example.com');
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('未認証の場合に空の情報を返す', () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+      update: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.userId).toBe('');
+    expect(result.current.email).toBe('');
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('ローディング中の場合にisLoadingがtrueを返す', () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: 'loading',
+      update: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('セッションにユーザー情報がない場合に空文字を返す', () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: {}, expires: '' },
+      status: 'authenticated',
+      update: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.userId).toBe('');
+    expect(result.current.email).toBe('');
+  });
+});


### PR DESCRIPTION
## 概要

データ層APIクライアントとuseAuthフックのテストを追加。

Closes #182

## 変更内容

- **memberApi** (7テスト): CRUD・エラーハンドリング・サマリー
- **medicationApi** (8テスト): CRUD・検索・在庫アラート
- **scheduleApi** (7テスト): CRUD・詳細取得・薬未検出時の除外・服薬完了
- **useAuth** (4テスト): 認証状態のテスト

## テスト

- 26テスト追加（合計671テスト全パス）
- ビルド成功確認済み