### PR TITLE
fix: ログイン認証にレート制限を追加

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import Credentials from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
 import { prisma } from './prisma';
 import { authConfig } from './auth.config';
+import { checkRateLimit } from './security';
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
@@ -16,8 +17,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       async authorize(credentials) {
         if (!credentials?.email || !credentials?.password) return null;
 
+        const email = (credentials.email as string).toLowerCase();
+        const rateLimit = checkRateLimit(`login:${email}`, { maxAttempts: 10, windowMs: 60 * 1000 });
+        if (!rateLimit.allowed) return null;
+
         const user = await prisma.user.findUnique({
-          where: { email: credentials.email as string },
+          where: { email },
         });
 
         if (!user) return null;


### PR DESCRIPTION
## Summary
- NextAuth Credentials Providerのauthorize関数にレート制限を追加
- メールアドレスベースで10回/60秒の制限(既存のcheckRateLimit利用)
- メールアドレスをlowerCaseに正規化して一貫性を向上
- ブルートフォース攻撃の防止

## Test plan
- [x] 1329テスト全通過
- [x] ビルド成功

closes #301