### PR TITLE
feat: 体調記録の症状同時出現パターン検出

### DIFF
--- a/src/__tests__/domain/entities/SymptomCoOccurrence.test.ts
+++ b/src/__tests__/domain/entities/SymptomCoOccurrence.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, HealthLog, SymptomType } from '@/domain/entities/HealthLog';
+
+const createLog = (symptoms: SymptomType[]): HealthLog => ({
+  id: 'log-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  userId: 'user-1',
+  conditionLevel: 3,
+  symptoms,
+  recordedAt: new Date('2026-03-05T08:00:00'),
+});
+
+describe('HealthLogEntity 症状同時出現パターン', () => {
+  describe('getSymptomPairs', () => {
+    it('空配列は空Mapを返す', () => {
+      const result = HealthLogEntity.getSymptomPairs([]);
+      expect(result.size).toBe(0);
+    });
+
+    it('症状が1つだけの記録ではペアが生成されない', () => {
+      const logs = [createLog(['headache'])];
+      const result = HealthLogEntity.getSymptomPairs(logs);
+      expect(result.size).toBe(0);
+    });
+
+    it('2つの症状から1ペアが生成される', () => {
+      const logs = [createLog(['headache', 'fever'])];
+      const result = HealthLogEntity.getSymptomPairs(logs);
+      expect(result.size).toBe(1);
+      expect(result.get('fever+headache')).toBe(1);
+    });
+
+    it('3つの症状から3ペアが生成される', () => {
+      const logs = [createLog(['headache', 'fever', 'fatigue'])];
+      const result = HealthLogEntity.getSymptomPairs(logs);
+      expect(result.size).toBe(3);
+    });
+
+    it('複数記録で同じペアのカウントが増える', () => {
+      const logs = [
+        createLog(['headache', 'fever']),
+        createLog(['headache', 'fever']),
+        createLog(['headache', 'fever']),
+      ];
+      const result = HealthLogEntity.getSymptomPairs(logs);
+      expect(result.get('fever+headache')).toBe(3);
+    });
+
+    it('ペアキーはアルファベット順にソートされる', () => {
+      const logs = [createLog(['nausea', 'headache'])];
+      const result = HealthLogEntity.getSymptomPairs(logs);
+      expect(result.has('headache+nausea')).toBe(true);
+    });
+
+    it('症状なしの記録は無視される', () => {
+      const logs = [createLog([])];
+      const result = HealthLogEntity.getSymptomPairs(logs);
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('getCoOccurrenceRate', () => {
+    it('同時出現率を正しく算出する', () => {
+      const logs = [
+        createLog(['headache', 'fever']),
+        createLog(['headache']),
+        createLog(['fever']),
+        createLog(['headache', 'fever']),
+      ];
+      // headache出現: 3回, そのうちfeverと同時: 2回 => 67%
+      expect(HealthLogEntity.getCoOccurrenceRate(logs, 'headache', 'fever')).toBe(67);
+    });
+
+    it('対象症状が存在しない場合は0を返す', () => {
+      const logs = [createLog(['headache'])];
+      expect(HealthLogEntity.getCoOccurrenceRate(logs, 'fever', 'nausea')).toBe(0);
+    });
+
+    it('全て同時出現なら100を返す', () => {
+      const logs = [
+        createLog(['headache', 'fever']),
+        createLog(['headache', 'fever']),
+      ];
+      expect(HealthLogEntity.getCoOccurrenceRate(logs, 'headache', 'fever')).toBe(100);
+    });
+
+    it('空配列は0を返す', () => {
+      expect(HealthLogEntity.getCoOccurrenceRate([], 'headache', 'fever')).toBe(0);
+    });
+  });
+
+  describe('getMostCommonPair', () => {
+    it('空配列はnullを返す', () => {
+      expect(HealthLogEntity.getMostCommonPair([])).toBeNull();
+    });
+
+    it('症状ペアがない場合はnullを返す', () => {
+      const logs = [createLog(['headache']), createLog(['fever'])];
+      expect(HealthLogEntity.getMostCommonPair(logs)).toBeNull();
+    });
+
+    it('最も多いペアを返す', () => {
+      const logs = [
+        createLog(['headache', 'fever']),
+        createLog(['headache', 'fever']),
+        createLog(['headache', 'nausea']),
+      ];
+      const result = HealthLogEntity.getMostCommonPair(logs);
+      expect(result).toEqual({ pair: 'fever+headache', count: 2 });
+    });
+
+    it('同数の場合はどちらかを返す', () => {
+      const logs = [
+        createLog(['headache', 'fever']),
+        createLog(['headache', 'nausea']),
+      ];
+      const result = HealthLogEntity.getMostCommonPair(logs);
+      expect(result).not.toBeNull();
+      expect(result!.count).toBe(1);
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -231,6 +231,50 @@ export class HealthLogEntity {
   }
 
   /**
+   * 症状のペア(同時出現)を集計する
+   */
+  static getSymptomPairs(logs: HealthLog[]): Map<string, number> {
+    const pairs = new Map<string, number>();
+    for (const log of logs) {
+      const sorted = [...log.symptoms].sort();
+      for (let i = 0; i < sorted.length; i++) {
+        for (let j = i + 1; j < sorted.length; j++) {
+          const key = `${sorted[i]}+${sorted[j]}`;
+          pairs.set(key, (pairs.get(key) || 0) + 1);
+        }
+      }
+    }
+    return pairs;
+  }
+
+  /**
+   * 特定の2症状の同時出現率を算出(0-100%)
+   */
+  static getCoOccurrenceRate(logs: HealthLog[], symptom1: SymptomType, symptom2: SymptomType): number {
+    const logsWithSymptom1 = logs.filter((l) => l.symptoms.includes(symptom1));
+    if (logsWithSymptom1.length === 0) return 0;
+    const coOccurrences = logsWithSymptom1.filter((l) => l.symptoms.includes(symptom2)).length;
+    return Math.round((coOccurrences / logsWithSymptom1.length) * 100);
+  }
+
+  /**
+   * 最も多い症状ペアを返す
+   */
+  static getMostCommonPair(logs: HealthLog[]): { pair: string; count: number } | null {
+    const pairs = HealthLogEntity.getSymptomPairs(logs);
+    if (pairs.size === 0) return null;
+    let maxPair = '';
+    let maxCount = 0;
+    for (const [pair, count] of pairs) {
+      if (count > maxCount) {
+        maxPair = pair;
+        maxCount = count;
+      }
+    }
+    return { pair: maxPair, count: maxCount };
+  }
+
+  /**
    * 体調レベルに応じた日本語ラベルを返す
    */
   static getConditionLevelLabel(level: ConditionLevel): string {


### PR DESCRIPTION
## Summary
- HealthLogEntityに症状同時出現パターン検出メソッド3つを追加
- getSymptomPairs: 全記録から症状ペアの出現回数をMap集計
- getCoOccurrenceRate: 特定2症状の同時出現率を0-100%で算出
- getMostCommonPair: 最頻出の症状ペアとカウントを返す

## Test plan
- [x] getSymptomPairs: 空配列、単一症状、2症状1ペア、3症状3ペア、複数記録カウント、ソート順
- [x] getCoOccurrenceRate: 正常算出、不在症状、全同時出現、空配列
- [x] getMostCommonPair: 空配列、ペアなし、最頻出、同数ケース

closes #283