### PR TITLE
refactor: CalendarEntity.isSameDayをDateRangeHelper利用に変更

### DIFF
--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -76,11 +76,7 @@ export class CalendarEntity {
    * 同じ日かどうかを判定
    */
   static isSameDay(a: Date, b: Date): boolean {
-    return (
-      a.getFullYear() === b.getFullYear() &&
-      a.getMonth() === b.getMonth() &&
-      a.getDate() === b.getDate()
-    );
+    return DateRangeHelper.toDateKey(a) === DateRangeHelper.toDateKey(b);
   }
 
   /**


### PR DESCRIPTION
## Summary
- CalendarEntity.isSameDayの3行比較(getFullYear/getMonth/getDate)をDateRangeHelper.toDateKeyの1行比較に簡略化
- 既存のDateRangeHelperとの一貫性を向上

## Test plan
- [x] 1308テスト全通過
- [x] ビルド成功

closes #297