### PR TITLE
feat: ダッシュボードに週間サマリーメッセージを表示

### DIFF
--- a/src/__tests__/domain/entities/GreetingMessage.test.ts
+++ b/src/__tests__/domain/entities/GreetingMessage.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity', () => {
+  describe('getTimeGreeting', () => {
+    it('朝(5-11時)は「おはよう」を返す', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(5)).toBe('おはよう');
+      expect(GreetingMessageEntity.getTimeGreeting(11)).toBe('おはよう');
+    });
+
+    it('昼(12-17時)は「こんにちは」を返す', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(12)).toBe('こんにちは');
+      expect(GreetingMessageEntity.getTimeGreeting(17)).toBe('こんにちは');
+    });
+
+    it('夜(18-4時)は「こんばんは」を返す', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(18)).toBe('こんばんは');
+      expect(GreetingMessageEntity.getTimeGreeting(23)).toBe('こんばんは');
+      expect(GreetingMessageEntity.getTimeGreeting(0)).toBe('こんばんは');
+      expect(GreetingMessageEntity.getTimeGreeting(4)).toBe('こんばんは');
+    });
+  });
+
+  describe('getWeeklySummaryMessage', () => {
+    it('90%以上は称賛メッセージを返す', () => {
+      const message = GreetingMessageEntity.getWeeklySummaryMessage(95);
+      expect(message).toContain('素晴らしい');
+    });
+
+    it('70-89%は良好メッセージを返す', () => {
+      const message = GreetingMessageEntity.getWeeklySummaryMessage(75);
+      expect(message).toContain('順調');
+    });
+
+    it('50-69%は励ましメッセージを返す', () => {
+      const message = GreetingMessageEntity.getWeeklySummaryMessage(55);
+      expect(message).toContain('少しずつ');
+    });
+
+    it('50%未満は応援メッセージを返す', () => {
+      const message = GreetingMessageEntity.getWeeklySummaryMessage(30);
+      expect(message).toContain('一緒に');
+    });
+
+    it('0%でもメッセージを返す', () => {
+      const message = GreetingMessageEntity.getWeeklySummaryMessage(0);
+      expect(message.length).toBeGreaterThan(0);
+    });
+
+    it('nullの場合はデフォルトメッセージを返す', () => {
+      const message = GreetingMessageEntity.getWeeklySummaryMessage(null);
+      expect(message).toContain('今日も');
+    });
+  });
+
+  describe('getDayOfWeekMessage', () => {
+    it('月曜日は週始まりメッセージを返す', () => {
+      expect(GreetingMessageEntity.getDayOfWeekMessage(1)).toContain('新しい週');
+    });
+
+    it('金曜日は週末メッセージを返す', () => {
+      expect(GreetingMessageEntity.getDayOfWeekMessage(5)).toContain('あと少し');
+    });
+
+    it('日曜日はゆっくりメッセージを返す', () => {
+      expect(GreetingMessageEntity.getDayOfWeekMessage(0)).toContain('ゆっくり');
+    });
+
+    it('その他の曜日は通常メッセージを返す', () => {
+      const msg = GreetingMessageEntity.getDayOfWeekMessage(3);
+      expect(msg.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,7 @@ export default function Dashboard() {
       </header>
 
       <main className="max-w-md mx-auto px-4 py-4">
-        <GreetingCard displayName={profile?.displayName || ''} />
+        <GreetingCard displayName={profile?.displayName || ''} weeklyRate={stats?.overall.weeklyRate} />
 
         <StreakCard streak={stats?.streak ?? null} isLoading={statsLoading} />
 

--- a/src/components/dashboard/GreetingCard.tsx
+++ b/src/components/dashboard/GreetingCard.tsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import { useCharacterStore } from '../../stores/characterStore';
 import { CharacterIcon } from '../shared/CharacterIcon';
+import { GreetingMessageEntity } from '../../domain/entities/GreetingMessage';
 
 interface GreetingCardProps {
   displayName: string;
+  weeklyRate?: number | null;
 }
 
-function getTimeGreeting(): string {
-  const hour = new Date().getHours();
-  if (hour >= 5 && hour < 12) return 'おはよう';
-  if (hour >= 12 && hour < 18) return 'こんにちは';
-  return 'こんばんは';
-}
-
-export const GreetingCard: React.FC<GreetingCardProps> = ({ displayName }) => {
+export const GreetingCard: React.FC<GreetingCardProps> = ({ displayName, weeklyRate }) => {
   const { getConfig } = useCharacterStore();
   const config = getConfig();
-  const greeting = getTimeGreeting();
+  const now = new Date();
+  const greeting = GreetingMessageEntity.getTimeGreeting(now.getHours());
+  const summaryMessage = GreetingMessageEntity.getWeeklySummaryMessage(weeklyRate ?? null);
 
   return (
     <div className="bg-primary-50 rounded-lg p-4 mb-6 flex items-center space-x-3">
@@ -25,7 +22,8 @@ export const GreetingCard: React.FC<GreetingCardProps> = ({ displayName }) => {
         <p className="text-sm font-medium text-primary-800">
           {greeting}、{displayName}さん
         </p>
-        <p className="text-xs text-primary-600">{config.name}より</p>
+        <p className="text-xs text-primary-600 mt-0.5">{summaryMessage}</p>
+        <p className="text-xs text-primary-400 mt-0.5">{config.name}より</p>
       </div>
     </div>
   );

--- a/src/domain/entities/GreetingMessage.ts
+++ b/src/domain/entities/GreetingMessage.ts
@@ -1,0 +1,39 @@
+/**
+ * 挨拶メッセージ生成エンティティ
+ */
+
+export class GreetingMessageEntity {
+  /**
+   * 時間帯に応じた挨拶を返す
+   */
+  static getTimeGreeting(hour: number): string {
+    if (hour >= 5 && hour < 12) return 'おはよう';
+    if (hour >= 12 && hour < 18) return 'こんにちは';
+    return 'こんばんは';
+  }
+
+  /**
+   * 週間達成率に応じたサマリーメッセージを返す
+   */
+  static getWeeklySummaryMessage(weeklyRate: number | null): string {
+    if (weeklyRate === null) return '今日もお薬を忘れずに';
+
+    if (weeklyRate >= 90) return '素晴らしい1週間です。この調子で続けましょう';
+    if (weeklyRate >= 70) return '順調にお薬を服用できています';
+    if (weeklyRate >= 50) return '少しずつ習慣にしていきましょう';
+    return '一緒に頑張りましょう。無理せず続けることが大切です';
+  }
+
+  /**
+   * 曜日に応じたメッセージを返す
+   */
+  static getDayOfWeekMessage(dayOfWeek: number): string {
+    switch (dayOfWeek) {
+      case 0: return 'ゆっくり休めていますか';
+      case 1: return '新しい週の始まりです';
+      case 5: return 'あと少しで週末です';
+      case 6: return 'お疲れさまでした';
+      default: return '今日も頑張りましょう';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- GreetingMessageEntityを新規作成し、挨拶ロジックをドメイン層に移動
- 週間達成率に応じた4段階の励ましメッセージを表示
- GreetingCardにweeklyRate propを追加して動的メッセージを生成

## Test plan
- [ ] GreetingMessageEntityのユニットテスト（13テスト）が全パス
- [ ] GreetingCardが達成率に応じたメッセージを表示することを確認
- [ ] 既存のGreetingCardテストが影響を受けないことを確認

closes #218