### PR TITLE
feat: スケジュール完了サマリー機能を追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleCompletionSummary.test.ts
+++ b/src/__tests__/domain/entities/ScheduleCompletionSummary.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 完了サマリー', () => {
+  describe('calculateCompletionRate', () => {
+    it('全て完了で100を返す', () => {
+      expect(ScheduleEntity.calculateCompletionRate(5, 5)).toBe(100);
+    });
+
+    it('0件完了で0を返す', () => {
+      expect(ScheduleEntity.calculateCompletionRate(0, 5)).toBe(0);
+    });
+
+    it('総数0で0を返す', () => {
+      expect(ScheduleEntity.calculateCompletionRate(0, 0)).toBe(0);
+    });
+
+    it('半分完了で50を返す', () => {
+      expect(ScheduleEntity.calculateCompletionRate(3, 6)).toBe(50);
+    });
+
+    it('端数は四捨五入する', () => {
+      expect(ScheduleEntity.calculateCompletionRate(1, 3)).toBe(33);
+    });
+  });
+
+  describe('getCompletionMessage', () => {
+    it('100%で全て完了メッセージ', () => {
+      expect(ScheduleEntity.getCompletionMessage(100)).toBe('全ての予定が完了しました');
+    });
+
+    it('80%以上であと少しメッセージ', () => {
+      expect(ScheduleEntity.getCompletionMessage(80)).toBe('あと少しで全て完了です');
+    });
+
+    it('50%以上で順調メッセージ', () => {
+      expect(ScheduleEntity.getCompletionMessage(50)).toBe('順調に進んでいます');
+    });
+
+    it('50%未満で頑張りましょうメッセージ', () => {
+      expect(ScheduleEntity.getCompletionMessage(49)).toBe('今日も頑張りましょう');
+    });
+
+    it('0%で頑張りましょうメッセージ', () => {
+      expect(ScheduleEntity.getCompletionMessage(0)).toBe('今日も頑張りましょう');
+    });
+
+    it('79%は順調メッセージ(境界)', () => {
+      expect(ScheduleEntity.getCompletionMessage(79)).toBe('順調に進んでいます');
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -194,6 +194,24 @@ export class ScheduleEntity {
     return groups;
   }
 
+  /**
+   * 完了率を算出(0-100%)
+   */
+  static calculateCompletionRate(completed: number, total: number): number {
+    if (total <= 0) return 0;
+    return Math.round((completed / total) * 100);
+  }
+
+  /**
+   * 完了率に応じたメッセージを返す
+   */
+  static getCompletionMessage(rate: number): string {
+    if (rate >= 100) return '全ての予定が完了しました';
+    if (rate >= 80) return 'あと少しで全て完了です';
+    if (rate >= 50) return '順調に進んでいます';
+    return '今日も頑張りましょう';
+  }
+
   get id(): string {
     return this.schedule.id;
   }


### PR DESCRIPTION
## Summary
- ScheduleEntityにcalculateCompletionRate/getCompletionMessageメソッドを追加
- 完了率(0-100%)算出と完了率に応じた4段階メッセージ生成

## Test plan
- [x] calculateCompletionRateテスト (5件)
- [x] getCompletionMessageテスト (6件)
- [x] 全テスト997件パス
- [x] ビルド成功

closes #243