### PR TITLE
ドメインエンティティのDAY_LABELS_JP依存をDateRangeHelperに統合

### DIFF
--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -2,7 +2,6 @@
  * 通院予約エンティティ
  */
 
-import { DAY_LABELS_JP } from '../../lib/constants';
 import { DateRangeHelper } from './DateRange';
 
 export interface Appointment {
@@ -56,7 +55,7 @@ export class AppointmentEntity {
    */
   getFormattedDate(): string {
     const d = new Date(this.appointment.appointmentDate);
-    return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日(${DAY_LABELS_JP[d.getDay()]})`;
+    return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日(${DateRangeHelper.getDayOfWeekLabel(d)})`;
   }
 
   /**

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -2,7 +2,6 @@
  * カレンダーユーティリティ
  */
 
-import { DAY_LABELS_JP } from '../../lib/constants';
 import { DateRangeHelper } from './DateRange';
 
 export interface CalendarDay {
@@ -90,7 +89,7 @@ export class CalendarEntity {
    * 曜日ヘッダーを取得
    */
   static getWeekdayHeaders(): string[] {
-    return [...DAY_LABELS_JP];
+    return DateRangeHelper.getDayLabels();
   }
 
   /**

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -94,9 +94,17 @@ export class DateRangeHelper {
   /**
    * 曜日の日本語ラベルを返す
    */
+  private static readonly DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
   static getDayOfWeekLabel(date: Date): string {
-    const labels = ['日', '月', '火', '水', '木', '金', '土'];
-    return labels[date.getDay()];
+    return DateRangeHelper.DAY_LABELS[date.getDay()];
+  }
+
+  /**
+   * 曜日ラベル配列を返す（日〜土）
+   */
+  static getDayLabels(): string[] {
+    return [...DateRangeHelper.DAY_LABELS];
   }
 
   /**

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -2,7 +2,6 @@
  * 体調記録エンティティ
  */
 
-import { DAY_LABELS_JP } from '../../lib/constants';
 import { DateRangeHelper } from './DateRange';
 import { MathHelper } from './MathHelper';
 
@@ -154,7 +153,7 @@ export class HealthLogEntity {
    */
   static formatDate(dateStr: string): string {
     const date = new Date(dateStr + 'T00:00:00');
-    return `${date.getMonth() + 1}月${date.getDate()}日(${DAY_LABELS_JP[date.getDay()]})`;
+    return `${date.getMonth() + 1}月${date.getDate()}日(${DateRangeHelper.getDayOfWeekLabel(date)})`;
   }
 
   /**
@@ -171,7 +170,7 @@ export class HealthLogEntity {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
       const dateKey = DateRangeHelper.toDateKey(d);
-      const dayLabel = DAY_LABELS_JP[d.getDay()];
+      const dayLabel = DateRangeHelper.getDayOfWeekLabel(d);
 
       const dayLogs = logs.filter((log) => DateRangeHelper.toDateKey(log.recordedAt) === dateKey);
 

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -2,7 +2,6 @@
  * 服薬記録エンティティ
  */
 
-import { DAY_LABELS_JP } from '../../lib/constants';
 import { DateRangeHelper } from './DateRange';
 import { ScheduleEntity } from './Schedule';
 
@@ -52,7 +51,7 @@ export class MedicationRecordEntity {
    */
   static formatDate(dateStr: string): string {
     const date = new Date(dateStr + 'T00:00:00');
-    return `${date.getMonth() + 1}月${date.getDate()}日(${DAY_LABELS_JP[date.getDay()]})`;
+    return `${date.getMonth() + 1}月${date.getDate()}日(${DateRangeHelper.getDayOfWeekLabel(date)})`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- DateRangeHelperにDAY_LABELS定数とgetDayLabels()メソッドを追加
- MedicationRecord, HealthLog, Calendar, Appointmentの4エンティティからlib/constantsのDAY_LABELS_JPインポートを除去
- ドメイン層のインフラ依存を削減し、曜日ラベルの取得先をDateRangeHelperに一元化

## Test plan
- [x] 全1410テストパス
- [x] ビルド成功

closes #321