### PR TITLE
AdherenceStatsEntityに前週比較メッセージ・遵守率レベル追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceComparison.test.ts
+++ b/src/__tests__/domain/entities/AdherenceComparison.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity 前週比較・遵守率レベル', () => {
+  describe('getComparisonMessage', () => {
+    it('改善(10%以上増加)は改善メッセージを返す', () => {
+      expect(AdherenceStatsEntity.getComparisonMessage(80, 60)).toBe('先週より改善しています');
+    });
+
+    it('同等(差が10%未満)は維持メッセージを返す', () => {
+      expect(AdherenceStatsEntity.getComparisonMessage(75, 70)).toBe('先週と同じペースです');
+    });
+
+    it('悪化(10%以上減少)は悪化メッセージを返す', () => {
+      expect(AdherenceStatsEntity.getComparisonMessage(50, 70)).toBe('先週より下がっています');
+    });
+
+    it('ちょうど10%増は改善メッセージ(境界)', () => {
+      expect(AdherenceStatsEntity.getComparisonMessage(70, 60)).toBe('先週より改善しています');
+    });
+
+    it('ちょうど10%減は悪化メッセージ(境界)', () => {
+      expect(AdherenceStatsEntity.getComparisonMessage(60, 70)).toBe('先週より下がっています');
+    });
+
+    it('9%増は維持メッセージ(境界)', () => {
+      expect(AdherenceStatsEntity.getComparisonMessage(69, 60)).toBe('先週と同じペースです');
+    });
+  });
+
+  describe('getAdherenceLevel', () => {
+    it('90%以上はexcellentを返す', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(90)).toBe('excellent');
+    });
+
+    it('100%はexcellentを返す', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(100)).toBe('excellent');
+    });
+
+    it('70%以上はgoodを返す', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(70)).toBe('good');
+    });
+
+    it('89%はgoodを返す(境界)', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(89)).toBe('good');
+    });
+
+    it('50%以上はfairを返す', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(50)).toBe('fair');
+    });
+
+    it('69%はfairを返す(境界)', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(69)).toBe('fair');
+    });
+
+    it('50%未満はpoorを返す', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(49)).toBe('poor');
+    });
+
+    it('0%はpoorを返す', () => {
+      expect(AdherenceStatsEntity.getAdherenceLevel(0)).toBe('poor');
+    });
+  });
+
+  describe('getAdherenceLevelStyle', () => {
+    it('excellentは緑系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getAdherenceLevelStyle('excellent');
+      expect(style.text).toContain('green');
+    });
+
+    it('goodは青系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getAdherenceLevelStyle('good');
+      expect(style.text).toContain('blue');
+    });
+
+    it('fairはオレンジ系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getAdherenceLevelStyle('fair');
+      expect(style.text).toContain('orange');
+    });
+
+    it('poorは赤系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getAdherenceLevelStyle('poor');
+      expect(style.text).toContain('red');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -160,4 +160,37 @@ export class AdherenceStatsEntity {
     if (streak < 30) return '素晴らしい習慣';
     return '完璧な継続';
   }
+
+  /**
+   * 今週と前週の遵守率を比較したメッセージを返す
+   */
+  static getComparisonMessage(currentRate: number, previousRate: number): string {
+    const diff = currentRate - previousRate;
+    if (diff >= 10) return '先週より改善しています';
+    if (diff <= -10) return '先週より下がっています';
+    return '先週と同じペースです';
+  }
+
+  /**
+   * 遵守率に応じたレベルを判定
+   */
+  static getAdherenceLevel(rate: number): 'excellent' | 'good' | 'fair' | 'poor' {
+    if (rate >= 90) return 'excellent';
+    if (rate >= 70) return 'good';
+    if (rate >= 50) return 'fair';
+    return 'poor';
+  }
+
+  /**
+   * 遵守率レベルに応じたスタイルクラスを返す
+   */
+  static getAdherenceLevelStyle(level: 'excellent' | 'good' | 'fair' | 'poor'): { bg: string; text: string } {
+    const styles: Record<string, { bg: string; text: string }> = {
+      excellent: { bg: 'bg-green-50', text: 'text-green-600' },
+      good: { bg: 'bg-blue-50', text: 'text-blue-600' },
+      fair: { bg: 'bg-orange-50', text: 'text-orange-600' },
+      poor: { bg: 'bg-red-50', text: 'text-red-600' },
+    };
+    return styles[level];
+  }
 }


### PR DESCRIPTION
## Summary
- getComparisonMessage: 今週と前週の遵守率差に応じた改善/維持/悪化メッセージ
- getAdherenceLevel: 遵守率に応じたexcellent/good/fair/poorレベル判定
- getAdherenceLevelStyle: 各レベルのTailwindスタイルクラス

## Test plan
- [x] 18テスト追加(全1193件パス)
- [x] ビルド成功

closes #279