### PR TITLE
feat: 通院予約リマインダー判定メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentReminder.test.ts
+++ b/src/__tests__/domain/entities/AppointmentReminder.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AppointmentEntity, Appointment } from '@/domain/entities/Appointment';
+
+const createAppointment = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: 'apt-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  appointmentDate: new Date('2026-03-10T00:00:00'),
+  reminderEnabled: true,
+  reminderDaysBefore: 3,
+  createdAt: new Date('2026-03-01'),
+  ...overrides,
+});
+
+describe('AppointmentEntity リマインダー判定', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-07T10:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('shouldRemind', () => {
+    it('リマインダー無効なら常にfalseを返す', () => {
+      const apt = createAppointment({ reminderEnabled: false, reminderDaysBefore: 3 });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.shouldRemind()).toBe(false);
+    });
+
+    it('リマインダー日数以内ならtrueを返す', () => {
+      // 今日:3/7, 予約:3/10, 残り3日, reminderDaysBefore:3
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-10'), reminderDaysBefore: 3 });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.shouldRemind()).toBe(true);
+    });
+
+    it('リマインダー日数を超えていたらfalseを返す', () => {
+      // 今日:3/7, 予約:3/11, 残り4日, reminderDaysBefore:3
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-11'), reminderDaysBefore: 3 });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.shouldRemind()).toBe(false);
+    });
+
+    it('過去の予約はfalseを返す', () => {
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-06') });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.shouldRemind()).toBe(false);
+    });
+
+    it('当日の予約はtrueを返す', () => {
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-07'), reminderDaysBefore: 1 });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.shouldRemind()).toBe(true);
+    });
+  });
+
+  describe('getReminderUrgency', () => {
+    it('当日はurgentを返す', () => {
+      expect(AppointmentEntity.getReminderUrgency(0)).toBe('urgent');
+    });
+
+    it('1日前はurgentを返す', () => {
+      expect(AppointmentEntity.getReminderUrgency(1)).toBe('urgent');
+    });
+
+    it('2日前はsoonを返す', () => {
+      expect(AppointmentEntity.getReminderUrgency(2)).toBe('soon');
+    });
+
+    it('3日前はsoonを返す', () => {
+      expect(AppointmentEntity.getReminderUrgency(3)).toBe('soon');
+    });
+
+    it('4日前はnormalを返す', () => {
+      expect(AppointmentEntity.getReminderUrgency(4)).toBe('normal');
+    });
+
+    it('7日前はnormalを返す', () => {
+      expect(AppointmentEntity.getReminderUrgency(7)).toBe('normal');
+    });
+
+    it('8日以上はnoneを返す', () => {
+      expect(AppointmentEntity.getReminderUrgency(8)).toBe('none');
+    });
+  });
+
+  describe('getStatusLabel', () => {
+    it('過去の予約は「完了」を返す', () => {
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-06') });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.getStatusLabel()).toBe('完了');
+    });
+
+    it('当日の予約は「本日」を返す', () => {
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-07') });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.getStatusLabel()).toBe('本日');
+    });
+
+    it('3日以内の予約は「もうすぐ」を返す', () => {
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-09') });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.getStatusLabel()).toBe('もうすぐ');
+    });
+
+    it('4日以上先の予約は「予定」を返す', () => {
+      const apt = createAppointment({ appointmentDate: new Date('2026-03-15') });
+      const entity = new AppointmentEntity(apt);
+      expect(entity.getStatusLabel()).toBe('予定');
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -105,6 +105,37 @@ export class AppointmentEntity {
     }).length;
   }
 
+  /**
+   * リマインダーを送信すべきタイミングか判定
+   */
+  shouldRemind(): boolean {
+    if (!this.appointment.reminderEnabled) return false;
+    const days = this.daysUntil();
+    if (days < 0) return false;
+    return days <= this.appointment.reminderDaysBefore;
+  }
+
+  /**
+   * 残り日数に応じたリマインダー緊急度を返す
+   */
+  static getReminderUrgency(daysUntil: number): 'urgent' | 'soon' | 'normal' | 'none' {
+    if (daysUntil <= 1) return 'urgent';
+    if (daysUntil <= 3) return 'soon';
+    if (daysUntil <= 7) return 'normal';
+    return 'none';
+  }
+
+  /**
+   * 予約の状態ラベルを返す
+   */
+  getStatusLabel(): string {
+    if (this.isPast()) return '完了';
+    if (this.isToday()) return '本日';
+    const days = this.daysUntil();
+    if (days <= 3) return 'もうすぐ';
+    return '予定';
+  }
+
   get id(): string {
     return this.appointment.id;
   }


### PR DESCRIPTION
## Summary
- AppointmentEntityにリマインダー関連メソッド3つを追加
- shouldRemind: リマインダー有効かつ日数以内か判定
- getReminderUrgency: 残り日数でurgent/soon/normal/noneの4段階判定
- getStatusLabel: 予約状態を完了/本日/もうすぐ/予定で表示

## Test plan
- [x] shouldRemind: 無効/有効、日数境界、過去、当日
- [x] getReminderUrgency: 0-8日の各境界値
- [x] getStatusLabel: 過去/当日/3日以内/4日以上

closes #295