### PR TITLE
fix: キャラクター切替時のデータ消失を修正

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom/vitest';
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+    get length() { return Object.keys(store).length; },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+});

--- a/src/presentation/hooks/useAdherenceStats.ts
+++ b/src/presentation/hooks/useAdherenceStats.ts
@@ -30,6 +30,7 @@ export const useAdherenceStats = (): UseAdherenceStatsResult => {
     () => useCase.execute(),
     [useCase],
     defaultStats,
+    'adherence-stats',
   );
 
   return {

--- a/src/presentation/hooks/useAdherenceTrends.ts
+++ b/src/presentation/hooks/useAdherenceTrends.ts
@@ -27,6 +27,7 @@ export const useAdherenceTrends = (): UseAdherenceTrendsResult => {
     () => useCase.execute(),
     [useCase],
     defaultTrend,
+    'adherence-trends',
   );
 
   return { trend: data, isLoading, error, refetch };

--- a/src/presentation/hooks/useAppointments.ts
+++ b/src/presentation/hooks/useAppointments.ts
@@ -38,6 +38,7 @@ export const useAppointments = (): UseAppointmentsResult => {
     },
     [useCases],
     [] as Appointment[],
+    'appointments',
   );
 
   const handleCreateAppointment = useCallback(async (input: CreateAppointmentInput) => {

--- a/src/presentation/hooks/useFetcher.ts
+++ b/src/presentation/hooks/useFetcher.ts
@@ -1,9 +1,10 @@
 /**
  * 汎用データ取得フック
  * 共通のfetch/loading/errorパターンを抽出
+ * cacheKeyを指定するとページ遷移時にキャッシュデータを即表示（stale-while-revalidate）
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 export interface UseFetcherResult<T> {
   data: T;
@@ -12,25 +13,46 @@ export interface UseFetcherResult<T> {
   refetch: () => Promise<void>;
 }
 
+const dataCache = new Map<string, unknown>();
+
 export function useFetcher<T>(
   asyncFn: () => Promise<T>,
   deps: React.DependencyList,
   initialValue: T,
+  cacheKey?: string,
 ): UseFetcherResult<T> {
-  const [data, setData] = useState<T>(initialValue);
-  const [isLoading, setIsLoading] = useState(true);
+  const cached = cacheKey ? (dataCache.get(cacheKey) as T | undefined) : undefined;
+  const [data, setData] = useState<T>(cached ?? initialValue);
+  const [isLoading, setIsLoading] = useState(cached === undefined);
   const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
 
   const fetchData = useCallback(async () => {
     try {
-      setIsLoading(true);
+      if (!dataCache.has(cacheKey ?? '')) {
+        setIsLoading(true);
+      }
       setError(null);
       const result = await asyncFn();
-      setData(result);
+      if (mountedRef.current) {
+        setData(result);
+        if (cacheKey) {
+          dataCache.set(cacheKey, result);
+        }
+      }
     } catch (err) {
-      setError(err instanceof Error ? err : new Error('Unknown error'));
+      if (mountedRef.current) {
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+      }
     } finally {
-      setIsLoading(false);
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);

--- a/src/presentation/hooks/useHospitals.ts
+++ b/src/presentation/hooks/useHospitals.ts
@@ -35,6 +35,7 @@ export const useHospitals = (): UseHospitalsResult => {
     () => useCases.getHospitals.execute(),
     [useCases],
     [] as Hospital[],
+    'hospitals',
   );
 
   const handleCreateHospital = useCallback(async (input: CreateHospitalInput) => {

--- a/src/presentation/hooks/useMedicationHistory.ts
+++ b/src/presentation/hooks/useMedicationHistory.ts
@@ -30,6 +30,7 @@ export const useMedicationHistory = (): UseMedicationHistoryResult => {
     () => useCases.getHistory.execute(),
     [useCases],
     [] as DailyRecordGroup[],
+    'medication-history',
   );
 
   const handleDeleteRecord = useCallback(async (recordId: string) => {

--- a/src/presentation/hooks/useMedications.ts
+++ b/src/presentation/hooks/useMedications.ts
@@ -34,6 +34,7 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
     () => useCases.getMedications.execute(memberId),
     [memberId, useCases],
     [] as MedicationViewModel[],
+    `medications-${memberId}`,
   );
 
   const handleCreateMedication = useCallback(async (input: CreateMedicationInput) => {

--- a/src/presentation/hooks/useMemberSummaries.ts
+++ b/src/presentation/hooks/useMemberSummaries.ts
@@ -24,6 +24,7 @@ export const useMemberSummaries = (): UseMemberSummariesResult => {
     () => useCase.execute(),
     [useCase],
     [] as MemberSummary[],
+    'member-summaries',
   );
 
   return { summaries: data, isLoading, error };

--- a/src/presentation/hooks/useMembers.ts
+++ b/src/presentation/hooks/useMembers.ts
@@ -35,6 +35,7 @@ export const useMembers = (userId: string): UseMembersResult => {
     () => useCases.getMembers.execute(userId),
     [userId, useCases],
     [] as Member[],
+    `members-${userId}`,
   );
 
   const handleCreateMember = useCallback(async (input: CreateMemberInput) => {

--- a/src/presentation/hooks/useSchedules.ts
+++ b/src/presentation/hooks/useSchedules.ts
@@ -45,6 +45,7 @@ export const useSchedules = (): UseSchedulesResult => {
     () => useCases.getSchedules.execute(),
     [useCases],
     [] as ScheduleWithDetails[],
+    'schedules',
   );
 
   const [isCreating, setIsCreating] = useState(false);

--- a/src/presentation/hooks/useStockAlerts.ts
+++ b/src/presentation/hooks/useStockAlerts.ts
@@ -25,6 +25,7 @@ export const useStockAlerts = (): UseStockAlertsResult => {
     () => useCase.execute(),
     [useCase],
     [] as StockAlert[],
+    'stock-alerts',
   );
 
   return { alerts: data, isLoading, error, refetch };

--- a/src/presentation/hooks/useTodaySchedules.ts
+++ b/src/presentation/hooks/useTodaySchedules.ts
@@ -31,6 +31,7 @@ export const useTodaySchedules = (userId: string): UseTodaySchedulesResult => {
     () => getTodaySchedulesUseCase.execute({ userId, date: new Date() }),
     [userId, getTodaySchedulesUseCase],
     [] as TodayScheduleViewModel[],
+    `today-schedules-${userId}`,
   );
 
   const markAsCompleted = useCallback(async (scheduleId: string) => {

--- a/src/presentation/hooks/useUserProfile.ts
+++ b/src/presentation/hooks/useUserProfile.ts
@@ -30,6 +30,7 @@ export const useUserProfile = (): UseUserProfileResult => {
     () => useCases.getProfile.execute(),
     [useCases],
     null as UserProfile | null,
+    'user-profile',
   );
 
   const handleUpdateProfile = useCallback(async (input: UpdateUserProfileInput): Promise<UserProfile> => {

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { CharacterType, CharacterConfig, CHARACTER_CONFIGS } from '../domain/entities/Character';
 
 type MessageKey = keyof CharacterConfig['messages'];
@@ -10,18 +11,26 @@ interface CharacterState {
   getMessage: (key: MessageKey) => string;
 }
 
-export const useCharacterStore = create<CharacterState>((set, get) => ({
-  selectedCharacter: 'cat',
+export const useCharacterStore = create<CharacterState>()(
+  persist(
+    (set, get) => ({
+      selectedCharacter: 'cat',
 
-  setCharacter: (character: CharacterType) => {
-    set({ selectedCharacter: character });
-  },
+      setCharacter: (character: CharacterType) => {
+        set({ selectedCharacter: character });
+      },
 
-  getConfig: () => {
-    return CHARACTER_CONFIGS[get().selectedCharacter];
-  },
+      getConfig: () => {
+        return CHARACTER_CONFIGS[get().selectedCharacter];
+      },
 
-  getMessage: (key: MessageKey) => {
-    return CHARACTER_CONFIGS[get().selectedCharacter].messages[key];
-  },
-}));
+      getMessage: (key: MessageKey) => {
+        return CHARACTER_CONFIGS[get().selectedCharacter].messages[key];
+      },
+    }),
+    {
+      name: 'character-storage',
+      partialize: (state) => ({ selectedCharacter: state.selectedCharacter }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- ZustandキャラクターストアにlocalStorage永続化を追加。キャラクター選択がページ遷移やリロードで維持される
- useFetcherにメモリキャッシュ機能を追加（stale-while-revalidate）。ページ遷移時にキャッシュデータを即表示し、裏で再取得する
- コンポーネントアンマウント時のstate更新を防止（レースコンディション対策）
- 全フックにcacheKeyを設定し、ダッシュボードのデータがキャラクター切替で0%/空にならないようにした

## Test plan
- [ ] キャラクターを変更してページ遷移しても選択が維持されること
- [ ] ダッシュボードのデータ（達成率、スケジュール、ユーザー名）がキャラクター切替で消えないこと
- [ ] ページリロード後もキャラクター選択が維持されること
- [ ] 全テスト通過（675/675）