### PR TITLE
MemberSummary・Medicationの日付処理をDateRangeHelper共通化

### DIFF
--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -2,6 +2,8 @@
  * お薬エンティティ
  */
 
+import { DateRangeHelper } from './DateRange';
+
 export type MedicationCategory =
   | 'regular'
   | 'supplement'
@@ -44,13 +46,9 @@ export class MedicationEntity {
       return false;
     }
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const alertDate = new Date(this.medication.stockAlertDate);
-    alertDate.setHours(0, 0, 0, 0);
-
-    const daysUntilAlert = Math.ceil(
-      (alertDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+    const daysUntilAlert = DateRangeHelper.diffDays(
+      new Date(),
+      new Date(this.medication.stockAlertDate),
     );
 
     if (daysUntilAlert <= 0) return false;

--- a/src/domain/entities/MemberSummary.ts
+++ b/src/domain/entities/MemberSummary.ts
@@ -2,6 +2,8 @@
  * メンバーサマリーエンティティ
  */
 
+import { DateRangeHelper } from './DateRange';
+
 export interface MemberSummary {
   readonly memberId: string;
   readonly memberName: string;
@@ -23,11 +25,7 @@ export class MemberSummaryEntity {
 
   getDaysUntilAppointment(): number | null {
     if (!this.summary.nextAppointmentDate) return null;
-    const now = new Date();
-    now.setHours(0, 0, 0, 0);
-    const appointmentDate = new Date(this.summary.nextAppointmentDate);
-    appointmentDate.setHours(0, 0, 0, 0);
-    return Math.ceil((appointmentDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+    return DateRangeHelper.diffDays(new Date(), new Date(this.summary.nextAppointmentDate));
   }
 
   getAppointmentLabel(): string {


### PR DESCRIPTION
## Summary
- MemberSummaryEntity.getDaysUntilAppointmentをDateRangeHelper.diffDaysに置き換え
- MedicationEntity.isLowStockをDateRangeHelper.diffDaysに置き換え
- setHours(0,0,0,0)パターンを更に2箇所削減

## Test plan
- [x] 全1146テストパス
- [x] ビルド成功

closes #273