### PR TITLE
refactor: 日付計算とスケジュール曜日処理をドメイン層に抽出

### DIFF
--- a/src/__tests__/domain/entities/DateRange.test.ts
+++ b/src/__tests__/domain/entities/DateRange.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper', () => {
+  describe('daysAgo', () => {
+    it('指定日数前の日付を0時で返す', () => {
+      const now = new Date('2026-03-05T15:30:00');
+      const result = DateRangeHelper.daysAgo(7, now);
+      expect(result.getFullYear()).toBe(2026);
+      expect(result.getMonth()).toBe(1); // Feb
+      expect(result.getDate()).toBe(26);
+      expect(result.getHours()).toBe(0);
+      expect(result.getMinutes()).toBe(0);
+    });
+
+    it('0日前は当日の0時を返す', () => {
+      const now = new Date('2026-03-05T15:30:00');
+      const result = DateRangeHelper.daysAgo(0, now);
+      expect(result.getDate()).toBe(5);
+      expect(result.getHours()).toBe(0);
+    });
+
+    it('30日前を正しく算出する', () => {
+      const now = new Date('2026-03-05T10:00:00');
+      const result = DateRangeHelper.daysAgo(30, now);
+      expect(result.getMonth()).toBe(1); // Feb
+      expect(result.getDate()).toBe(3);
+    });
+  });
+
+  describe('calculateExpectedByDayOfWeek', () => {
+    it('毎日のスケジュールは全曜日に加算する', () => {
+      const schedules = [{ daysOfWeek: [] as string[] }];
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek(schedules);
+      expect(result).toEqual([1, 1, 1, 1, 1, 1, 1]);
+    });
+
+    it('特定曜日のスケジュールは該当曜日のみ加算する', () => {
+      const schedules = [{ daysOfWeek: ['mon', 'wed', 'fri'] }];
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek(schedules);
+      expect(result).toEqual([0, 1, 0, 1, 0, 1, 0]);
+    });
+
+    it('複数スケジュールを合算する', () => {
+      const schedules = [
+        { daysOfWeek: ['mon'] },
+        { daysOfWeek: [] as string[] },
+      ];
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek(schedules);
+      expect(result).toEqual([1, 2, 1, 1, 1, 1, 1]);
+    });
+
+    it('空のスケジュールは全て0を返す', () => {
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek([]);
+      expect(result).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+  });
+});

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -2,16 +2,12 @@ import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
-  const sevenDaysAgo = new Date(now);
-  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-  sevenDaysAgo.setHours(0, 0, 0, 0);
-
-  const thirtyDaysAgo = new Date(now);
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-  thirtyDaysAgo.setHours(0, 0, 0, 0);
+  const sevenDaysAgo = DateRangeHelper.daysAgo(7, now);
+  const thirtyDaysAgo = DateRangeHelper.daysAgo(30, now);
 
   const [weeklyRecords, monthlyRecords, allRecordDates, schedules, members] = await Promise.all([
     prisma.medicationRecord.findMany({

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -2,17 +2,13 @@ import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
 import { DAY_LABELS_JP } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
-  const fourteenDaysAgo = new Date(now);
-  fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14);
-  fourteenDaysAgo.setHours(0, 0, 0, 0);
-
-  const sevenDaysAgo = new Date(now);
-  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-  sevenDaysAgo.setHours(0, 0, 0, 0);
+  const fourteenDaysAgo = DateRangeHelper.daysAgo(14, now);
+  const sevenDaysAgo = DateRangeHelper.daysAgo(7, now);
 
   const [records, schedules] = await Promise.all([
     prisma.medicationRecord.findMany({
@@ -27,20 +23,7 @@ export const GET = withAuth(async (userId) => {
     }),
   ]);
 
-  const dayToIndex: Record<string, number> = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
-
-  // 曜日別の期待数
-  const expectedByDay = new Array(7).fill(0);
-  for (const schedule of schedules) {
-    if (schedule.daysOfWeek.length === 0) {
-      for (let i = 0; i < 7; i++) expectedByDay[i] += 1;
-    } else {
-      for (const day of schedule.daysOfWeek) {
-        const dayIndex = dayToIndex[day];
-        if (dayIndex !== undefined) expectedByDay[dayIndex] += 1;
-      }
-    }
-  }
+  const expectedByDay = DateRangeHelper.calculateExpectedByDayOfWeek(schedules);
 
   const currentByDay = new Array(7).fill(0);
   const previousByDay = new Array(7).fill(0);

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -1,0 +1,38 @@
+/**
+ * 日付範囲計算ヘルパー
+ */
+
+const DAY_TO_INDEX: Record<string, number> = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+};
+
+export class DateRangeHelper {
+  /**
+   * 指定日数前の日付を0時0分0秒で返す
+   */
+  static daysAgo(days: number, from: Date = new Date()): Date {
+    const date = new Date(from);
+    date.setDate(date.getDate() - days);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  /**
+   * スケジュールの曜日配列から曜日別の期待数を算出
+   * 返り値: [日, 月, 火, 水, 木, 金, 土] の順で期待数
+   */
+  static calculateExpectedByDayOfWeek(schedules: { daysOfWeek: string[] }[]): number[] {
+    const expected = new Array(7).fill(0);
+    for (const schedule of schedules) {
+      if (schedule.daysOfWeek.length === 0) {
+        for (let i = 0; i < 7; i++) expected[i] += 1;
+      } else {
+        for (const day of schedule.daysOfWeek) {
+          const index = DAY_TO_INDEX[day];
+          if (index !== undefined) expected[index] += 1;
+        }
+      }
+    }
+    return expected;
+  }
+}


### PR DESCRIPTION
## Summary
- DateRangeHelperクラスを新規作成し、日付範囲計算を共通化
- 曜日別期待数の集計ロジックをドメイン層に集約
- stats/trends APIルートから重複コードを除去

## Test plan
- [ ] DateRangeHelperのユニットテスト（7テスト）が全パス
- [ ] 既存の全テスト（821テスト）がパスすることを確認
- [ ] stats/trends APIが正常に動作することを確認

closes #212