### PR TITLE
feat: ストリーク評価・ランク判定メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/StreakRank.test.ts
+++ b/src/__tests__/domain/entities/StreakRank.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity ストリーク評価', () => {
+  describe('getStreakRank', () => {
+    it('0日はbronzeを返す', () => {
+      expect(AdherenceStatsEntity.getStreakRank(0)).toBe('bronze');
+    });
+
+    it('6日はbronzeを返す', () => {
+      expect(AdherenceStatsEntity.getStreakRank(6)).toBe('bronze');
+    });
+
+    it('7日はsilverを返す(境界)', () => {
+      expect(AdherenceStatsEntity.getStreakRank(7)).toBe('silver');
+    });
+
+    it('29日はsilverを返す', () => {
+      expect(AdherenceStatsEntity.getStreakRank(29)).toBe('silver');
+    });
+
+    it('30日はgoldを返す(境界)', () => {
+      expect(AdherenceStatsEntity.getStreakRank(30)).toBe('gold');
+    });
+
+    it('89日はgoldを返す', () => {
+      expect(AdherenceStatsEntity.getStreakRank(89)).toBe('gold');
+    });
+
+    it('90日はplatinumを返す(境界)', () => {
+      expect(AdherenceStatsEntity.getStreakRank(90)).toBe('platinum');
+    });
+
+    it('365日はplatinumを返す', () => {
+      expect(AdherenceStatsEntity.getStreakRank(365)).toBe('platinum');
+    });
+  });
+
+  describe('getStreakRankStyle', () => {
+    it('bronzeは茶色系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getStreakRankStyle('bronze');
+      expect(style.text).toContain('orange');
+    });
+
+    it('silverは灰色系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getStreakRankStyle('silver');
+      expect(style.text).toContain('gray');
+    });
+
+    it('goldは黄色系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getStreakRankStyle('gold');
+      expect(style.text).toContain('yellow');
+    });
+
+    it('platinumは紫系スタイルを返す', () => {
+      const style = AdherenceStatsEntity.getStreakRankStyle('platinum');
+      expect(style.text).toContain('purple');
+    });
+  });
+
+  describe('isStreakMilestone', () => {
+    it('7日はマイルストーンを返す', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(7)).toBe(true);
+    });
+
+    it('14日はマイルストーンを返す', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(14)).toBe(true);
+    });
+
+    it('30日はマイルストーンを返す', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(30)).toBe(true);
+    });
+
+    it('60日はマイルストーンを返す', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(60)).toBe(true);
+    });
+
+    it('90日はマイルストーンを返す', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(90)).toBe(true);
+    });
+
+    it('100日はマイルストーンを返す', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(100)).toBe(true);
+    });
+
+    it('365日はマイルストーンを返す', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(365)).toBe(true);
+    });
+
+    it('8日はマイルストーンでない', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(8)).toBe(false);
+    });
+
+    it('0日はマイルストーンでない', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(0)).toBe(false);
+    });
+
+    it('15日はマイルストーンでない', () => {
+      expect(AdherenceStatsEntity.isStreakMilestone(15)).toBe(false);
+    });
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -193,4 +193,35 @@ export class AdherenceStatsEntity {
     };
     return styles[level];
   }
+
+  /**
+   * ストリーク日数に応じたランクを判定
+   */
+  static getStreakRank(streak: number): 'bronze' | 'silver' | 'gold' | 'platinum' {
+    if (streak >= 90) return 'platinum';
+    if (streak >= 30) return 'gold';
+    if (streak >= 7) return 'silver';
+    return 'bronze';
+  }
+
+  /**
+   * ストリークランクに応じたスタイルクラスを返す
+   */
+  static getStreakRankStyle(rank: 'bronze' | 'silver' | 'gold' | 'platinum'): { bg: string; text: string } {
+    const styles: Record<string, { bg: string; text: string }> = {
+      bronze: { bg: 'bg-orange-50', text: 'text-orange-600' },
+      silver: { bg: 'bg-gray-50', text: 'text-gray-600' },
+      gold: { bg: 'bg-yellow-50', text: 'text-yellow-600' },
+      platinum: { bg: 'bg-purple-50', text: 'text-purple-600' },
+    };
+    return styles[rank];
+  }
+
+  /**
+   * マイルストーン日数かどうかを判定
+   */
+  static isStreakMilestone(streak: number): boolean {
+    const milestones = [7, 14, 30, 60, 90, 100, 180, 365];
+    return milestones.includes(streak);
+  }
 }


### PR DESCRIPTION
## Summary
- AdherenceStatsEntityにストリーク評価メソッド3つを追加
- getStreakRank: 連続日数に応じたbronze/silver/gold/platinumランク判定
- getStreakRankStyle: ランクに応じたTailwindスタイルクラス
- isStreakMilestone: 特定日数(7/14/30/60/90/100/180/365)でのマイルストーン達成判定

## Test plan
- [x] getStreakRank: 各ランクの境界値(0/6/7/29/30/89/90/365)
- [x] getStreakRankStyle: 各ランクのスタイル確認
- [x] isStreakMilestone: マイルストーン日/非マイルストーン日

closes #293