### PR TITLE
feat: 体調記録ページに症状頻度サマリーを追加

### DIFF
--- a/src/__tests__/components/health-logs/SymptomFrequencySummary.test.tsx
+++ b/src/__tests__/components/health-logs/SymptomFrequencySummary.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SymptomFrequencySummary } from '../../../components/health-logs/SymptomFrequencySummary';
+
+describe('SymptomFrequencySummary', () => {
+  it('症状がない場合は何も表示しない', () => {
+    const { container } = render(<SymptomFrequencySummary symptoms={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('症状頻度を表示する', () => {
+    const symptoms = [
+      { symptom: 'headache' as const, count: 5 },
+      { symptom: 'fatigue' as const, count: 3 },
+    ];
+    render(<SymptomFrequencySummary symptoms={symptoms} />);
+    expect(screen.getByText('頭痛')).toBeDefined();
+    expect(screen.getByText('倦怠感')).toBeDefined();
+    expect(screen.getByText('5回')).toBeDefined();
+    expect(screen.getByText('3回')).toBeDefined();
+  });
+
+  it('タイトルを表示する', () => {
+    const symptoms = [{ symptom: 'fever' as const, count: 2 }];
+    render(<SymptomFrequencySummary symptoms={symptoms} />);
+    expect(screen.getByText('よく記録された症状')).toBeDefined();
+  });
+
+  it('バーの幅が最大カウントに対する割合で表示される', () => {
+    const symptoms = [
+      { symptom: 'headache' as const, count: 10 },
+      { symptom: 'fever' as const, count: 5 },
+    ];
+    const { container } = render(<SymptomFrequencySummary symptoms={symptoms} />);
+    const bars = container.querySelectorAll('[data-testid="symptom-bar"]');
+    expect(bars.length).toBe(2);
+    expect((bars[0] as HTMLElement).style.width).toBe('100%');
+    expect((bars[1] as HTMLElement).style.width).toBe('50%');
+  });
+});

--- a/src/app/health-logs/page.tsx
+++ b/src/app/health-logs/page.tsx
@@ -6,6 +6,7 @@ import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { HealthLogList } from '@/components/health-logs/HealthLogList';
 import { HealthLogForm } from '@/components/health-logs/HealthLogForm';
 import { HealthWeeklyTrend } from '@/components/health-logs/HealthWeeklyTrend';
+import { SymptomFrequencySummary } from '@/components/health-logs/SymptomFrequencySummary';
 import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAuth } from '@/hooks/useAuth';
@@ -24,6 +25,11 @@ export default function HealthLogsPage() {
 
   const weeklyAverages = useMemo(
     () => HealthLogEntity.getDailyAverages(allLogs, 7, new Date()),
+    [allLogs],
+  );
+
+  const frequentSymptoms = useMemo(
+    () => HealthLogEntity.getMostFrequentSymptoms(allLogs, 5),
     [allLogs],
   );
 
@@ -69,6 +75,8 @@ export default function HealthLogsPage() {
         )}
 
         <HealthWeeklyTrend averages={weeklyAverages} />
+
+        <SymptomFrequencySummary symptoms={frequentSymptoms} />
 
         <HealthLogList groups={groups} isLoading={isLoading} onDelete={deleteLog} />
       </main>

--- a/src/components/health-logs/SymptomFrequencySummary.tsx
+++ b/src/components/health-logs/SymptomFrequencySummary.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Thermometer } from 'lucide-react';
+import { SymptomType, SYMPTOM_LABELS } from '@/domain/entities/HealthLog';
+
+interface SymptomFrequency {
+  symptom: SymptomType;
+  count: number;
+}
+
+interface SymptomFrequencySummaryProps {
+  symptoms: SymptomFrequency[];
+}
+
+export const SymptomFrequencySummary: React.FC<SymptomFrequencySummaryProps> = React.memo(({ symptoms }) => {
+  if (symptoms.length === 0) return null;
+
+  const maxCount = Math.max(...symptoms.map((s) => s.count));
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-4 border border-gray-200 mb-4">
+      <div className="flex items-center space-x-2 mb-3">
+        <Thermometer size={16} className="text-primary-600" />
+        <h3 className="text-sm font-semibold text-gray-700">よく記録された症状</h3>
+      </div>
+
+      <div className="space-y-2">
+        {symptoms.map((item) => (
+          <div key={item.symptom} className="flex items-center space-x-2">
+            <span className="text-xs text-gray-600 w-12 shrink-0">{SYMPTOM_LABELS[item.symptom]}</span>
+            <div className="flex-1 bg-gray-100 rounded-full h-4">
+              <div
+                data-testid="symptom-bar"
+                className="bg-primary-400 rounded-full h-4"
+                style={{ width: `${(item.count / maxCount) * 100}%` }}
+              />
+            </div>
+            <span className="text-xs text-gray-500 w-8 text-right shrink-0">{item.count}回</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+SymptomFrequencySummary.displayName = 'SymptomFrequencySummary';


### PR DESCRIPTION
## Summary
- SymptomFrequencySummaryコンポーネントを新規作成
- よく記録された症状を横棒グラフで上位5件まで表示
- HealthLogEntityの既存getMostFrequentSymptomsメソッドを活用
- 体調記録ページに週間トレンドと合わせて統合

## Test plan
- [x] SymptomFrequencySummaryコンポーネントのテスト (4件)
- [x] 全テスト883件パス
- [x] ビルド成功

closes #223