### PR TITLE
服薬記録のタイミング分析機能を追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationTiming.test.ts
+++ b/src/__tests__/domain/entities/MedicationTiming.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (takenAt: Date): MedicationRecord => ({
+  id: 'rec-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  medicationId: 'med-1',
+  medicationName: '薬A',
+  userId: 'user-1',
+  takenAt,
+});
+
+describe('MedicationRecordEntity 服薬タイミング分析', () => {
+  describe('getAverageTimeTaken', () => {
+    it('空配列はnullを返す', () => {
+      expect(MedicationRecordEntity.getAverageTimeTaken([])).toBeNull();
+    });
+
+    it('単一記録はその時刻を返す', () => {
+      const records = [createRecord(new Date('2026-03-05T08:30:00'))];
+      const result = MedicationRecordEntity.getAverageTimeTaken(records);
+      expect(result).toBe('08:30');
+    });
+
+    it('複数記録の平均時刻を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-05T08:00:00')),
+        createRecord(new Date('2026-03-05T10:00:00')),
+      ];
+      const result = MedicationRecordEntity.getAverageTimeTaken(records);
+      expect(result).toBe('09:00');
+    });
+
+    it('分も含めた平均を正しく計算する', () => {
+      const records = [
+        createRecord(new Date('2026-03-05T08:00:00')),
+        createRecord(new Date('2026-03-05T09:00:00')),
+        createRecord(new Date('2026-03-05T10:30:00')),
+      ];
+      const result = MedicationRecordEntity.getAverageTimeTaken(records);
+      expect(result).toBe('09:10');
+    });
+  });
+
+  describe('getTimePeriodDistribution', () => {
+    it('空配列は全時間帯0を返す', () => {
+      const result = MedicationRecordEntity.getTimePeriodDistribution([]);
+      expect(result.morning).toBe(0);
+      expect(result.afternoon).toBe(0);
+      expect(result.evening).toBe(0);
+      expect(result.night).toBe(0);
+    });
+
+    it('各時間帯に正しく分類する', () => {
+      const records = [
+        createRecord(new Date('2026-03-05T07:00:00')), // morning
+        createRecord(new Date('2026-03-05T08:00:00')), // morning
+        createRecord(new Date('2026-03-05T13:00:00')), // afternoon
+        createRecord(new Date('2026-03-05T18:00:00')), // evening
+        createRecord(new Date('2026-03-05T22:00:00')), // night
+      ];
+      const result = MedicationRecordEntity.getTimePeriodDistribution(records);
+      expect(result.morning).toBe(2);
+      expect(result.afternoon).toBe(1);
+      expect(result.evening).toBe(1);
+      expect(result.night).toBe(1);
+    });
+
+    it('深夜0時はnightに分類する', () => {
+      const records = [createRecord(new Date('2026-03-05T00:00:00'))];
+      const result = MedicationRecordEntity.getTimePeriodDistribution(records);
+      expect(result.night).toBe(1);
+    });
+  });
+
+  describe('getMostActiveHour', () => {
+    it('空配列はnullを返す', () => {
+      expect(MedicationRecordEntity.getMostActiveHour([])).toBeNull();
+    });
+
+    it('最も多い時間(時)を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-05T08:00:00')),
+        createRecord(new Date('2026-03-05T08:30:00')),
+        createRecord(new Date('2026-03-05T08:45:00')),
+        createRecord(new Date('2026-03-05T12:00:00')),
+      ];
+      expect(MedicationRecordEntity.getMostActiveHour(records)).toBe(8);
+    });
+
+    it('同数の場合は最初の時間を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-05T08:00:00')),
+        createRecord(new Date('2026-03-05T12:00:00')),
+      ];
+      const result = MedicationRecordEntity.getMostActiveHour(records);
+      expect(result).not.toBeNull();
+    });
+
+    it('単一記録はその時間を返す', () => {
+      const records = [createRecord(new Date('2026-03-05T15:30:00'))];
+      expect(MedicationRecordEntity.getMostActiveHour(records)).toBe(15);
+    });
+  });
+});

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -4,6 +4,7 @@
 
 import { DAY_LABELS_JP } from '../../lib/constants';
 import { DateRangeHelper } from './DateRange';
+import { ScheduleEntity } from './Schedule';
 
 export interface MedicationRecord {
   readonly id: string;
@@ -142,5 +143,59 @@ export class MedicationRecordEntity {
    */
   static getTotalRecordCount(records: MedicationRecord[]): number {
     return records.length;
+  }
+
+  /**
+   * 平均服薬時刻をHH:mm形式で返す
+   */
+  static getAverageTimeTaken(records: MedicationRecord[]): string | null {
+    if (records.length === 0) return null;
+    const totalMinutes = records.reduce((sum, r) => {
+      const d = new Date(r.takenAt);
+      return sum + d.getHours() * 60 + d.getMinutes();
+    }, 0);
+    const avg = Math.round(totalMinutes / records.length);
+    const h = Math.floor(avg / 60).toString().padStart(2, '0');
+    const m = (avg % 60).toString().padStart(2, '0');
+    return `${h}:${m}`;
+  }
+
+  /**
+   * 時間帯別の服薬件数分布を返す
+   */
+  static getTimePeriodDistribution(records: MedicationRecord[]): {
+    morning: number;
+    afternoon: number;
+    evening: number;
+    night: number;
+  } {
+    const dist = { morning: 0, afternoon: 0, evening: 0, night: 0 };
+    for (const r of records) {
+      const time = MedicationRecordEntity.formatTime(new Date(r.takenAt));
+      const period = ScheduleEntity.getTimePeriod(time);
+      dist[period]++;
+    }
+    return dist;
+  }
+
+  /**
+   * 最も服薬が多い時間(時)を返す
+   */
+  static getMostActiveHour(records: MedicationRecord[]): number | null {
+    if (records.length === 0) return null;
+    const counts: Record<number, number> = {};
+    for (const r of records) {
+      const hour = new Date(r.takenAt).getHours();
+      counts[hour] = (counts[hour] || 0) + 1;
+    }
+    let maxHour = 0;
+    let maxCount = 0;
+    for (const [hour, count] of Object.entries(counts)) {
+      if (count > maxCount) {
+        maxHour = Number(hour);
+        maxCount = count;
+      }
+    }
+    return maxHour;
   }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityに服薬タイミング分析メソッドを追加
- getAverageTimeTaken: 平均服薬時刻をHH:mm形式で算出
- getTimePeriodDistribution: 朝/昼/夕/夜の時間帯別件数分布
- getMostActiveHour: 最も服薬が多い時間(時)を特定
- ScheduleEntity.getTimePeriodを活用して時間帯分類を共通化

## Test plan
- [x] TDDテスト11件追加・全パス
- [x] 全1382テストパス
- [x] ビルド成功

closes #315