### PR TITLE
MemberEntity・DateRangeHelperのエッジケーステストを追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangeHelper.edge.test.ts
+++ b/src/__tests__/domain/entities/DateRangeHelper.edge.test.ts
@@ -105,4 +105,87 @@ describe('DateRangeHelper エッジケーステスト', () => {
       expect(DateRangeHelper.toDateKey(new Date(2026, 9, 10))).toBe('2026-10-10');
     });
   });
+
+  describe('diffDays 追加境界値', () => {
+    it('同日は0を返す', () => {
+      const d = new Date('2026-03-05');
+      expect(DateRangeHelper.diffDays(d, d)).toBe(0);
+    });
+
+    it('逆順は負の値を返す', () => {
+      expect(DateRangeHelper.diffDays(new Date('2026-03-06'), new Date('2026-03-05'))).toBe(-1);
+    });
+
+    it('月をまたぐ2月28日→3月1日は1日', () => {
+      expect(DateRangeHelper.diffDays(new Date('2026-02-28'), new Date('2026-03-01'))).toBe(1);
+    });
+
+    it('年をまたぐ12月31日→1月1日は1日', () => {
+      expect(DateRangeHelper.diffDays(new Date('2025-12-31'), new Date('2026-01-01'))).toBe(1);
+    });
+  });
+
+  describe('isWithinDays 境界値', () => {
+    it('ちょうどdays日はtrueを返す', () => {
+      expect(DateRangeHelper.isWithinDays(new Date('2026-03-10'), new Date('2026-03-05'), 5)).toBe(true);
+    });
+
+    it('days+1日はfalseを返す', () => {
+      expect(DateRangeHelper.isWithinDays(new Date('2026-03-11'), new Date('2026-03-05'), 5)).toBe(false);
+    });
+
+    it('過去方向もtrueを返す', () => {
+      expect(DateRangeHelper.isWithinDays(new Date('2026-03-01'), new Date('2026-03-05'), 5)).toBe(true);
+    });
+  });
+
+  describe('getDatesBetween 追加テスト', () => {
+    it('7日間は7要素を返す', () => {
+      const result = DateRangeHelper.getDatesBetween(new Date('2026-03-01'), new Date('2026-03-07'));
+      expect(result).toHaveLength(7);
+    });
+
+    it('年をまたぐ場合も正しく生成する', () => {
+      const result = DateRangeHelper.getDatesBetween(new Date('2025-12-30'), new Date('2026-01-02'));
+      expect(result).toEqual(['2025-12-30', '2025-12-31', '2026-01-01', '2026-01-02']);
+    });
+  });
+
+  describe('getDayLabels', () => {
+    it('7要素の配列を返す', () => {
+      expect(DateRangeHelper.getDayLabels()).toHaveLength(7);
+    });
+
+    it('日〜土の順序で返す', () => {
+      expect(DateRangeHelper.getDayLabels()).toEqual(['日', '月', '火', '水', '木', '金', '土']);
+    });
+
+    it('返り値は元配列のコピーである', () => {
+      const a = DateRangeHelper.getDayLabels();
+      const b = DateRangeHelper.getDayLabels();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('isWeekend 全曜日', () => {
+    it('月〜金はfalse', () => {
+      for (let i = 2; i <= 6; i++) {
+        const d = new Date(`2026-03-0${i}`);
+        expect(DateRangeHelper.isWeekend(d)).toBe(false);
+      }
+    });
+
+    it('土日はtrue', () => {
+      expect(DateRangeHelper.isWeekend(new Date('2026-03-07'))).toBe(true);
+      expect(DateRangeHelper.isWeekend(new Date('2026-03-01'))).toBe(true);
+    });
+  });
+
+  describe('daysAgo 追加テスト', () => {
+    it('負の日数は未来の日付を返す', () => {
+      const from = new Date('2026-03-05');
+      const result = DateRangeHelper.daysAgo(-3, from);
+      expect(DateRangeHelper.toDateKey(result)).toBe('2026-03-08');
+    });
+  });
 });

--- a/src/__tests__/domain/entities/MemberEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberEntity.edge.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemberEntity, Member } from '@/domain/entities/Member';
+
+const createMember = (overrides: Partial<Member> = {}): Member => ({
+  id: 'member-1',
+  userId: 'user-1',
+  memberType: 'human',
+  name: '太郎',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ...overrides,
+});
+
+describe('MemberEntity エッジケーステスト', () => {
+  describe('getAge 境界値', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('birthDateがnullの場合はnullを返す', () => {
+      const entity = new MemberEntity(createMember({ birthDate: undefined }));
+      expect(entity.getAge()).toBeNull();
+    });
+
+    it('誕生日当日は正しい年齢を返す', () => {
+      const entity = new MemberEntity(createMember({ birthDate: new Date('1996-03-05') }));
+      expect(entity.getAge()).toBe(30);
+    });
+
+    it('誕生日前日はまだ前の年齢', () => {
+      const entity = new MemberEntity(createMember({ birthDate: new Date('1996-03-06') }));
+      expect(entity.getAge()).toBe(29);
+    });
+
+    it('生まれたばかり（同年）は0歳', () => {
+      const entity = new MemberEntity(createMember({ birthDate: new Date('2026-01-01') }));
+      expect(entity.getAge()).toBe(0);
+    });
+
+    it('うるう年2月29日生まれ（3月5日時点）', () => {
+      const entity = new MemberEntity(createMember({ birthDate: new Date('2000-02-29') }));
+      expect(entity.getAge()).toBe(26);
+    });
+  });
+
+  describe('getMemberIcon 全パターン', () => {
+    it('humanはUserを返す', () => {
+      expect(MemberEntity.getMemberIcon('human')).toBe('User');
+    });
+
+    it('petType=dogはDogを返す', () => {
+      expect(MemberEntity.getMemberIcon('pet', 'dog')).toBe('Dog');
+    });
+
+    it('petType=catはCatを返す', () => {
+      expect(MemberEntity.getMemberIcon('pet', 'cat')).toBe('Cat');
+    });
+
+    it('petType=rabbitはRabbitを返す', () => {
+      expect(MemberEntity.getMemberIcon('pet', 'rabbit')).toBe('Rabbit');
+    });
+
+    it('petType=birdはBirdを返す', () => {
+      expect(MemberEntity.getMemberIcon('pet', 'bird')).toBe('Bird');
+    });
+
+    it('petType=otherはPawPrintを返す', () => {
+      expect(MemberEntity.getMemberIcon('pet', 'other')).toBe('PawPrint');
+    });
+
+    it('petType未指定はPawPrintを返す', () => {
+      expect(MemberEntity.getMemberIcon('pet')).toBe('PawPrint');
+    });
+  });
+
+  describe('validateName 追加境界値', () => {
+    it('ちょうど1文字はvalid', () => {
+      expect(MemberEntity.validateName('あ').valid).toBe(true);
+    });
+
+    it('ちょうど20文字はvalid', () => {
+      expect(MemberEntity.validateName('あ'.repeat(20)).valid).toBe(true);
+    });
+
+    it('ちょうど21文字はinvalid', () => {
+      expect(MemberEntity.validateName('あ'.repeat(21)).valid).toBe(false);
+    });
+
+    it('タブ文字のみはinvalid', () => {
+      expect(MemberEntity.validateName('\t\t').valid).toBe(false);
+    });
+  });
+
+  describe('getDisplayInfo', () => {
+    it('humanの場合のtypeLabelは家族', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'human' }));
+      expect(entity.getDisplayInfo().typeLabel).toBe('家族');
+    });
+
+    it('petの場合のtypeLabelはペット', () => {
+      const entity = new MemberEntity(createMember({ memberType: 'pet', petType: 'dog' }));
+      expect(entity.getDisplayInfo().typeLabel).toBe('ペット');
+    });
+  });
+
+  describe('sanitizeName 追加テスト', () => {
+    it('タブ文字も空白として正規化する', () => {
+      expect(MemberEntity.sanitizeName('山田\t太郎')).toBe('山田 太郎');
+    });
+
+    it('改行文字も空白として正規化する', () => {
+      expect(MemberEntity.sanitizeName('山田\n太郎')).toBe('山田 太郎');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MemberEntity: getAge境界値(誕生日当日/前日/うるう年)、getMemberIcon全ペットタイプ、validateName/sanitizeName境界値
- DateRangeHelper: diffDays(月/年またぎ)、isWithinDays境界値、getDatesBetween追加、getDayLabelsコピー検証、isWeekend全曜日、daysAgo負値

## Test plan
- [x] 35件のテスト追加・全パス
- [x] 全1445テストパス
- [x] ビルド成功

closes #323