### PR TITLE
refactor: APIルートからビジネスロジックをドメイン層に抽出

### DIFF
--- a/src/__tests__/domain/entities/AdherenceStats.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStats.test.ts
@@ -33,6 +33,52 @@ describe('AdherenceStatsEntity', () => {
     });
   });
 
+  describe('getActiveDaysCount', () => {
+    it('空配列は7を返す（毎日）', () => {
+      expect(AdherenceStatsEntity.getActiveDaysCount([])).toBe(7);
+    });
+
+    it('指定された曜日数を返す', () => {
+      expect(AdherenceStatsEntity.getActiveDaysCount(['mon', 'wed', 'fri'])).toBe(3);
+    });
+  });
+
+  describe('calculateWeeklyExpected', () => {
+    it('週間期待数を正しく算出する', () => {
+      const schedules = [
+        { daysOfWeek: ['mon', 'wed', 'fri'] },
+        { daysOfWeek: [] },
+      ];
+      expect(AdherenceStatsEntity.calculateWeeklyExpected(schedules)).toBe(10);
+    });
+
+    it('空配列の場合0を返す', () => {
+      expect(AdherenceStatsEntity.calculateWeeklyExpected([])).toBe(0);
+    });
+  });
+
+  describe('calculateMonthlyExpected', () => {
+    it('月間期待数を正しく算出する', () => {
+      const schedules = [{ daysOfWeek: [] }]; // 毎日 = 7日/週
+      const expected = Math.round(7 * (30 / 7));
+      expect(AdherenceStatsEntity.calculateMonthlyExpected(schedules)).toBe(expected);
+    });
+  });
+
+  describe('calculateRate', () => {
+    it('遵守率を正しく算出する', () => {
+      expect(AdherenceStatsEntity.calculateRate(7, 10)).toBe(70);
+    });
+
+    it('100%を超えない', () => {
+      expect(AdherenceStatsEntity.calculateRate(15, 10)).toBe(100);
+    });
+
+    it('期待値0の場合は0を返す', () => {
+      expect(AdherenceStatsEntity.calculateRate(5, 0)).toBe(0);
+    });
+  });
+
   describe('data', () => {
     it('統計データにアクセスできる', () => {
       const stats = {

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
@@ -35,32 +36,22 @@ export const GET = withAuth(async (userId) => {
     }),
   ]);
 
-  // 1週間のスケジュール数を計算（各スケジュールの有効曜日数）
-  // daysOfWeekが空配列の場合は毎日（7日）として計算
-  const getActiveDays = (daysOfWeek: string[]) => daysOfWeek.length === 0 ? 7 : daysOfWeek.length;
+  const weeklyExpected = AdherenceStatsEntity.calculateWeeklyExpected(schedules);
+  const monthlyExpected = AdherenceStatsEntity.calculateMonthlyExpected(schedules);
 
-  const weeklyExpected = schedules.reduce((sum, s) => sum + Math.min(getActiveDays(s.daysOfWeek), 7), 0);
-  const monthlyExpected = schedules.reduce((sum, s) => {
-    const daysPerWeek = getActiveDays(s.daysOfWeek);
-    return sum + Math.round(daysPerWeek * (30 / 7));
-  }, 0);
-
-  // メンバー別の統計
   const memberStats = members.map((member) => {
     const memberSchedules = schedules.filter((s) => s.memberId === member.id);
     const memberWeekly = weeklyRecords.filter((r) => r.memberId === member.id);
     const memberMonthly = monthlyRecords.filter((r) => r.memberId === member.id);
 
-    const expected7 = memberSchedules.reduce((sum, s) => sum + Math.min(getActiveDays(s.daysOfWeek), 7), 0);
-    const expected30 = memberSchedules.reduce((sum, s) => {
-      return sum + Math.round(getActiveDays(s.daysOfWeek) * (30 / 7));
-    }, 0);
+    const expected7 = AdherenceStatsEntity.calculateWeeklyExpected(memberSchedules);
+    const expected30 = AdherenceStatsEntity.calculateMonthlyExpected(memberSchedules);
 
     return {
       memberId: member.id,
       memberName: member.name,
-      weeklyRate: expected7 > 0 ? Math.min(100, Math.round((memberWeekly.length / expected7) * 100)) : 0,
-      monthlyRate: expected30 > 0 ? Math.min(100, Math.round((memberMonthly.length / expected30) * 100)) : 0,
+      weeklyRate: AdherenceStatsEntity.calculateRate(memberWeekly.length, expected7),
+      monthlyRate: AdherenceStatsEntity.calculateRate(memberMonthly.length, expected30),
       weeklyCount: memberWeekly.length,
       monthlyCount: memberMonthly.length,
     };
@@ -68,8 +59,8 @@ export const GET = withAuth(async (userId) => {
 
   return success({
     overall: {
-      weeklyRate: weeklyExpected > 0 ? Math.min(100, Math.round((weeklyRecords.length / weeklyExpected) * 100)) : 0,
-      monthlyRate: monthlyExpected > 0 ? Math.min(100, Math.round((monthlyRecords.length / monthlyExpected) * 100)) : 0,
+      weeklyRate: AdherenceStatsEntity.calculateRate(weeklyRecords.length, weeklyExpected),
+      monthlyRate: AdherenceStatsEntity.calculateRate(monthlyRecords.length, monthlyExpected),
       weeklyCount: weeklyRecords.length,
       monthlyCount: monthlyRecords.length,
     },

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
 import { DAY_LABELS_JP } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
@@ -26,14 +27,12 @@ export const GET = withAuth(async (userId) => {
     }),
   ]);
 
-  // 英語の曜日名からJavaScript Date.getDay()のインデックスへの変換
   const dayToIndex: Record<string, number> = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
 
-  // 曜日別の期待数（スケジュールから）
+  // 曜日別の期待数
   const expectedByDay = new Array(7).fill(0);
   for (const schedule of schedules) {
     if (schedule.daysOfWeek.length === 0) {
-      // 空配列は毎日有効
       for (let i = 0; i < 7; i++) expectedByDay[i] += 1;
     } else {
       for (const day of schedule.daysOfWeek) {
@@ -43,7 +42,6 @@ export const GET = withAuth(async (userId) => {
     }
   }
 
-  // 直近7日の曜日別実績
   const currentByDay = new Array(7).fill(0);
   const previousByDay = new Array(7).fill(0);
 
@@ -61,10 +59,9 @@ export const GET = withAuth(async (userId) => {
     dayLabel: label,
     count: currentByDay[i],
     expected: expectedByDay[i],
-    rate: expectedByDay[i] > 0 ? Math.min(100, Math.round((currentByDay[i] / expectedByDay[i]) * 100)) : 0,
+    rate: AdherenceStatsEntity.calculateRate(currentByDay[i], expectedByDay[i]),
   }));
 
-  // ベスト/ワーストの曜日（期待値のある曜日のみ）
   const activeDays = dayOfWeekStats.filter((d) => d.expected > 0);
   const bestDay = activeDays.length > 0
     ? activeDays.reduce((a, b) => (a.rate >= b.rate ? a : b)).dayLabel
@@ -73,13 +70,12 @@ export const GET = withAuth(async (userId) => {
     ? activeDays.reduce((a, b) => (a.rate <= b.rate ? a : b)).dayLabel
     : '-';
 
-  // 前期間と今期間の全体率
   const currentTotal = currentByDay.reduce((a, b) => a + b, 0);
   const previousTotal = previousByDay.reduce((a, b) => a + b, 0);
   const weeklyExpected = expectedByDay.reduce((a, b) => a + b, 0);
 
-  const currentPeriodRate = weeklyExpected > 0 ? Math.min(100, Math.round((currentTotal / weeklyExpected) * 100)) : 0;
-  const previousPeriodRate = weeklyExpected > 0 ? Math.min(100, Math.round((previousTotal / weeklyExpected) * 100)) : 0;
+  const currentPeriodRate = AdherenceStatsEntity.calculateRate(currentTotal, weeklyExpected);
+  const previousPeriodRate = AdherenceStatsEntity.calculateRate(previousTotal, weeklyExpected);
 
   return success({
     dayOfWeekStats,

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { createScheduleSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
+import { ScheduleEntity, Schedule } from '@/domain/entities/Schedule';
 
 export const GET = withAuth(async (userId) => {
   const schedules = await prisma.schedule.findMany({ where: { userId }, take: 200 });
@@ -20,8 +21,9 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    // 重複チェック: 同じ薬・同じ時刻・曜日が重複するスケジュール
     const daysOfWeek = parsed.data.daysOfWeek ?? [];
+
+    // ドメインエンティティによる重複チェック
     const existing = await prisma.schedule.findFirst({
       where: {
         userId,
@@ -31,13 +33,23 @@ export async function POST(request: Request) {
       },
     });
 
-    if (existing && daysOfWeek.length > 0) {
-      const overlapping = daysOfWeek.some((day) => existing.daysOfWeek.includes(day));
-      if (overlapping) {
+    if (existing) {
+      const newScheduleData: Schedule = {
+        id: '',
+        medicationId: parsed.data.medicationId,
+        userId,
+        memberId: parsed.data.memberId,
+        scheduledTime: parsed.data.scheduledTime,
+        daysOfWeek: daysOfWeek as Schedule['daysOfWeek'],
+        isEnabled: true,
+        reminderMinutesBefore: parsed.data.reminderMinutesBefore ?? 5,
+        createdAt: new Date(),
+      };
+      const entity = new ScheduleEntity(newScheduleData);
+      const existingSchedule: Schedule = { ...existing, daysOfWeek: existing.daysOfWeek as Schedule['daysOfWeek'] };
+      if (entity.hasOverlap(existingSchedule)) {
         return errorResponse('同じ薬の同じ時刻に既にスケジュールが存在します');
       }
-    } else if (existing && daysOfWeek.length === 0) {
-      return errorResponse('同じ薬の同じ時刻に既にスケジュールが存在します');
     }
 
     const schedule = await prisma.schedule.create({

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -54,4 +54,39 @@ export class AdherenceStatsEntity {
   get data(): AdherenceStats {
     return this.stats;
   }
+
+  /**
+   * 曜日配列の有効日数を取得（空配列は毎日=7日）
+   */
+  static getActiveDaysCount(daysOfWeek: string[]): number {
+    return daysOfWeek.length === 0 ? 7 : daysOfWeek.length;
+  }
+
+  /**
+   * 週間期待数を算出
+   */
+  static calculateWeeklyExpected(schedules: { daysOfWeek: string[] }[]): number {
+    return schedules.reduce(
+      (sum, s) => sum + Math.min(AdherenceStatsEntity.getActiveDaysCount(s.daysOfWeek), 7),
+      0,
+    );
+  }
+
+  /**
+   * 月間期待数を算出（30日ベース）
+   */
+  static calculateMonthlyExpected(schedules: { daysOfWeek: string[] }[]): number {
+    return schedules.reduce((sum, s) => {
+      const daysPerWeek = AdherenceStatsEntity.getActiveDaysCount(s.daysOfWeek);
+      return sum + Math.round(daysPerWeek * (30 / 7));
+    }, 0);
+  }
+
+  /**
+   * 遵守率を算出（0-100%）
+   */
+  static calculateRate(actual: number, expected: number): number {
+    if (expected <= 0) return 0;
+    return Math.min(100, Math.round((actual / expected) * 100));
+  }
 }


### PR DESCRIPTION
## Summary
- 服薬遵守率の計算ロジックをAdherenceStatsEntityに集約
- APIルート（stats, trends）から計算ロジックを除去し、ドメインエンティティに委譲
- スケジュール重複検証をScheduleEntity.hasOverlapに統一
- テスト8件追加で計算ロジックの正確性を担保

## Test plan
- [x] AdherenceStatsEntity計算テスト（8件追加）
- [x] 既存テスト全てパス
- [x] ビルド成功確認
- [x] 全760テストパス

closes #199