### PR TITLE
fix: テストファイルのTypeScriptエラーを修正

### DIFF
--- a/src/__tests__/components/appointments/AppointmentForm.test.tsx
+++ b/src/__tests__/components/appointments/AppointmentForm.test.tsx
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { AppointmentForm } from '@/components/appointments/AppointmentForm';
 import { Member } from '@/domain/entities/Member';
 import { Hospital } from '@/domain/entities/Hospital';
 
 const mockMembers: Member[] = [
-  { id: 'm1', userId: 'u1', memberType: 'human', name: '太郎', isActive: true, createdAt: new Date(), updatedAt: new Date() },
-  { id: 'm2', userId: 'u1', memberType: 'pet', petType: 'dog', name: 'ポチ', isActive: true, createdAt: new Date(), updatedAt: new Date() },
+  { id: 'm1', userId: 'u1', memberType: 'human', name: '太郎', createdAt: new Date(), updatedAt: new Date() },
+  { id: 'm2', userId: 'u1', memberType: 'pet', petType: 'dog', name: 'ポチ', createdAt: new Date(), updatedAt: new Date() },
 ];
 
 const mockHospitals: Hospital[] = [

--- a/src/__tests__/components/dashboard/TodayScheduleList.extra.test.tsx
+++ b/src/__tests__/components/dashboard/TodayScheduleList.extra.test.tsx
@@ -7,10 +7,14 @@ const createSchedule = (overrides: Partial<TodayScheduleViewModel> = {}): TodayS
   scheduleId: 'sch-1',
   medicationId: 'med-1',
   medicationName: 'テスト薬',
+  userId: 'user-1',
   memberId: 'member-1',
   memberName: 'テスト太郎',
+  memberType: 'human',
   scheduledTime: '08:00',
   status: 'pending',
+  isEnabled: true,
+  reminderMinutesBefore: 5,
   ...overrides,
 });
 

--- a/src/__tests__/components/dashboard/TodayScheduleList.test.tsx
+++ b/src/__tests__/components/dashboard/TodayScheduleList.test.tsx
@@ -7,9 +7,14 @@ const createSchedule = (overrides: Partial<TodayScheduleViewModel> = {}): TodayS
   scheduleId: 'schedule-1',
   medicationId: 'med-1',
   medicationName: 'アスピリン',
+  userId: 'user-1',
+  memberId: 'member-1',
   memberName: '太郎',
+  memberType: 'human',
   scheduledTime: '08:00',
   status: 'pending' as const,
+  isEnabled: true,
+  reminderMinutesBefore: 5,
   ...overrides,
 });
 

--- a/src/__tests__/components/dashboard/WeeklySummaryCard.test.tsx
+++ b/src/__tests__/components/dashboard/WeeklySummaryCard.test.tsx
@@ -7,10 +7,14 @@ const createSchedule = (status: 'pending' | 'completed' | 'overdue'): TodaySched
   scheduleId: `s-${Math.random()}`,
   medicationId: 'med-1',
   medicationName: 'テスト薬',
+  userId: 'user-1',
   memberName: '太郎',
   memberId: 'member-1',
+  memberType: 'human',
   scheduledTime: '08:00',
   status,
+  isEnabled: true,
+  reminderMinutesBefore: 5,
 });
 
 describe('WeeklySummaryCard', () => {

--- a/src/__tests__/components/hospitals/HospitalForm.test.tsx
+++ b/src/__tests__/components/hospitals/HospitalForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { HospitalForm } from '@/components/hospitals/HospitalForm';
 

--- a/src/__tests__/components/hospitals/HospitalList.test.tsx
+++ b/src/__tests__/components/hospitals/HospitalList.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { HospitalList } from '@/components/hospitals/HospitalList';
 import { Hospital } from '@/domain/entities/Hospital';

--- a/src/__tests__/components/medications/MedicationForm.test.tsx
+++ b/src/__tests__/components/medications/MedicationForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MedicationForm } from '@/components/medications/MedicationForm';
 

--- a/src/__tests__/components/medications/MedicationList.test.tsx
+++ b/src/__tests__/components/medications/MedicationList.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MedicationList } from '@/components/medications/MedicationList';
 import { MedicationViewModel } from '@/domain/usecases/ManageMedications';

--- a/src/__tests__/components/medications/MedicationSearch.test.tsx
+++ b/src/__tests__/components/medications/MedicationSearch.test.tsx
@@ -15,6 +15,7 @@ describe('MedicationSearch', () => {
       results: [],
       isSearching: false,
       hasSearched: false,
+      error: null,
       search: mockSearch,
     });
   });
@@ -35,6 +36,7 @@ describe('MedicationSearch', () => {
       results: [{ id: '1', name: 'アスピリン', category: 'regular', memberId: 'm1', memberName: '太郎' }],
       isSearching: false,
       hasSearched: true,
+      error: null,
       search: mockSearch,
     });
 
@@ -48,6 +50,7 @@ describe('MedicationSearch', () => {
       results: [],
       isSearching: false,
       hasSearched: true,
+      error: null,
       search: mockSearch,
     });
 
@@ -76,6 +79,7 @@ describe('MedicationSearch', () => {
       results: [result],
       isSearching: false,
       hasSearched: true,
+      error: null,
       search: mockSearch,
     });
     const onSelect = vi.fn();

--- a/src/__tests__/components/medications/TakeWithNotesButton.test.tsx
+++ b/src/__tests__/components/medications/TakeWithNotesButton.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { TakeWithNotesButton } from '@/components/medications/TakeWithNotesButton';
 

--- a/src/__tests__/components/members/MemberForm.test.tsx
+++ b/src/__tests__/components/members/MemberForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemberForm } from '@/components/members/MemberForm';
 

--- a/src/__tests__/components/schedules/ScheduleForm.test.tsx
+++ b/src/__tests__/components/schedules/ScheduleForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ScheduleForm } from '@/components/schedules/ScheduleForm';
 

--- a/src/__tests__/components/shared/MedicationSortSelector.test.tsx
+++ b/src/__tests__/components/shared/MedicationSortSelector.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MedicationSortSelector } from '@/components/shared/MedicationSortSelector';
 

--- a/src/__tests__/data/api/medicationApi.test.ts
+++ b/src/__tests__/data/api/medicationApi.test.ts
@@ -56,6 +56,7 @@ describe('medicationApi', () => {
     const result = await medicationApi.createMedication({
       name: '頭痛薬',
       memberId: 'member-1',
+      userId: 'user-1',
       category: 'regular',
       dosage: '1錠',
       frequency: '1日3回',

--- a/src/__tests__/domain/usecases/ManageMedicationRecords.test.ts
+++ b/src/__tests__/domain/usecases/ManageMedicationRecords.test.ts
@@ -43,6 +43,7 @@ const createMockRepository = (): MedicationRecordRepository => ({
   createRecord: vi.fn().mockResolvedValue(undefined),
   deleteRecord: vi.fn().mockResolvedValue(undefined),
   getAdherenceStats: vi.fn().mockResolvedValue(mockStats),
+  getAdherenceTrends: vi.fn().mockResolvedValue(null),
 });
 
 describe('GetMedicationHistory', () => {

--- a/src/__tests__/domain/usecases/ManageMembers.test.ts
+++ b/src/__tests__/domain/usecases/ManageMembers.test.ts
@@ -18,6 +18,7 @@ const createMockRepository = (): MemberRepository => ({
   createMember: vi.fn().mockResolvedValue(mockMember),
   updateMember: vi.fn().mockResolvedValue({ ...mockMember, name: '更新太郎' }),
   deleteMember: vi.fn().mockResolvedValue(undefined),
+  getMemberSummaries: vi.fn().mockResolvedValue([]),
 });
 
 describe('GetMembers', () => {

--- a/src/__tests__/lib/api-helpers.test.ts
+++ b/src/__tests__/lib/api-helpers.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/lib/prisma', () => ({
 import { auth } from '@/lib/auth';
 import { withAuth, withOwnershipCheck, verifyResourceOwnership, validateParamId, validateBodySize } from '@/lib/api-helpers';
 
-const mockAuth = vi.mocked(auth);
+const mockAuth = vi.mocked(auth) as unknown as ReturnType<typeof vi.fn>;
 
 describe('withAuth', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- beforeEachのvitest importを9ファイルに追加
- TodayScheduleViewModelのファクトリ関数に必須プロパティ（userId, memberType, isEnabled, reminderMinutesBefore）を追加
- MedicationSearchテストのモック戻り値にerrorプロパティを追加
- medicationApiテストのcreateInput にuserIdを追加
- ManageMedicationRecordsテストのモックリポジトリにgetAdherenceTrendsを追加
- ManageMembersテストのモックリポジトリにgetMemberSummariesを追加
- api-helpersテストのauth関数の型キャストを修正（NextMiddlewareの型不整合を解消）

## Test plan
- [x] npx tsc --noEmit が通過すること
- [x] npx vitest run が全テスト通過すること（86ファイル、675テスト）