### PR TITLE
feat: カレンダー週間サマリーメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarWeekSummary.test.ts
+++ b/src/__tests__/domain/entities/CalendarWeekSummary.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity, CalendarDay } from '@/domain/entities/Calendar';
+
+const createDay = (overrides: Partial<CalendarDay> = {}): CalendarDay => ({
+  date: new Date('2026-03-05'),
+  isCurrentMonth: true,
+  isToday: false,
+  recordCount: 0,
+  averageCondition: null,
+  ...overrides,
+});
+
+describe('CalendarEntity 週間サマリー', () => {
+  describe('getWeekSummary', () => {
+    it('空配列は記録数0・平均nullを返す', () => {
+      const result = CalendarEntity.getWeekSummary([]);
+      expect(result.totalRecords).toBe(0);
+      expect(result.averageCondition).toBeNull();
+    });
+
+    it('全日に記録がある場合の集計', () => {
+      const days = [
+        createDay({ recordCount: 2, averageCondition: 4 }),
+        createDay({ recordCount: 1, averageCondition: 3 }),
+        createDay({ recordCount: 3, averageCondition: 5 }),
+      ];
+      const result = CalendarEntity.getWeekSummary(days);
+      expect(result.totalRecords).toBe(6);
+      expect(result.averageCondition).toBe(4);
+    });
+
+    it('一部の日に記録がない場合はnull以外の日で平均を計算', () => {
+      const days = [
+        createDay({ recordCount: 2, averageCondition: 4 }),
+        createDay({ recordCount: 0, averageCondition: null }),
+        createDay({ recordCount: 1, averageCondition: 2 }),
+      ];
+      const result = CalendarEntity.getWeekSummary(days);
+      expect(result.totalRecords).toBe(3);
+      expect(result.averageCondition).toBe(3);
+    });
+
+    it('全日記録なしの場合は平均null', () => {
+      const days = [
+        createDay({ recordCount: 0, averageCondition: null }),
+        createDay({ recordCount: 0, averageCondition: null }),
+      ];
+      const result = CalendarEntity.getWeekSummary(days);
+      expect(result.totalRecords).toBe(0);
+      expect(result.averageCondition).toBeNull();
+    });
+
+    it('記録がある日数を正しくカウントする', () => {
+      const days = [
+        createDay({ recordCount: 2 }),
+        createDay({ recordCount: 0 }),
+        createDay({ recordCount: 1 }),
+        createDay({ recordCount: 0 }),
+        createDay({ recordCount: 3 }),
+      ];
+      const result = CalendarEntity.getWeekSummary(days);
+      expect(result.daysWithRecords).toBe(3);
+    });
+  });
+
+  describe('getWeekCompletionStatus', () => {
+    it('全日に記録があればcompleteを返す', () => {
+      const days = [
+        createDay({ recordCount: 1 }),
+        createDay({ recordCount: 2 }),
+        createDay({ recordCount: 1 }),
+      ];
+      expect(CalendarEntity.getWeekCompletionStatus(days)).toBe('complete');
+    });
+
+    it('一部の日に記録があればpartialを返す', () => {
+      const days = [
+        createDay({ recordCount: 1 }),
+        createDay({ recordCount: 0 }),
+        createDay({ recordCount: 1 }),
+      ];
+      expect(CalendarEntity.getWeekCompletionStatus(days)).toBe('partial');
+    });
+
+    it('全日記録なしはemptyを返す', () => {
+      const days = [
+        createDay({ recordCount: 0 }),
+        createDay({ recordCount: 0 }),
+      ];
+      expect(CalendarEntity.getWeekCompletionStatus(days)).toBe('empty');
+    });
+
+    it('空配列はemptyを返す', () => {
+      expect(CalendarEntity.getWeekCompletionStatus([])).toBe('empty');
+    });
+  });
+
+  describe('getBusiestDay', () => {
+    it('空配列はnullを返す', () => {
+      expect(CalendarEntity.getBusiestDay([])).toBeNull();
+    });
+
+    it('最も記録が多い日を返す', () => {
+      const days = [
+        createDay({ date: new Date('2026-03-02'), recordCount: 2 }),
+        createDay({ date: new Date('2026-03-03'), recordCount: 5 }),
+        createDay({ date: new Date('2026-03-04'), recordCount: 1 }),
+      ];
+      const result = CalendarEntity.getBusiestDay(days);
+      expect(result!.recordCount).toBe(5);
+    });
+
+    it('全て0件の場合はnullを返す', () => {
+      const days = [
+        createDay({ recordCount: 0 }),
+        createDay({ recordCount: 0 }),
+      ];
+      expect(CalendarEntity.getBusiestDay(days)).toBeNull();
+    });
+
+    it('同数の場合は最初の日を返す', () => {
+      const days = [
+        createDay({ date: new Date('2026-03-02'), recordCount: 3 }),
+        createDay({ date: new Date('2026-03-03'), recordCount: 3 }),
+      ];
+      const result = CalendarEntity.getBusiestDay(days);
+      expect(result!.date.getDate()).toBe(2);
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -135,6 +135,47 @@ export class CalendarEntity {
   }
 
   /**
+   * 週間サマリーを算出
+   */
+  static getWeekSummary(days: CalendarDay[]): {
+    totalRecords: number;
+    averageCondition: number | null;
+    daysWithRecords: number;
+  } {
+    const totalRecords = days.reduce((sum, d) => sum + d.recordCount, 0);
+    const daysWithCondition = days.filter((d) => d.averageCondition !== null);
+    const daysWithRecords = days.filter((d) => d.recordCount > 0).length;
+    const averageCondition =
+      daysWithCondition.length > 0
+        ? Math.round(
+            daysWithCondition.reduce((sum, d) => sum + (d.averageCondition as number), 0) /
+              daysWithCondition.length,
+          )
+        : null;
+    return { totalRecords, averageCondition, daysWithRecords };
+  }
+
+  /**
+   * 週の完了状態を判定
+   */
+  static getWeekCompletionStatus(days: CalendarDay[]): 'complete' | 'partial' | 'empty' {
+    if (days.length === 0) return 'empty';
+    const hasRecord = days.filter((d) => d.recordCount > 0).length;
+    if (hasRecord === 0) return 'empty';
+    if (hasRecord === days.length) return 'complete';
+    return 'partial';
+  }
+
+  /**
+   * 最も記録が多い日を返す
+   */
+  static getBusiestDay(days: CalendarDay[]): CalendarDay | null {
+    if (days.length === 0) return null;
+    const max = days.reduce((best, d) => (d.recordCount > best.recordCount ? d : best), days[0]);
+    return max.recordCount > 0 ? max : null;
+  }
+
+  /**
    * 日付をYYYY-MM-DD形式に変換
    */
   static formatDateKey(date: Date): string {


### PR DESCRIPTION
## Summary
- CalendarEntityに週間サマリー関連メソッド3つを追加
- getWeekSummary: 記録数合計・平均体調レベル・記録日数の集計
- getWeekCompletionStatus: 全完了/一部/なしの判定
- getBusiestDay: 最多記録日の取得

## Test plan
- [x] getWeekSummary: 空配列、全日記録、一部記録、全日なし、日数カウント
- [x] getWeekCompletionStatus: complete/partial/empty/空配列
- [x] getBusiestDay: 空配列、最多日、全0件、同数

closes #291