### PR TITLE
refactor: 日付キー生成とDAY_LABELS_JPの重複を解消

### DIFF
--- a/src/__tests__/domain/entities/DateRange.test.ts
+++ b/src/__tests__/domain/entities/DateRange.test.ts
@@ -55,4 +55,21 @@ describe('DateRangeHelper', () => {
       expect(result).toEqual([0, 0, 0, 0, 0, 0, 0]);
     });
   });
+
+  describe('toDateKey', () => {
+    it('日付をYYYY-MM-DD形式に変換する', () => {
+      const date = new Date('2026-03-05T15:30:00');
+      expect(DateRangeHelper.toDateKey(date)).toBe('2026-03-05');
+    });
+
+    it('月日が1桁の場合はゼロパディングする', () => {
+      const date = new Date('2026-01-09T00:00:00');
+      expect(DateRangeHelper.toDateKey(date)).toBe('2026-01-09');
+    });
+
+    it('年末年始の日付を正しく変換する', () => {
+      const date = new Date('2025-12-31T23:59:59');
+      expect(DateRangeHelper.toDateKey(date)).toBe('2025-12-31');
+    });
+  });
 });

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -2,6 +2,8 @@
  * 服薬アドヒアランス統計エンティティ
  */
 
+import { DateRangeHelper } from './DateRange';
+
 export interface MemberAdherenceStats {
   readonly memberId: string;
   readonly memberName: string;
@@ -98,24 +100,14 @@ export class AdherenceStatsEntity {
   }
 
   /**
-   * 日付をYYYY-MM-DD形式のキーに変換
-   */
-  private static toDateKey(date: Date): string {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, '0');
-    const d = String(date.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
-  }
-
-  /**
    * 現在のストリーク（連続服薬日数）を算出
    * todayから遡って連続して記録がある日数を返す
    */
   static calculateStreak(recordDates: Date[], today: Date): number {
     if (recordDates.length === 0) return 0;
 
-    const uniqueDays = new Set(recordDates.map((d) => AdherenceStatsEntity.toDateKey(d)));
-    const todayKey = AdherenceStatsEntity.toDateKey(today);
+    const uniqueDays = new Set(recordDates.map((d) => DateRangeHelper.toDateKey(d)));
+    const todayKey = DateRangeHelper.toDateKey(today);
 
     if (!uniqueDays.has(todayKey)) return 0;
 
@@ -123,7 +115,7 @@ export class AdherenceStatsEntity {
     const current = new Date(today);
     current.setHours(0, 0, 0, 0);
 
-    while (uniqueDays.has(AdherenceStatsEntity.toDateKey(current))) {
+    while (uniqueDays.has(DateRangeHelper.toDateKey(current))) {
       streak++;
       current.setDate(current.getDate() - 1);
     }
@@ -137,7 +129,7 @@ export class AdherenceStatsEntity {
   static calculateLongestStreak(recordDates: Date[]): number {
     if (recordDates.length === 0) return 0;
 
-    const uniqueDays = [...new Set(recordDates.map((d) => AdherenceStatsEntity.toDateKey(d)))].sort().reverse();
+    const uniqueDays = [...new Set(recordDates.map((d) => DateRangeHelper.toDateKey(d)))].sort().reverse();
 
     let longest = 1;
     let current = 1;

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -2,6 +2,9 @@
  * カレンダーユーティリティ
  */
 
+import { DAY_LABELS_JP } from '../../lib/constants';
+import { DateRangeHelper } from './DateRange';
+
 export interface CalendarDay {
   date: Date;
   isCurrentMonth: boolean;
@@ -91,7 +94,7 @@ export class CalendarEntity {
    * 曜日ヘッダーを取得
    */
   static getWeekdayHeaders(): string[] {
-    return ['日', '月', '火', '水', '木', '金', '土'];
+    return [...DAY_LABELS_JP];
   }
 
   /**
@@ -135,9 +138,6 @@ export class CalendarEntity {
    * 日付をYYYY-MM-DD形式に変換
    */
   static formatDateKey(date: Date): string {
-    const y = date.getFullYear();
-    const m = String(date.getMonth() + 1).padStart(2, '0');
-    const d = String(date.getDate()).padStart(2, '0');
-    return `${y}-${m}-${d}`;
+    return DateRangeHelper.toDateKey(date);
   }
 }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -8,6 +8,16 @@ const DAY_TO_INDEX: Record<string, number> = {
 
 export class DateRangeHelper {
   /**
+   * 日付をYYYY-MM-DD形式のキーに変換
+   */
+  static toDateKey(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  /**
    * 指定日数前の日付を0時0分0秒で返す
    */
   static daysAgo(days: number, from: Date = new Date()): Date {

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -2,6 +2,9 @@
  * 体調記録エンティティ
  */
 
+import { DAY_LABELS_JP } from '../../lib/constants';
+import { DateRangeHelper } from './DateRange';
+
 export const CONDITION_LEVELS = [1, 2, 3, 4, 5] as const;
 export type ConditionLevel = (typeof CONDITION_LEVELS)[number];
 
@@ -94,8 +97,7 @@ export class HealthLogEntity {
     const groups = new Map<string, HealthLog[]>();
 
     for (const log of logs) {
-      const d = log.recordedAt;
-      const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      const dateStr = DateRangeHelper.toDateKey(log.recordedAt);
       if (!groups.has(dateStr)) {
         groups.set(dateStr, []);
       }
@@ -137,8 +139,7 @@ export class HealthLogEntity {
    */
   static formatDate(dateStr: string): string {
     const date = new Date(dateStr + 'T00:00:00');
-    const days = ['日', '月', '火', '水', '木', '金', '土'];
-    return `${date.getMonth() + 1}月${date.getDate()}日(${days[date.getDay()]})`;
+    return `${date.getMonth() + 1}月${date.getDate()}日(${DAY_LABELS_JP[date.getDay()]})`;
   }
 
   /**
@@ -149,20 +150,15 @@ export class HealthLogEntity {
     days: number,
     today: Date,
   ): { date: string; dayLabel: string; average: number | null }[] {
-    const dayLabels = ['日', '月', '火', '水', '木', '金', '土'];
     const result: { date: string; dayLabel: string; average: number | null }[] = [];
 
     for (let i = days - 1; i >= 0; i--) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
-      const dateKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-      const dayLabel = dayLabels[d.getDay()];
+      const dateKey = DateRangeHelper.toDateKey(d);
+      const dayLabel = DAY_LABELS_JP[d.getDay()];
 
-      const dayLogs = logs.filter((log) => {
-        const ld = log.recordedAt;
-        const logKey = `${ld.getFullYear()}-${String(ld.getMonth() + 1).padStart(2, '0')}-${String(ld.getDate()).padStart(2, '0')}`;
-        return logKey === dateKey;
-      });
+      const dayLogs = logs.filter((log) => DateRangeHelper.toDateKey(log.recordedAt) === dateKey);
 
       if (dayLogs.length === 0) {
         result.push({ date: dateKey, dayLabel, average: null });

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -2,6 +2,9 @@
  * 服薬記録エンティティ
  */
 
+import { DAY_LABELS_JP } from '../../lib/constants';
+import { DateRangeHelper } from './DateRange';
+
 export interface MedicationRecord {
   readonly id: string;
   readonly memberId: string;
@@ -31,8 +34,7 @@ export class MedicationRecordEntity {
     const groups = new Map<string, MedicationRecord[]>();
 
     for (const record of records) {
-      const d = record.takenAt;
-      const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      const dateStr = DateRangeHelper.toDateKey(record.takenAt);
       if (!groups.has(dateStr)) {
         groups.set(dateStr, []);
       }
@@ -49,8 +51,7 @@ export class MedicationRecordEntity {
    */
   static formatDate(dateStr: string): string {
     const date = new Date(dateStr + 'T00:00:00');
-    const days = ['日', '月', '火', '水', '木', '金', '土'];
-    return `${date.getMonth() + 1}月${date.getDate()}日(${days[date.getDay()]})`;
+    return `${date.getMonth() + 1}月${date.getDate()}日(${DAY_LABELS_JP[date.getDay()]})`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- DateRangeHelper.toDateKey()を新規追加し、4エンティティに散在していたYYYY-MM-DD変換ロジックを集約
- HealthLog, MedicationRecord, Calendar内のハードコーディングされた曜日配列をDAY_LABELS_JP定数に統一
- AdherenceStats.toDateKey()をDateRangeHelper.toDateKey()に置換

## Test plan
- [x] DateRangeHelper.toDateKeyのテスト (3件追加)
- [x] 既存テスト886件全パス
- [x] ビルド成功

closes #225