### PR TITLE
APIルートのtake値をQUERY_LIMITS定数に統一

### DIFF
--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -2,12 +2,13 @@ import { prisma } from '@/lib/prisma';
 import { createAppointmentSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const appointments = await prisma.appointment.findMany({
     where: { userId },
     orderBy: { appointmentDate: 'asc' },
-    take: 200,
+    take: QUERY_LIMITS.APPOINTMENTS,
     include: {
       member: { select: { name: true } },
       hospital: { select: { name: true } },

--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -2,12 +2,13 @@ import { prisma } from '@/lib/prisma';
 import { createHealthLogSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const logs = await prisma.healthLog.findMany({
     where: { userId },
     orderBy: { recordedAt: 'desc' },
-    take: 100,
+    take: QUERY_LIMITS.DEFAULT,
     include: {
       member: { select: { name: true } },
     },

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -2,9 +2,10 @@ import { prisma } from '@/lib/prisma';
 import { createHospitalSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, validateBodySize } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const hospitals = await prisma.hospital.findMany({ where: { userId }, take: 100 });
+  const hospitals = await prisma.hospital.findMany({ where: { userId }, take: QUERY_LIMITS.DEFAULT });
   return success(hospitals);
 });
 

--- a/src/app/api/medications/alerts/route.ts
+++ b/src/app/api/medications/alerts/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { StockAlertEntity } from '@/domain/entities/StockAlert';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
@@ -15,12 +16,12 @@ export const GET = withAuth(async (userId) => {
       },
       include: { member: { select: { id: true, name: true } } },
       orderBy: { stockAlertDate: 'asc' },
-      take: 500,
+      take: QUERY_LIMITS.SCHEDULES,
     }),
     prisma.schedule.findMany({
       where: { userId, isEnabled: true },
       select: { medicationId: true },
-      take: 5000,
+      take: QUERY_LIMITS.RECORDS,
     }),
   ]);
 

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -2,9 +2,10 @@ import { prisma } from '@/lib/prisma';
 import { createMemberSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, validateBodySize } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const members = await prisma.member.findMany({ where: { userId }, take: 100 });
+  const members = await prisma.member.findMany({ where: { userId }, take: QUERY_LIMITS.MEMBERS });
   return success(members);
 });
 

--- a/src/app/api/members/summary/route.ts
+++ b/src/app/api/members/summary/route.ts
@@ -1,24 +1,25 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const [members, medications, appointments] = await Promise.all([
     prisma.member.findMany({
       where: { userId },
       select: { id: true, name: true, memberType: true },
-      take: 100,
+      take: QUERY_LIMITS.MEMBERS,
     }),
     prisma.medication.findMany({
       where: { userId, isActive: true },
       select: { memberId: true },
-      take: 500,
+      take: QUERY_LIMITS.SCHEDULES,
     }),
     prisma.appointment.findMany({
       where: { userId, appointmentDate: { gte: new Date() } },
       select: { memberId: true, appointmentDate: true },
       orderBy: { appointmentDate: 'asc' },
-      take: 500,
+      take: QUERY_LIMITS.APPOINTMENTS,
     }),
   ]);
 

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -2,12 +2,13 @@ import { prisma } from '@/lib/prisma';
 import { createRecordSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const records = await prisma.medicationRecord.findMany({
     where: { userId },
     orderBy: { takenAt: 'desc' },
-    take: 100,
+    take: QUERY_LIMITS.DEFAULT,
     include: {
       member: { select: { name: true } },
       medication: { select: { name: true } },

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -3,7 +3,7 @@ import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
 import { DateRangeHelper } from '@/domain/entities/DateRange';
-import { DAY_LABELS_JP } from '@/lib/constants';
+import { DAY_LABELS_JP, QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
@@ -14,12 +14,12 @@ export const GET = withAuth(async (userId) => {
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: fourteenDaysAgo } },
       select: { takenAt: true },
-      take: 5000,
+      take: QUERY_LIMITS.RECORDS,
     }),
     prisma.schedule.findMany({
       where: { userId, isEnabled: true },
       select: { daysOfWeek: true },
-      take: 1000,
+      take: QUERY_LIMITS.SCHEDULES,
     }),
   ]);
 

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -3,9 +3,10 @@ import { createScheduleSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
 import { ScheduleEntity, Schedule } from '@/domain/entities/Schedule';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const schedules = await prisma.schedule.findMany({ where: { userId }, take: 200 });
+  const schedules = await prisma.schedule.findMany({ where: { userId }, take: QUERY_LIMITS.SCHEDULES });
   return success(schedules);
 });
 

--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
   const now = new Date();
@@ -15,17 +16,17 @@ export const GET = withAuth(async (userId) => {
       include: {
         medication: { select: { id: true, name: true } },
       },
-      take: 500,
+      take: QUERY_LIMITS.SCHEDULES,
     }),
     prisma.medicationRecord.findMany({
       where: { userId, takenAt: { gte: todayStart, lte: todayEnd } },
       select: { scheduleId: true, medicationId: true },
-      take: 5000,
+      take: QUERY_LIMITS.RECORDS,
     }),
     prisma.member.findMany({
       where: { userId },
       select: { id: true, name: true, memberType: true },
-      take: 100,
+      take: QUERY_LIMITS.MEMBERS,
     }),
   ]);
 


### PR DESCRIPTION
## Summary
- 10のAPIルートでハードコードされていたtake値をQUERY_LIMITS定数に統一
- 対象: schedules, schedules/today, records, records/trends, appointments, health-logs, members, members/summary, hospitals, medications/alerts
- 一元管理により将来の上限値変更が容易に

## Test plan
- [x] 全1038テストパス
- [x] ビルド成功

closes #253