### PR TITLE
DateRangeHelperに期間分析ユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangePeriodAnalysis.test.ts
+++ b/src/__tests__/domain/entities/DateRangePeriodAnalysis.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper 期間分析ユーティリティ', () => {
+  describe('getDatesBetween', () => {
+    it('同日の場合は1要素を返す', () => {
+      const from = new Date('2026-03-01');
+      const to = new Date('2026-03-01');
+      expect(DateRangeHelper.getDatesBetween(from, to)).toEqual(['2026-03-01']);
+    });
+
+    it('連続3日間の日付キーを返す', () => {
+      const from = new Date('2026-03-01');
+      const to = new Date('2026-03-03');
+      expect(DateRangeHelper.getDatesBetween(from, to)).toEqual([
+        '2026-03-01',
+        '2026-03-02',
+        '2026-03-03',
+      ]);
+    });
+
+    it('月をまたぐ場合も正しく返す', () => {
+      const from = new Date('2026-02-27');
+      const to = new Date('2026-03-02');
+      expect(DateRangeHelper.getDatesBetween(from, to)).toEqual([
+        '2026-02-27',
+        '2026-02-28',
+        '2026-03-01',
+        '2026-03-02',
+      ]);
+    });
+
+    it('fromがtoより後の場合は空配列を返す', () => {
+      const from = new Date('2026-03-05');
+      const to = new Date('2026-03-01');
+      expect(DateRangeHelper.getDatesBetween(from, to)).toEqual([]);
+    });
+  });
+
+  describe('getDayOfWeekLabel', () => {
+    it('日曜日は"日"を返す', () => {
+      expect(DateRangeHelper.getDayOfWeekLabel(new Date('2026-03-01'))).toBe('日');
+    });
+
+    it('月曜日は"月"を返す', () => {
+      expect(DateRangeHelper.getDayOfWeekLabel(new Date('2026-03-02'))).toBe('月');
+    });
+
+    it('土曜日は"土"を返す', () => {
+      expect(DateRangeHelper.getDayOfWeekLabel(new Date('2026-03-07'))).toBe('土');
+    });
+  });
+
+  describe('isWeekend', () => {
+    it('土曜日はtrueを返す', () => {
+      expect(DateRangeHelper.isWeekend(new Date('2026-03-07'))).toBe(true);
+    });
+
+    it('日曜日はtrueを返す', () => {
+      expect(DateRangeHelper.isWeekend(new Date('2026-03-01'))).toBe(true);
+    });
+
+    it('月曜日はfalseを返す', () => {
+      expect(DateRangeHelper.isWeekend(new Date('2026-03-02'))).toBe(false);
+    });
+
+    it('金曜日はfalseを返す', () => {
+      expect(DateRangeHelper.isWeekend(new Date('2026-03-06'))).toBe(false);
+    });
+  });
+
+  describe('getWeekNumber', () => {
+    it('1月1日は第1週を返す', () => {
+      expect(DateRangeHelper.getWeekNumber(new Date('2026-01-01'))).toBe(1);
+    });
+
+    it('1月8日は第2週を返す', () => {
+      expect(DateRangeHelper.getWeekNumber(new Date('2026-01-08'))).toBe(2);
+    });
+
+    it('12月31日は正しい週番号を返す', () => {
+      const week = DateRangeHelper.getWeekNumber(new Date('2026-12-31'));
+      expect(week).toBeGreaterThanOrEqual(52);
+      expect(week).toBeLessThanOrEqual(53);
+    });
+  });
+});

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -76,4 +76,44 @@ export class DateRangeHelper {
   static isWithinDays(date: Date, reference: Date, days: number): boolean {
     return Math.abs(DateRangeHelper.diffDays(reference, date)) <= days;
   }
+
+  /**
+   * 2つの日付間の全日付キー（YYYY-MM-DD）を配列で返す
+   */
+  static getDatesBetween(from: Date, to: Date): string[] {
+    const result: string[] = [];
+    const current = DateRangeHelper.toStartOfDay(from);
+    const end = DateRangeHelper.toStartOfDay(to);
+    while (current <= end) {
+      result.push(DateRangeHelper.toDateKey(current));
+      current.setDate(current.getDate() + 1);
+    }
+    return result;
+  }
+
+  /**
+   * 曜日の日本語ラベルを返す
+   */
+  static getDayOfWeekLabel(date: Date): string {
+    const labels = ['日', '月', '火', '水', '木', '金', '土'];
+    return labels[date.getDay()];
+  }
+
+  /**
+   * 土日かどうかを判定
+   */
+  static isWeekend(date: Date): boolean {
+    const day = date.getDay();
+    return day === 0 || day === 6;
+  }
+
+  /**
+   * 年内の週番号を返す（1始まり）
+   */
+  static getWeekNumber(date: Date): number {
+    const start = new Date(date.getFullYear(), 0, 1);
+    const diff = date.getTime() - start.getTime();
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    return Math.ceil((days + 1) / 7);
+  }
 }


### PR DESCRIPTION
## Summary
- getDatesBetween: 2つの日付間の全日付キー(YYYY-MM-DD)配列を生成
- getDayOfWeekLabel: 曜日の日本語ラベル取得
- isWeekend: 土日判定
- getWeekNumber: 年内の週番号取得（1始まり）

## Test plan
- [x] TDDテスト14件追加・全パス
- [x] 全1410テストパス
- [x] ビルド成功

closes #319