### PR TITLE
feat: 服薬情報の表示サマリーメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationDisplaySummary.test.ts
+++ b/src/__tests__/domain/entities/MedicationDisplaySummary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity, Medication } from '@/domain/entities/Medication';
+
+const createMedication = (overrides: Partial<Medication> = {}): Medication => ({
+  id: 'med-1',
+  memberId: 'member-1',
+  userId: 'user-1',
+  name: '薬A',
+  category: 'regular',
+  isActive: true,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ...overrides,
+});
+
+describe('MedicationEntity 表示サマリー', () => {
+  describe('getDosageSummary', () => {
+    it('用量と頻度の両方がある場合は結合して返す', () => {
+      const entity = new MedicationEntity(createMedication({ dosage: '1錠', frequency: '1日3回' }));
+      expect(entity.getDosageSummary()).toBe('1錠 / 1日3回');
+    });
+
+    it('用量のみの場合は用量だけ返す', () => {
+      const entity = new MedicationEntity(createMedication({ dosage: '1錠' }));
+      expect(entity.getDosageSummary()).toBe('1錠');
+    });
+
+    it('頻度のみの場合は頻度だけ返す', () => {
+      const entity = new MedicationEntity(createMedication({ frequency: '1日3回' }));
+      expect(entity.getDosageSummary()).toBe('1日3回');
+    });
+
+    it('両方なしの場合は空文字を返す', () => {
+      const entity = new MedicationEntity(createMedication());
+      expect(entity.getDosageSummary()).toBe('');
+    });
+  });
+
+  describe('getStockStatus', () => {
+    it('在庫未設定はunknownを返す', () => {
+      const entity = new MedicationEntity(createMedication());
+      expect(entity.getStockStatus()).toBe('unknown');
+    });
+
+    it('在庫0はcriticalを返す', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 0 }));
+      expect(entity.getStockStatus()).toBe('critical');
+    });
+
+    it('在庫5以下はlowを返す', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 5 }));
+      expect(entity.getStockStatus()).toBe('low');
+    });
+
+    it('在庫6以上はsafeを返す', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 6 }));
+      expect(entity.getStockStatus()).toBe('safe');
+    });
+
+    it('在庫100はsafeを返す', () => {
+      const entity = new MedicationEntity(createMedication({ stockQuantity: 100 }));
+      expect(entity.getStockStatus()).toBe('safe');
+    });
+  });
+
+  describe('getStockStatusLabel', () => {
+    it('safeは「十分」を返す', () => {
+      expect(MedicationEntity.getStockStatusLabel('safe')).toBe('十分');
+    });
+
+    it('lowは「残りわずか」を返す', () => {
+      expect(MedicationEntity.getStockStatusLabel('low')).toBe('残りわずか');
+    });
+
+    it('criticalは「在庫切れ」を返す', () => {
+      expect(MedicationEntity.getStockStatusLabel('critical')).toBe('在庫切れ');
+    });
+
+    it('unknownは「未設定」を返す', () => {
+      expect(MedicationEntity.getStockStatusLabel('unknown')).toBe('未設定');
+    });
+  });
+});

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -119,11 +119,41 @@ export class MedicationEntity {
   }
 
   getDisplayInfo(): { name: string; categoryLabel: string; dosageInfo: string } {
-    const dosageParts = [this.medication.dosage, this.medication.frequency].filter(Boolean);
     return {
       name: this.medication.name,
       categoryLabel: MedicationEntity.categoryLabels[this.medication.category],
-      dosageInfo: dosageParts.join(' / '),
+      dosageInfo: this.getDosageSummary(),
     };
+  }
+
+  /**
+   * 用量と頻度の統合表示文字列を返す
+   */
+  getDosageSummary(): string {
+    const parts = [this.medication.dosage, this.medication.frequency].filter(Boolean);
+    return parts.join(' / ');
+  }
+
+  /**
+   * 在庫状態を判定する
+   */
+  getStockStatus(): 'safe' | 'low' | 'critical' | 'unknown' {
+    if (this.medication.stockQuantity === undefined) return 'unknown';
+    if (this.medication.stockQuantity === 0) return 'critical';
+    if (this.medication.stockQuantity <= 5) return 'low';
+    return 'safe';
+  }
+
+  /**
+   * 在庫状態の日本語ラベルを返す
+   */
+  static getStockStatusLabel(status: 'safe' | 'low' | 'critical' | 'unknown'): string {
+    const labels: Record<string, string> = {
+      safe: '十分',
+      low: '残りわずか',
+      critical: '在庫切れ',
+      unknown: '未設定',
+    };
+    return labels[status];
   }
 }


### PR DESCRIPTION
## Summary
- MedicationEntityに表示用メソッド3つを追加
- getDosageSummary: 用量・頻度の統合表示(getDisplayInfoのdosageInfoを抽出)
- getStockStatus: 在庫量に基づくsafe/low/critical/unknown判定
- getStockStatusLabel: 各状態の日本語ラベル

## Test plan
- [x] getDosageSummary: 両方あり、片方のみ、なし
- [x] getStockStatus: 未設定、0、5以下、6以上
- [x] getStockStatusLabel: 全4状態のラベル

closes #303