### PR TITLE
fix: APIクエリのtake上限を統一定数化

### DIFF
--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -3,6 +3,7 @@ import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
 import { DateRangeHelper } from '@/domain/entities/DateRange';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
@@ -13,23 +14,23 @@ export const GET = withAuth(async (userId) => {
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: sevenDaysAgo } },
       select: { memberId: true, medicationId: true, takenAt: true },
-      take: 5000,
+      take: QUERY_LIMITS.RECORDS,
     }),
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: thirtyDaysAgo } },
       select: { memberId: true, medicationId: true, takenAt: true },
-      take: 5000,
+      take: QUERY_LIMITS.RECORDS,
     }),
     prisma.medicationRecord.findMany({
       where: { userId },
       select: { takenAt: true },
       orderBy: { takenAt: 'desc' },
-      take: 10000,
+      take: QUERY_LIMITS.RECORDS,
     }),
     prisma.schedule.findMany({
       where: { userId, isEnabled: true },
       select: { memberId: true, medicationId: true, daysOfWeek: true },
-      take: 1000,
+      take: QUERY_LIMITS.SCHEDULES,
     }),
     prisma.member.findMany({
       where: { userId },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,3 +4,12 @@
 
 /** 曜日ラベル（日曜始まり、Date.getDay()のインデックスに対応） */
 export const DAY_LABELS_JP = ['日', '月', '火', '水', '木', '金', '土'] as const;
+
+/** APIクエリのtake上限値 */
+export const QUERY_LIMITS = {
+  DEFAULT: 100,
+  RECORDS: 5000,
+  SCHEDULES: 500,
+  MEMBERS: 100,
+  APPOINTMENTS: 200,
+} as const;


### PR DESCRIPTION
## Summary
- QUERY_LIMITS定数をlib/constantsに追加(DEFAULT: 100, RECORDS: 5000, SCHEDULES: 500, MEMBERS: 100, APPOINTMENTS: 200)
- records/stats/route.tsのtake: 10000をQUERY_LIMITS.RECORDS(5000)に引き下げ
- 同ルートの他のtake値もQUERY_LIMITS定数に置換

## Test plan
- [x] 全テスト986件パス
- [x] ビルド成功

closes #241