### PR TITLE
CalendarEntity・AppointmentEntityのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentEntity.edge.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity, Appointment } from '@/domain/entities/Appointment';
+
+const createAppointment = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: 'apt-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  appointmentDate: new Date('2026-03-05'),
+  reminderEnabled: true,
+  reminderDaysBefore: 1,
+  createdAt: new Date('2026-01-01'),
+  ...overrides,
+});
+
+describe('AppointmentEntity エッジケーステスト', () => {
+  describe('getFormattedDate 年初・年末', () => {
+    it('1月1日を正しくフォーマットする', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: new Date('2026-01-01T00:00:00') }),
+      );
+      expect(entity.getFormattedDate()).toBe('2026年1月1日(木)');
+    });
+
+    it('12月31日を正しくフォーマットする', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: new Date('2026-12-31T00:00:00') }),
+      );
+      expect(entity.getFormattedDate()).toBe('2026年12月31日(木)');
+    });
+
+    it('閏年2月29日を正しくフォーマットする', () => {
+      const entity = new AppointmentEntity(
+        createAppointment({ appointmentDate: new Date('2024-02-29T00:00:00') }),
+      );
+      expect(entity.getFormattedDate()).toBe('2024年2月29日(木)');
+    });
+  });
+
+  describe('countByType エッジケース', () => {
+    it('空配列は空オブジェクトを返す', () => {
+      expect(AppointmentEntity.countByType([])).toEqual({});
+    });
+
+    it('appointmentType未設定はotherにカウントされる', () => {
+      const appointments = [createAppointment()];
+      expect(AppointmentEntity.countByType(appointments)).toEqual({ other: 1 });
+    });
+
+    it('複数種別を正しくカウントする', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'treatment' }),
+        createAppointment({ appointmentType: 'vaccination' }),
+        createAppointment({ appointmentType: 'vaccination' }),
+        createAppointment({ appointmentType: 'vaccination' }),
+      ];
+      expect(AppointmentEntity.countByType(appointments)).toEqual({
+        checkup: 2,
+        treatment: 1,
+        vaccination: 3,
+      });
+    });
+
+    it('全て同じ種別の場合', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'surgery' }),
+        createAppointment({ appointmentType: 'surgery' }),
+      ];
+      expect(AppointmentEntity.countByType(appointments)).toEqual({ surgery: 2 });
+    });
+  });
+
+  describe('getUpcomingCount エッジケース', () => {
+    const today = new Date('2026-03-05T12:00:00');
+
+    it('空配列は0を返す', () => {
+      expect(AppointmentEntity.getUpcomingCount([], today)).toBe(0);
+    });
+
+    it('全て過去の予約は0を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentDate: new Date('2026-03-01') }),
+        createAppointment({ appointmentDate: new Date('2026-02-28') }),
+      ];
+      expect(AppointmentEntity.getUpcomingCount(appointments, today)).toBe(0);
+    });
+
+    it('当日の予約はカウントに含まれる', () => {
+      const appointments = [
+        createAppointment({ appointmentDate: new Date('2026-03-05') }),
+      ];
+      expect(AppointmentEntity.getUpcomingCount(appointments, today)).toBe(1);
+    });
+
+    it('過去と未来が混在する場合、未来のみカウント', () => {
+      const appointments = [
+        createAppointment({ appointmentDate: new Date('2026-03-01') }),
+        createAppointment({ appointmentDate: new Date('2026-03-05') }),
+        createAppointment({ appointmentDate: new Date('2026-03-10') }),
+        createAppointment({ appointmentDate: new Date('2026-04-01') }),
+      ];
+      expect(AppointmentEntity.getUpcomingCount(appointments, today)).toBe(3);
+    });
+
+    it('全て未来の予約は全件を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentDate: new Date('2026-03-10') }),
+        createAppointment({ appointmentDate: new Date('2026-04-01') }),
+      ];
+      expect(AppointmentEntity.getUpcomingCount(appointments, today)).toBe(2);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/CalendarEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarEntity.edge.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity エッジケーステスト', () => {
+  describe('getConditionColor 境界値', () => {
+    it('レベル5は緑を返す', () => {
+      expect(CalendarEntity.getConditionColor(5)).toBe('bg-green-100');
+    });
+
+    it('レベル4はちょうど緑の境界', () => {
+      expect(CalendarEntity.getConditionColor(4)).toBe('bg-green-100');
+    });
+
+    it('レベル3.9は黄色を返す', () => {
+      expect(CalendarEntity.getConditionColor(3.9)).toBe('bg-yellow-100');
+    });
+
+    it('レベル3はちょうど黄色の境界', () => {
+      expect(CalendarEntity.getConditionColor(3)).toBe('bg-yellow-100');
+    });
+
+    it('レベル2.9はオレンジを返す', () => {
+      expect(CalendarEntity.getConditionColor(2.9)).toBe('bg-orange-100');
+    });
+
+    it('レベル2はちょうどオレンジの境界', () => {
+      expect(CalendarEntity.getConditionColor(2)).toBe('bg-orange-100');
+    });
+
+    it('レベル1.9は赤を返す', () => {
+      expect(CalendarEntity.getConditionColor(1.9)).toBe('bg-red-100');
+    });
+
+    it('レベル0は赤を返す', () => {
+      expect(CalendarEntity.getConditionColor(0)).toBe('bg-red-100');
+    });
+  });
+
+  describe('generateMonth 月初が日曜日の場合', () => {
+    it('前月の日が含まれない', () => {
+      // 2026年2月1日は日曜日
+      const days = CalendarEntity.generateMonth(2026, 1);
+      const firstDay = days[0];
+      expect(firstDay.date.getMonth()).toBe(1);
+      expect(firstDay.date.getDate()).toBe(1);
+      expect(firstDay.isCurrentMonth).toBe(true);
+    });
+  });
+
+  describe('generateMonth 月初が土曜日の場合', () => {
+    it('前月の日が6日分含まれる', () => {
+      // 2026年8月1日は土曜日
+      const days = CalendarEntity.generateMonth(2026, 7);
+      const prevMonthDays = days.filter((d) => !d.isCurrentMonth && d.date.getMonth() === 6);
+      expect(prevMonthDays).toHaveLength(6);
+    });
+  });
+
+  describe('getMonthLabel 境界値', () => {
+    it('0月は1月と表示', () => {
+      expect(CalendarEntity.getMonthLabel(2026, 0)).toBe('2026年1月');
+    });
+
+    it('11月は12月と表示', () => {
+      expect(CalendarEntity.getMonthLabel(2026, 11)).toBe('2026年12月');
+    });
+  });
+
+  describe('getWeekdayHeaders', () => {
+    it('元の配列を変更しても影響しない', () => {
+      const headers1 = CalendarEntity.getWeekdayHeaders();
+      headers1[0] = '変更';
+      const headers2 = CalendarEntity.getWeekdayHeaders();
+      expect(headers2[0]).toBe('日');
+    });
+  });
+
+  describe('formatDateKey 月末境界', () => {
+    it('2月28日(非閏年)', () => {
+      expect(CalendarEntity.formatDateKey(new Date(2025, 1, 28))).toBe('2025-02-28');
+    });
+
+    it('2月29日(閏年)', () => {
+      expect(CalendarEntity.formatDateKey(new Date(2024, 1, 29))).toBe('2024-02-29');
+    });
+
+    it('9月30日(30日月の末日)', () => {
+      expect(CalendarEntity.formatDateKey(new Date(2026, 8, 30))).toBe('2026-09-30');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- CalendarEntityのgetConditionColor境界値(小数点含む)、generateMonth月初曜日パターン、formatDateKey月末境界テスト追加(16件)
- AppointmentEntityのgetFormattedDate年初・年末・閏年、countByType空配列/未設定/複数種別、getUpcomingCount境界テスト追加(12件)
- テスト総数: 1010 → 1038件(+28件)

## Test plan
- [x] 新規28テスト全てパス
- [x] 既存テスト含め全1038件パス
- [x] ビルド成功

closes #251