### PR TITLE
fix: セキュリティ強化（CSPヘッダー、APIバリデーション）

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,7 @@ const nextConfig: NextConfig = {
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
           { key: 'Permissions-Policy', value: 'geolocation=(), microphone=(), camera=()' },
           { key: 'X-XSS-Protection', value: '1; mode=block' },
-          { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" },
+          { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" },
         ],
       },
     ];

--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createHealthLogSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const logs = await prisma.healthLog.findMany({
@@ -21,6 +21,9 @@ export const GET = withAuth(async (userId) => {
 });
 
 export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = createHealthLogSchema.safeParse(body);

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -141,7 +141,7 @@ export const updateAppointmentSchema = z.object({
 export const createHealthLogSchema = z.object({
   memberId: idField,
   conditionLevel: z.number().int().min(1, '体調レベルは1以上を指定してください').max(5, '体調レベルは5以下を指定してください'),
-  symptoms: z.array(z.string().max(50)).max(10).optional(),
+  symptoms: z.array(z.enum(['headache', 'fever', 'fatigue', 'nausea', 'stomachache', 'dizziness', 'cough', 'runny_nose', 'joint_pain', 'insomnia'])).max(10).optional(),
   notes: z.string().trim().max(500).optional(),
 });
 


### PR DESCRIPTION
## Summary
- CSPヘッダーからunsafe-evalを除去し、font-src・connect-srcを追加
- 体調記録の症状バリデーションを文字列からenum型に強化
- health-logs POSTにリクエストボディサイズ制限を追加

## Test plan
- [ ] CSPヘッダーが正しく適用されていることを確認
- [ ] 不正な症状値でAPIリクエストが拒否されることを確認
- [ ] 大きなリクエストボディが拒否されることを確認

closes #203