### PR TITLE
DateRangeHelperに期間ラベル・日付差分メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangePeriod.test.ts
+++ b/src/__tests__/domain/entities/DateRangePeriod.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper 期間ラベル・日付差分', () => {
+  describe('getPeriodLabel', () => {
+    it('7日は「過去7日間」を返す', () => {
+      expect(DateRangeHelper.getPeriodLabel(7)).toBe('過去7日間');
+    });
+
+    it('30日は「過去30日間」を返す', () => {
+      expect(DateRangeHelper.getPeriodLabel(30)).toBe('過去30日間');
+    });
+
+    it('1日は「過去1日間」を返す', () => {
+      expect(DateRangeHelper.getPeriodLabel(1)).toBe('過去1日間');
+    });
+
+    it('90日は「過去90日間」を返す', () => {
+      expect(DateRangeHelper.getPeriodLabel(90)).toBe('過去90日間');
+    });
+  });
+
+  describe('diffDays', () => {
+    it('同じ日は0を返す', () => {
+      const date = new Date('2026-03-05');
+      expect(DateRangeHelper.diffDays(date, date)).toBe(0);
+    });
+
+    it('1日後は1を返す', () => {
+      const from = new Date('2026-03-05');
+      const to = new Date('2026-03-06');
+      expect(DateRangeHelper.diffDays(from, to)).toBe(1);
+    });
+
+    it('過去の日は負の値を返す', () => {
+      const from = new Date('2026-03-05');
+      const to = new Date('2026-03-03');
+      expect(DateRangeHelper.diffDays(from, to)).toBe(-2);
+    });
+
+    it('年跨ぎも正しく計算する', () => {
+      const from = new Date('2025-12-30');
+      const to = new Date('2026-01-02');
+      expect(DateRangeHelper.diffDays(from, to)).toBe(3);
+    });
+
+    it('月末跨ぎも正しく計算する', () => {
+      const from = new Date('2026-02-28');
+      const to = new Date('2026-03-01');
+      expect(DateRangeHelper.diffDays(from, to)).toBe(1);
+    });
+  });
+
+  describe('isWithinDays', () => {
+    it('範囲内ならtrueを返す', () => {
+      const date = new Date('2026-03-03');
+      const reference = new Date('2026-03-05');
+      expect(DateRangeHelper.isWithinDays(date, reference, 7)).toBe(true);
+    });
+
+    it('ちょうど境界はtrueを返す', () => {
+      const date = new Date('2026-02-26');
+      const reference = new Date('2026-03-05');
+      expect(DateRangeHelper.isWithinDays(date, reference, 7)).toBe(true);
+    });
+
+    it('範囲外はfalseを返す', () => {
+      const date = new Date('2026-02-25');
+      const reference = new Date('2026-03-05');
+      expect(DateRangeHelper.isWithinDays(date, reference, 7)).toBe(false);
+    });
+
+    it('未来の日付もtrueを返す', () => {
+      const date = new Date('2026-03-07');
+      const reference = new Date('2026-03-05');
+      expect(DateRangeHelper.isWithinDays(date, reference, 7)).toBe(true);
+    });
+
+    it('0日指定で同日のみtrue', () => {
+      const date = new Date('2026-03-05');
+      const reference = new Date('2026-03-05');
+      expect(DateRangeHelper.isWithinDays(date, reference, 0)).toBe(true);
+    });
+  });
+});

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -45,4 +45,29 @@ export class DateRangeHelper {
     }
     return expected;
   }
+
+  /**
+   * 日数から期間ラベルを生成
+   */
+  static getPeriodLabel(days: number): string {
+    return `過去${days}日間`;
+  }
+
+  /**
+   * 2つの日付間の日数差を計算（to - from）
+   */
+  static diffDays(from: Date, to: Date): number {
+    const fromStart = new Date(from);
+    fromStart.setHours(0, 0, 0, 0);
+    const toStart = new Date(to);
+    toStart.setHours(0, 0, 0, 0);
+    return Math.round((toStart.getTime() - fromStart.getTime()) / (1000 * 60 * 60 * 24));
+  }
+
+  /**
+   * 日付が基準日からdays日以内かどうかを判定
+   */
+  static isWithinDays(date: Date, reference: Date, days: number): boolean {
+    return Math.abs(DateRangeHelper.diffDays(reference, date)) <= days;
+  }
 }


### PR DESCRIPTION
## Summary
- getPeriodLabel: 日数から「過去N日間」ラベルを生成
- diffDays: 2つの日付間の日数差を計算
- isWithinDays: 日付が基準日からN日以内かどうかを判定

## Test plan
- [x] 14テスト追加(全1083件パス)
- [x] ビルド成功

closes #259