### PR TITLE
MemberSummaryEntity・MedicationRecordEntityのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationRecordEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordEntity.edge.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord, DailyRecordGroup } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (overrides: Partial<MedicationRecord> = {}): MedicationRecord => ({
+  id: 'rec-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  medicationId: 'med-1',
+  medicationName: '薬A',
+  userId: 'user-1',
+  takenAt: new Date('2026-03-05T08:00:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity エッジケーステスト', () => {
+  describe('groupByDate', () => {
+    it('空配列は空配列を返す', () => {
+      expect(MedicationRecordEntity.groupByDate([])).toEqual([]);
+    });
+
+    it('新しい日付が先に来る(降順)', () => {
+      const records = [
+        createRecord({ id: 'r1', takenAt: new Date('2026-03-03T08:00:00') }),
+        createRecord({ id: 'r2', takenAt: new Date('2026-03-05T08:00:00') }),
+        createRecord({ id: 'r3', takenAt: new Date('2026-03-04T08:00:00') }),
+      ];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups[0].date).toBe('2026-03-05');
+      expect(groups[1].date).toBe('2026-03-04');
+      expect(groups[2].date).toBe('2026-03-03');
+    });
+
+    it('同じ日の記録は同じグループに入る', () => {
+      const records = [
+        createRecord({ id: 'r1', takenAt: new Date('2026-03-05T08:00:00') }),
+        createRecord({ id: 'r2', takenAt: new Date('2026-03-05T12:00:00') }),
+        createRecord({ id: 'r3', takenAt: new Date('2026-03-05T18:00:00') }),
+      ];
+      const groups = MedicationRecordEntity.groupByDate(records);
+      expect(groups).toHaveLength(1);
+      expect(groups[0].records).toHaveLength(3);
+    });
+  });
+
+  describe('formatDate', () => {
+    it('月初の日付を正しくフォーマットする', () => {
+      expect(MedicationRecordEntity.formatDate('2026-03-01')).toMatch(/3月1日/);
+    });
+
+    it('月末の日付を正しくフォーマットする', () => {
+      expect(MedicationRecordEntity.formatDate('2026-03-31')).toMatch(/3月31日/);
+    });
+  });
+
+  describe('formatTime', () => {
+    it('0時0分は00:00を返す', () => {
+      const date = new Date('2026-03-05T00:00:00');
+      expect(MedicationRecordEntity.formatTime(date)).toBe('00:00');
+    });
+
+    it('23時59分は23:59を返す', () => {
+      const date = new Date('2026-03-05T23:59:00');
+      expect(MedicationRecordEntity.formatTime(date)).toBe('23:59');
+    });
+
+    it('9時5分は09:05を返す(ゼロパディング)', () => {
+      const date = new Date('2026-03-05T09:05:00');
+      expect(MedicationRecordEntity.formatTime(date)).toBe('09:05');
+    });
+  });
+
+  describe('filterByMember', () => {
+    it('memberIdがnullなら全件返す', () => {
+      const records = [createRecord(), createRecord({ memberId: 'member-2' })];
+      expect(MedicationRecordEntity.filterByMember(records, null)).toHaveLength(2);
+    });
+
+    it('指定メンバーの記録のみを返す', () => {
+      const records = [
+        createRecord({ memberId: 'member-1' }),
+        createRecord({ memberId: 'member-2' }),
+        createRecord({ memberId: 'member-1' }),
+      ];
+      expect(MedicationRecordEntity.filterByMember(records, 'member-1')).toHaveLength(2);
+    });
+
+    it('該当メンバーがいなければ空配列を返す', () => {
+      const records = [createRecord({ memberId: 'member-1' })];
+      expect(MedicationRecordEntity.filterByMember(records, 'member-999')).toHaveLength(0);
+    });
+  });
+
+  describe('filterGroupsByMember', () => {
+    const groups: DailyRecordGroup[] = [
+      {
+        date: '2026-03-05',
+        records: [
+          createRecord({ memberId: 'member-1' }),
+          createRecord({ memberId: 'member-2' }),
+        ],
+      },
+      {
+        date: '2026-03-04',
+        records: [createRecord({ memberId: 'member-2' })],
+      },
+    ];
+
+    it('memberIdがnullなら全グループを返す', () => {
+      expect(MedicationRecordEntity.filterGroupsByMember(groups, null)).toHaveLength(2);
+    });
+
+    it('フィルタ後に空になったグループは除外される', () => {
+      const result = MedicationRecordEntity.filterGroupsByMember(groups, 'member-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].date).toBe('2026-03-05');
+      expect(result[0].records).toHaveLength(1);
+    });
+
+    it('該当メンバーがいなければ空配列を返す', () => {
+      expect(MedicationRecordEntity.filterGroupsByMember(groups, 'member-999')).toHaveLength(0);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberSummaryEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberSummaryEntity.edge.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MemberSummaryEntity, MemberSummary } from '@/domain/entities/MemberSummary';
+
+const createSummary = (overrides: Partial<MemberSummary> = {}): MemberSummary => ({
+  memberId: 'member-1',
+  memberName: '太郎',
+  memberType: 'human',
+  medicationCount: 0,
+  nextAppointmentDate: null,
+  ...overrides,
+});
+
+describe('MemberSummaryEntity エッジケーステスト', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('getAppointmentLabel 境界値', () => {
+    it('予約なしは空文字を返す', () => {
+      const entity = new MemberSummaryEntity(createSummary());
+      expect(entity.getAppointmentLabel()).toBe('');
+    });
+
+    it('今日の予約は「今日」を返す', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T10:00:00'));
+      const entity = new MemberSummaryEntity(
+        createSummary({ nextAppointmentDate: '2026-03-05' }),
+      );
+      expect(entity.getAppointmentLabel()).toBe('今日');
+    });
+
+    it('明日の予約は「明日」を返す', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T10:00:00'));
+      const entity = new MemberSummaryEntity(
+        createSummary({ nextAppointmentDate: '2026-03-06' }),
+      );
+      expect(entity.getAppointmentLabel()).toBe('明日');
+    });
+
+    it('2日後の予約は「2日後」を返す', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T10:00:00'));
+      const entity = new MemberSummaryEntity(
+        createSummary({ nextAppointmentDate: '2026-03-07' }),
+      );
+      expect(entity.getAppointmentLabel()).toBe('2日後');
+    });
+
+    it('30日後の予約は「30日後」を返す', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T10:00:00'));
+      const entity = new MemberSummaryEntity(
+        createSummary({ nextAppointmentDate: '2026-04-04' }),
+      );
+      expect(entity.getAppointmentLabel()).toBe('30日後');
+    });
+  });
+
+  describe('hasUpcomingAppointment', () => {
+    it('予約ありはtrueを返す', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ nextAppointmentDate: '2026-04-01' }),
+      );
+      expect(entity.hasUpcomingAppointment()).toBe(true);
+    });
+
+    it('予約なしはfalseを返す', () => {
+      const entity = new MemberSummaryEntity(createSummary());
+      expect(entity.hasUpcomingAppointment()).toBe(false);
+    });
+  });
+
+  describe('getActivityLevel 全組合せ', () => {
+    it('薬0・予約なし → inactive', () => {
+      const entity = new MemberSummaryEntity(createSummary({ medicationCount: 0 }));
+      expect(entity.getActivityLevel()).toBe('inactive');
+    });
+
+    it('薬1・予約なし → moderate', () => {
+      const entity = new MemberSummaryEntity(createSummary({ medicationCount: 1 }));
+      expect(entity.getActivityLevel()).toBe('moderate');
+    });
+
+    it('薬0・予約あり → moderate', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ medicationCount: 0, nextAppointmentDate: '2026-04-01' }),
+      );
+      expect(entity.getActivityLevel()).toBe('moderate');
+    });
+
+    it('薬1・予約あり → active', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ medicationCount: 1, nextAppointmentDate: '2026-04-01' }),
+      );
+      expect(entity.getActivityLevel()).toBe('active');
+    });
+
+    it('薬10・予約あり → active', () => {
+      const entity = new MemberSummaryEntity(
+        createSummary({ medicationCount: 10, nextAppointmentDate: '2026-04-01' }),
+      );
+      expect(entity.getActivityLevel()).toBe('active');
+    });
+  });
+
+  describe('getMemberTypeLabel 境界値', () => {
+    it('humanは家族を返す', () => {
+      expect(MemberSummaryEntity.getMemberTypeLabel('human')).toBe('家族');
+    });
+
+    it('petはペットを返す', () => {
+      expect(MemberSummaryEntity.getMemberTypeLabel('pet')).toBe('ペット');
+    });
+
+    it('空文字はそのまま返す', () => {
+      expect(MemberSummaryEntity.getMemberTypeLabel('')).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MemberSummaryEntity: getAppointmentLabel境界値(今日/明日/N日後)、getActivityLevel全4パターン、getMemberTypeLabel境界テスト(15件)
- MedicationRecordEntity: groupByDateソート順・同日グループ化、formatDate/formatTime境界値、filterByMember/filterGroupsByMember網羅テスト(14件)
- テスト総数: 1146 → 1175件(+29件)

## Test plan
- [x] 新規29テスト全てパス
- [x] 全1175テストパス
- [x] ビルド成功

closes #275