### PR TITLE
feat: 服薬記録のメモフィルター機能を追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationRecordNotes.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordNotes.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord, DailyRecordGroup } from '@/domain/entities/MedicationRecord';
+
+const makeRecord = (overrides: Partial<MedicationRecord>): MedicationRecord => ({
+  id: 'rec-1',
+  memberId: 'member-1',
+  memberName: 'Test',
+  medicationId: 'med-1',
+  medicationName: 'Test Med',
+  userId: 'user-1',
+  takenAt: new Date('2026-03-05T08:00:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity メモフィルター', () => {
+  describe('hasNotes', () => {
+    it('メモありの記録はtrueを返す', () => {
+      const record = makeRecord({ notes: 'テストメモ' });
+      expect(MedicationRecordEntity.hasNotes(record)).toBe(true);
+    });
+
+    it('メモなしの記録はfalseを返す', () => {
+      const record = makeRecord({});
+      expect(MedicationRecordEntity.hasNotes(record)).toBe(false);
+    });
+
+    it('空文字のメモはfalseを返す', () => {
+      const record = makeRecord({ notes: '' });
+      expect(MedicationRecordEntity.hasNotes(record)).toBe(false);
+    });
+
+    it('空白のみのメモはfalseを返す', () => {
+      const record = makeRecord({ notes: '   ' });
+      expect(MedicationRecordEntity.hasNotes(record)).toBe(false);
+    });
+  });
+
+  describe('filterWithNotes', () => {
+    it('メモ付き記録のみを返す', () => {
+      const records = [
+        makeRecord({ id: '1', notes: 'メモあり' }),
+        makeRecord({ id: '2' }),
+        makeRecord({ id: '3', notes: '別のメモ' }),
+      ];
+      const result = MedicationRecordEntity.filterWithNotes(records);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('1');
+      expect(result[1].id).toBe('3');
+    });
+
+    it('メモ付き記録がない場合は空配列を返す', () => {
+      const records = [makeRecord({ id: '1' }), makeRecord({ id: '2' })];
+      const result = MedicationRecordEntity.filterWithNotes(records);
+      expect(result).toHaveLength(0);
+    });
+
+    it('空配列の場合は空配列を返す', () => {
+      expect(MedicationRecordEntity.filterWithNotes([])).toHaveLength(0);
+    });
+  });
+
+  describe('filterGroupsWithNotes', () => {
+    it('グループ内のメモ付き記録のみを残す', () => {
+      const groups: DailyRecordGroup[] = [
+        {
+          date: '2026-03-05',
+          records: [
+            makeRecord({ id: '1', notes: 'メモ' }),
+            makeRecord({ id: '2' }),
+          ],
+        },
+      ];
+      const result = MedicationRecordEntity.filterGroupsWithNotes(groups);
+      expect(result).toHaveLength(1);
+      expect(result[0].records).toHaveLength(1);
+      expect(result[0].records[0].id).toBe('1');
+    });
+
+    it('メモ付き記録がないグループは除外する', () => {
+      const groups: DailyRecordGroup[] = [
+        {
+          date: '2026-03-05',
+          records: [makeRecord({ id: '1' })],
+        },
+        {
+          date: '2026-03-04',
+          records: [makeRecord({ id: '2', notes: 'メモ' })],
+        },
+      ];
+      const result = MedicationRecordEntity.filterGroupsWithNotes(groups);
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe('2026-03-04');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleTimePeriod.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimePeriod.test.ts
@@ -79,7 +79,7 @@ describe('ScheduleEntity 時間帯グループ化', () => {
         { scheduledTime: '18:00', id: '3' },
         { scheduledTime: '22:00', id: '4' },
       ];
-      const result = ScheduleEntity.groupByTimePeriod(schedules as any);
+      const result = ScheduleEntity.groupByTimePeriod(schedules);
       expect(result[0].schedules).toHaveLength(1); // morning
       expect(result[1].schedules).toHaveLength(1); // afternoon
       expect(result[2].schedules).toHaveLength(1); // evening
@@ -92,7 +92,7 @@ describe('ScheduleEntity 時間帯グループ化', () => {
         { scheduledTime: '09:00', id: '2' },
         { scheduledTime: '10:00', id: '3' },
       ];
-      const result = ScheduleEntity.groupByTimePeriod(schedules as any);
+      const result = ScheduleEntity.groupByTimePeriod(schedules);
       expect(result[0].schedules).toHaveLength(3); // all morning
       expect(result[1].schedules).toHaveLength(0);
       expect(result[2].schedules).toHaveLength(0);

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -85,4 +85,30 @@ export class MedicationRecordEntity {
       }))
       .filter((g) => g.records.length > 0);
   }
+
+  /**
+   * 記録にメモが含まれているか判定
+   */
+  static hasNotes(record: MedicationRecord): boolean {
+    return !!record.notes && record.notes.trim().length > 0;
+  }
+
+  /**
+   * メモ付き記録のみをフィルタリング
+   */
+  static filterWithNotes(records: MedicationRecord[]): MedicationRecord[] {
+    return records.filter((r) => MedicationRecordEntity.hasNotes(r));
+  }
+
+  /**
+   * グループ内のメモ付き記録のみを残し、空グループは除外
+   */
+  static filterGroupsWithNotes(groups: DailyRecordGroup[]): DailyRecordGroup[] {
+    return groups
+      .map((g) => ({
+        ...g,
+        records: g.records.filter((r) => MedicationRecordEntity.hasNotes(r)),
+      }))
+      .filter((g) => g.records.length > 0);
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityにhasNotes/filterWithNotes/filterGroupsWithNotesメソッドを追加
- 空文字・空白のみのメモは「メモなし」として扱う
- ScheduleTimePeriodテストのas anyを除去(lint修正)

## Test plan
- [x] hasNotesテスト (4件)
- [x] filterWithNotesテスト (3件)
- [x] filterGroupsWithNotesテスト (2件)
- [x] 全テスト946件パス
- [x] ビルド成功(lint警告0)

closes #233