### PR TITLE
日付正規化パターンをtoStartOfDayに共通化

### DIFF
--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -3,6 +3,7 @@
  */
 
 import { DAY_LABELS_JP } from '../../lib/constants';
+import { DateRangeHelper } from './DateRange';
 
 export interface Appointment {
   readonly id: string;
@@ -29,10 +30,8 @@ export class AppointmentEntity {
    * 予約が今日かどうか
    */
   isToday(): boolean {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const date = new Date(this.appointment.appointmentDate);
-    date.setHours(0, 0, 0, 0);
+    const today = DateRangeHelper.toStartOfDay(new Date());
+    const date = DateRangeHelper.toStartOfDay(new Date(this.appointment.appointmentDate));
     return today.getTime() === date.getTime();
   }
 
@@ -40,10 +39,8 @@ export class AppointmentEntity {
    * 予約が過去かどうか
    */
   isPast(): boolean {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const date = new Date(this.appointment.appointmentDate);
-    date.setHours(0, 0, 0, 0);
+    const today = DateRangeHelper.toStartOfDay(new Date());
+    const date = DateRangeHelper.toStartOfDay(new Date(this.appointment.appointmentDate));
     return date.getTime() < today.getTime();
   }
 
@@ -51,11 +48,7 @@ export class AppointmentEntity {
    * 予約日までの残り日数
    */
   daysUntil(): number {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const date = new Date(this.appointment.appointmentDate);
-    date.setHours(0, 0, 0, 0);
-    return Math.ceil((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    return DateRangeHelper.diffDays(new Date(), new Date(this.appointment.appointmentDate));
   }
 
   /**
@@ -105,11 +98,9 @@ export class AppointmentEntity {
    * 今日以降の予約件数を返す
    */
   static getUpcomingCount(appointments: Appointment[], today: Date): number {
-    const todayStart = new Date(today);
-    todayStart.setHours(0, 0, 0, 0);
+    const todayStart = DateRangeHelper.toStartOfDay(today);
     return appointments.filter((apt) => {
-      const aptDate = new Date(apt.appointmentDate);
-      aptDate.setHours(0, 0, 0, 0);
+      const aptDate = DateRangeHelper.toStartOfDay(new Date(apt.appointmentDate));
       return aptDate.getTime() >= todayStart.getTime();
     }).length;
   }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -18,12 +18,20 @@ export class DateRangeHelper {
   }
 
   /**
+   * 日付を0時0分0秒に正規化したコピーを返す
+   */
+  static toStartOfDay(date: Date): Date {
+    const d = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+
+  /**
    * 指定日数前の日付を0時0分0秒で返す
    */
   static daysAgo(days: number, from: Date = new Date()): Date {
-    const date = new Date(from);
+    const date = DateRangeHelper.toStartOfDay(from);
     date.setDate(date.getDate() - days);
-    date.setHours(0, 0, 0, 0);
     return date;
   }
 
@@ -57,10 +65,8 @@ export class DateRangeHelper {
    * 2つの日付間の日数差を計算（to - from）
    */
   static diffDays(from: Date, to: Date): number {
-    const fromStart = new Date(from);
-    fromStart.setHours(0, 0, 0, 0);
-    const toStart = new Date(to);
-    toStart.setHours(0, 0, 0, 0);
+    const fromStart = DateRangeHelper.toStartOfDay(from);
+    const toStart = DateRangeHelper.toStartOfDay(to);
     return Math.round((toStart.getTime() - fromStart.getTime()) / (1000 * 60 * 60 * 24));
   }
 


### PR DESCRIPTION
## Summary
- DateRangeHelper.toStartOfDay()メソッドを追加(日付を0時0分0秒に正規化)
- AppointmentEntityのisToday/isPast/daysUntil/getUpcomingCountをtoStartOfDay/diffDaysで書き換え
- daysAgo/diffDaysも内部でtoStartOfDayを利用するよう統一

## Test plan
- [x] 全1083テストパス
- [x] ビルド成功

closes #261