### PR TITLE
refactor: パーセント計算の共通化と重複メソッド解消

### DIFF
--- a/src/__tests__/domain/entities/HealthLogTrendMessage.test.ts
+++ b/src/__tests__/domain/entities/HealthLogTrendMessage.test.ts
@@ -33,25 +33,25 @@ describe('HealthLogEntity トレンドメッセージ・スタイル', () => {
     });
   });
 
-  describe('getConditionLevelLabel', () => {
+  describe('getConditionLabel', () => {
     it('レベル1は「とても悪い」を返す', () => {
-      expect(HealthLogEntity.getConditionLevelLabel(1)).toBe('とても悪い');
+      expect(HealthLogEntity.getConditionLabel(1)).toBe('とても悪い');
     });
 
     it('レベル2は「悪い」を返す', () => {
-      expect(HealthLogEntity.getConditionLevelLabel(2)).toBe('悪い');
+      expect(HealthLogEntity.getConditionLabel(2)).toBe('悪い');
     });
 
     it('レベル3は「普通」を返す', () => {
-      expect(HealthLogEntity.getConditionLevelLabel(3)).toBe('普通');
+      expect(HealthLogEntity.getConditionLabel(3)).toBe('普通');
     });
 
     it('レベル4は「良い」を返す', () => {
-      expect(HealthLogEntity.getConditionLevelLabel(4)).toBe('良い');
+      expect(HealthLogEntity.getConditionLabel(4)).toBe('良い');
     });
 
     it('レベル5は「とても良い」を返す', () => {
-      expect(HealthLogEntity.getConditionLevelLabel(5)).toBe('とても良い');
+      expect(HealthLogEntity.getConditionLabel(5)).toBe('とても良い');
     });
   });
 });

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -3,6 +3,7 @@
  */
 
 import { DateRangeHelper } from './DateRange';
+import { MathHelper } from './MathHelper';
 
 export interface MemberAdherenceStats {
   readonly memberId: string;
@@ -95,8 +96,7 @@ export class AdherenceStatsEntity {
    * 遵守率を算出（0-100%）
    */
   static calculateRate(actual: number, expected: number): number {
-    if (expected <= 0) return 0;
-    return Math.min(100, Math.round((actual / expected) * 100));
+    return MathHelper.calculatePercentage(actual, expected, true);
   }
 
   /**

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -4,6 +4,7 @@
 
 import { DAY_LABELS_JP } from '../../lib/constants';
 import { DateRangeHelper } from './DateRange';
+import { MathHelper } from './MathHelper';
 
 export const CONDITION_LEVELS = [1, 2, 3, 4, 5] as const;
 export type ConditionLevel = (typeof CONDITION_LEVELS)[number];
@@ -254,7 +255,7 @@ export class HealthLogEntity {
     const logsWithSymptom1 = logs.filter((l) => l.symptoms.includes(symptom1));
     if (logsWithSymptom1.length === 0) return 0;
     const coOccurrences = logsWithSymptom1.filter((l) => l.symptoms.includes(symptom2)).length;
-    return Math.round((coOccurrences / logsWithSymptom1.length) * 100);
+    return MathHelper.calculatePercentage(coOccurrences, logsWithSymptom1.length);
   }
 
   /**
@@ -274,17 +275,4 @@ export class HealthLogEntity {
     return { pair: maxPair, count: maxCount };
   }
 
-  /**
-   * 体調レベルに応じた日本語ラベルを返す
-   */
-  static getConditionLevelLabel(level: ConditionLevel): string {
-    const labels: Record<ConditionLevel, string> = {
-      1: 'とても悪い',
-      2: '悪い',
-      3: '普通',
-      4: '良い',
-      5: 'とても良い',
-    };
-    return labels[level];
-  }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -1,0 +1,16 @@
+/**
+ * 数値計算ヘルパー
+ */
+export class MathHelper {
+  /**
+   * パーセントを算出(0-100%)
+   * @param numerator 分子
+   * @param denominator 分母
+   * @param cap trueの場合100%を上限にする
+   */
+  static calculatePercentage(numerator: number, denominator: number, cap: boolean = false): number {
+    if (denominator <= 0) return 0;
+    const result = Math.round((numerator / denominator) * 100);
+    return cap ? Math.min(100, result) : result;
+  }
+}

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -3,6 +3,8 @@
  * ビジネスロジックの中核となるドメインモデル
  */
 
+import { MathHelper } from './MathHelper';
+
 export type DayOfWeek = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
 export type ScheduleStatus = 'pending' | 'completed' | 'overdue';
 export type OverdueLevel = 'none' | 'warning' | 'danger';
@@ -198,8 +200,7 @@ export class ScheduleEntity {
    * 完了率を算出(0-100%)
    */
   static calculateCompletionRate(completed: number, total: number): number {
-    if (total <= 0) return 0;
-    return Math.round((completed / total) * 100);
+    return MathHelper.calculatePercentage(completed, total);
   }
 
   /**
@@ -223,8 +224,7 @@ export class ScheduleEntity {
    * 飲み忘れ率を算出(0-100%)
    */
   static getOverdueRate(overdueCount: number, total: number): number {
-    if (total <= 0) return 0;
-    return Math.round((overdueCount / total) * 100);
+    return MathHelper.calculatePercentage(overdueCount, total);
   }
 
   /**


### PR DESCRIPTION
## Summary
- MathHelper.calculatePercentageをドメインヘルパーとして新規追加
- Schedule.calculateCompletionRate/getOverdueRateをMathHelper利用に変更
- AdherenceStats.calculateRateをMathHelper利用に変更(cap=true)
- HealthLog.getCoOccurrenceRateをMathHelper利用に変更
- HealthLog.getConditionLevelLabel(getConditionLabelと完全重複)を削除

## Test plan
- [x] 既存1226テスト全通過
- [x] ビルド成功

closes #285