### PR TITLE
リレーション展開パターンをflattenRelationsに共通化

### DIFF
--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createAppointmentSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const appointments = await prisma.appointment.findMany({
@@ -13,13 +13,9 @@ export const GET = withAuth(async (userId) => {
       hospital: { select: { name: true } },
     },
   });
-  const result = appointments.map((a) => ({
-    ...a,
-    memberName: a.member.name,
-    hospitalName: a.hospital?.name,
-    member: undefined,
-    hospital: undefined,
-  }));
+  const result = appointments.map((a) =>
+    flattenRelations(a, { member: 'memberName', hospital: 'hospitalName' }),
+  );
   return success(result);
 });
 

--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createHealthLogSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const logs = await prisma.healthLog.findMany({
@@ -12,11 +12,9 @@ export const GET = withAuth(async (userId) => {
       member: { select: { name: true } },
     },
   });
-  const result = logs.map((log) => ({
-    ...log,
-    memberName: log.member.name,
-    member: undefined,
-  }));
+  const result = logs.map((log) =>
+    flattenRelations(log, { member: 'memberName' }),
+  );
   return success(result);
 });
 

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createRecordSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
 
 export const GET = withAuth(async (userId) => {
   const records = await prisma.medicationRecord.findMany({
@@ -13,13 +13,9 @@ export const GET = withAuth(async (userId) => {
       medication: { select: { name: true } },
     },
   });
-  const result = records.map((r) => ({
-    ...r,
-    memberName: r.member.name,
-    medicationName: r.medication.name,
-    member: undefined,
-    medication: undefined,
-  }));
+  const result = records.map((r) =>
+    flattenRelations(r, { member: 'memberName', medication: 'medicationName' }),
+  );
   return success(result);
 });
 

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -80,6 +80,24 @@ export function validateParamId(id: string): Response | null {
  * リクエストボディのサイズを検証する
  * 制限を超える場合は413レスポンスを返す
  */
+/**
+ * Prismaのincludeで取得したリレーションオブジェクトを
+ * フラットなフィールドに変換する
+ * 例: { member: { name: '太郎' } } → { memberName: '太郎', member: undefined }
+ */
+export function flattenRelations(
+  record: Record<string, unknown>,
+  mappings: Record<string, string>,
+): Record<string, unknown> {
+  const result = { ...record };
+  for (const [relationKey, flatKey] of Object.entries(mappings)) {
+    const relation = record[relationKey] as { name: string } | null | undefined;
+    result[flatKey] = relation?.name;
+    result[relationKey] = undefined;
+  }
+  return result;
+}
+
 const MAX_BODY_SIZE = 100 * 1024; // 100KB
 
 export function validateBodySize(request: Request): Response | null {


### PR DESCRIPTION
## Summary
- records, appointments, health-logsの3つのAPIルートで重複していたリレーション展開パターンをapi-helpersのflattenRelations関数に抽出
- `{ ...r, memberName: r.member.name, member: undefined }` のような冗長な展開コードを `flattenRelations(r, { member: 'memberName' })` に統一

## Test plan
- [x] 既存テスト1010件全てパス
- [x] ビルド成功

closes #249