### PR TITLE
forgot-passwordルートにZodスキーマバリデーションを追加

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates, generateVerificationCode } from '@/lib/email';
+import { forgotPasswordSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { validateBodySize } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
@@ -11,11 +12,10 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const email = (body.email ?? '').trim().toLowerCase();
+    const parsed = forgotPasswordSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-    if (!email) {
-      return errorResponse('メールアドレスを入力してください');
-    }
+    const email = parsed.data.email;
 
     const ip = request.headers.get('x-forwarded-for') ?? 'unknown';
     const rateLimit = checkRateLimit(`forgot:${ip}`, { maxAttempts: 5, windowMs: 60 * 1000 });

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -155,3 +155,7 @@ export const signUpSchema = z.object({
     .regex(/[0-9]/, 'パスワードには数字を含めてください'),
   displayName: z.string().trim().min(1, '表示名は必須です').max(100),
 });
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),
+});


### PR DESCRIPTION
## Summary
- forgotPasswordSchemaをlib/schemas.tsに追加（メール形式検証・254文字上限）
- forgot-passwordルートの手動メールパースをZodスキーマ検証に置き換え
- 不正なメール形式のリクエストを適切にバリデーションエラーとして返却

## Test plan
- [x] 全1445テストパス
- [x] ビルド成功

closes #325