### PR TITLE
feat: 体調レベルに応じたアイコン名取得メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/HealthLogIcon.test.ts
+++ b/src/__tests__/domain/entities/HealthLogIcon.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, ConditionLevel } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity getConditionIcon', () => {
+  it('レベル1はFrownアイコン', () => {
+    expect(HealthLogEntity.getConditionIcon(1)).toBe('Frown');
+  });
+
+  it('レベル2はMehアイコン', () => {
+    expect(HealthLogEntity.getConditionIcon(2)).toBe('Meh');
+  });
+
+  it('レベル3はMinusCircleアイコン', () => {
+    expect(HealthLogEntity.getConditionIcon(3)).toBe('MinusCircle');
+  });
+
+  it('レベル4はSmileアイコン', () => {
+    expect(HealthLogEntity.getConditionIcon(4)).toBe('Smile');
+  });
+
+  it('レベル5はLaughアイコン', () => {
+    expect(HealthLogEntity.getConditionIcon(5)).toBe('Laugh');
+  });
+
+  it('全レベルで文字列を返す', () => {
+    const levels: ConditionLevel[] = [1, 2, 3, 4, 5];
+    for (const level of levels) {
+      const icon = HealthLogEntity.getConditionIcon(level);
+      expect(typeof icon).toBe('string');
+      expect(icon.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -84,6 +84,20 @@ export class HealthLogEntity {
   }
 
   /**
+   * 体調レベルに応じたlucide-reactアイコン名を取得
+   */
+  static getConditionIcon(level: ConditionLevel): string {
+    const icons: Record<ConditionLevel, string> = {
+      1: 'Frown',
+      2: 'Meh',
+      3: 'MinusCircle',
+      4: 'Smile',
+      5: 'Laugh',
+    };
+    return icons[level];
+  }
+
+  /**
    * 症状ラベルを取得
    */
   static getSymptomLabel(symptom: SymptomType): string {


### PR DESCRIPTION
## Summary
- HealthLogEntityにgetConditionIconメソッドを追加
- 各レベルに対応するlucide-reactアイコン名(Frown/Meh/MinusCircle/Smile/Laugh)を返す

## Test plan
- [x] getConditionIconテスト (6件)
- [x] 全テスト952件パス
- [x] ビルド成功

closes #235