### PR TITLE
feat: 服薬履歴にカレンダービューを追加

### DIFF
--- a/src/__tests__/components/history/MedicationCalendar.test.tsx
+++ b/src/__tests__/components/history/MedicationCalendar.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MedicationCalendar } from '@/components/history/MedicationCalendar';
+import { MedicationRecord } from '@/domain/entities/MedicationRecord';
+import { HealthLog, ConditionLevel } from '@/domain/entities/HealthLog';
+
+describe('MedicationCalendar', () => {
+  const mockRecords: MedicationRecord[] = [
+    {
+      id: 'r1',
+      memberId: 'm1',
+      memberName: 'テスト太郎',
+      medicationId: 'med1',
+      medicationName: '薬A',
+      userId: 'u1',
+      takenAt: new Date('2026-03-05T10:00:00'),
+    },
+    {
+      id: 'r2',
+      memberId: 'm1',
+      memberName: 'テスト太郎',
+      medicationId: 'med2',
+      medicationName: '薬B',
+      userId: 'u1',
+      takenAt: new Date('2026-03-05T14:00:00'),
+    },
+  ];
+
+  const mockHealthLogs: HealthLog[] = [
+    {
+      id: 'h1',
+      memberId: 'm1',
+      memberName: 'テスト太郎',
+      userId: 'u1',
+      conditionLevel: 4 as ConditionLevel,
+      symptoms: [],
+      recordedAt: new Date('2026-03-05T10:00:00'),
+    },
+  ];
+
+  const defaultProps = {
+    records: mockRecords,
+    healthLogs: mockHealthLogs,
+    onSelectDate: vi.fn(),
+    selectedDate: null,
+  };
+
+  it('月名を表示する', () => {
+    render(<MedicationCalendar {...defaultProps} />);
+    // 現在の月が表示される
+    const now = new Date();
+    const expectedLabel = `${now.getFullYear()}年${now.getMonth() + 1}月`;
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+
+  it('曜日ヘッダーを表示する', () => {
+    render(<MedicationCalendar {...defaultProps} />);
+    expect(screen.getByText('日')).toBeInTheDocument();
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('土')).toBeInTheDocument();
+  });
+
+  it('前月・翌月ボタンが表示される', () => {
+    render(<MedicationCalendar {...defaultProps} />);
+    expect(screen.getByLabelText('前月')).toBeInTheDocument();
+    expect(screen.getByLabelText('翌月')).toBeInTheDocument();
+  });
+
+  it('前月ボタンをクリックすると月が変わる', () => {
+    render(<MedicationCalendar {...defaultProps} />);
+    const now = new Date();
+    fireEvent.click(screen.getByLabelText('前月'));
+
+    const prevMonth = now.getMonth() === 0 ? 12 : now.getMonth();
+    const prevYear = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear();
+    const expectedLabel = `${prevYear}年${prevMonth}月`;
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+
+  it('翌月ボタンをクリックすると月が変わる', () => {
+    render(<MedicationCalendar {...defaultProps} />);
+    const now = new Date();
+    fireEvent.click(screen.getByLabelText('翌月'));
+
+    const nextMonth = now.getMonth() === 11 ? 1 : now.getMonth() + 2;
+    const nextYear = now.getMonth() === 11 ? now.getFullYear() + 1 : now.getFullYear();
+    const expectedLabel = `${nextYear}年${nextMonth}月`;
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+
+  it('日付をクリックするとonSelectDateが呼ばれる', () => {
+    const onSelectDate = vi.fn();
+    render(<MedicationCalendar {...defaultProps} onSelectDate={onSelectDate} />);
+
+    // 1日目のボタンをクリック
+    const dayButtons = screen.getAllByRole('button').filter((b) => !b.getAttribute('aria-label'));
+    if (dayButtons.length > 0) {
+      fireEvent.click(dayButtons[0]);
+      expect(onSelectDate).toHaveBeenCalled();
+    }
+  });
+
+  it('凡例が表示される', () => {
+    render(<MedicationCalendar {...defaultProps} />);
+    expect(screen.getByText('1-2件')).toBeInTheDocument();
+    expect(screen.getByText('3-5件')).toBeInTheDocument();
+    expect(screen.getByText('6件+')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/domain/entities/CalendarEntity.test.ts
+++ b/src/__tests__/domain/entities/CalendarEntity.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity', () => {
+  const fixedToday = new Date('2026-03-05T00:00:00');
+
+  describe('generateMonth', () => {
+    it('42日分のカレンダーデータを生成する', () => {
+      const days = CalendarEntity.generateMonth(2026, 2, fixedToday); // 3月 (0-indexed: 2)
+      expect(days).toHaveLength(42);
+    });
+
+    it('当月の日はisCurrentMonth=trueになる', () => {
+      const days = CalendarEntity.generateMonth(2026, 2, fixedToday);
+      const currentMonthDays = days.filter((d) => d.isCurrentMonth);
+      expect(currentMonthDays).toHaveLength(31); // 2026年3月は31日
+    });
+
+    it('今日の日付はisToday=trueになる', () => {
+      const days = CalendarEntity.generateMonth(2026, 2, fixedToday);
+      const todayDays = days.filter((d) => d.isToday);
+      expect(todayDays).toHaveLength(1);
+      expect(todayDays[0].date.getDate()).toBe(5);
+    });
+
+    it('前月の日が含まれる', () => {
+      const days = CalendarEntity.generateMonth(2026, 2, fixedToday);
+      const prevMonthDays = days.filter((d) => !d.isCurrentMonth && d.date.getMonth() === 1);
+      expect(prevMonthDays.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('全ての日のrecordCountが0で初期化される', () => {
+      const days = CalendarEntity.generateMonth(2026, 2, fixedToday);
+      expect(days.every((d) => d.recordCount === 0)).toBe(true);
+    });
+  });
+
+  describe('isSameDay', () => {
+    it('同じ日付ならtrueを返す', () => {
+      const a = new Date('2026-03-05T10:00:00');
+      const b = new Date('2026-03-05T15:00:00');
+      expect(CalendarEntity.isSameDay(a, b)).toBe(true);
+    });
+
+    it('異なる日付ならfalseを返す', () => {
+      const a = new Date('2026-03-05');
+      const b = new Date('2026-03-06');
+      expect(CalendarEntity.isSameDay(a, b)).toBe(false);
+    });
+  });
+
+  describe('getMonthLabel', () => {
+    it('日本語の月名を返す', () => {
+      expect(CalendarEntity.getMonthLabel(2026, 2)).toBe('2026年3月');
+      expect(CalendarEntity.getMonthLabel(2026, 0)).toBe('2026年1月');
+      expect(CalendarEntity.getMonthLabel(2026, 11)).toBe('2026年12月');
+    });
+  });
+
+  describe('getWeekdayHeaders', () => {
+    it('7日分の曜日を返す', () => {
+      const headers = CalendarEntity.getWeekdayHeaders();
+      expect(headers).toHaveLength(7);
+      expect(headers[0]).toBe('日');
+      expect(headers[6]).toBe('土');
+    });
+  });
+
+  describe('getPreviousMonth', () => {
+    it('前月を返す', () => {
+      expect(CalendarEntity.getPreviousMonth(2026, 2)).toEqual({ year: 2026, month: 1 });
+    });
+
+    it('1月の前月は前年12月', () => {
+      expect(CalendarEntity.getPreviousMonth(2026, 0)).toEqual({ year: 2025, month: 11 });
+    });
+  });
+
+  describe('getNextMonth', () => {
+    it('翌月を返す', () => {
+      expect(CalendarEntity.getNextMonth(2026, 2)).toEqual({ year: 2026, month: 3 });
+    });
+
+    it('12月の翌月は翌年1月', () => {
+      expect(CalendarEntity.getNextMonth(2026, 11)).toEqual({ year: 2027, month: 0 });
+    });
+  });
+
+  describe('getRecordCountColor', () => {
+    it('0件は空文字を返す', () => {
+      expect(CalendarEntity.getRecordCountColor(0)).toBe('');
+    });
+
+    it('1-2件は薄い緑', () => {
+      expect(CalendarEntity.getRecordCountColor(1)).toBe('bg-green-100');
+      expect(CalendarEntity.getRecordCountColor(2)).toBe('bg-green-100');
+    });
+
+    it('3-5件は中間の緑', () => {
+      expect(CalendarEntity.getRecordCountColor(3)).toBe('bg-green-200');
+    });
+
+    it('6件以上は濃い緑', () => {
+      expect(CalendarEntity.getRecordCountColor(6)).toBe('bg-green-300');
+    });
+  });
+
+  describe('getConditionColor', () => {
+    it('nullは空文字を返す', () => {
+      expect(CalendarEntity.getConditionColor(null)).toBe('');
+    });
+
+    it('レベル4以上は緑', () => {
+      expect(CalendarEntity.getConditionColor(4)).toBe('bg-green-100');
+    });
+
+    it('レベル3は黄色', () => {
+      expect(CalendarEntity.getConditionColor(3)).toBe('bg-yellow-100');
+    });
+
+    it('レベル2はオレンジ', () => {
+      expect(CalendarEntity.getConditionColor(2)).toBe('bg-orange-100');
+    });
+
+    it('レベル1は赤', () => {
+      expect(CalendarEntity.getConditionColor(1)).toBe('bg-red-100');
+    });
+  });
+
+  describe('formatDateKey', () => {
+    it('日付をYYYY-MM-DD形式に変換する', () => {
+      expect(CalendarEntity.formatDateKey(new Date(2026, 2, 5))).toBe('2026-03-05');
+      expect(CalendarEntity.formatDateKey(new Date(2026, 0, 1))).toBe('2026-01-01');
+    });
+  });
+});

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,22 +1,108 @@
 'use client';
 
+import { useState, useMemo } from 'react';
+import { Calendar, List } from 'lucide-react';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { MedicationHistoryList } from '@/components/history/MedicationHistoryList';
+import { MedicationCalendar } from '@/components/history/MedicationCalendar';
 import { useMedicationHistory } from '@/presentation/hooks/useMedicationHistory';
+import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+type ViewMode = 'list' | 'calendar';
 
 export default function HistoryPage() {
   const { groups, isLoading, deleteRecord } = useMedicationHistory();
+  const { groups: healthLogGroups } = useHealthLogs();
+  const [viewMode, setViewMode] = useState<ViewMode>('calendar');
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  // groupsからフラットなレコード配列を取得
+  const allRecords = useMemo(
+    () => groups.flatMap((g) => g.records),
+    [groups],
+  );
+
+  // groupsからフラットな体調記録配列を取得
+  const allHealthLogs = useMemo(
+    () => healthLogGroups.flatMap((g) => g.logs),
+    [healthLogGroups],
+  );
+
+  // 選択日のレコードをフィルタリング
+  const filteredGroups = useMemo(() => {
+    if (!selectedDate) return groups;
+    const filtered = groups
+      .map((g) => ({
+        ...g,
+        records: g.records.filter((r) => {
+          const d = r.takenAt;
+          const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+          return key === selectedDate;
+        }),
+      }))
+      .filter((g) => g.records.length > 0);
+    return filtered;
+  }, [groups, selectedDate]);
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
       <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-md mx-auto px-4 py-3">
+        <div className="max-w-md mx-auto px-4 py-3 flex items-center justify-between">
           <h1 className="text-xl font-bold text-primary-600">服薬履歴</h1>
+          <div className="flex items-center space-x-1 bg-gray-100 rounded-lg p-0.5">
+            <button
+              onClick={() => setViewMode('calendar')}
+              className={`p-1.5 rounded-md transition-colors ${
+                viewMode === 'calendar' ? 'bg-white shadow-sm text-primary-600' : 'text-gray-500'
+              }`}
+              aria-label="カレンダー表示"
+            >
+              <Calendar size={18} />
+            </button>
+            <button
+              onClick={() => { setViewMode('list'); setSelectedDate(null); }}
+              className={`p-1.5 rounded-md transition-colors ${
+                viewMode === 'list' ? 'bg-white shadow-sm text-primary-600' : 'text-gray-500'
+              }`}
+              aria-label="リスト表示"
+            >
+              <List size={18} />
+            </button>
+          </div>
         </div>
       </header>
 
       <main className="max-w-md mx-auto px-4 py-4">
-        <MedicationHistoryList groups={groups} isLoading={isLoading} onDelete={deleteRecord} />
+        {viewMode === 'calendar' ? (
+          <div className="space-y-4">
+            <MedicationCalendar
+              records={allRecords}
+              healthLogs={allHealthLogs}
+              onSelectDate={(dateKey) => setSelectedDate(dateKey === selectedDate ? null : dateKey)}
+              selectedDate={selectedDate}
+            />
+            {selectedDate && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-600 mb-2">
+                  {MedicationRecordEntity.formatDate(selectedDate)} の記録
+                </h3>
+                <MedicationHistoryList
+                  groups={filteredGroups}
+                  isLoading={isLoading}
+                  onDelete={deleteRecord}
+                />
+              </div>
+            )}
+            {!selectedDate && (
+              <p className="text-center text-sm text-gray-400 py-2">
+                日付をタップして詳細を表示
+              </p>
+            )}
+          </div>
+        ) : (
+          <MedicationHistoryList groups={groups} isLoading={isLoading} onDelete={deleteRecord} />
+        )}
       </main>
 
       <BottomNavigation activePath="/history" />

--- a/src/components/history/MedicationCalendar.tsx
+++ b/src/components/history/MedicationCalendar.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { CalendarEntity, CalendarDay } from '../../domain/entities/Calendar';
+import { MedicationRecord } from '../../domain/entities/MedicationRecord';
+import { HealthLog } from '../../domain/entities/HealthLog';
+
+interface MedicationCalendarProps {
+  records: MedicationRecord[];
+  healthLogs: HealthLog[];
+  onSelectDate: (dateKey: string) => void;
+  selectedDate: string | null;
+}
+
+export const MedicationCalendar: React.FC<MedicationCalendarProps> = ({
+  records,
+  healthLogs,
+  onSelectDate,
+  selectedDate,
+}) => {
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth());
+
+  const days = useMemo(() => {
+    const baseDays = CalendarEntity.generateMonth(year, month, today);
+
+    // 記録件数をマッピング
+    const recordCounts = new Map<string, number>();
+    for (const record of records) {
+      const key = CalendarEntity.formatDateKey(record.takenAt);
+      recordCounts.set(key, (recordCounts.get(key) || 0) + 1);
+    }
+
+    // 体調レベルをマッピング
+    const conditionMap = new Map<string, number[]>();
+    for (const log of healthLogs) {
+      const key = CalendarEntity.formatDateKey(log.recordedAt);
+      if (!conditionMap.has(key)) conditionMap.set(key, []);
+      conditionMap.get(key)!.push(log.conditionLevel);
+    }
+
+    return baseDays.map((day) => {
+      const key = CalendarEntity.formatDateKey(day.date);
+      const conditions = conditionMap.get(key);
+      return {
+        ...day,
+        recordCount: recordCounts.get(key) || 0,
+        averageCondition: conditions
+          ? Math.round((conditions.reduce((a, b) => a + b, 0) / conditions.length) * 10) / 10
+          : null,
+      };
+    });
+  }, [year, month, records, healthLogs, today]);
+
+  const handlePrevMonth = () => {
+    const prev = CalendarEntity.getPreviousMonth(year, month);
+    setYear(prev.year);
+    setMonth(prev.month);
+  };
+
+  const handleNextMonth = () => {
+    const next = CalendarEntity.getNextMonth(year, month);
+    setYear(next.year);
+    setMonth(next.month);
+  };
+
+  const weekdays = CalendarEntity.getWeekdayHeaders();
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={handlePrevMonth}
+          className="p-1 text-gray-500 hover:text-gray-700 transition-colors"
+          aria-label="前月"
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <h3 className="text-base font-semibold text-gray-800">
+          {CalendarEntity.getMonthLabel(year, month)}
+        </h3>
+        <button
+          onClick={handleNextMonth}
+          className="p-1 text-gray-500 hover:text-gray-700 transition-colors"
+          aria-label="翌月"
+        >
+          <ChevronRight size={20} />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-7 gap-0.5 mb-1">
+        {weekdays.map((day, i) => (
+          <div
+            key={day}
+            className={`text-center text-xs font-medium py-1 ${
+              i === 0 ? 'text-red-400' : i === 6 ? 'text-blue-400' : 'text-gray-500'
+            }`}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-0.5">
+        {days.map((day, index) => (
+          <CalendarDayCell
+            key={index}
+            day={day}
+            isSelected={selectedDate === CalendarEntity.formatDateKey(day.date)}
+            onClick={() => onSelectDate(CalendarEntity.formatDateKey(day.date))}
+          />
+        ))}
+      </div>
+
+      <div className="flex items-center justify-center space-x-4 mt-3 text-xs text-gray-500">
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-sm bg-green-100" />
+          <span>1-2件</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-sm bg-green-200" />
+          <span>3-5件</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-sm bg-green-300" />
+          <span>6件+</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface CalendarDayCellProps {
+  day: CalendarDay;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const CalendarDayCell: React.FC<CalendarDayCellProps> = ({ day, isSelected, onClick }) => {
+  const bgColor = CalendarEntity.getRecordCountColor(day.recordCount);
+  const dayOfWeek = day.date.getDay();
+
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        relative aspect-square flex flex-col items-center justify-center
+        text-sm rounded-md transition-colors
+        ${day.isCurrentMonth ? 'text-gray-800' : 'text-gray-300'}
+        ${day.isToday ? 'ring-2 ring-primary-500' : ''}
+        ${isSelected ? 'bg-primary-100 ring-2 ring-primary-600' : bgColor || 'hover:bg-gray-50'}
+        ${dayOfWeek === 0 && day.isCurrentMonth ? 'text-red-500' : ''}
+        ${dayOfWeek === 6 && day.isCurrentMonth ? 'text-blue-500' : ''}
+      `}
+    >
+      <span className="leading-none">{day.date.getDate()}</span>
+      {day.recordCount > 0 && day.isCurrentMonth && (
+        <span className="text-[10px] text-gray-500 leading-none mt-0.5">
+          {day.recordCount}
+        </span>
+      )}
+    </button>
+  );
+};

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -1,0 +1,143 @@
+/**
+ * カレンダーユーティリティ
+ */
+
+export interface CalendarDay {
+  date: Date;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  recordCount: number;
+  averageCondition: number | null;
+}
+
+export interface CalendarMonth {
+  year: number;
+  month: number;
+  days: CalendarDay[];
+}
+
+export class CalendarEntity {
+  /**
+   * 指定月のカレンダーデータを生成
+   * 前月末・翌月初の日も含めて6週分を生成
+   */
+  static generateMonth(year: number, month: number, today: Date = new Date()): CalendarDay[] {
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+
+    // 日曜始まりのカレンダー
+    const startOffset = firstDay.getDay();
+    const days: CalendarDay[] = [];
+
+    // 前月の日を追加
+    for (let i = startOffset - 1; i >= 0; i--) {
+      const date = new Date(year, month, -i);
+      days.push({
+        date,
+        isCurrentMonth: false,
+        isToday: CalendarEntity.isSameDay(date, today),
+        recordCount: 0,
+        averageCondition: null,
+      });
+    }
+
+    // 当月の日を追加
+    for (let d = 1; d <= lastDay.getDate(); d++) {
+      const date = new Date(year, month, d);
+      days.push({
+        date,
+        isCurrentMonth: true,
+        isToday: CalendarEntity.isSameDay(date, today),
+        recordCount: 0,
+        averageCondition: null,
+      });
+    }
+
+    // 翌月の日を追加（6週分に揃える）
+    const remaining = 42 - days.length;
+    for (let i = 1; i <= remaining; i++) {
+      const date = new Date(year, month + 1, i);
+      days.push({
+        date,
+        isCurrentMonth: false,
+        isToday: CalendarEntity.isSameDay(date, today),
+        recordCount: 0,
+        averageCondition: null,
+      });
+    }
+
+    return days;
+  }
+
+  /**
+   * 同じ日かどうかを判定
+   */
+  static isSameDay(a: Date, b: Date): boolean {
+    return (
+      a.getFullYear() === b.getFullYear() &&
+      a.getMonth() === b.getMonth() &&
+      a.getDate() === b.getDate()
+    );
+  }
+
+  /**
+   * 月名を日本語で取得
+   */
+  static getMonthLabel(year: number, month: number): string {
+    return `${year}年${month + 1}月`;
+  }
+
+  /**
+   * 曜日ヘッダーを取得
+   */
+  static getWeekdayHeaders(): string[] {
+    return ['日', '月', '火', '水', '木', '金', '土'];
+  }
+
+  /**
+   * 前月のyear, monthを取得
+   */
+  static getPreviousMonth(year: number, month: number): { year: number; month: number } {
+    if (month === 0) return { year: year - 1, month: 11 };
+    return { year, month: month - 1 };
+  }
+
+  /**
+   * 翌月のyear, monthを取得
+   */
+  static getNextMonth(year: number, month: number): { year: number; month: number } {
+    if (month === 11) return { year: year + 1, month: 0 };
+    return { year, month: month + 1 };
+  }
+
+  /**
+   * 服薬件数に応じた背景色クラスを取得
+   */
+  static getRecordCountColor(count: number): string {
+    if (count === 0) return '';
+    if (count <= 2) return 'bg-green-100';
+    if (count <= 5) return 'bg-green-200';
+    return 'bg-green-300';
+  }
+
+  /**
+   * 体調レベルに応じた背景色クラスを取得
+   */
+  static getConditionColor(level: number | null): string {
+    if (level === null) return '';
+    if (level >= 4) return 'bg-green-100';
+    if (level >= 3) return 'bg-yellow-100';
+    if (level >= 2) return 'bg-orange-100';
+    return 'bg-red-100';
+  }
+
+  /**
+   * 日付をYYYY-MM-DD形式に変換
+   */
+  static formatDateKey(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+}


### PR DESCRIPTION
## Summary
- 服薬履歴ページにカレンダー形式の表示機能を追加
- 日毎の服薬件数を色の濃さで視覚化
- カレンダー/リスト表示の切り替えUI
- 日付タップで該当日の服薬記録を表示

## Test plan
- [x] CalendarEntityのユニットテスト（23件）
- [x] MedicationCalendarコンポーネントテスト（7件）
- [x] ビルド成功確認
- [x] 全734テストパス

closes #195