### PR TITLE
feat: 履歴画面にメンバー別フィルタリングを追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationRecordFilter.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordFilter.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord, DailyRecordGroup } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (overrides: Partial<MedicationRecord> = {}): MedicationRecord => ({
+  id: 'r1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  medicationId: 'med-1',
+  medicationName: 'テスト薬A',
+  userId: 'user-1',
+  takenAt: new Date('2026-03-05T10:00:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity - filterByMember', () => {
+  it('メンバーIDでレコードをフィルタリングする', () => {
+    const records = [
+      createRecord({ id: 'r1', memberId: 'member-1' }),
+      createRecord({ id: 'r2', memberId: 'member-2', memberName: 'テスト花子' }),
+      createRecord({ id: 'r3', memberId: 'member-1' }),
+    ];
+    const filtered = MedicationRecordEntity.filterByMember(records, 'member-1');
+    expect(filtered).toHaveLength(2);
+    expect(filtered.every((r) => r.memberId === 'member-1')).toBe(true);
+  });
+
+  it('nullの場合は全レコードを返す', () => {
+    const records = [
+      createRecord({ id: 'r1', memberId: 'member-1' }),
+      createRecord({ id: 'r2', memberId: 'member-2' }),
+    ];
+    const filtered = MedicationRecordEntity.filterByMember(records, null);
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('該当するメンバーがいない場合は空配列を返す', () => {
+    const records = [
+      createRecord({ id: 'r1', memberId: 'member-1' }),
+    ];
+    const filtered = MedicationRecordEntity.filterByMember(records, 'member-999');
+    expect(filtered).toHaveLength(0);
+  });
+
+  it('空配列の場合は空配列を返す', () => {
+    const filtered = MedicationRecordEntity.filterByMember([], 'member-1');
+    expect(filtered).toHaveLength(0);
+  });
+});
+
+describe('MedicationRecordEntity - filterGroupsByMember', () => {
+  it('グループ内のレコードをメンバーIDでフィルタリングする', () => {
+    const groups: DailyRecordGroup[] = [
+      {
+        date: '2026-03-05',
+        records: [
+          createRecord({ id: 'r1', memberId: 'member-1' }),
+          createRecord({ id: 'r2', memberId: 'member-2', memberName: 'テスト花子' }),
+        ],
+      },
+      {
+        date: '2026-03-04',
+        records: [
+          createRecord({ id: 'r3', memberId: 'member-2', memberName: 'テスト花子', takenAt: new Date('2026-03-04T10:00:00') }),
+        ],
+      },
+    ];
+
+    const filtered = MedicationRecordEntity.filterGroupsByMember(groups, 'member-1');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].date).toBe('2026-03-05');
+    expect(filtered[0].records).toHaveLength(1);
+  });
+
+  it('nullの場合は全グループを返す', () => {
+    const groups: DailyRecordGroup[] = [
+      {
+        date: '2026-03-05',
+        records: [createRecord({ id: 'r1' }), createRecord({ id: 'r2' })],
+      },
+    ];
+    const filtered = MedicationRecordEntity.filterGroupsByMember(groups, null);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].records).toHaveLength(2);
+  });
+
+  it('フィルタ後に空になったグループは除外する', () => {
+    const groups: DailyRecordGroup[] = [
+      {
+        date: '2026-03-05',
+        records: [
+          createRecord({ id: 'r1', memberId: 'member-2', memberName: 'テスト花子' }),
+        ],
+      },
+    ];
+    const filtered = MedicationRecordEntity.filterGroupsByMember(groups, 'member-1');
+    expect(filtered).toHaveLength(0);
+  });
+});

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -5,22 +5,42 @@ import { Calendar, List } from 'lucide-react';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { MedicationHistoryList } from '@/components/history/MedicationHistoryList';
 import { MedicationCalendar } from '@/components/history/MedicationCalendar';
+import { MemberFilter } from '@/components/shared/MemberFilter';
 import { useMedicationHistory } from '@/presentation/hooks/useMedicationHistory';
 import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
+import { useMembers } from '@/presentation/hooks/useMembers';
+import { useAuth } from '@/hooks/useAuth';
 import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
 
 type ViewMode = 'list' | 'calendar';
 
 export default function HistoryPage() {
+  const { userId } = useAuth();
   const { groups, isLoading, deleteRecord } = useMedicationHistory();
   const { groups: healthLogGroups } = useHealthLogs();
+  const { members } = useMembers(userId);
   const [viewMode, setViewMode] = useState<ViewMode>('calendar');
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
 
-  // groupsからフラットなレコード配列を取得
+  const memberOptions = useMemo(
+    () => members.map((m) => ({ id: m.id, name: m.name })),
+    [members],
+  );
+
+  // メンバーフィルタ適用済みグループ
+  const memberFilteredGroups = useMemo(
+    () => MedicationRecordEntity.filterGroupsByMember(groups, selectedMemberId),
+    [groups, selectedMemberId],
+  );
+
+  // groupsからフラットなレコード配列を取得（メンバーフィルタ適用済み）
   const allRecords = useMemo(
-    () => groups.flatMap((g) => g.records),
-    [groups],
+    () => MedicationRecordEntity.filterByMember(
+      groups.flatMap((g) => g.records),
+      selectedMemberId,
+    ),
+    [groups, selectedMemberId],
   );
 
   // groupsからフラットな体調記録配列を取得
@@ -31,8 +51,8 @@ export default function HistoryPage() {
 
   // 選択日のレコードをフィルタリング
   const filteredGroups = useMemo(() => {
-    if (!selectedDate) return groups;
-    const filtered = groups
+    if (!selectedDate) return memberFilteredGroups;
+    const filtered = memberFilteredGroups
       .map((g) => ({
         ...g,
         records: g.records.filter((r) => {
@@ -43,7 +63,7 @@ export default function HistoryPage() {
       }))
       .filter((g) => g.records.length > 0);
     return filtered;
-  }, [groups, selectedDate]);
+  }, [memberFilteredGroups, selectedDate]);
 
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
@@ -74,6 +94,13 @@ export default function HistoryPage() {
       </header>
 
       <main className="max-w-md mx-auto px-4 py-4">
+        <div className="mb-4">
+          <MemberFilter
+            members={memberOptions}
+            selectedMemberId={selectedMemberId}
+            onSelect={setSelectedMemberId}
+          />
+        </div>
         {viewMode === 'calendar' ? (
           <div className="space-y-4">
             <MedicationCalendar
@@ -101,7 +128,7 @@ export default function HistoryPage() {
             )}
           </div>
         ) : (
-          <MedicationHistoryList groups={groups} isLoading={isLoading} onDelete={deleteRecord} />
+          <MedicationHistoryList groups={memberFilteredGroups} isLoading={isLoading} onDelete={deleteRecord} />
         )}
       </main>
 

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -61,4 +61,27 @@ export class MedicationRecordEntity {
     const m = date.getMinutes().toString().padStart(2, '0');
     return `${h}:${m}`;
   }
+
+  /**
+   * メンバーIDでレコードをフィルタリング
+   * nullの場合は全レコードを返す
+   */
+  static filterByMember(records: MedicationRecord[], memberId: string | null): MedicationRecord[] {
+    if (memberId === null) return records;
+    return records.filter((r) => r.memberId === memberId);
+  }
+
+  /**
+   * グループ内のレコードをメンバーIDでフィルタリング
+   * フィルタ後に空になったグループは除外する
+   */
+  static filterGroupsByMember(groups: DailyRecordGroup[], memberId: string | null): DailyRecordGroup[] {
+    if (memberId === null) return groups;
+    return groups
+      .map((g) => ({
+        ...g,
+        records: g.records.filter((r) => r.memberId === memberId),
+      }))
+      .filter((g) => g.records.length > 0);
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityにメンバーフィルタリングメソッドを追加
- 履歴画面にメンバーフィルタを配置（カレンダー/リスト両対応）
- 特定メンバーの服薬状況を素早く確認可能に

## Test plan
- [ ] filterByMember/filterGroupsByMemberのユニットテスト（7テスト）が全パス
- [ ] 履歴画面でメンバーフィルタが正しく動作することを確認
- [ ] カレンダービューとリストビューの両方でフィルタが効くことを確認

closes #208