### PR TITLE
test: エンティティの境界値・フォーマットテストを追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationRecordEntity.format.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordEntity.format.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - フォーマット', () => {
+  describe('formatDate', () => {
+    it('平日の日付を正しくフォーマットする', () => {
+      expect(MedicationRecordEntity.formatDate('2026-03-05')).toBe('3月5日(木)');
+    });
+
+    it('月初を正しくフォーマットする', () => {
+      expect(MedicationRecordEntity.formatDate('2026-01-01')).toBe('1月1日(木)');
+    });
+
+    it('月末を正しくフォーマットする', () => {
+      expect(MedicationRecordEntity.formatDate('2026-12-31')).toBe('12月31日(木)');
+    });
+
+    it('日曜日を正しく表示する', () => {
+      expect(MedicationRecordEntity.formatDate('2026-03-01')).toBe('3月1日(日)');
+    });
+
+    it('土曜日を正しく表示する', () => {
+      expect(MedicationRecordEntity.formatDate('2026-03-07')).toBe('3月7日(土)');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('午前の時刻をフォーマットする', () => {
+      expect(MedicationRecordEntity.formatTime(new Date('2026-03-05T08:30:00'))).toBe('08:30');
+    });
+
+    it('午後の時刻をフォーマットする', () => {
+      expect(MedicationRecordEntity.formatTime(new Date('2026-03-05T15:45:00'))).toBe('15:45');
+    });
+
+    it('深夜0時をフォーマットする', () => {
+      expect(MedicationRecordEntity.formatTime(new Date('2026-03-05T00:00:00'))).toBe('00:00');
+    });
+
+    it('23:59をフォーマットする', () => {
+      expect(MedicationRecordEntity.formatTime(new Date('2026-03-05T23:59:00'))).toBe('23:59');
+    });
+  });
+
+  describe('groupByDate', () => {
+    const createRecord = (id: string, takenAt: string): MedicationRecord => ({
+      id,
+      memberId: 'member-1',
+      memberName: 'テスト太郎',
+      medicationId: 'med-1',
+      medicationName: 'テスト薬',
+      userId: 'user-1',
+      takenAt: new Date(takenAt),
+    });
+
+    it('同じ日の記録を1グループにまとめる', () => {
+      const records = [
+        createRecord('r1', '2026-03-05T08:00:00'),
+        createRecord('r2', '2026-03-05T20:00:00'),
+      ];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].records).toHaveLength(2);
+    });
+
+    it('新しい日付が先に来る', () => {
+      const records = [
+        createRecord('r1', '2026-03-03T10:00:00'),
+        createRecord('r2', '2026-03-05T10:00:00'),
+        createRecord('r3', '2026-03-04T10:00:00'),
+      ];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups[0].date).toBe('2026-03-05');
+      expect(groups[1].date).toBe('2026-03-04');
+      expect(groups[2].date).toBe('2026-03-03');
+    });
+
+    it('空配列は空配列を返す', () => {
+      expect(MedicationRecordEntity.groupByDate([])).toEqual([]);
+    });
+
+    it('年をまたぐ記録を正しくグループ化する', () => {
+      const records = [
+        createRecord('r1', '2026-01-01T00:00:00'),
+        createRecord('r2', '2025-12-31T23:59:00'),
+      ];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups).toHaveLength(2);
+      expect(groups[0].date).toBe('2026-01-01');
+      expect(groups[1].date).toBe('2025-12-31');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleEntity.edge.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity, Schedule, DayOfWeek } from '@/domain/entities/Schedule';
+
+const createSchedule = (overrides: Partial<Schedule> = {}): Schedule => ({
+  id: 'sched-1',
+  medicationId: 'med-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  scheduledTime: '08:00',
+  daysOfWeek: [] as readonly DayOfWeek[],
+  isEnabled: true,
+  reminderMinutesBefore: 10,
+  createdAt: new Date('2026-01-01'),
+  ...overrides,
+});
+
+describe('ScheduleEntity - エッジケース', () => {
+  describe('getStatus - 境界値', () => {
+    it('予定時刻ちょうどの場合はpendingを返す', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule);
+      const exactTime = new Date('2026-03-05T08:00:00');
+      expect(entity.getStatus(exactTime, false)).toBe('pending');
+    });
+
+    it('予定時刻の1秒後はoverdueを返す', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule);
+      const afterTime = new Date('2026-03-05T08:00:01');
+      expect(entity.getStatus(afterTime, false)).toBe('overdue');
+    });
+
+    it('completedフラグが優先される', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule);
+      const afterTime = new Date('2026-03-05T10:00:00');
+      expect(entity.getStatus(afterTime, true)).toBe('completed');
+    });
+
+    it('深夜0時のスケジュールを正しく判定する', () => {
+      const schedule = createSchedule({ scheduledTime: '00:00' });
+      const entity = new ScheduleEntity(schedule);
+      const beforeMidnight = new Date('2026-03-05T23:59:59');
+      // 23:59:59 > 00:00:00 (同日) なのでoverdue
+      expect(entity.getStatus(beforeMidnight, false)).toBe('overdue');
+    });
+  });
+
+  describe('isActiveOnDay - 境界値', () => {
+    it('無効なスケジュールは常にfalseを返す', () => {
+      const schedule = createSchedule({ isEnabled: false });
+      const entity = new ScheduleEntity(schedule);
+      expect(entity.isActiveOnDay(new Date('2026-03-05'))).toBe(false);
+    });
+
+    it('曜日未設定（毎日）で有効なスケジュールはtrueを返す', () => {
+      const schedule = createSchedule({ daysOfWeek: [], isEnabled: true });
+      const entity = new ScheduleEntity(schedule);
+      // 全曜日でtrue
+      for (let i = 0; i < 7; i++) {
+        const date = new Date(2026, 2, 1 + i); // 2026-03-01(日)から
+        expect(entity.isActiveOnDay(date)).toBe(true);
+      }
+    });
+
+    it('月曜のみ設定で月曜日はtrue、火曜はfalseを返す', () => {
+      const schedule = createSchedule({ daysOfWeek: ['mon'] });
+      const entity = new ScheduleEntity(schedule);
+      const monday = new Date('2026-03-02'); // 月曜
+      const tuesday = new Date('2026-03-03'); // 火曜
+      expect(entity.isActiveOnDay(monday)).toBe(true);
+      expect(entity.isActiveOnDay(tuesday)).toBe(false);
+    });
+  });
+
+  describe('hasOverlap - 境界値', () => {
+    it('異なる薬では重複しない', () => {
+      const schedule1 = createSchedule({ medicationId: 'med-1', scheduledTime: '08:00' });
+      const schedule2 = createSchedule({ medicationId: 'med-2', scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule1);
+      expect(entity.hasOverlap(schedule2)).toBe(false);
+    });
+
+    it('同じ薬で時刻が1分違えば重複しない', () => {
+      const schedule1 = createSchedule({ scheduledTime: '08:00' });
+      const schedule2 = createSchedule({ scheduledTime: '08:01' });
+      const entity = new ScheduleEntity(schedule1);
+      expect(entity.hasOverlap(schedule2)).toBe(false);
+    });
+
+    it('同じ薬・時刻で片方が毎日なら重複する', () => {
+      const schedule1 = createSchedule({ scheduledTime: '08:00', daysOfWeek: [] });
+      const schedule2 = createSchedule({ scheduledTime: '08:00', daysOfWeek: ['mon'] });
+      const entity = new ScheduleEntity(schedule1);
+      expect(entity.hasOverlap(schedule2)).toBe(true);
+    });
+
+    it('同じ薬・時刻で曜日が重ならなければ重複しない', () => {
+      const schedule1 = createSchedule({ scheduledTime: '08:00', daysOfWeek: ['mon', 'wed'] });
+      const schedule2 = createSchedule({ scheduledTime: '08:00', daysOfWeek: ['tue', 'thu'] });
+      const entity = new ScheduleEntity(schedule1);
+      expect(entity.hasOverlap(schedule2)).toBe(false);
+    });
+  });
+
+  describe('getReminderTime', () => {
+    it('リマインダー時刻を正しく算出する', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00', reminderMinutesBefore: 30 });
+      const entity = new ScheduleEntity(schedule);
+      const result = entity.getReminderTime(new Date('2026-03-05'));
+      expect(result.getHours()).toBe(7);
+      expect(result.getMinutes()).toBe(30);
+    });
+
+    it('リマインダー0分の場合は予定時刻と同じになる', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00', reminderMinutesBefore: 0 });
+      const entity = new ScheduleEntity(schedule);
+      const result = entity.getReminderTime(new Date('2026-03-05'));
+      expect(result.getHours()).toBe(8);
+      expect(result.getMinutes()).toBe(0);
+    });
+
+    it('深夜跨ぎのリマインダーを正しく処理する', () => {
+      const schedule = createSchedule({ scheduledTime: '00:15', reminderMinutesBefore: 30 });
+      const entity = new ScheduleEntity(schedule);
+      const result = entity.getReminderTime(new Date('2026-03-05'));
+      expect(result.getHours()).toBe(23);
+      expect(result.getMinutes()).toBe(45);
+      expect(result.getDate()).toBe(4); // 前日
+    });
+  });
+
+  describe('getOverdueLevel - 境界値', () => {
+    it('29分はnoneを返す', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule);
+      const time = new Date('2026-03-05T08:29:59');
+      expect(entity.getOverdueLevel(time, false)).toBe('none');
+    });
+
+    it('30分はwarningを返す', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule);
+      const time = new Date('2026-03-05T08:30:00');
+      expect(entity.getOverdueLevel(time, false)).toBe('warning');
+    });
+
+    it('59分はwarningを返す', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule);
+      const time = new Date('2026-03-05T08:59:59');
+      expect(entity.getOverdueLevel(time, false)).toBe('warning');
+    });
+
+    it('60分はdangerを返す', () => {
+      const schedule = createSchedule({ scheduledTime: '08:00' });
+      const entity = new ScheduleEntity(schedule);
+      const time = new Date('2026-03-05T09:00:00');
+      expect(entity.getOverdueLevel(time, false)).toBe('danger');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ScheduleEntityの全メソッドに対する境界値テスト(18件)を追加
- MedicationRecordEntityのフォーマット・グループ化メソッドのエッジケーステスト(13件)を追加
- テスト総数: 821 → 852

## Test plan
- [ ] 新規テスト31件が全パス
- [ ] 既存テストに影響がないことを確認

closes #214