### PR TITLE
MemberSummaryEntityにアクティビティレベル判定追加

### DIFF
--- a/src/__tests__/domain/entities/MemberActivity.test.ts
+++ b/src/__tests__/domain/entities/MemberActivity.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { MemberSummaryEntity, MemberSummary } from '@/domain/entities/MemberSummary';
+
+const createSummary = (overrides: Partial<MemberSummary> = {}): MemberSummary => ({
+  memberId: 'member-1',
+  memberName: '太郎',
+  memberType: 'human',
+  medicationCount: 3,
+  nextAppointmentDate: null,
+  ...overrides,
+});
+
+describe('MemberSummaryEntity 活動状況', () => {
+  describe('hasMedications', () => {
+    it('薬が0件ならfalseを返す', () => {
+      const entity = new MemberSummaryEntity(createSummary({ medicationCount: 0 }));
+      expect(entity.hasMedications()).toBe(false);
+    });
+
+    it('薬が1件以上ならtrueを返す', () => {
+      const entity = new MemberSummaryEntity(createSummary({ medicationCount: 1 }));
+      expect(entity.hasMedications()).toBe(true);
+    });
+
+    it('薬が複数件でもtrueを返す', () => {
+      const entity = new MemberSummaryEntity(createSummary({ medicationCount: 10 }));
+      expect(entity.hasMedications()).toBe(true);
+    });
+  });
+
+  describe('getActivityLevel', () => {
+    it('薬あり・予約ありはactiveを返す', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ medicationCount: 3, nextAppointmentDate: '2026-04-01' }),
+      );
+      expect(entity.getActivityLevel()).toBe('active');
+    });
+
+    it('薬あり・予約なしはmoderateを返す', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ medicationCount: 2, nextAppointmentDate: null }),
+      );
+      expect(entity.getActivityLevel()).toBe('moderate');
+    });
+
+    it('薬なし・予約ありはmoderateを返す', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ medicationCount: 0, nextAppointmentDate: '2026-04-01' }),
+      );
+      expect(entity.getActivityLevel()).toBe('moderate');
+    });
+
+    it('薬なし・予約なしはinactiveを返す', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ medicationCount: 0, nextAppointmentDate: null }),
+      );
+      expect(entity.getActivityLevel()).toBe('inactive');
+    });
+  });
+
+  describe('getMemberTypeLabel', () => {
+    it('humanは「家族」を返す', () => {
+      expect(MemberSummaryEntity.getMemberTypeLabel('human')).toBe('家族');
+    });
+
+    it('petは「ペット」を返す', () => {
+      expect(MemberSummaryEntity.getMemberTypeLabel('pet')).toBe('ペット');
+    });
+
+    it('未知の種別はそのまま返す', () => {
+      expect(MemberSummaryEntity.getMemberTypeLabel('other')).toBe('other');
+    });
+  });
+});

--- a/src/domain/entities/MemberSummary.ts
+++ b/src/domain/entities/MemberSummary.ts
@@ -37,4 +37,33 @@ export class MemberSummaryEntity {
     if (days === 1) return '明日';
     return `${days}日後`;
   }
+
+  /**
+   * 薬が登録されているか判定
+   */
+  hasMedications(): boolean {
+    return this.summary.medicationCount > 0;
+  }
+
+  /**
+   * 薬・予約の登録状況に応じたアクティビティレベルを返す
+   */
+  getActivityLevel(): 'active' | 'moderate' | 'inactive' {
+    const hasMeds = this.hasMedications();
+    const hasAppt = this.hasUpcomingAppointment();
+    if (hasMeds && hasAppt) return 'active';
+    if (hasMeds || hasAppt) return 'moderate';
+    return 'inactive';
+  }
+
+  /**
+   * メンバー種別の日本語ラベルを返す
+   */
+  static getMemberTypeLabel(memberType: string): string {
+    const labels: Record<string, string> = {
+      human: '家族',
+      pet: 'ペット',
+    };
+    return labels[memberType] ?? memberType;
+  }
 }


### PR DESCRIPTION
## Summary
- hasMedications: 薬が登録されているか判定
- getActivityLevel: 薬・予約の登録状況に応じたactive/moderate/inactiveレベル判定
- getMemberTypeLabel: メンバー種別の日本語ラベル(家族/ペット)

## Test plan
- [x] 10テスト追加(全1146件パス)
- [x] ビルド成功

closes #271