### PR TITLE
feat: スケジュール日別完了率サマリーメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/DailyCompletionSummary.test.ts
+++ b/src/__tests__/domain/entities/DailyCompletionSummary.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity, ScheduleStatus } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 日別完了率サマリー', () => {
+  describe('getDailyCompletionSummary', () => {
+    it('空配列はゼロサマリーを返す', () => {
+      const result = ScheduleEntity.getDailyCompletionSummary([]);
+      expect(result.completed).toBe(0);
+      expect(result.pending).toBe(0);
+      expect(result.overdue).toBe(0);
+      expect(result.total).toBe(0);
+      expect(result.rate).toBe(0);
+    });
+
+    it('全完了の場合', () => {
+      const statuses: ScheduleStatus[] = ['completed', 'completed', 'completed'];
+      const result = ScheduleEntity.getDailyCompletionSummary(statuses);
+      expect(result.completed).toBe(3);
+      expect(result.pending).toBe(0);
+      expect(result.overdue).toBe(0);
+      expect(result.total).toBe(3);
+      expect(result.rate).toBe(100);
+    });
+
+    it('混合の場合', () => {
+      const statuses: ScheduleStatus[] = ['completed', 'pending', 'overdue', 'completed'];
+      const result = ScheduleEntity.getDailyCompletionSummary(statuses);
+      expect(result.completed).toBe(2);
+      expect(result.pending).toBe(1);
+      expect(result.overdue).toBe(1);
+      expect(result.total).toBe(4);
+      expect(result.rate).toBe(50);
+    });
+
+    it('全未完了の場合は0%', () => {
+      const statuses: ScheduleStatus[] = ['pending', 'overdue'];
+      const result = ScheduleEntity.getDailyCompletionSummary(statuses);
+      expect(result.completed).toBe(0);
+      expect(result.rate).toBe(0);
+    });
+  });
+
+  describe('getProgressMessage', () => {
+    it('完了0件で合計0は「予定がありません」を返す', () => {
+      expect(ScheduleEntity.getProgressMessage(0, 0)).toBe('予定がありません');
+    });
+
+    it('全完了は達成メッセージを返す', () => {
+      expect(ScheduleEntity.getProgressMessage(5, 5)).toBe('全ての予定を達成しました');
+    });
+
+    it('半分以上完了は応援メッセージを返す', () => {
+      expect(ScheduleEntity.getProgressMessage(3, 5)).toBe('もう少しで全て完了です');
+    });
+
+    it('半分未満完了は進行中メッセージを返す', () => {
+      expect(ScheduleEntity.getProgressMessage(1, 5)).toBe('少しずつ進めていきましょう');
+    });
+
+    it('0件完了で合計ありは開始メッセージを返す', () => {
+      expect(ScheduleEntity.getProgressMessage(0, 3)).toBe('少しずつ進めていきましょう');
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -261,6 +261,39 @@ export class ScheduleEntity {
     return 'none';
   }
 
+  /**
+   * ステータス配列から日別完了サマリーを算出
+   */
+  static getDailyCompletionSummary(statuses: ScheduleStatus[]): {
+    completed: number;
+    pending: number;
+    overdue: number;
+    total: number;
+    rate: number;
+  } {
+    const completed = statuses.filter((s) => s === 'completed').length;
+    const pending = statuses.filter((s) => s === 'pending').length;
+    const overdue = statuses.filter((s) => s === 'overdue').length;
+    const total = statuses.length;
+    return {
+      completed,
+      pending,
+      overdue,
+      total,
+      rate: MathHelper.calculatePercentage(completed, total),
+    };
+  }
+
+  /**
+   * 完了数と合計数に応じた進捗メッセージを返す
+   */
+  static getProgressMessage(completed: number, total: number): string {
+    if (total === 0) return '予定がありません';
+    if (completed === total) return '全ての予定を達成しました';
+    if (completed >= total / 2) return 'もう少しで全て完了です';
+    return '少しずつ進めていきましょう';
+  }
+
   get id(): string {
     return this.schedule.id;
   }


### PR DESCRIPTION
## Summary
- ScheduleEntityに日別完了率サマリーメソッド2つを追加
- getDailyCompletionSummary: ステータス配列から完了/未完了/遅延の件数・完了率を集計
- getProgressMessage: 完了数と合計に応じた応援メッセージ(4パターン)

## Test plan
- [x] getDailyCompletionSummary: 空配列、全完了、混合、全未完了
- [x] getProgressMessage: 予定なし、全達成、半分以上、半分未満

closes #307