### PR TITLE
fix: 達成率APIのdaysOfWeek計算バグを修正

### DIFF
--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -36,9 +36,12 @@ export const GET = withAuth(async (userId) => {
   ]);
 
   // 1週間のスケジュール数を計算（各スケジュールの有効曜日数）
-  const weeklyExpected = schedules.reduce((sum, s) => sum + Math.min(s.daysOfWeek.length, 7), 0);
+  // daysOfWeekが空配列の場合は毎日（7日）として計算
+  const getActiveDays = (daysOfWeek: string[]) => daysOfWeek.length === 0 ? 7 : daysOfWeek.length;
+
+  const weeklyExpected = schedules.reduce((sum, s) => sum + Math.min(getActiveDays(s.daysOfWeek), 7), 0);
   const monthlyExpected = schedules.reduce((sum, s) => {
-    const daysPerWeek = s.daysOfWeek.length;
+    const daysPerWeek = getActiveDays(s.daysOfWeek);
     return sum + Math.round(daysPerWeek * (30 / 7));
   }, 0);
 
@@ -48,9 +51,9 @@ export const GET = withAuth(async (userId) => {
     const memberWeekly = weeklyRecords.filter((r) => r.memberId === member.id);
     const memberMonthly = monthlyRecords.filter((r) => r.memberId === member.id);
 
-    const expected7 = memberSchedules.reduce((sum, s) => sum + Math.min(s.daysOfWeek.length, 7), 0);
+    const expected7 = memberSchedules.reduce((sum, s) => sum + Math.min(getActiveDays(s.daysOfWeek), 7), 0);
     const expected30 = memberSchedules.reduce((sum, s) => {
-      return sum + Math.round(s.daysOfWeek.length * (30 / 7));
+      return sum + Math.round(getActiveDays(s.daysOfWeek) * (30 / 7));
     }, 0);
 
     return {

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -26,12 +26,20 @@ export const GET = withAuth(async (userId) => {
     }),
   ]);
 
+  // 英語の曜日名からJavaScript Date.getDay()のインデックスへの変換
+  const dayToIndex: Record<string, number> = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+
   // 曜日別の期待数（スケジュールから）
   const expectedByDay = new Array(7).fill(0);
   for (const schedule of schedules) {
-    for (const day of schedule.daysOfWeek) {
-      const dayIndex = (DAY_LABELS_JP as readonly string[]).indexOf(day);
-      if (dayIndex >= 0) expectedByDay[dayIndex] += 1;
+    if (schedule.daysOfWeek.length === 0) {
+      // 空配列は毎日有効
+      for (let i = 0; i < 7; i++) expectedByDay[i] += 1;
+    } else {
+      for (const day of schedule.daysOfWeek) {
+        const dayIndex = dayToIndex[day];
+        if (dayIndex !== undefined) expectedByDay[dayIndex] += 1;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- stats APIで`daysOfWeek`が空配列（毎日有効）の場合、期待服薬数が0として計算され達成率が常に0%になるバグを修正
- trends APIで`daysOfWeek`の英語値（mon, tue等）を日本語ラベル（日, 月等）と比較していたため曜日別統計が常に0になるバグを修正
- trends APIで空の`daysOfWeek`配列を全曜日（7日）として処理するよう修正

## Test plan
- [x] npx tsc --noEmit 通過
- [x] npx vitest run 全テスト通過（675件）
- [ ] ダッシュボードで達成率が正しく表示されることを確認
- [ ] キャラクター切り替え後もデータが維持されることを確認

closes #189