### PR TITLE
feat: スケジュール時間近接検出メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleTimeProximity.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimeProximity.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 時間近接検出', () => {
+  describe('getTimeDiffMinutes', () => {
+    it('同じ時刻は0分を返す', () => {
+      expect(ScheduleEntity.getTimeDiffMinutes('08:00', '08:00')).toBe(0);
+    });
+
+    it('30分差を正しく返す', () => {
+      expect(ScheduleEntity.getTimeDiffMinutes('08:00', '08:30')).toBe(30);
+    });
+
+    it('順序を逆にしても同じ結果(絶対値)', () => {
+      expect(ScheduleEntity.getTimeDiffMinutes('08:30', '08:00')).toBe(30);
+    });
+
+    it('時間をまたぐ差を正しく計算する', () => {
+      expect(ScheduleEntity.getTimeDiffMinutes('08:45', '09:15')).toBe(30);
+    });
+
+    it('大きな差を正しく計算する', () => {
+      expect(ScheduleEntity.getTimeDiffMinutes('08:00', '20:00')).toBe(720);
+    });
+
+    it('深夜と早朝の差を正しく計算する', () => {
+      expect(ScheduleEntity.getTimeDiffMinutes('00:00', '23:59')).toBe(1439);
+    });
+  });
+
+  describe('isTimeClose', () => {
+    it('差が閾値未満なら近接と判定する', () => {
+      expect(ScheduleEntity.isTimeClose('08:00', '08:25', 30)).toBe(true);
+    });
+
+    it('差がちょうど閾値なら近接と判定する(境界)', () => {
+      expect(ScheduleEntity.isTimeClose('08:00', '08:30', 30)).toBe(true);
+    });
+
+    it('差が閾値を超えたら近接でないと判定する', () => {
+      expect(ScheduleEntity.isTimeClose('08:00', '08:31', 30)).toBe(false);
+    });
+
+    it('デフォルト閾値(30分)で動作する', () => {
+      expect(ScheduleEntity.isTimeClose('08:00', '08:29')).toBe(true);
+      expect(ScheduleEntity.isTimeClose('08:00', '08:31')).toBe(false);
+    });
+
+    it('同じ時刻は常に近接と判定する', () => {
+      expect(ScheduleEntity.isTimeClose('12:00', '12:00', 1)).toBe(true);
+    });
+  });
+
+  describe('getTimeProximityLevel', () => {
+    it('15分以内はwarningを返す', () => {
+      expect(ScheduleEntity.getTimeProximityLevel(10)).toBe('warning');
+    });
+
+    it('ちょうど15分はwarningを返す(境界)', () => {
+      expect(ScheduleEntity.getTimeProximityLevel(15)).toBe('warning');
+    });
+
+    it('16分はinfoを返す', () => {
+      expect(ScheduleEntity.getTimeProximityLevel(16)).toBe('info');
+    });
+
+    it('30分はinfoを返す(境界)', () => {
+      expect(ScheduleEntity.getTimeProximityLevel(30)).toBe('info');
+    });
+
+    it('31分はnoneを返す', () => {
+      expect(ScheduleEntity.getTimeProximityLevel(31)).toBe('none');
+    });
+
+    it('0分はwarningを返す', () => {
+      expect(ScheduleEntity.getTimeProximityLevel(0)).toBe('warning');
+    });
+
+    it('60分以上はnoneを返す', () => {
+      expect(ScheduleEntity.getTimeProximityLevel(60)).toBe('none');
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -236,6 +236,31 @@ export class ScheduleEntity {
     return 'good';
   }
 
+  /**
+   * 2つの時刻文字列(HH:mm)間の差を分で返す(絶対値)
+   */
+  static getTimeDiffMinutes(time1: string, time2: string): number {
+    const [h1, m1] = time1.split(':').map(Number);
+    const [h2, m2] = time2.split(':').map(Number);
+    return Math.abs(h1 * 60 + m1 - (h2 * 60 + m2));
+  }
+
+  /**
+   * 2つの時刻が指定分数以内に近接しているか判定
+   */
+  static isTimeClose(time1: string, time2: string, thresholdMinutes: number = 30): boolean {
+    return ScheduleEntity.getTimeDiffMinutes(time1, time2) <= thresholdMinutes;
+  }
+
+  /**
+   * 時間差(分)に応じた近接レベルを返す
+   */
+  static getTimeProximityLevel(diffMinutes: number): 'warning' | 'info' | 'none' {
+    if (diffMinutes <= 15) return 'warning';
+    if (diffMinutes <= 30) return 'info';
+    return 'none';
+  }
+
   get id(): string {
     return this.schedule.id;
   }


### PR DESCRIPTION
## Summary
- ScheduleEntityに時間近接検出用のstaticメソッド3つを追加
- getTimeDiffMinutes: HH:mm形式の2時刻間の差分(分)を算出
- isTimeClose: 指定閾値以内かの近接判定(デフォルト30分)
- getTimeProximityLevel: 分差に応じたwarning/info/noneレベル判定

## Test plan
- [x] getTimeDiffMinutes: 同時刻、30分差、逆順、時間またぎ、大差、深夜-早朝
- [x] isTimeClose: 閾値未満/ちょうど/超過、デフォルト閾値、同時刻
- [x] getTimeProximityLevel: 15分以内/ちょうど/超過、30分境界、0分、60分以上

closes #281