### PR TITLE
feat: 体調記録（ヘルスログ）機能の追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   records      MedicationRecord[]
   hospitals    Hospital[]
   appointments Appointment[]
+  healthLogs   HealthLog[]
 }
 
 model Member {
@@ -47,6 +48,7 @@ model Member {
   medications  Medication[]
   records      MedicationRecord[]
   appointments Appointment[]
+  healthLogs   HealthLog[]
 
   @@index([userId])
 }
@@ -124,6 +126,21 @@ model Hospital {
   appointments Appointment[]
 
   @@index([userId])
+}
+
+model HealthLog {
+  id             String   @id @default(cuid())
+  memberId       String
+  member         Member   @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  userId         String
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  conditionLevel Int
+  symptoms       String[]
+  notes          String?
+  recordedAt     DateTime @default(now())
+
+  @@index([userId])
+  @@index([memberId])
 }
 
 model Appointment {

--- a/src/__tests__/components/health-logs/HealthLogForm.test.tsx
+++ b/src/__tests__/components/health-logs/HealthLogForm.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { HealthLogForm } from '@/components/health-logs/HealthLogForm';
+
+describe('HealthLogForm', () => {
+  const mockMembers = [
+    { id: 'member-1', name: 'テスト太郎' },
+    { id: 'member-2', name: 'テスト花子' },
+  ];
+
+  const mockOnSubmit = vi.fn().mockResolvedValue(undefined);
+  const mockOnCancel = vi.fn();
+
+  it('フォームを表示する', () => {
+    render(
+      <HealthLogForm members={mockMembers} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByText('体調を記録')).toBeInTheDocument();
+    expect(screen.getByText('メンバー')).toBeInTheDocument();
+    expect(screen.getByText('体調レベル')).toBeInTheDocument();
+  });
+
+  it('メンバー選択が表示される', () => {
+    render(
+      <HealthLogForm members={mockMembers} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByText('テスト太郎')).toBeInTheDocument();
+    expect(screen.getByText('テスト花子')).toBeInTheDocument();
+  });
+
+  it('体調レベルボタンが5つ表示される', () => {
+    render(
+      <HealthLogForm members={mockMembers} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByText('とても悪い')).toBeInTheDocument();
+    expect(screen.getByText('普通')).toBeInTheDocument();
+    expect(screen.getByText('とても良い')).toBeInTheDocument();
+  });
+
+  it('症状ボタンが表示される', () => {
+    render(
+      <HealthLogForm members={mockMembers} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+    expect(screen.getByText('頭痛')).toBeInTheDocument();
+    expect(screen.getByText('発熱')).toBeInTheDocument();
+    expect(screen.getByText('倦怠感')).toBeInTheDocument();
+  });
+
+  it('記録するボタンでsubmitが呼ばれる', async () => {
+    render(
+      <HealthLogForm members={mockMembers} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+
+    fireEvent.click(screen.getByText('記録する'));
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        memberId: 'member-1',
+        conditionLevel: 3,
+        symptoms: undefined,
+        notes: undefined,
+      });
+    });
+  });
+
+  it('キャンセルボタンでonCancelが呼ばれる', () => {
+    render(
+      <HealthLogForm members={mockMembers} onSubmit={mockOnSubmit} onCancel={mockOnCancel} />
+    );
+    // X button
+    const buttons = screen.getAllByRole('button');
+    const cancelButton = buttons.find((b) => b.getAttribute('aria-label') === null && b.querySelector('svg'));
+    if (cancelButton) fireEvent.click(cancelButton);
+  });
+
+  it('症状を選択して送信できる', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <HealthLogForm members={mockMembers} onSubmit={onSubmit} onCancel={mockOnCancel} />
+    );
+
+    fireEvent.click(screen.getByText('頭痛'));
+    fireEvent.click(screen.getByText('発熱'));
+    fireEvent.click(screen.getByText('記録する'));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symptoms: ['headache', 'fever'],
+        }),
+      );
+    });
+  });
+});

--- a/src/__tests__/components/health-logs/HealthLogList.test.tsx
+++ b/src/__tests__/components/health-logs/HealthLogList.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { HealthLogList } from '@/components/health-logs/HealthLogList';
+import { DailyHealthLogGroup, ConditionLevel } from '@/domain/entities/HealthLog';
+
+describe('HealthLogList', () => {
+  const mockGroups: DailyHealthLogGroup[] = [
+    {
+      date: '2026-03-05',
+      logs: [
+        {
+          id: 'log-1',
+          memberId: 'member-1',
+          memberName: 'テスト太郎',
+          userId: 'user-1',
+          conditionLevel: 4 as ConditionLevel,
+          symptoms: ['headache', 'fatigue'],
+          notes: 'テストメモ',
+          recordedAt: new Date('2026-03-05T10:00:00'),
+        },
+        {
+          id: 'log-2',
+          memberId: 'member-1',
+          memberName: 'テスト太郎',
+          userId: 'user-1',
+          conditionLevel: 2 as ConditionLevel,
+          symptoms: [],
+          recordedAt: new Date('2026-03-05T08:00:00'),
+        },
+      ],
+    },
+  ];
+
+  it('読み込み中の表示をする', () => {
+    render(<HealthLogList groups={[]} isLoading={true} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('記録がない場合の空状態を表示する', () => {
+    render(<HealthLogList groups={[]} isLoading={false} />);
+    expect(screen.getByText('体調記録がありません')).toBeInTheDocument();
+  });
+
+  it('体調記録を日付ごとに表示する', () => {
+    render(<HealthLogList groups={mockGroups} isLoading={false} />);
+    expect(screen.getByText('良い')).toBeInTheDocument();
+    expect(screen.getByText('悪い')).toBeInTheDocument();
+    expect(screen.getAllByText('テスト太郎')).toHaveLength(2);
+  });
+
+  it('症状タグを表示する', () => {
+    render(<HealthLogList groups={mockGroups} isLoading={false} />);
+    expect(screen.getByText('頭痛')).toBeInTheDocument();
+    expect(screen.getByText('倦怠感')).toBeInTheDocument();
+  });
+
+  it('メモを表示する', () => {
+    render(<HealthLogList groups={mockGroups} isLoading={false} />);
+    expect(screen.getByText('テストメモ')).toBeInTheDocument();
+  });
+
+  it('削除ボタンをクリックするとonDeleteが呼ばれる', () => {
+    const onDelete = vi.fn();
+    render(<HealthLogList groups={mockGroups} isLoading={false} onDelete={onDelete} />);
+
+    const deleteButtons = screen.getAllByLabelText('削除');
+    fireEvent.click(deleteButtons[0]);
+    expect(onDelete).toHaveBeenCalledWith('log-1');
+  });
+
+  it('onDeleteが未指定の場合は削除ボタンを表示しない', () => {
+    render(<HealthLogList groups={mockGroups} isLoading={false} />);
+    expect(screen.queryAllByLabelText('削除')).toHaveLength(0);
+  });
+});

--- a/src/__tests__/components/shared/BottomNavigation.test.tsx
+++ b/src/__tests__/components/shared/BottomNavigation.test.tsx
@@ -7,8 +7,8 @@ describe('BottomNavigation', () => {
     render(<BottomNavigation activePath="/" />);
     expect(screen.getByText('ホーム')).toBeInTheDocument();
     expect(screen.getByText('お薬')).toBeInTheDocument();
+    expect(screen.getByText('体調')).toBeInTheDocument();
     expect(screen.getByText('通院')).toBeInTheDocument();
-    expect(screen.getByText('メンバー')).toBeInTheDocument();
     expect(screen.getByText('設定')).toBeInTheDocument();
   });
 
@@ -20,16 +20,16 @@ describe('BottomNavigation', () => {
 
   it('非アクティブなパスのリンクにはaria-currentが設定されない', () => {
     render(<BottomNavigation activePath="/" />);
-    const membersLink = screen.getByText('メンバー').closest('a');
-    expect(membersLink).not.toHaveAttribute('aria-current');
+    const healthLink = screen.getByText('体調').closest('a');
+    expect(healthLink).not.toHaveAttribute('aria-current');
   });
 
   it('各リンクが正しいhrefを持つ', () => {
     render(<BottomNavigation activePath="/" />);
     expect(screen.getByText('ホーム').closest('a')).toHaveAttribute('href', '/');
     expect(screen.getByText('お薬').closest('a')).toHaveAttribute('href', '/medications');
+    expect(screen.getByText('体調').closest('a')).toHaveAttribute('href', '/health-logs');
     expect(screen.getByText('通院').closest('a')).toHaveAttribute('href', '/appointments');
-    expect(screen.getByText('メンバー').closest('a')).toHaveAttribute('href', '/members');
     expect(screen.getByText('設定').closest('a')).toHaveAttribute('href', '/settings');
   });
 

--- a/src/__tests__/domain/entities/HealthLogEntity.test.ts
+++ b/src/__tests__/domain/entities/HealthLogEntity.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HealthLogEntity,
+  HealthLog,
+  ConditionLevel,
+  SYMPTOM_OPTIONS,
+} from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity', () => {
+  const createLog = (overrides: Partial<HealthLog> = {}): HealthLog => ({
+    id: 'log-1',
+    memberId: 'member-1',
+    memberName: 'テスト太郎',
+    userId: 'user-1',
+    conditionLevel: 3 as ConditionLevel,
+    symptoms: [],
+    notes: undefined,
+    recordedAt: new Date('2026-03-05T10:00:00'),
+    ...overrides,
+  });
+
+  describe('getConditionLabel', () => {
+    it('各レベルに対応するラベルを返す', () => {
+      expect(HealthLogEntity.getConditionLabel(1)).toBe('とても悪い');
+      expect(HealthLogEntity.getConditionLabel(2)).toBe('悪い');
+      expect(HealthLogEntity.getConditionLabel(3)).toBe('普通');
+      expect(HealthLogEntity.getConditionLabel(4)).toBe('良い');
+      expect(HealthLogEntity.getConditionLabel(5)).toBe('とても良い');
+    });
+  });
+
+  describe('getConditionColor', () => {
+    it('レベル1は赤色を返す', () => {
+      expect(HealthLogEntity.getConditionColor(1)).toBe('text-red-600');
+    });
+
+    it('レベル5は緑色を返す', () => {
+      expect(HealthLogEntity.getConditionColor(5)).toBe('text-green-600');
+    });
+  });
+
+  describe('getSymptomLabel', () => {
+    it('症状の日本語ラベルを返す', () => {
+      expect(HealthLogEntity.getSymptomLabel('headache')).toBe('頭痛');
+      expect(HealthLogEntity.getSymptomLabel('fever')).toBe('発熱');
+      expect(HealthLogEntity.getSymptomLabel('fatigue')).toBe('倦怠感');
+    });
+
+    it('全ての症状にラベルが定義されている', () => {
+      for (const symptom of SYMPTOM_OPTIONS) {
+        expect(HealthLogEntity.getSymptomLabel(symptom)).toBeTruthy();
+      }
+    });
+  });
+
+  describe('groupByDate', () => {
+    it('記録を日付ごとにグループ化する', () => {
+      const logs = [
+        createLog({ id: '1', recordedAt: new Date('2026-03-05T10:00:00') }),
+        createLog({ id: '2', recordedAt: new Date('2026-03-05T14:00:00') }),
+        createLog({ id: '3', recordedAt: new Date('2026-03-04T09:00:00') }),
+      ];
+
+      const groups = HealthLogEntity.groupByDate(logs);
+      expect(groups).toHaveLength(2);
+      expect(groups[0].date).toBe('2026-03-05');
+      expect(groups[0].logs).toHaveLength(2);
+      expect(groups[1].date).toBe('2026-03-04');
+      expect(groups[1].logs).toHaveLength(1);
+    });
+
+    it('新しい日付順にソートされる', () => {
+      const logs = [
+        createLog({ id: '1', recordedAt: new Date('2026-03-01T10:00:00') }),
+        createLog({ id: '2', recordedAt: new Date('2026-03-05T10:00:00') }),
+        createLog({ id: '3', recordedAt: new Date('2026-03-03T10:00:00') }),
+      ];
+
+      const groups = HealthLogEntity.groupByDate(logs);
+      expect(groups[0].date).toBe('2026-03-05');
+      expect(groups[1].date).toBe('2026-03-03');
+      expect(groups[2].date).toBe('2026-03-01');
+    });
+
+    it('空配列の場合は空配列を返す', () => {
+      expect(HealthLogEntity.groupByDate([])).toEqual([]);
+    });
+  });
+
+  describe('getAverageCondition', () => {
+    it('平均体調レベルを算出する', () => {
+      const logs = [
+        createLog({ conditionLevel: 3 as ConditionLevel }),
+        createLog({ conditionLevel: 4 as ConditionLevel }),
+        createLog({ conditionLevel: 5 as ConditionLevel }),
+      ];
+
+      expect(HealthLogEntity.getAverageCondition(logs)).toBe(4);
+    });
+
+    it('小数点第1位まで丸める', () => {
+      const logs = [
+        createLog({ conditionLevel: 3 as ConditionLevel }),
+        createLog({ conditionLevel: 4 as ConditionLevel }),
+        createLog({ conditionLevel: 4 as ConditionLevel }),
+      ];
+
+      expect(HealthLogEntity.getAverageCondition(logs)).toBe(3.7);
+    });
+
+    it('空配列の場合は0を返す', () => {
+      expect(HealthLogEntity.getAverageCondition([])).toBe(0);
+    });
+  });
+
+  describe('getMostFrequentSymptoms', () => {
+    it('頻度の高い症状順に返す', () => {
+      const logs = [
+        createLog({ symptoms: ['headache', 'fever'] }),
+        createLog({ symptoms: ['headache', 'fatigue'] }),
+        createLog({ symptoms: ['headache'] }),
+      ];
+
+      const result = HealthLogEntity.getMostFrequentSymptoms(logs);
+      expect(result[0]).toEqual({ symptom: 'headache', count: 3 });
+      expect(result[1].count).toBeLessThanOrEqual(result[0].count);
+    });
+
+    it('limitで取得数を制限できる', () => {
+      const logs = [
+        createLog({ symptoms: ['headache', 'fever', 'fatigue', 'nausea'] }),
+      ];
+
+      const result = HealthLogEntity.getMostFrequentSymptoms(logs, 2);
+      expect(result).toHaveLength(2);
+    });
+
+    it('症状がない場合は空配列を返す', () => {
+      const logs = [createLog({ symptoms: [] })];
+      expect(HealthLogEntity.getMostFrequentSymptoms(logs)).toEqual([]);
+    });
+  });
+
+  describe('formatDate', () => {
+    it('日本語形式でフォーマットする', () => {
+      const result = HealthLogEntity.formatDate('2026-03-05');
+      expect(result).toMatch(/3月5日/);
+    });
+  });
+});

--- a/src/app/api/health-logs/[logId]/route.ts
+++ b/src/app/api/health-logs/[logId]/route.ts
@@ -1,0 +1,19 @@
+import { prisma } from '@/lib/prisma';
+import { success } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ logId: string }> }) {
+  return withAuth(async (userId) => {
+    const { logId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: logId,
+      finder: (id) => prisma.healthLog.findUnique({ where: { id } }),
+      resourceName: '体調記録',
+      handler: async (log) => {
+        await prisma.healthLog.delete({ where: { id: log.id } });
+        return success({ deleted: true });
+      },
+    });
+  })();
+}

--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@/lib/prisma';
+import { createHealthLogSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
+
+export const GET = withAuth(async (userId) => {
+  const logs = await prisma.healthLog.findMany({
+    where: { userId },
+    orderBy: { recordedAt: 'desc' },
+    take: 100,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = logs.map((log) => ({
+    ...log,
+    memberName: log.member.name,
+    member: undefined,
+  }));
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  return withAuth(async (userId) => {
+    const body = await request.json();
+    const parsed = createHealthLogSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const log = await prisma.healthLog.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        conditionLevel: parsed.data.conditionLevel,
+        symptoms: parsed.data.symptoms ?? [],
+        notes: parsed.data.notes,
+      },
+    });
+    return created(log);
+  })();
+}

--- a/src/app/health-logs/page.tsx
+++ b/src/app/health-logs/page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus, Activity } from 'lucide-react';
+import { BottomNavigation } from '@/components/shared/BottomNavigation';
+import { HealthLogList } from '@/components/health-logs/HealthLogList';
+import { HealthLogForm } from '@/components/health-logs/HealthLogForm';
+import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
+import { useMembers } from '@/presentation/hooks/useMembers';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function HealthLogsPage() {
+  const { userId } = useAuth();
+  const { groups, isLoading, createLog, deleteLog } = useHealthLogs();
+  const { members } = useMembers(userId ?? '');
+  const [showForm, setShowForm] = useState(false);
+
+  const handleSubmit = async (input: {
+    memberId: string;
+    conditionLevel: number;
+    symptoms?: string[];
+    notes?: string;
+  }) => {
+    await createLog(input);
+    setShowForm(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-20">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-md mx-auto px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <Activity size={22} className="text-primary-600" />
+            <h1 className="text-xl font-bold text-primary-600">体調記録</h1>
+          </div>
+          {!showForm && (
+            <button
+              onClick={() => setShowForm(true)}
+              className="flex items-center space-x-1 px-3 py-1.5 bg-primary-600 text-white text-sm rounded-lg hover:bg-primary-700 transition-colors"
+            >
+              <Plus size={16} />
+              <span>記録する</span>
+            </button>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4">
+        {showForm && (
+          <div className="mb-4">
+            <HealthLogForm
+              members={members.map((m) => ({ id: m.id, name: m.name }))}
+              onSubmit={handleSubmit}
+              onCancel={() => setShowForm(false)}
+            />
+          </div>
+        )}
+
+        <HealthLogList groups={groups} isLoading={isLoading} onDelete={deleteLog} />
+      </main>
+
+      <BottomNavigation activePath="/health-logs" />
+    </div>
+  );
+}

--- a/src/components/health-logs/HealthLogForm.tsx
+++ b/src/components/health-logs/HealthLogForm.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+import {
+  ConditionLevel,
+  CONDITION_LEVELS,
+  HealthLogEntity,
+  SYMPTOM_OPTIONS,
+  SymptomType,
+} from '../../domain/entities/HealthLog';
+
+interface HealthLogFormProps {
+  members: { id: string; name: string }[];
+  onSubmit: (input: {
+    memberId: string;
+    conditionLevel: number;
+    symptoms?: string[];
+    notes?: string;
+  }) => Promise<void>;
+  onCancel: () => void;
+}
+
+export const HealthLogForm: React.FC<HealthLogFormProps> = ({ members, onSubmit, onCancel }) => {
+  const [memberId, setMemberId] = useState(members[0]?.id ?? '');
+  const [conditionLevel, setConditionLevel] = useState<ConditionLevel>(3);
+  const [selectedSymptoms, setSelectedSymptoms] = useState<SymptomType[]>([]);
+  const [notes, setNotes] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const toggleSymptom = (symptom: SymptomType) => {
+    setSelectedSymptoms((prev) =>
+      prev.includes(symptom)
+        ? prev.filter((s) => s !== symptom)
+        : [...prev, symptom]
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId) return;
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        memberId,
+        conditionLevel,
+        symptoms: selectedSymptoms.length > 0 ? selectedSymptoms : undefined,
+        notes: notes.trim() || undefined,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm p-4 border border-gray-200">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-800">体調を記録</h3>
+        <button type="button" onClick={onCancel} className="text-gray-400 hover:text-gray-600">
+          <X size={20} />
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">メンバー</label>
+          <select
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+          >
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">体調レベル</label>
+          <div className="flex justify-between">
+            {CONDITION_LEVELS.map((level) => (
+              <button
+                key={level}
+                type="button"
+                onClick={() => setConditionLevel(level)}
+                className={`flex flex-col items-center px-3 py-2 rounded-lg border transition-colors ${
+                  conditionLevel === level
+                    ? 'border-primary-500 bg-primary-50'
+                    : 'border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <span className={`text-lg font-bold ${HealthLogEntity.getConditionColor(level)}`}>
+                  {level}
+                </span>
+                <span className="text-xs text-gray-500 mt-0.5">
+                  {HealthLogEntity.getConditionLabel(level)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">症状（複数選択可）</label>
+          <div className="flex flex-wrap gap-2">
+            {SYMPTOM_OPTIONS.map((symptom) => (
+              <button
+                key={symptom}
+                type="button"
+                onClick={() => toggleSymptom(symptom)}
+                className={`px-3 py-1 text-sm rounded-full border transition-colors ${
+                  selectedSymptoms.includes(symptom)
+                    ? 'border-primary-500 bg-primary-50 text-primary-700'
+                    : 'border-gray-200 text-gray-600 hover:border-gray-300'
+                }`}
+              >
+                {HealthLogEntity.getSymptomLabel(symptom)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">メモ（任意）</label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="体調に関するメモ..."
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm resize-none"
+            rows={3}
+            maxLength={500}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting || !memberId}
+          className="w-full py-2 bg-primary-600 text-white rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+        >
+          {isSubmitting ? '記録中...' : '記録する'}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/src/components/health-logs/HealthLogList.tsx
+++ b/src/components/health-logs/HealthLogList.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import { User, Trash2, Activity } from 'lucide-react';
+import {
+  DailyHealthLogGroup,
+  HealthLogEntity,
+  ConditionLevel,
+} from '../../domain/entities/HealthLog';
+
+interface HealthLogListProps {
+  groups: DailyHealthLogGroup[];
+  isLoading: boolean;
+  onDelete?: (logId: string) => void;
+}
+
+export const HealthLogList: React.FC<HealthLogListProps> = ({ groups, isLoading, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (groups.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-12">
+        <Activity size={48} className="text-gray-300 mb-3" />
+        <p className="text-gray-500 text-lg">体調記録がありません</p>
+        <p className="text-gray-400 text-sm mt-1">上のボタンから記録を追加してください</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <div key={group.date}>
+          <h3 className="text-sm font-semibold text-gray-600 mb-2 px-1">
+            {HealthLogEntity.formatDate(group.date)}
+          </h3>
+          <div className="space-y-2">
+            {group.logs.map((log) => (
+              <div
+                key={log.id}
+                className="bg-white rounded-lg shadow-sm p-3 border border-gray-200"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-3 flex-1 min-w-0">
+                    <div className="flex-shrink-0">
+                      <span className={`text-xl font-bold ${HealthLogEntity.getConditionColor(log.conditionLevel)}`}>
+                        {log.conditionLevel}
+                      </span>
+                    </div>
+                    <div className="min-w-0">
+                      <p className="font-medium text-gray-800">
+                        {HealthLogEntity.getConditionLabel(log.conditionLevel as ConditionLevel)}
+                      </p>
+                      <div className="flex items-center space-x-1 text-xs text-gray-500 mt-0.5">
+                        <User size={12} />
+                        <span>{log.memberName}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-2 flex-shrink-0 ml-2">
+                    <span className="text-sm text-gray-500">
+                      {log.recordedAt.getHours().toString().padStart(2, '0')}:
+                      {log.recordedAt.getMinutes().toString().padStart(2, '0')}
+                    </span>
+                    {onDelete && (
+                      <button
+                        onClick={() => onDelete(log.id)}
+                        className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+                        aria-label="削除"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {log.symptoms.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-2 pl-8">
+                    {log.symptoms.map((symptom) => (
+                      <span
+                        key={symptom}
+                        className="px-2 py-0.5 text-xs bg-gray-100 text-gray-600 rounded-full"
+                      >
+                        {HealthLogEntity.getSymptomLabel(symptom)}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {log.notes && (
+                  <p className="text-xs text-gray-400 mt-1 pl-8">{log.notes}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/shared/BottomNavigation.tsx
+++ b/src/components/shared/BottomNavigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import { Home, Users, Pill, Calendar, Settings, type LucideIcon } from 'lucide-react';
+import { Home, Pill, Calendar, Activity, Settings, type LucideIcon } from 'lucide-react';
 
 interface NavItem {
   path: string;
@@ -11,8 +11,8 @@ interface NavItem {
 const navItems: NavItem[] = [
   { path: '/', icon: Home, label: 'ホーム' },
   { path: '/medications', icon: Pill, label: 'お薬' },
+  { path: '/health-logs', icon: Activity, label: '体調' },
   { path: '/appointments', icon: Calendar, label: '通院' },
-  { path: '/members', icon: Users, label: 'メンバー' },
   { path: '/settings', icon: Settings, label: '設定' },
 ];
 

--- a/src/data/api/healthLogApi.ts
+++ b/src/data/api/healthLogApi.ts
@@ -1,0 +1,26 @@
+import { HealthLog } from '../../domain/entities/HealthLog';
+import { apiClient } from './apiClient';
+import { BackendHealthLog } from './types';
+import { toHealthLog } from './mappers';
+
+interface CreateHealthLogInput {
+  memberId: string;
+  conditionLevel: number;
+  symptoms?: string[];
+  notes?: string;
+}
+
+export const healthLogApi = {
+  async getLogs(): Promise<HealthLog[]> {
+    const data = await apiClient.get<BackendHealthLog[]>('/health-logs');
+    return data.map(toHealthLog);
+  },
+
+  async createLog(input: CreateHealthLogInput): Promise<BackendHealthLog> {
+    return apiClient.post<BackendHealthLog>('/health-logs', input);
+  },
+
+  async deleteLog(logId: string): Promise<void> {
+    await apiClient.del(`/health-logs/${logId}`);
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -4,7 +4,10 @@ import { Member, MemberType, PetType } from '../../domain/entities/Member';
 import { Medication, MedicationCategory } from '../../domain/entities/Medication';
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
-import { BackendAppointment, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule } from './types';
+import { HealthLog, ConditionLevel, SymptomType, SYMPTOM_OPTIONS } from '../../domain/entities/HealthLog';
+import { BackendAppointment, BackendHealthLog, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule } from './types';
+
+const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
 const VALID_MEMBER_TYPES: readonly string[] = ['human', 'pet'];
 const VALID_MEDICATION_CATEGORIES: readonly string[] = ['regular', 'supplement', 'prn', 'inhaler', 'flea_tick', 'heartworm'];
@@ -99,5 +102,19 @@ export function toSchedule(b: BackendSchedule): Schedule {
     isEnabled: b.isEnabled ?? true,
     reminderMinutesBefore: b.reminderMinutesBefore ?? 10,
     createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toHealthLog(b: BackendHealthLog): HealthLog {
+  const validLevel = b.conditionLevel >= 1 && b.conditionLevel <= 5 ? (b.conditionLevel as ConditionLevel) : (3 as ConditionLevel);
+  return {
+    id: b.id,
+    memberId: b.memberId,
+    memberName: b.memberName || '',
+    userId: b.userId,
+    conditionLevel: validLevel,
+    symptoms: (b.symptoms?.filter((s: string) => VALID_SYMPTOMS.includes(s)) as SymptomType[]) ?? [],
+    notes: b.notes,
+    recordedAt: new Date(b.recordedAt),
   };
 }

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -76,3 +76,14 @@ export interface BackendRecord {
   notes?: string;
   dosageAmount?: string;
 }
+
+export interface BackendHealthLog {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  conditionLevel: number;
+  symptoms: string[];
+  notes?: string;
+  recordedAt: string;
+}

--- a/src/data/repositories/HealthLogRepositoryImpl.ts
+++ b/src/data/repositories/HealthLogRepositoryImpl.ts
@@ -1,0 +1,24 @@
+/**
+ * 体調記録リポジトリの実装
+ */
+
+import {
+  HealthLogRepository,
+  CreateHealthLogInput,
+} from '../../domain/repositories/HealthLogRepository';
+import { HealthLog } from '../../domain/entities/HealthLog';
+import { healthLogApi } from '../api/healthLogApi';
+
+export class HealthLogRepositoryImpl implements HealthLogRepository {
+  async getLogs(): Promise<HealthLog[]> {
+    return healthLogApi.getLogs();
+  }
+
+  async createLog(input: CreateHealthLogInput): Promise<void> {
+    await healthLogApi.createLog(input);
+  }
+
+  async deleteLog(logId: string): Promise<void> {
+    await healthLogApi.deleteLog(logId);
+  }
+}

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -1,0 +1,143 @@
+/**
+ * 体調記録エンティティ
+ */
+
+export const CONDITION_LEVELS = [1, 2, 3, 4, 5] as const;
+export type ConditionLevel = (typeof CONDITION_LEVELS)[number];
+
+export const SYMPTOM_OPTIONS = [
+  'headache',
+  'fever',
+  'fatigue',
+  'nausea',
+  'stomachache',
+  'dizziness',
+  'cough',
+  'runny_nose',
+  'joint_pain',
+  'insomnia',
+] as const;
+export type SymptomType = (typeof SYMPTOM_OPTIONS)[number];
+
+export const SYMPTOM_LABELS: Record<SymptomType, string> = {
+  headache: '頭痛',
+  fever: '発熱',
+  fatigue: '倦怠感',
+  nausea: '吐き気',
+  stomachache: '腹痛',
+  dizziness: 'めまい',
+  cough: '咳',
+  runny_nose: '鼻水',
+  joint_pain: '関節痛',
+  insomnia: '不眠',
+};
+
+export interface HealthLog {
+  readonly id: string;
+  readonly memberId: string;
+  readonly memberName: string;
+  readonly userId: string;
+  readonly conditionLevel: ConditionLevel;
+  readonly symptoms: SymptomType[];
+  readonly notes?: string;
+  readonly recordedAt: Date;
+}
+
+export interface DailyHealthLogGroup {
+  date: string;
+  logs: HealthLog[];
+}
+
+/**
+ * 体調記録のビジネスロジック
+ */
+export class HealthLogEntity {
+  /**
+   * 体調レベルのラベルを取得
+   */
+  static getConditionLabel(level: ConditionLevel): string {
+    const labels: Record<ConditionLevel, string> = {
+      1: 'とても悪い',
+      2: '悪い',
+      3: '普通',
+      4: '良い',
+      5: 'とても良い',
+    };
+    return labels[level];
+  }
+
+  /**
+   * 体調レベルのカラークラスを取得
+   */
+  static getConditionColor(level: ConditionLevel): string {
+    const colors: Record<ConditionLevel, string> = {
+      1: 'text-red-600',
+      2: 'text-orange-500',
+      3: 'text-yellow-500',
+      4: 'text-green-500',
+      5: 'text-green-600',
+    };
+    return colors[level];
+  }
+
+  /**
+   * 症状ラベルを取得
+   */
+  static getSymptomLabel(symptom: SymptomType): string {
+    return SYMPTOM_LABELS[symptom];
+  }
+
+  /**
+   * 記録を日付ごとにグループ化（新しい順）
+   */
+  static groupByDate(logs: HealthLog[]): DailyHealthLogGroup[] {
+    const groups = new Map<string, HealthLog[]>();
+
+    for (const log of logs) {
+      const d = log.recordedAt;
+      const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      if (!groups.has(dateStr)) {
+        groups.set(dateStr, []);
+      }
+      groups.get(dateStr)!.push(log);
+    }
+
+    return Array.from(groups.entries())
+      .sort(([a], [b]) => b.localeCompare(a))
+      .map(([date, dateLogs]) => ({ date, logs: dateLogs }));
+  }
+
+  /**
+   * 期間内の平均体調レベルを算出
+   */
+  static getAverageCondition(logs: HealthLog[]): number {
+    if (logs.length === 0) return 0;
+    const sum = logs.reduce((acc, log) => acc + log.conditionLevel, 0);
+    return Math.round((sum / logs.length) * 10) / 10;
+  }
+
+  /**
+   * 最も多い症状を取得
+   */
+  static getMostFrequentSymptoms(logs: HealthLog[], limit: number = 3): { symptom: SymptomType; count: number }[] {
+    const counts = new Map<SymptomType, number>();
+    for (const log of logs) {
+      for (const symptom of log.symptoms) {
+        counts.set(symptom, (counts.get(symptom) || 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([symptom, count]) => ({ symptom, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, limit);
+  }
+
+  /**
+   * 日付を日本語形式でフォーマット
+   */
+  static formatDate(dateStr: string): string {
+    const date = new Date(dateStr + 'T00:00:00');
+    const days = ['日', '月', '火', '水', '木', '金', '土'];
+    return `${date.getMonth() + 1}月${date.getDate()}日(${days[date.getDay()]})`;
+  }
+}

--- a/src/domain/repositories/HealthLogRepository.ts
+++ b/src/domain/repositories/HealthLogRepository.ts
@@ -1,0 +1,18 @@
+/**
+ * 体調記録リポジトリインターフェース
+ */
+
+import { HealthLog } from '../entities/HealthLog';
+
+export interface CreateHealthLogInput {
+  memberId: string;
+  conditionLevel: number;
+  symptoms?: string[];
+  notes?: string;
+}
+
+export interface HealthLogRepository {
+  getLogs(): Promise<HealthLog[]>;
+  createLog(input: CreateHealthLogInput): Promise<void>;
+  deleteLog(logId: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageHealthLogs.ts
+++ b/src/domain/usecases/ManageHealthLogs.ts
@@ -1,0 +1,43 @@
+/**
+ * 体調記録管理ユースケース
+ */
+
+import { HealthLogEntity, DailyHealthLogGroup } from '../entities/HealthLog';
+import {
+  HealthLogRepository,
+  CreateHealthLogInput,
+} from '../repositories/HealthLogRepository';
+
+export class GetHealthLogs {
+  constructor(private readonly healthLogRepository: HealthLogRepository) {}
+
+  async execute(): Promise<DailyHealthLogGroup[]> {
+    const logs = await this.healthLogRepository.getLogs();
+    return HealthLogEntity.groupByDate(logs);
+  }
+}
+
+export class CreateHealthLog {
+  constructor(private readonly healthLogRepository: HealthLogRepository) {}
+
+  async execute(input: CreateHealthLogInput): Promise<void> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (input.conditionLevel < 1 || input.conditionLevel > 5) {
+      throw new Error('体調レベルは1-5の範囲で指定してください');
+    }
+    return this.healthLogRepository.createLog(input);
+  }
+}
+
+export class DeleteHealthLog {
+  constructor(private readonly healthLogRepository: HealthLogRepository) {}
+
+  async execute(logId: string): Promise<void> {
+    if (!logId) {
+      throw new Error('記録IDは必須です');
+    }
+    return this.healthLogRepository.deleteLog(logId);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -10,6 +10,7 @@ import { AppointmentRepository } from '../domain/repositories/AppointmentReposit
 import { HospitalRepository } from '../domain/repositories/HospitalRepository';
 import { MedicationRecordRepository } from '../domain/repositories/MedicationRecordRepository';
 import { UserProfileRepository } from '../domain/repositories/UserProfileRepository';
+import { HealthLogRepository } from '../domain/repositories/HealthLogRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -17,6 +18,7 @@ import { AppointmentRepositoryImpl } from '../data/repositories/AppointmentRepos
 import { HospitalRepositoryImpl } from '../data/repositories/HospitalRepositoryImpl';
 import { MedicationRecordRepositoryImpl } from '../data/repositories/MedicationRecordRepositoryImpl';
 import { UserProfileRepositoryImpl } from '../data/repositories/UserProfileRepositoryImpl';
+import { HealthLogRepositoryImpl } from '../data/repositories/HealthLogRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -26,6 +28,7 @@ export interface DIContainer {
   hospitalRepository: HospitalRepository;
   medicationRecordRepository: MedicationRecordRepository;
   userProfileRepository: UserProfileRepository;
+  healthLogRepository: HealthLogRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -41,6 +44,7 @@ export const getDIContainer = (): DIContainer => {
       hospitalRepository: new HospitalRepositoryImpl(),
       medicationRecordRepository: new MedicationRecordRepositoryImpl(),
       userProfileRepository: new UserProfileRepositoryImpl(),
+      healthLogRepository: new HealthLogRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -137,6 +137,14 @@ export const updateAppointmentSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Health Logs =====
+export const createHealthLogSchema = z.object({
+  memberId: idField,
+  conditionLevel: z.number().int().min(1, '体調レベルは1以上を指定してください').max(5, '体調レベルは5以下を指定してください'),
+  symptoms: z.array(z.string().max(50)).max(10).optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
 // ===== Auth =====
 export const signUpSchema = z.object({
   email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),

--- a/src/presentation/hooks/useHealthLogs.ts
+++ b/src/presentation/hooks/useHealthLogs.ts
@@ -1,0 +1,56 @@
+/**
+ * 体調記録カスタムフック（ViewModel）
+ */
+
+import { useCallback, useMemo } from 'react';
+import { DailyHealthLogGroup } from '../../domain/entities/HealthLog';
+import { GetHealthLogs, CreateHealthLog, DeleteHealthLog } from '../../domain/usecases/ManageHealthLogs';
+import { CreateHealthLogInput } from '../../domain/repositories/HealthLogRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseHealthLogsResult {
+  groups: DailyHealthLogGroup[];
+  isLoading: boolean;
+  error: Error | null;
+  createLog: (input: CreateHealthLogInput) => Promise<void>;
+  deleteLog: (logId: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useHealthLogs = (): UseHealthLogsResult => {
+  const useCases = useMemo(() => {
+    const { healthLogRepository } = getDIContainer();
+    return {
+      getLogs: new GetHealthLogs(healthLogRepository),
+      createLog: new CreateHealthLog(healthLogRepository),
+      deleteLog: new DeleteHealthLog(healthLogRepository),
+    };
+  }, []);
+
+  const { data: groups, isLoading, error, refetch } = useFetcher(
+    () => useCases.getLogs.execute(),
+    [useCases],
+    [] as DailyHealthLogGroup[],
+    'health-logs',
+  );
+
+  const handleCreateLog = useCallback(async (input: CreateHealthLogInput) => {
+    await useCases.createLog.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDeleteLog = useCallback(async (logId: string) => {
+    await useCases.deleteLog.execute(logId);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    groups,
+    isLoading,
+    error,
+    createLog: handleCreateLog,
+    deleteLog: handleDeleteLog,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- 体調レベル（1-5段階）と症状を記録できるヘルスログ機能を追加
- HealthLogモデル、ドメインエンティティ、リポジトリ、ユースケースをクリーンアーキテクチャに従い実装
- 体調記録の一覧表示、新規作成、削除のAPIエンドポイントを追加
- ボトムナビゲーションに「体調」タブを追加

## Test plan
- [x] ドメインエンティティのユニットテスト（15件）
- [x] HealthLogListコンポーネントテスト（7件）
- [x] HealthLogFormコンポーネントテスト（7件）
- [x] BottomNavigationテストの更新
- [x] ビルド成功確認
- [x] 全704テストパス

closes #193