### PR TITLE
feat: 服薬ストリーク（連続日数）をダッシュボードに表示

### DIFF
--- a/src/__tests__/components/dashboard/StreakCard.test.tsx
+++ b/src/__tests__/components/dashboard/StreakCard.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StreakCard } from '@/components/dashboard/StreakCard';
+
+describe('StreakCard', () => {
+  it('ストリーク情報を表示する', () => {
+    render(
+      <StreakCard
+        streak={{ current: 5, longest: 12, message: '良いスタート' }}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('日連続')).toBeInTheDocument();
+    expect(screen.getByText('良いスタート')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('ローディング中はnullを返す', () => {
+    const { container } = render(
+      <StreakCard streak={null} isLoading={true} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('streakがnullの場合はnullを返す', () => {
+    const { container } = render(
+      <StreakCard streak={null} isLoading={false} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('連続0日の場合も正しく表示する', () => {
+    render(
+      <StreakCard
+        streak={{ current: 0, longest: 8, message: '今日から始めよう' }}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('今日から始めよう')).toBeInTheDocument();
+  });
+
+  it('最長記録ラベルを表示する', () => {
+    render(
+      <StreakCard
+        streak={{ current: 3, longest: 15, message: '良いスタート' }}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByText('最長記録')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/domain/entities/AdherenceStreak.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStreak.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity - Streak', () => {
+  describe('calculateStreak', () => {
+    it('毎日記録がある場合、連続日数を正しく算出する', () => {
+      const today = new Date('2026-03-05');
+      const recordDates = [
+        new Date('2026-03-05'),
+        new Date('2026-03-04'),
+        new Date('2026-03-03'),
+        new Date('2026-03-02'),
+      ];
+      expect(AdherenceStatsEntity.calculateStreak(recordDates, today)).toBe(4);
+    });
+
+    it('今日の記録がない場合は0を返す', () => {
+      const today = new Date('2026-03-05');
+      const recordDates = [
+        new Date('2026-03-04'),
+        new Date('2026-03-03'),
+      ];
+      expect(AdherenceStatsEntity.calculateStreak(recordDates, today)).toBe(0);
+    });
+
+    it('途中で途切れた場合、途切れるまでの日数を返す', () => {
+      const today = new Date('2026-03-05');
+      const recordDates = [
+        new Date('2026-03-05'),
+        new Date('2026-03-04'),
+        // 3/3はスキップ
+        new Date('2026-03-02'),
+        new Date('2026-03-01'),
+      ];
+      expect(AdherenceStatsEntity.calculateStreak(recordDates, today)).toBe(2);
+    });
+
+    it('記録がない場合は0を返す', () => {
+      const today = new Date('2026-03-05');
+      expect(AdherenceStatsEntity.calculateStreak([], today)).toBe(0);
+    });
+
+    it('同じ日に複数記録があっても1日としてカウントする', () => {
+      const today = new Date('2026-03-05');
+      const recordDates = [
+        new Date('2026-03-05T08:00:00'),
+        new Date('2026-03-05T12:00:00'),
+        new Date('2026-03-05T20:00:00'),
+        new Date('2026-03-04T09:00:00'),
+        new Date('2026-03-04T21:00:00'),
+      ];
+      expect(AdherenceStatsEntity.calculateStreak(recordDates, today)).toBe(2);
+    });
+  });
+
+  describe('calculateLongestStreak', () => {
+    it('最長連続日数を正しく算出する', () => {
+      const recordDates = [
+        new Date('2026-03-05'),
+        new Date('2026-03-04'),
+        // gap
+        new Date('2026-03-01'),
+        new Date('2026-02-28'),
+        new Date('2026-02-27'),
+        new Date('2026-02-26'),
+      ];
+      expect(AdherenceStatsEntity.calculateLongestStreak(recordDates)).toBe(4);
+    });
+
+    it('記録がない場合は0を返す', () => {
+      expect(AdherenceStatsEntity.calculateLongestStreak([])).toBe(0);
+    });
+
+    it('全て連続している場合はその日数を返す', () => {
+      const recordDates = [
+        new Date('2026-03-05'),
+        new Date('2026-03-04'),
+        new Date('2026-03-03'),
+      ];
+      expect(AdherenceStatsEntity.calculateLongestStreak(recordDates)).toBe(3);
+    });
+
+    it('全て離れている場合は1を返す', () => {
+      const recordDates = [
+        new Date('2026-03-05'),
+        new Date('2026-03-03'),
+        new Date('2026-03-01'),
+      ];
+      expect(AdherenceStatsEntity.calculateLongestStreak(recordDates)).toBe(1);
+    });
+  });
+
+  describe('getStreakMessage', () => {
+    it('0日の場合は応援メッセージを返す', () => {
+      const message = AdherenceStatsEntity.getStreakMessage(0);
+      expect(message).toBe('今日から始めよう');
+    });
+
+    it('1-6日の場合は継続メッセージを返す', () => {
+      expect(AdherenceStatsEntity.getStreakMessage(1)).toBe('良いスタート');
+      expect(AdherenceStatsEntity.getStreakMessage(6)).toBe('良いスタート');
+    });
+
+    it('7-29日の場合は称賛メッセージを返す', () => {
+      expect(AdherenceStatsEntity.getStreakMessage(7)).toBe('素晴らしい習慣');
+      expect(AdherenceStatsEntity.getStreakMessage(29)).toBe('素晴らしい習慣');
+    });
+
+    it('30日以上の場合は最高評価メッセージを返す', () => {
+      expect(AdherenceStatsEntity.getStreakMessage(30)).toBe('完璧な継続');
+      expect(AdherenceStatsEntity.getStreakMessage(100)).toBe('完璧な継続');
+    });
+  });
+});

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -13,7 +13,7 @@ export const GET = withAuth(async (userId) => {
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
   thirtyDaysAgo.setHours(0, 0, 0, 0);
 
-  const [weeklyRecords, monthlyRecords, schedules, members] = await Promise.all([
+  const [weeklyRecords, monthlyRecords, allRecordDates, schedules, members] = await Promise.all([
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: sevenDaysAgo } },
       select: { memberId: true, medicationId: true, takenAt: true },
@@ -23,6 +23,12 @@ export const GET = withAuth(async (userId) => {
       where: { userId, takenAt: { gte: thirtyDaysAgo } },
       select: { memberId: true, medicationId: true, takenAt: true },
       take: 5000,
+    }),
+    prisma.medicationRecord.findMany({
+      where: { userId },
+      select: { takenAt: true },
+      orderBy: { takenAt: 'desc' },
+      take: 10000,
     }),
     prisma.schedule.findMany({
       where: { userId, isEnabled: true },
@@ -57,6 +63,10 @@ export const GET = withAuth(async (userId) => {
     };
   });
 
+  const recordDates = allRecordDates.map((r) => r.takenAt);
+  const currentStreak = AdherenceStatsEntity.calculateStreak(recordDates, now);
+  const longestStreak = AdherenceStatsEntity.calculateLongestStreak(recordDates);
+
   return success({
     overall: {
       weeklyRate: AdherenceStatsEntity.calculateRate(weeklyRecords.length, weeklyExpected),
@@ -65,5 +75,10 @@ export const GET = withAuth(async (userId) => {
       monthlyCount: monthlyRecords.length,
     },
     members: memberStats,
+    streak: {
+      current: currentStreak,
+      longest: longestStreak,
+      message: AdherenceStatsEntity.getStreakMessage(currentStreak),
+    },
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ import { AdherenceTrendCard } from '@/components/dashboard/AdherenceTrendCard';
 import { StockAlertList } from '@/components/dashboard/StockAlertList';
 import { WeeklySummaryCard } from '@/components/dashboard/WeeklySummaryCard';
 import { GreetingCard } from '@/components/dashboard/GreetingCard';
+import { StreakCard } from '@/components/dashboard/StreakCard';
 import { MemberFilter } from '@/components/shared/MemberFilter';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 
@@ -50,6 +51,8 @@ export default function Dashboard() {
 
       <main className="max-w-md mx-auto px-4 py-4">
         <GreetingCard displayName={profile?.displayName || ''} />
+
+        <StreakCard streak={stats?.streak ?? null} isLoading={statsLoading} />
 
         <AdherenceStatsCard stats={stats} isLoading={statsLoading} />
 

--- a/src/components/dashboard/StreakCard.tsx
+++ b/src/components/dashboard/StreakCard.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Flame, Trophy } from 'lucide-react';
+import { StreakInfo } from '@/domain/entities/AdherenceStats';
+
+interface StreakCardProps {
+  streak: StreakInfo | null;
+  isLoading: boolean;
+}
+
+export const StreakCard: React.FC<StreakCardProps> = React.memo(({ streak, isLoading }) => {
+  if (isLoading || !streak) return null;
+
+  return (
+    <div className="mb-6">
+      <div className="bg-white rounded-lg shadow-sm p-4 border border-gray-200">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <div className="flex items-center justify-center w-10 h-10 rounded-full bg-orange-100">
+              <Flame size={20} className="text-orange-500" />
+            </div>
+            <div>
+              <div className="flex items-baseline space-x-1">
+                <span className="text-3xl font-bold text-gray-900">{streak.current}</span>
+                <span className="text-sm text-gray-500">日連続</span>
+              </div>
+              <p className="text-xs text-gray-500 mt-0.5">{streak.message}</p>
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="flex items-center space-x-1 text-gray-400">
+              <Trophy size={14} />
+              <span className="text-xs">最長記録</span>
+            </div>
+            <span className="text-lg font-semibold text-gray-700">{streak.longest}</span>
+            <span className="text-xs text-gray-400 ml-0.5">日</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+StreakCard.displayName = 'StreakCard';

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -11,6 +11,12 @@ export interface MemberAdherenceStats {
   readonly monthlyCount: number;
 }
 
+export interface StreakInfo {
+  readonly current: number;
+  readonly longest: number;
+  readonly message: string;
+}
+
 export interface AdherenceStats {
   readonly overall: {
     readonly weeklyRate: number;
@@ -19,6 +25,7 @@ export interface AdherenceStats {
     readonly monthlyCount: number;
   };
   readonly members: MemberAdherenceStats[];
+  readonly streak?: StreakInfo;
 }
 
 /**
@@ -88,5 +95,77 @@ export class AdherenceStatsEntity {
   static calculateRate(actual: number, expected: number): number {
     if (expected <= 0) return 0;
     return Math.min(100, Math.round((actual / expected) * 100));
+  }
+
+  /**
+   * 日付をYYYY-MM-DD形式のキーに変換
+   */
+  private static toDateKey(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  /**
+   * 現在のストリーク（連続服薬日数）を算出
+   * todayから遡って連続して記録がある日数を返す
+   */
+  static calculateStreak(recordDates: Date[], today: Date): number {
+    if (recordDates.length === 0) return 0;
+
+    const uniqueDays = new Set(recordDates.map((d) => AdherenceStatsEntity.toDateKey(d)));
+    const todayKey = AdherenceStatsEntity.toDateKey(today);
+
+    if (!uniqueDays.has(todayKey)) return 0;
+
+    let streak = 0;
+    const current = new Date(today);
+    current.setHours(0, 0, 0, 0);
+
+    while (uniqueDays.has(AdherenceStatsEntity.toDateKey(current))) {
+      streak++;
+      current.setDate(current.getDate() - 1);
+    }
+
+    return streak;
+  }
+
+  /**
+   * 最長ストリーク（連続服薬日数の最大値）を算出
+   */
+  static calculateLongestStreak(recordDates: Date[]): number {
+    if (recordDates.length === 0) return 0;
+
+    const uniqueDays = [...new Set(recordDates.map((d) => AdherenceStatsEntity.toDateKey(d)))].sort().reverse();
+
+    let longest = 1;
+    let current = 1;
+
+    for (let i = 1; i < uniqueDays.length; i++) {
+      const prevDate = new Date(uniqueDays[i - 1] + 'T00:00:00');
+      const currDate = new Date(uniqueDays[i] + 'T00:00:00');
+      const diffMs = prevDate.getTime() - currDate.getTime();
+      const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+      if (diffDays === 1) {
+        current++;
+        longest = Math.max(longest, current);
+      } else {
+        current = 1;
+      }
+    }
+
+    return longest;
+  }
+
+  /**
+   * ストリークに応じた応援メッセージを返す
+   */
+  static getStreakMessage(streak: number): string {
+    if (streak === 0) return '今日から始めよう';
+    if (streak < 7) return '良いスタート';
+    if (streak < 30) return '素晴らしい習慣';
+    return '完璧な継続';
   }
 }


### PR DESCRIPTION
## Summary
- AdherenceStatsEntityにストリーク計算ロジック（現在の連続日数・最長記録・メッセージ）を追加
- StreakCardコンポーネントを新規作成し、ダッシュボードに配置
- stats APIにストリーク情報を含めるよう拡張

## Test plan
- [ ] ストリーク計算ロジックのユニットテスト（13テスト）が全パス
- [ ] StreakCardコンポーネントテスト（5テスト）が全パス
- [ ] ダッシュボードにストリークカードが表示されることを確認

closes #206