### PR TITLE
MedicationEntity・DateRangeHelperのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangeHelper.edge.test.ts
+++ b/src/__tests__/domain/entities/DateRangeHelper.edge.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper エッジケーステスト', () => {
+  describe('toStartOfDay', () => {
+    it('時刻が0時0分0秒0ミリ秒にリセットされる', () => {
+      const date = new Date('2026-03-05T15:30:45.123');
+      const result = DateRangeHelper.toStartOfDay(date);
+      expect(result.getHours()).toBe(0);
+      expect(result.getMinutes()).toBe(0);
+      expect(result.getSeconds()).toBe(0);
+      expect(result.getMilliseconds()).toBe(0);
+    });
+
+    it('元の日付を変更しない', () => {
+      const date = new Date('2026-03-05T15:30:00');
+      DateRangeHelper.toStartOfDay(date);
+      expect(date.getHours()).toBe(15);
+    });
+
+    it('既に0時の場合もそのまま返す', () => {
+      const date = new Date('2026-03-05T00:00:00.000');
+      const result = DateRangeHelper.toStartOfDay(date);
+      expect(result.getTime()).toBe(date.getTime());
+    });
+
+    it('23:59:59の場合も0時にリセットされる', () => {
+      const date = new Date('2026-03-05T23:59:59.999');
+      const result = DateRangeHelper.toStartOfDay(date);
+      expect(result.getHours()).toBe(0);
+      expect(result.getDate()).toBe(5);
+    });
+  });
+
+  describe('daysAgo 境界値', () => {
+    it('0日前は当日を返す', () => {
+      const from = new Date('2026-03-05T10:00:00');
+      const result = DateRangeHelper.daysAgo(0, from);
+      expect(result.getDate()).toBe(5);
+      expect(result.getHours()).toBe(0);
+    });
+
+    it('月跨ぎ(3月1日の2日前は2月27日)', () => {
+      const from = new Date('2026-03-01');
+      const result = DateRangeHelper.daysAgo(2, from);
+      expect(result.getMonth()).toBe(1); // 2月
+      expect(result.getDate()).toBe(27);
+    });
+
+    it('年跨ぎ(1月1日の1日前は12月31日)', () => {
+      const from = new Date('2026-01-01');
+      const result = DateRangeHelper.daysAgo(1, from);
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(11);
+      expect(result.getDate()).toBe(31);
+    });
+  });
+
+  describe('calculateExpectedByDayOfWeek', () => {
+    it('空配列は全て0を返す', () => {
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek([]);
+      expect(result).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('曜日未設定(空配列)のスケジュールは全曜日+1', () => {
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek([{ daysOfWeek: [] }]);
+      expect(result).toEqual([1, 1, 1, 1, 1, 1, 1]);
+    });
+
+    it('月水金のスケジュールは月水金のみ+1', () => {
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek([
+        { daysOfWeek: ['mon', 'wed', 'fri'] },
+      ]);
+      expect(result).toEqual([0, 1, 0, 1, 0, 1, 0]);
+    });
+
+    it('複数スケジュールは加算される', () => {
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek([
+        { daysOfWeek: ['mon'] },
+        { daysOfWeek: ['mon', 'tue'] },
+        { daysOfWeek: [] },
+      ]);
+      // 日:1, 月:3, 火:2, 水:1, 木:1, 金:1, 土:1
+      expect(result).toEqual([1, 3, 2, 1, 1, 1, 1]);
+    });
+
+    it('不正な曜日名は無視される', () => {
+      const result = DateRangeHelper.calculateExpectedByDayOfWeek([
+        { daysOfWeek: ['mon', 'invalid'] },
+      ]);
+      expect(result).toEqual([0, 1, 0, 0, 0, 0, 0]);
+    });
+  });
+
+  describe('toDateKey 境界値', () => {
+    it('1月1日のゼロパディング', () => {
+      expect(DateRangeHelper.toDateKey(new Date(2026, 0, 1))).toBe('2026-01-01');
+    });
+
+    it('12月31日', () => {
+      expect(DateRangeHelper.toDateKey(new Date(2026, 11, 31))).toBe('2026-12-31');
+    });
+
+    it('10月10日(パディング不要)', () => {
+      expect(DateRangeHelper.toDateKey(new Date(2026, 9, 10))).toBe('2026-10-10');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationEntity.edge.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity, Medication } from '@/domain/entities/Medication';
+
+const createMedication = (overrides: Partial<Medication> = {}): Medication => ({
+  id: 'med-1',
+  memberId: 'member-1',
+  userId: 'user-1',
+  name: 'テスト薬',
+  category: 'regular',
+  isActive: true,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ...overrides,
+});
+
+describe('MedicationEntity エッジケーステスト', () => {
+  describe('decreaseStock 境界値', () => {
+    it('在庫0から減らしても0のまま', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 0 }));
+      const result = entity.decreaseStock(1);
+      expect(result.stockQuantity).toBe(0);
+    });
+
+    it('在庫1から1減らすと0になる', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 1 }));
+      const result = entity.decreaseStock(1);
+      expect(result.stockQuantity).toBe(0);
+    });
+
+    it('在庫より多く減らしても0になる(負にならない)', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 3 }));
+      const result = entity.decreaseStock(10);
+      expect(result.stockQuantity).toBe(0);
+    });
+
+    it('デフォルト引数で1減る', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 5 }));
+      const result = entity.decreaseStock();
+      expect(result.stockQuantity).toBe(4);
+    });
+
+    it('stockQuantity未設定の場合は元のデータをそのまま返す', () => {
+      const med = createMedication();
+      const entity = new MedicationEntity(med);
+      const result = entity.decreaseStock(1);
+      expect(result).toBe(med);
+    });
+  });
+
+  describe('increaseStock 境界値', () => {
+    it('0に追加できる', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 0 }));
+      const result = entity.increaseStock(10);
+      expect(result.stockQuantity).toBe(10);
+    });
+
+    it('stockQuantity未設定の場合は元のデータをそのまま返す', () => {
+      const med = createMedication();
+      const entity = new MedicationEntity(med);
+      const result = entity.increaseStock(5);
+      expect(result).toBe(med);
+    });
+
+    it('大量追加できる', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 100 }));
+      const result = entity.increaseStock(9999);
+      expect(result.stockQuantity).toBe(10099);
+    });
+  });
+
+  describe('isLowStock 境界値', () => {
+    it('stockQuantity未設定はfalse', () => {
+      const entity = new MedicationEntity(createMedication({ stockAlertDate: new Date('2026-03-15') }));
+      expect(entity.isLowStock()).toBe(false);
+    });
+
+    it('stockAlertDate未設定はfalse', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 5 }));
+      expect(entity.isLowStock()).toBe(false);
+    });
+
+    it('両方未設定はfalse', () => {
+      const entity = new MedicationEntity(createMedication());
+      expect(entity.isLowStock()).toBe(false);
+    });
+  });
+
+  describe('getDisplayInfo', () => {
+    it('dosageとfrequency両方あるとスラッシュ区切り', () => {
+      const entity = new MedicationEntity(
+        createMedication({ dosage: '1錠', frequency: '1日3回' }),
+      );
+      const info = entity.getDisplayInfo();
+      expect(info.dosageInfo).toBe('1錠 / 1日3回');
+    });
+
+    it('dosageのみの場合', () => {
+      const entity = new MedicationEntity(createMedication({ dosage: '2錠' }));
+      const info = entity.getDisplayInfo();
+      expect(info.dosageInfo).toBe('2錠');
+    });
+
+    it('frequencyのみの場合', () => {
+      const entity = new MedicationEntity(createMedication({ frequency: '毎食後' }));
+      const info = entity.getDisplayInfo();
+      expect(info.dosageInfo).toBe('毎食後');
+    });
+
+    it('両方未設定の場合は空文字', () => {
+      const entity = new MedicationEntity(createMedication());
+      const info = entity.getDisplayInfo();
+      expect(info.dosageInfo).toBe('');
+    });
+
+    it('categoryLabelが正しい', () => {
+      const entity = new MedicationEntity(createMedication({ category: 'supplement' }));
+      const info = entity.getDisplayInfo();
+      expect(info.categoryLabel).toBe('サプリメント');
+    });
+  });
+
+  describe('getCategoryLabel', () => {
+    it('全カテゴリのラベルが取得できる', () => {
+      expect(MedicationEntity.getCategoryLabel('regular')).toBe('常用薬');
+      expect(MedicationEntity.getCategoryLabel('supplement')).toBe('サプリメント');
+      expect(MedicationEntity.getCategoryLabel('prn')).toBe('頓服薬');
+      expect(MedicationEntity.getCategoryLabel('inhaler')).toBe('吸入薬');
+      expect(MedicationEntity.getCategoryLabel('flea_tick')).toBe('ノミ・ダニ薬');
+      expect(MedicationEntity.getCategoryLabel('heartworm')).toBe('フィラリア薬');
+    });
+  });
+
+  describe('getAllCategories', () => {
+    it('6カテゴリ分のデータを返す', () => {
+      const categories = MedicationEntity.getAllCategories();
+      expect(categories).toHaveLength(6);
+    });
+
+    it('各カテゴリにidとlabelが含まれる', () => {
+      const categories = MedicationEntity.getAllCategories();
+      for (const cat of categories) {
+        expect(cat.id).toBeTruthy();
+        expect(cat.label).toBeTruthy();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MedicationEntityのdecreaseStock/increaseStock境界値、isLowStock未設定パターン、getDisplayInfo組合せテスト追加(19件)
- DateRangeHelperのtoStartOfDay不変性、daysAgo月/年跨ぎ、calculateExpectedByDayOfWeek複数パターンテスト追加(15件)
- テスト総数: 1083 → 1117件(+34件)

## Test plan
- [x] 新規34テスト全てパス
- [x] 全1117テストパス
- [x] ビルド成功

closes #263