### PR TITLE
fix: 全POST/PUTエンドポイントにリクエストボディサイズ制限を適用

### DIFF
--- a/src/app/api/appointments/[appointmentId]/route.ts
+++ b/src/app/api/appointments/[appointmentId]/route.ts
@@ -1,11 +1,14 @@
 import { prisma } from '@/lib/prisma';
 import { updateAppointmentSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
 
 const findAppointment = (id: string) => prisma.appointment.findUnique({ where: { id } });
 
 export async function PUT(request: Request, { params }: { params: Promise<{ appointmentId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const { appointmentId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createAppointmentSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const appointments = await prisma.appointment.findMany({
@@ -24,6 +24,9 @@ export const GET = withAuth(async (userId) => {
 });
 
 export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = createAppointmentSchema.safeParse(body);

--- a/src/app/api/hospitals/[hospitalId]/route.ts
+++ b/src/app/api/hospitals/[hospitalId]/route.ts
@@ -1,11 +1,14 @@
 import { prisma } from '@/lib/prisma';
 import { updateHospitalSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
 
 const findHospital = (id: string) => prisma.hospital.findUnique({ where: { id } });
 
 export async function PUT(request: Request, { params }: { params: Promise<{ hospitalId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const { hospitalId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createHospitalSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth } from '@/lib/api-helpers';
+import { withAuth, validateBodySize } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const hospitals = await prisma.hospital.findMany({ where: { userId }, take: 100 });
@@ -9,6 +9,9 @@ export const GET = withAuth(async (userId) => {
 });
 
 export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = createHospitalSchema.safeParse(body);

--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateMedicationSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
 
 const findMedication = (id: string) => prisma.medication.findUnique({ where: { id } });
 
@@ -19,6 +19,9 @@ export async function GET(_request: Request, { params }: { params: Promise<{ med
 }
 
 export async function PUT(request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const { medicationId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/medications/[medicationId]/stock/route.ts
+++ b/src/app/api/medications/[medicationId]/stock/route.ts
@@ -2,12 +2,15 @@ import { prisma } from '@/lib/prisma';
 import { updateStockSchema } from '@/lib/schemas';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
 
 const findMedicationWithMember = (id: string) =>
   prisma.medication.findUnique({ where: { id }, include: { member: true } });
 
 export async function PUT(request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const { medicationId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -1,9 +1,12 @@
 import { prisma } from '@/lib/prisma';
 import { createMedicationSchema } from '@/lib/schemas';
 import { created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
 
 export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = createMedicationSchema.safeParse(body);

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateMemberSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
 
 const findMember = (id: string) => prisma.member.findUnique({ where: { id } });
 
@@ -19,6 +19,9 @@ export async function GET(_request: Request, { params }: { params: Promise<{ mem
 }
 
 export async function PUT(request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const { memberId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createMemberSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth } from '@/lib/api-helpers';
+import { withAuth, validateBodySize } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const members = await prisma.member.findMany({ where: { userId }, take: 100 });
@@ -9,6 +9,9 @@ export const GET = withAuth(async (userId) => {
 });
 
 export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = createMemberSchema.safeParse(body);

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createRecordSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const records = await prisma.medicationRecord.findMany({
@@ -24,6 +24,9 @@ export const GET = withAuth(async (userId) => {
 });
 
 export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = createRecordSchema.safeParse(body);

--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -1,11 +1,14 @@
 import { prisma } from '@/lib/prisma';
 import { updateScheduleSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
 
 const findSchedule = (id: string) => prisma.schedule.findUnique({ where: { id } });
 
 export async function PUT(request: Request, { params }: { params: Promise<{ scheduleId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const { scheduleId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createScheduleSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
 import { ScheduleEntity, Schedule } from '@/domain/entities/Schedule';
 
 export const GET = withAuth(async (userId) => {
@@ -10,6 +10,9 @@ export const GET = withAuth(async (userId) => {
 });
 
 export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = createScheduleSchema.safeParse(body);

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateUserProfileSchema } from '@/lib/schemas';
 import { success, errorResponse, notFound } from '@/lib/auth-helpers';
-import { withAuth } from '@/lib/api-helpers';
+import { withAuth, validateBodySize } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const user = await prisma.user.findUnique({ where: { id: userId } });
@@ -17,6 +17,9 @@ export const GET = withAuth(async (userId) => {
 });
 
 export async function PUT(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
   return withAuth(async (userId) => {
     const body = await request.json();
     const parsed = updateUserProfileSchema.safeParse(body);


### PR DESCRIPTION
## Summary
- 13のPOST/PUTエンドポイントにvalidateBodySize()によるリクエストサイズ制限を追加
- 大容量リクエストによるDoS攻撃を防止
- 対象: members, medications, schedules, records, appointments, hospitals, users/me

## Test plan
- [ ] 全テスト（852件）がパスすることを確認
- [ ] ビルドが成功することを確認
- [ ] 100KBを超えるリクエストが拒否されることを確認

closes #216