### PR TITLE
残りAPIルートのtake値をQUERY_LIMITS定数に統一

### DIFF
--- a/src/app/api/medications/member/[memberId]/route.ts
+++ b/src/app/api/medications/member/[memberId]/route.ts
@@ -1,13 +1,14 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth, validateParamId } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
     const { memberId } = await params;
     const idError = validateParamId(memberId);
     if (idError) return idError;
-    const medications = await prisma.medication.findMany({ where: { memberId, userId }, take: 200 });
+    const medications = await prisma.medication.findMany({ where: { memberId, userId }, take: QUERY_LIMITS.APPOINTMENTS });
     return success(medications);
   })();
 }

--- a/src/app/api/medications/search/route.ts
+++ b/src/app/api/medications/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(request: NextRequest) {
   return withAuth(async (userId) => {
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
       },
       include: { member: { select: { id: true, name: true } } },
       orderBy: { name: 'asc' },
-      take: 20,
+      take: QUERY_LIMITS.DEFAULT,
     });
 
     const results = medications.map((med) => ({

--- a/src/app/api/records/member/[memberId]/route.ts
+++ b/src/app/api/records/member/[memberId]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { success } from '@/lib/auth-helpers';
 import { withAuth, validateParamId } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
@@ -10,7 +11,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ mem
     const records = await prisma.medicationRecord.findMany({
       where: { memberId, userId },
       orderBy: { takenAt: 'desc' },
-      take: 50,
+      take: QUERY_LIMITS.DEFAULT,
     });
     return success(records);
   })();

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -35,7 +35,7 @@ export const GET = withAuth(async (userId) => {
     prisma.member.findMany({
       where: { userId },
       select: { id: true, name: true },
-      take: 100,
+      take: QUERY_LIMITS.MEMBERS,
     }),
   ]);
 


### PR DESCRIPTION
## Summary
- medications/member/[memberId], records/member/[memberId], records/stats, medications/searchの4ルートのハードコードtake値をQUERY_LIMITS定数に置き換え
- 全APIルートからハードコードされたtake値を完全に排除

## Test plan
- [x] 全1117テストパス
- [x] ビルド成功

closes #265