### PR TITLE
feat: お薬の在庫残日数を自動計算して表示

### DIFF
--- a/src/__tests__/components/dashboard/StockAlertList.test.tsx
+++ b/src/__tests__/components/dashboard/StockAlertList.test.tsx
@@ -51,8 +51,17 @@ describe('StockAlertList', () => {
 
   it('残り日数を表示する', () => {
     render(<StockAlertList alerts={alerts} isLoading={false} />);
-    expect(screen.getByText('残り5日分')).toBeInTheDocument();
+    expect(screen.getAllByText('残量不明')).toHaveLength(2);
+    expect(screen.getByText('残5錠')).toBeInTheDocument();
     expect(screen.getByText('あと5日')).toBeInTheDocument();
+  });
+
+  it('remainingDaysがある場合は残日数を表示する', () => {
+    const alertsWithDays = [
+      { ...alerts[0], remainingDays: 10 },
+    ];
+    render(<StockAlertList alerts={alertsWithDays} isLoading={false} />);
+    expect(screen.getByText('約10日分')).toBeInTheDocument();
   });
 
   it('期限超過のアラートには期限超過を表示する', () => {

--- a/src/__tests__/domain/entities/StockAlert.test.ts
+++ b/src/__tests__/domain/entities/StockAlert.test.ts
@@ -70,4 +70,48 @@ describe('StockAlertEntity', () => {
       expect(entity.data).toBe(alert);
     });
   });
+
+  describe('calculateRemainingDays', () => {
+    it('在庫数と1日消費量から残日数を算出する', () => {
+      expect(StockAlertEntity.calculateRemainingDays(30, 2)).toBe(15);
+    });
+
+    it('1日1回の場合は在庫数がそのまま残日数になる', () => {
+      expect(StockAlertEntity.calculateRemainingDays(10, 1)).toBe(10);
+    });
+
+    it('1日3回の場合は在庫数の1/3が残日数になる', () => {
+      expect(StockAlertEntity.calculateRemainingDays(9, 3)).toBe(3);
+    });
+
+    it('割り切れない場合は切り捨てる', () => {
+      expect(StockAlertEntity.calculateRemainingDays(10, 3)).toBe(3);
+    });
+
+    it('消費量が0の場合はnullを返す', () => {
+      expect(StockAlertEntity.calculateRemainingDays(10, 0)).toBeNull();
+    });
+
+    it('在庫が0の場合は0を返す', () => {
+      expect(StockAlertEntity.calculateRemainingDays(0, 2)).toBe(0);
+    });
+
+    it('在庫がnullの場合はnullを返す', () => {
+      expect(StockAlertEntity.calculateRemainingDays(null, 2)).toBeNull();
+    });
+  });
+
+  describe('getRemainingDaysLabel', () => {
+    it('残日数からラベルを生成する', () => {
+      expect(StockAlertEntity.getRemainingDaysLabel(15)).toBe('約15日分');
+    });
+
+    it('0日の場合は在庫切れラベルを返す', () => {
+      expect(StockAlertEntity.getRemainingDaysLabel(0)).toBe('在庫切れ');
+    });
+
+    it('nullの場合は不明ラベルを返す', () => {
+      expect(StockAlertEntity.getRemainingDaysLabel(null)).toBe('残量不明');
+    });
+  });
 });

--- a/src/app/api/medications/alerts/route.ts
+++ b/src/app/api/medications/alerts/route.ts
@@ -1,20 +1,34 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
 
-  const medications = await prisma.medication.findMany({
-    where: {
-      userId,
-      isActive: true,
-      stockAlertDate: { not: null },
-    },
-    include: { member: { select: { id: true, name: true } } },
-    orderBy: { stockAlertDate: 'asc' },
-    take: 500,
-  });
+  const [medications, schedules] = await Promise.all([
+    prisma.medication.findMany({
+      where: {
+        userId,
+        isActive: true,
+        stockAlertDate: { not: null },
+      },
+      include: { member: { select: { id: true, name: true } } },
+      orderBy: { stockAlertDate: 'asc' },
+      take: 500,
+    }),
+    prisma.schedule.findMany({
+      where: { userId, isEnabled: true },
+      select: { medicationId: true },
+      take: 5000,
+    }),
+  ]);
+
+  // 各薬の1日あたりのスケジュール数をカウント
+  const scheduleCountByMed = new Map<string, number>();
+  for (const s of schedules) {
+    scheduleCountByMed.set(s.medicationId, (scheduleCountByMed.get(s.medicationId) ?? 0) + 1);
+  }
 
   const alerts = medications
     .filter((med) => {
@@ -24,6 +38,9 @@ export const GET = withAuth(async (userId) => {
     })
     .map((med) => {
       const daysUntil = Math.ceil((med.stockAlertDate!.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+      const dailyConsumption = scheduleCountByMed.get(med.id) ?? 0;
+      const remainingDays = StockAlertEntity.calculateRemainingDays(med.stockQuantity, dailyConsumption);
+
       return {
         medicationId: med.id,
         medicationName: med.name,
@@ -33,6 +50,7 @@ export const GET = withAuth(async (userId) => {
         stockAlertDate: med.stockAlertDate!.toISOString(),
         daysUntilAlert: daysUntil,
         isOverdue: daysUntil <= 0,
+        remainingDays,
       };
     });
 

--- a/src/components/dashboard/StockAlertList.tsx
+++ b/src/components/dashboard/StockAlertList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { AlertTriangle } from 'lucide-react';
-import { StockAlert } from '../../domain/entities/StockAlert';
+import { StockAlert, StockAlertEntity } from '../../domain/entities/StockAlert';
 
 interface StockAlertListProps {
   alerts: StockAlert[];
@@ -41,8 +41,11 @@ const StockAlertItem: React.FC<StockAlertItemProps> = React.memo(({ alert }) => 
         <p className="text-xs text-gray-500">{alert.memberName}</p>
       </div>
       <div className="text-right">
+        <p className="text-sm font-medium text-gray-700">
+          {StockAlertEntity.getRemainingDaysLabel(alert.remainingDays ?? null)}
+        </p>
         {alert.stockQuantity !== null && (
-          <p className="text-sm font-medium text-gray-700">残り{alert.stockQuantity}日分</p>
+          <p className="text-xs text-gray-400">残{alert.stockQuantity}錠</p>
         )}
         <p className={`text-xs font-medium ${alert.isOverdue ? 'text-red-600' : 'text-yellow-600'}`}>
           {alert.isOverdue ? '期限超過' : `あと${alert.daysUntilAlert}日`}

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -11,6 +11,7 @@ export interface StockAlert {
   readonly stockAlertDate: string;
   readonly daysUntilAlert: number;
   readonly isOverdue: boolean;
+  readonly remainingDays?: number | null;
 }
 
 export class StockAlertEntity {
@@ -33,5 +34,23 @@ export class StockAlertEntity {
 
   get data(): StockAlert {
     return this.alert;
+  }
+
+  /**
+   * 在庫数と1日消費量から残日数を算出（切り捨て）
+   */
+  static calculateRemainingDays(stockQuantity: number | null, dailyConsumption: number): number | null {
+    if (stockQuantity === null) return null;
+    if (dailyConsumption <= 0) return null;
+    return Math.floor(stockQuantity / dailyConsumption);
+  }
+
+  /**
+   * 残日数のラベルを生成
+   */
+  static getRemainingDaysLabel(remainingDays: number | null): string {
+    if (remainingDays === null) return '残量不明';
+    if (remainingDays === 0) return '在庫切れ';
+    return `約${remainingDays}日分`;
   }
 }


### PR DESCRIPTION
## Summary
- StockAlertEntityに在庫残日数計算ロジックを追加（在庫数 / 1日消費量）
- alerts APIにスケジュール数ベースの残日数計算を組み込み
- StockAlertListの表示を改善（残日数・残錠数を表示）

## Test plan
- [ ] calculateRemainingDays/getRemainingDaysLabelのユニットテスト（10テスト）が全パス
- [ ] StockAlertListコンポーネントテスト（7テスト）が全パス
- [ ] 在庫アラートに残日数が正しく表示されることを確認

closes #210