### PR TITLE
MedicationRecordEntityに日別服薬回数・薬別頻度集計追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationRecordSummary.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordSummary.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (overrides: Partial<MedicationRecord> = {}): MedicationRecord => ({
+  id: 'rec-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  medicationId: 'med-1',
+  medicationName: '薬A',
+  userId: 'user-1',
+  takenAt: new Date('2026-03-05T08:00:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity 服薬集計', () => {
+  describe('getDailyRecordCounts', () => {
+    it('空配列は空マップを返す', () => {
+      expect(MedicationRecordEntity.getDailyRecordCounts([])).toEqual({});
+    });
+
+    it('同じ日の記録をカウントする', () => {
+      const records = [
+        createRecord({ takenAt: new Date('2026-03-05T08:00:00') }),
+        createRecord({ takenAt: new Date('2026-03-05T12:00:00') }),
+        createRecord({ takenAt: new Date('2026-03-05T18:00:00') }),
+      ];
+      const counts = MedicationRecordEntity.getDailyRecordCounts(records);
+      expect(counts['2026-03-05']).toBe(3);
+    });
+
+    it('異なる日の記録を別々にカウントする', () => {
+      const records = [
+        createRecord({ takenAt: new Date('2026-03-04T08:00:00') }),
+        createRecord({ takenAt: new Date('2026-03-05T08:00:00') }),
+        createRecord({ takenAt: new Date('2026-03-05T12:00:00') }),
+      ];
+      const counts = MedicationRecordEntity.getDailyRecordCounts(records);
+      expect(counts['2026-03-04']).toBe(1);
+      expect(counts['2026-03-05']).toBe(2);
+    });
+  });
+
+  describe('getMedicationFrequency', () => {
+    it('空配列は空配列を返す', () => {
+      expect(MedicationRecordEntity.getMedicationFrequency([])).toEqual([]);
+    });
+
+    it('薬別にカウントしてソートする', () => {
+      const records = [
+        createRecord({ medicationName: '薬B' }),
+        createRecord({ medicationName: '薬A' }),
+        createRecord({ medicationName: '薬A' }),
+        createRecord({ medicationName: '薬A' }),
+        createRecord({ medicationName: '薬B' }),
+      ];
+      const freq = MedicationRecordEntity.getMedicationFrequency(records);
+      expect(freq).toEqual([
+        { medicationName: '薬A', count: 3 },
+        { medicationName: '薬B', count: 2 },
+      ]);
+    });
+
+    it('同じ回数の薬がある場合も正しく返す', () => {
+      const records = [
+        createRecord({ medicationName: '薬A' }),
+        createRecord({ medicationName: '薬B' }),
+      ];
+      const freq = MedicationRecordEntity.getMedicationFrequency(records);
+      expect(freq).toHaveLength(2);
+      expect(freq[0].count).toBe(1);
+      expect(freq[1].count).toBe(1);
+    });
+  });
+
+  describe('getTotalRecordCount', () => {
+    it('空配列は0を返す', () => {
+      expect(MedicationRecordEntity.getTotalRecordCount([])).toBe(0);
+    });
+
+    it('配列の長さを返す', () => {
+      const records = [createRecord(), createRecord(), createRecord()];
+      expect(MedicationRecordEntity.getTotalRecordCount(records)).toBe(3);
+    });
+  });
+});

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -111,4 +111,36 @@ export class MedicationRecordEntity {
       }))
       .filter((g) => g.records.length > 0);
   }
+
+  /**
+   * 日別の服薬回数を集計
+   */
+  static getDailyRecordCounts(records: MedicationRecord[]): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const record of records) {
+      const key = DateRangeHelper.toDateKey(new Date(record.takenAt));
+      counts[key] = (counts[key] || 0) + 1;
+    }
+    return counts;
+  }
+
+  /**
+   * 薬別の服薬回数をランキング形式で返す(多い順)
+   */
+  static getMedicationFrequency(records: MedicationRecord[]): { medicationName: string; count: number }[] {
+    const counts: Record<string, number> = {};
+    for (const record of records) {
+      counts[record.medicationName] = (counts[record.medicationName] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([medicationName, count]) => ({ medicationName, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  /**
+   * 総服薬回数を返す
+   */
+  static getTotalRecordCount(records: MedicationRecord[]): number {
+    return records.length;
+  }
 }


### PR DESCRIPTION
## Summary
- getDailyRecordCounts: 日別の服薬回数をRecord<日付, 回数>で集計
- getMedicationFrequency: 薬別の服薬回数を多い順にランキング
- getTotalRecordCount: 総服薬回数

## Test plan
- [x] 8テスト追加(全1136件パス)
- [x] ビルド成功

closes #269