### PR TITLE
通院種別追加・スケジュール表示バグ修正・UI改善

### DIFF
--- a/src/__tests__/components/dashboard/AdherenceTrendCard.test.tsx
+++ b/src/__tests__/components/dashboard/AdherenceTrendCard.test.tsx
@@ -34,7 +34,7 @@ describe('AdherenceTrendCard', () => {
 
   it('タイトルを表示する', () => {
     render(<AdherenceTrendCard trend={createTrend()} isLoading={false} />);
-    expect(screen.getByText('服薬トレンド（週間）')).toBeInTheDocument();
+    expect(screen.getByText('お薬の達成率（週間）')).toBeInTheDocument();
   });
 
   it('変化率を表示する', () => {

--- a/src/__tests__/domain/entities/AppointmentEntity.test.ts
+++ b/src/__tests__/domain/entities/AppointmentEntity.test.ts
@@ -121,6 +121,12 @@ describe('AppointmentEntity', () => {
         ['vaccination', '予防接種'],
         ['surgery', '手術'],
         ['consultation', '相談'],
+        ['medication_pickup', 'お薬'],
+        ['examination', '検査'],
+        ['flea_tick', 'ノミ・ダニ薬'],
+        ['heartworm', 'フィラリア'],
+        ['therapeutic_diet', '療養食'],
+        ['grooming', 'トリミング'],
         ['other', 'その他'],
       ];
       for (const [type, label] of cases) {

--- a/src/__tests__/domain/entities/ScheduleEntity.test.ts
+++ b/src/__tests__/domain/entities/ScheduleEntity.test.ts
@@ -57,6 +57,16 @@ describe('ScheduleEntity', () => {
       const monday = new Date('2024-06-03');
       expect(entity.isActiveOnDay(monday)).toBe(false);
     });
+
+    it('曜日が空配列（毎日）の場合、全ての日で true を返す', () => {
+      const entity = new ScheduleEntity(createSchedule({ daysOfWeek: [] }));
+      const monday = new Date('2024-06-03');
+      const tuesday = new Date('2024-06-04');
+      const sunday = new Date('2024-06-02');
+      expect(entity.isActiveOnDay(monday)).toBe(true);
+      expect(entity.isActiveOnDay(tuesday)).toBe(true);
+      expect(entity.isActiveOnDay(sunday)).toBe(true);
+    });
   });
 
   describe('getStatus (境界値)', () => {

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useRef, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
@@ -22,6 +22,8 @@ export default function AppointmentsPage() {
   const [showForm, setShowForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const editFormRef = useRef<HTMLDivElement>(null);
 
   const appointmentDates = useMemo(() => appointments.map((a) => new Date(a.appointmentDate)), [appointments]);
   const counts = useMemo(() => getAppointmentCounts(appointments), [appointments]);
@@ -38,16 +40,28 @@ export default function AppointmentsPage() {
   const handleEdit = (appointment: Appointment) => {
     setEditingAppointment(appointment);
     setShowForm(false);
+    setUpdateError(null);
   };
+
+  useEffect(() => {
+    if (editingAppointment && editFormRef.current) {
+      editFormRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [editingAppointment]);
 
   const handleUpdate = async (data: AppointmentFormData) => {
     if (!editingAppointment) return;
-    await updateAppointment(editingAppointment.id, {
-      appointmentDate: data.appointmentDate,
-      type: data.type,
-      notes: data.notes,
-    });
-    setEditingAppointment(null);
+    setUpdateError(null);
+    try {
+      await updateAppointment(editingAppointment.id, {
+        appointmentDate: data.appointmentDate,
+        type: data.type,
+        notes: data.notes,
+      });
+      setEditingAppointment(null);
+    } catch {
+      setUpdateError('更新に失敗しました。もう一度お試しください。');
+    }
   };
 
   const handleCancelEdit = () => {
@@ -55,6 +69,7 @@ export default function AppointmentsPage() {
   };
 
   const handleDelete = async (appointmentId: string) => {
+    if (!window.confirm('この予約を削除しますか？')) return;
     await deleteAppointment(appointmentId);
   };
 
@@ -101,8 +116,11 @@ export default function AppointmentsPage() {
         )}
 
         {editingAppointment && !membersLoading && members.length > 0 && (
-          <div className="mb-6 bg-white rounded-lg shadow-md p-4 border border-blue-200">
+          <div ref={editFormRef} className="mb-6 bg-white rounded-lg shadow-md p-4 border border-blue-200">
             <h2 className="text-sm font-semibold text-gray-700 mb-3">通院予約の編集</h2>
+            {updateError && (
+              <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2 mb-3">{updateError}</p>
+            )}
             <AppointmentForm
               key={editingAppointment.id}
               members={members}

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -88,7 +88,13 @@ export default function Members() {
         <MemberList
           members={members}
           isLoading={isLoading}
-          onDelete={deleteMember}
+          onDelete={(memberId) => {
+            const member = members.find((m) => m.id === memberId);
+            const name = member?.name || 'このメンバー';
+            if (window.confirm(`${name}を削除しますか？\n関連するお薬やスケジュールも全て削除されます。`)) {
+              deleteMember(memberId);
+            }
+          }}
           onEdit={handleEdit}
           summaries={summaries}
         />

--- a/src/components/dashboard/AdherenceStatsCard.tsx
+++ b/src/components/dashboard/AdherenceStatsCard.tsx
@@ -31,7 +31,7 @@ export const AdherenceStatsCard: React.FC<AdherenceStatsCardProps> = React.memo(
     <div className="mb-6">
       <div className="flex items-center space-x-2 mb-3">
         <TrendingUp size={18} className="text-primary-600" />
-        <h2 className="text-lg font-semibold text-gray-800">服薬アドヒアランス</h2>
+        <h2 className="text-lg font-semibold text-gray-800">お薬の達成率</h2>
       </div>
 
       <div className="bg-white rounded-lg shadow-sm p-4 border border-gray-200">

--- a/src/components/dashboard/AdherenceTrendCard.tsx
+++ b/src/components/dashboard/AdherenceTrendCard.tsx
@@ -25,7 +25,7 @@ export const AdherenceTrendCard: React.FC<AdherenceTrendCardProps> = ({ trend, i
   return (
     <div className="bg-white rounded-lg shadow-md p-4 mb-4 border border-gray-200">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold text-gray-700">服薬トレンド（週間）</h3>
+        <h3 className="text-sm font-semibold text-gray-700">お薬の達成率（週間）</h3>
         <div className={`flex items-center space-x-1 ${trendColor}`}>
           <TrendIcon size={16} />
           <span className="text-sm font-medium">{entity.getRateChangeLabel()}</span>

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -75,6 +75,12 @@ export class AppointmentEntity {
     vaccination: '予防接種',
     surgery: '手術',
     consultation: '相談',
+    medication_pickup: 'お薬',
+    examination: '検査',
+    flea_tick: 'ノミ・ダニ薬',
+    heartworm: 'フィラリア',
+    therapeutic_diet: '療養食',
+    grooming: 'トリミング',
     other: 'その他',
   };
 

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -51,6 +51,11 @@ export class ScheduleEntity {
       return false;
     }
 
+    // 曜日が未設定（空配列）の場合は毎日有効
+    if (this.schedule.daysOfWeek.length === 0) {
+      return true;
+    }
+
     const dayMap: Record<number, DayOfWeek> = {
       0: 'sun',
       1: 'mon',


### PR DESCRIPTION
## Summary
- 通院予約の種別にお薬/検査/ノミ・ダニ薬/フィラリア/療養食/トリミングを追加
- `ScheduleEntity.isActiveOnDay()` で daysOfWeek が空配列（毎日）の場合に false を返すバグを修正。ホーム画面の服薬スケジュール表示バラつきの原因
- 通院予約編集のエラーハンドリング追加、編集フォームへの自動スクロール
- 「服薬アドヒアランス」を「お薬の達成率」に変更（専門用語を一般的な表現に）
- メンバー削除と通院予約削除に確認ダイアログを追加（誤削除防止）

## Test plan
- [x] 全テスト通過（675 passed）
- [x] ビルド成功
- [ ] 通院予約で新しい種別が選択できることを確認
- [ ] 編集ボタン押下時にフォームまでスクロールされることを確認
- [ ] ホーム画面でキャラクター切替後も服薬スケジュールが正しく表示されることを確認
- [ ] メンバー削除時に確認ダイアログが表示されることを確認

closes #186