### PR TITLE
feat: メンバー種別に応じたアイコン名取得メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/MemberIcon.test.ts
+++ b/src/__tests__/domain/entities/MemberIcon.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity getMemberIcon', () => {
+  it('人間メンバーはUserアイコン', () => {
+    expect(MemberEntity.getMemberIcon('human')).toBe('User');
+  });
+
+  it('犬はDogアイコン', () => {
+    expect(MemberEntity.getMemberIcon('pet', 'dog')).toBe('Dog');
+  });
+
+  it('猫はCatアイコン', () => {
+    expect(MemberEntity.getMemberIcon('pet', 'cat')).toBe('Cat');
+  });
+
+  it('うさぎはRabbitアイコン', () => {
+    expect(MemberEntity.getMemberIcon('pet', 'rabbit')).toBe('Rabbit');
+  });
+
+  it('鳥はBirdアイコン', () => {
+    expect(MemberEntity.getMemberIcon('pet', 'bird')).toBe('Bird');
+  });
+
+  it('その他ペットはPawPrintアイコン', () => {
+    expect(MemberEntity.getMemberIcon('pet', 'other')).toBe('PawPrint');
+  });
+
+  it('ペットでpetType未指定はPawPrintアイコン', () => {
+    expect(MemberEntity.getMemberIcon('pet')).toBe('PawPrint');
+  });
+});

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -91,4 +91,18 @@ export class MemberEntity {
       typeLabel: this.isPet() ? 'ペット' : '家族',
     };
   }
+
+  /**
+   * メンバー種別に応じたlucide-reactアイコン名を返す
+   */
+  static getMemberIcon(memberType: MemberType, petType?: PetType): string {
+    if (memberType === 'human') return 'User';
+    const petIcons: Record<string, string> = {
+      dog: 'Dog',
+      cat: 'Cat',
+      rabbit: 'Rabbit',
+      bird: 'Bird',
+    };
+    return petIcons[petType ?? ''] ?? 'PawPrint';
+  }
 }


### PR DESCRIPTION
## Summary
- MemberEntityにgetMemberIconメソッドを追加
- 人間(User)/犬(Dog)/猫(Cat)/うさぎ(Rabbit)/鳥(Bird)/その他(PawPrint)に対応

## Test plan
- [x] getMemberIconテスト (7件)
- [x] 全テスト1010件パス
- [x] ビルド成功

closes #247