### PR TITLE
HealthLogEntityに体調トレンドメッセージ・レベルラベル追加

### DIFF
--- a/src/__tests__/domain/entities/HealthLogTrendMessage.test.ts
+++ b/src/__tests__/domain/entities/HealthLogTrendMessage.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity トレンドメッセージ・スタイル', () => {
+  describe('getConditionTrendMessage', () => {
+    it('上昇トレンドは改善メッセージを返す', () => {
+      expect(HealthLogEntity.getConditionTrendMessage('up')).toBe('体調が改善傾向です');
+    });
+
+    it('下降トレンドは悪化メッセージを返す', () => {
+      expect(HealthLogEntity.getConditionTrendMessage('down')).toBe('体調が下降傾向です');
+    });
+
+    it('安定トレンドは安定メッセージを返す', () => {
+      expect(HealthLogEntity.getConditionTrendMessage('stable')).toBe('体調は安定しています');
+    });
+  });
+
+  describe('getConditionTrendStyle', () => {
+    it('上昇トレンドは緑系スタイルを返す', () => {
+      const style = HealthLogEntity.getConditionTrendStyle('up');
+      expect(style.text).toContain('green');
+    });
+
+    it('下降トレンドは赤系スタイルを返す', () => {
+      const style = HealthLogEntity.getConditionTrendStyle('down');
+      expect(style.text).toContain('red');
+    });
+
+    it('安定トレンドは灰色系スタイルを返す', () => {
+      const style = HealthLogEntity.getConditionTrendStyle('stable');
+      expect(style.text).toContain('gray');
+    });
+  });
+
+  describe('getConditionLevelLabel', () => {
+    it('レベル1は「とても悪い」を返す', () => {
+      expect(HealthLogEntity.getConditionLevelLabel(1)).toBe('とても悪い');
+    });
+
+    it('レベル2は「悪い」を返す', () => {
+      expect(HealthLogEntity.getConditionLevelLabel(2)).toBe('悪い');
+    });
+
+    it('レベル3は「普通」を返す', () => {
+      expect(HealthLogEntity.getConditionLevelLabel(3)).toBe('普通');
+    });
+
+    it('レベル4は「良い」を返す', () => {
+      expect(HealthLogEntity.getConditionLevelLabel(4)).toBe('良い');
+    });
+
+    it('レベル5は「とても良い」を返す', () => {
+      expect(HealthLogEntity.getConditionLevelLabel(5)).toBe('とても良い');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -205,4 +205,42 @@ export class HealthLogEntity {
     if (diff < -0.5) return 'down';
     return 'stable';
   }
+
+  /**
+   * トレンド方向に応じたメッセージを返す
+   */
+  static getConditionTrendMessage(direction: 'up' | 'down' | 'stable'): string {
+    const messages: Record<string, string> = {
+      up: '体調が改善傾向です',
+      down: '体調が下降傾向です',
+      stable: '体調は安定しています',
+    };
+    return messages[direction];
+  }
+
+  /**
+   * トレンド方向に応じたスタイルクラスを返す
+   */
+  static getConditionTrendStyle(direction: 'up' | 'down' | 'stable'): { text: string; icon: string } {
+    const styles: Record<string, { text: string; icon: string }> = {
+      up: { text: 'text-green-600', icon: 'TrendingUp' },
+      down: { text: 'text-red-600', icon: 'TrendingDown' },
+      stable: { text: 'text-gray-600', icon: 'Minus' },
+    };
+    return styles[direction];
+  }
+
+  /**
+   * 体調レベルに応じた日本語ラベルを返す
+   */
+  static getConditionLevelLabel(level: ConditionLevel): string {
+    const labels: Record<ConditionLevel, string> = {
+      1: 'とても悪い',
+      2: '悪い',
+      3: '普通',
+      4: '良い',
+      5: 'とても良い',
+    };
+    return labels[level];
+  }
 }


### PR DESCRIPTION
## Summary
- getConditionTrendMessage: トレンド方向(up/down/stable)に応じた日本語メッセージ
- getConditionTrendStyle: トレンド方向に応じたTailwindスタイルクラスとアイコン名
- getConditionLevelLabel: 体調レベル1-5の日本語ラベル(とても悪い〜とても良い)

## Test plan
- [x] 11テスト追加(全1128件パス)
- [x] ビルド成功

closes #267