### PR TITLE
test: HealthLogEntity及びGreetingMessageEntityのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/GreetingMessageEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/GreetingMessageEntity.edge.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity 境界値テスト', () => {
+  describe('getTimeGreeting', () => {
+    it('4時はこんばんは(夜)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(4)).toBe('こんばんは');
+    });
+
+    it('5時はおはよう(朝の境界)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(5)).toBe('おはよう');
+    });
+
+    it('11時はおはよう(朝の終わり)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(11)).toBe('おはよう');
+    });
+
+    it('12時はこんにちは(昼の境界)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(12)).toBe('こんにちは');
+    });
+
+    it('17時はこんにちは(昼の終わり)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(17)).toBe('こんにちは');
+    });
+
+    it('18時はこんばんは(夜の境界)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(18)).toBe('こんばんは');
+    });
+
+    it('0時はこんばんは(深夜)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(0)).toBe('こんばんは');
+    });
+
+    it('23時はこんばんは(深夜前)', () => {
+      expect(GreetingMessageEntity.getTimeGreeting(23)).toBe('こんばんは');
+    });
+  });
+
+  describe('getWeeklySummaryMessage', () => {
+    it('89%は順調メッセージ', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(89)).toBe('順調にお薬を服用できています');
+    });
+
+    it('90%は素晴らしいメッセージ(境界)', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(90)).toBe('素晴らしい1週間です。この調子で続けましょう');
+    });
+
+    it('100%は素晴らしいメッセージ', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(100)).toBe('素晴らしい1週間です。この調子で続けましょう');
+    });
+
+    it('70%は順調メッセージ(境界)', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(70)).toBe('順調にお薬を服用できています');
+    });
+
+    it('69%は少しずつメッセージ', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(69)).toBe('少しずつ習慣にしていきましょう');
+    });
+
+    it('50%は少しずつメッセージ(境界)', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(50)).toBe('少しずつ習慣にしていきましょう');
+    });
+
+    it('49%は頑張りましょうメッセージ', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(49)).toBe('一緒に頑張りましょう。無理せず続けることが大切です');
+    });
+
+    it('0%は頑張りましょうメッセージ', () => {
+      expect(GreetingMessageEntity.getWeeklySummaryMessage(0)).toBe('一緒に頑張りましょう。無理せず続けることが大切です');
+    });
+  });
+
+  describe('getDayOfWeekMessage', () => {
+    it('全曜日でメッセージを返す', () => {
+      for (let i = 0; i <= 6; i++) {
+        const message = GreetingMessageEntity.getDayOfWeekMessage(i);
+        expect(typeof message).toBe('string');
+        expect(message.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('火水木は同じデフォルトメッセージ', () => {
+      expect(GreetingMessageEntity.getDayOfWeekMessage(2)).toBe('今日も頑張りましょう');
+      expect(GreetingMessageEntity.getDayOfWeekMessage(3)).toBe('今日も頑張りましょう');
+      expect(GreetingMessageEntity.getDayOfWeekMessage(4)).toBe('今日も頑張りましょう');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HealthLogEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/HealthLogEntity.edge.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, HealthLog, ConditionLevel } from '@/domain/entities/HealthLog';
+
+const makeLog = (overrides: Partial<HealthLog> & { conditionLevel: ConditionLevel; recordedAt: Date }): HealthLog => ({
+  id: 'log-1',
+  memberId: 'member-1',
+  memberName: 'Test',
+  userId: 'user-1',
+  symptoms: [],
+  ...overrides,
+});
+
+describe('HealthLogEntity エッジケース', () => {
+  describe('getDailyAverages', () => {
+    it('0日指定で空配列を返す', () => {
+      const result = HealthLogEntity.getDailyAverages([], 0, new Date('2026-03-05'));
+      expect(result).toEqual([]);
+    });
+
+    it('全日データなしの場合averageがnull', () => {
+      const result = HealthLogEntity.getDailyAverages([], 3, new Date('2026-03-05'));
+      expect(result).toHaveLength(3);
+      expect(result.every((d) => d.average === null)).toBe(true);
+    });
+
+    it('同日に複数記録がある場合は平均を丸める', () => {
+      const logs = [
+        makeLog({ conditionLevel: 3, recordedAt: new Date('2026-03-05T08:00:00') }),
+        makeLog({ conditionLevel: 4, recordedAt: new Date('2026-03-05T20:00:00') }),
+      ];
+      const result = HealthLogEntity.getDailyAverages(logs, 1, new Date('2026-03-05'));
+      expect(result[0].average).toBe(4); // Math.round(3.5) = 4
+    });
+
+    it('1日指定で当日のみ返す', () => {
+      const result = HealthLogEntity.getDailyAverages([], 1, new Date('2026-03-05'));
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe('2026-03-05');
+    });
+
+    it('年をまたぐ範囲を正しく処理する', () => {
+      const result = HealthLogEntity.getDailyAverages([], 3, new Date('2026-01-01'));
+      expect(result[0].date).toBe('2025-12-30');
+      expect(result[2].date).toBe('2026-01-01');
+    });
+  });
+
+  describe('getConditionTrendDirection', () => {
+    it('全てnullの場合stableを返す', () => {
+      const result = HealthLogEntity.getConditionTrendDirection([
+        { average: null },
+        { average: null },
+        { average: null },
+      ]);
+      expect(result).toBe('stable');
+    });
+
+    it('1件のみの場合stableを返す', () => {
+      const result = HealthLogEntity.getConditionTrendDirection([{ average: 5 }]);
+      expect(result).toBe('stable');
+    });
+
+    it('全て同値の場合stableを返す', () => {
+      const result = HealthLogEntity.getConditionTrendDirection([
+        { average: 3 },
+        { average: 3 },
+        { average: 3 },
+        { average: 3 },
+      ]);
+      expect(result).toBe('stable');
+    });
+
+    it('差が0.5以下の場合stableを返す', () => {
+      const result = HealthLogEntity.getConditionTrendDirection([
+        { average: 3 },
+        { average: 3 },
+        { average: 3 },
+        { average: 3.5 },
+      ]);
+      expect(result).toBe('stable');
+    });
+
+    it('nullが混在しても有効な値で判定する', () => {
+      const result = HealthLogEntity.getConditionTrendDirection([
+        { average: 1 },
+        { average: null },
+        { average: null },
+        { average: 5 },
+      ]);
+      expect(result).toBe('up');
+    });
+  });
+
+  describe('getMostFrequentSymptoms', () => {
+    it('同数の症状はソート順に返す', () => {
+      const logs = [
+        makeLog({ conditionLevel: 3, recordedAt: new Date(), symptoms: ['headache'] }),
+        makeLog({ conditionLevel: 3, recordedAt: new Date(), symptoms: ['fever'] }),
+      ];
+      const result = HealthLogEntity.getMostFrequentSymptoms(logs, 3);
+      expect(result).toHaveLength(2);
+      expect(result[0].count).toBe(1);
+      expect(result[1].count).toBe(1);
+    });
+
+    it('limitが0の場合空配列を返す', () => {
+      const logs = [
+        makeLog({ conditionLevel: 3, recordedAt: new Date(), symptoms: ['headache'] }),
+      ];
+      const result = HealthLogEntity.getMostFrequentSymptoms(logs, 0);
+      expect(result).toHaveLength(0);
+    });
+
+    it('症状なしの記録のみの場合空配列を返す', () => {
+      const logs = [
+        makeLog({ conditionLevel: 3, recordedAt: new Date(), symptoms: [] }),
+        makeLog({ conditionLevel: 4, recordedAt: new Date(), symptoms: [] }),
+      ];
+      const result = HealthLogEntity.getMostFrequentSymptoms(logs);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('getAverageCondition', () => {
+    it('空配列で0を返す', () => {
+      expect(HealthLogEntity.getAverageCondition([])).toBe(0);
+    });
+
+    it('1件のみでそのレベルを返す', () => {
+      const logs = [makeLog({ conditionLevel: 4, recordedAt: new Date() })];
+      expect(HealthLogEntity.getAverageCondition(logs)).toBe(4);
+    });
+
+    it('小数点1桁に丸める', () => {
+      const logs = [
+        makeLog({ conditionLevel: 1, recordedAt: new Date() }),
+        makeLog({ conditionLevel: 2, recordedAt: new Date() }),
+        makeLog({ conditionLevel: 3, recordedAt: new Date() }),
+      ];
+      expect(HealthLogEntity.getAverageCondition(logs)).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- HealthLogEntityのgetDailyAverages, getConditionTrendDirection, getMostFrequentSymptoms, getAverageConditionの境界値テスト16件追加
- GreetingMessageEntityのgetTimeGreeting, getWeeklySummaryMessage, getDayOfWeekMessageの境界値テスト18件追加

## Test plan
- [x] HealthLogEntity境界値テスト (16件)
- [x] GreetingMessageEntity境界値テスト (18件)
- [x] 全テスト920件パス

closes #227