### PR TITLE
ScheduleEntityにスケジュール重複検知機能を追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleOverlap.test.ts
+++ b/src/__tests__/domain/entities/ScheduleOverlap.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+interface SimpleSchedule {
+  id: string;
+  time: string;
+  daysOfWeek: string[];
+  medicationName: string;
+}
+
+describe('ScheduleEntity スケジュール重複検知', () => {
+  describe('findOverlappingSchedules', () => {
+    it('空配列は空配列を返す', () => {
+      expect(ScheduleEntity.findOverlappingSchedules([])).toEqual([]);
+    });
+
+    it('1件のみは空配列を返す', () => {
+      const schedules: SimpleSchedule[] = [
+        { id: '1', time: '08:00', daysOfWeek: ['mon'], medicationName: '薬A' },
+      ];
+      expect(ScheduleEntity.findOverlappingSchedules(schedules)).toEqual([]);
+    });
+
+    it('同じ時間・同じ曜日のスケジュールは重複として検知する', () => {
+      const schedules: SimpleSchedule[] = [
+        { id: '1', time: '08:00', daysOfWeek: ['mon'], medicationName: '薬A' },
+        { id: '2', time: '08:00', daysOfWeek: ['mon'], medicationName: '薬B' },
+      ];
+      const result = ScheduleEntity.findOverlappingSchedules(schedules);
+      expect(result).toHaveLength(1);
+      expect(result[0].scheduleIds).toContain('1');
+      expect(result[0].scheduleIds).toContain('2');
+    });
+
+    it('異なる時間は重複しない', () => {
+      const schedules: SimpleSchedule[] = [
+        { id: '1', time: '08:00', daysOfWeek: ['mon'], medicationName: '薬A' },
+        { id: '2', time: '12:00', daysOfWeek: ['mon'], medicationName: '薬B' },
+      ];
+      expect(ScheduleEntity.findOverlappingSchedules(schedules)).toEqual([]);
+    });
+
+    it('異なる曜日は重複しない', () => {
+      const schedules: SimpleSchedule[] = [
+        { id: '1', time: '08:00', daysOfWeek: ['mon'], medicationName: '薬A' },
+        { id: '2', time: '08:00', daysOfWeek: ['tue'], medicationName: '薬B' },
+      ];
+      expect(ScheduleEntity.findOverlappingSchedules(schedules)).toEqual([]);
+    });
+
+    it('曜日未設定（毎日）同士は時間が同じなら重複する', () => {
+      const schedules: SimpleSchedule[] = [
+        { id: '1', time: '08:00', daysOfWeek: [], medicationName: '薬A' },
+        { id: '2', time: '08:00', daysOfWeek: [], medicationName: '薬B' },
+      ];
+      const result = ScheduleEntity.findOverlappingSchedules(schedules);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('hasTimeConflict', () => {
+    it('同じ時間はtrueを返す', () => {
+      expect(ScheduleEntity.hasTimeConflict('08:00', '08:00')).toBe(true);
+    });
+
+    it('15分差以内はtrueを返す（デフォルト）', () => {
+      expect(ScheduleEntity.hasTimeConflict('08:00', '08:10')).toBe(true);
+    });
+
+    it('16分差はfalseを返す（デフォルト）', () => {
+      expect(ScheduleEntity.hasTimeConflict('08:00', '08:16')).toBe(false);
+    });
+
+    it('カスタム閾値で判定する', () => {
+      expect(ScheduleEntity.hasTimeConflict('08:00', '08:25', 30)).toBe(true);
+      expect(ScheduleEntity.hasTimeConflict('08:00', '08:31', 30)).toBe(false);
+    });
+  });
+
+  describe('getConflictMessage', () => {
+    it('重複メッセージを生成する', () => {
+      const result = ScheduleEntity.getConflictMessage('薬A', '薬B', '08:00');
+      expect(result).toBe('薬Aと薬Bが08:00に重複しています');
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -301,4 +301,41 @@ export class ScheduleEntity {
   get data(): Schedule {
     return this.schedule;
   }
+
+  /**
+   * 同じ時間・同じ曜日の重複スケジュールを検知する
+   */
+  static findOverlappingSchedules(
+    schedules: { id: string; time: string; daysOfWeek: string[]; medicationName: string }[],
+  ): { scheduleIds: string[]; time: string; day: string }[] {
+    const overlaps: { scheduleIds: string[]; time: string; day: string }[] = [];
+    for (let i = 0; i < schedules.length; i++) {
+      for (let j = i + 1; j < schedules.length; j++) {
+        const a = schedules[i];
+        const b = schedules[j];
+        if (a.time !== b.time) continue;
+        const aDays = a.daysOfWeek.length === 0 ? ['every'] : a.daysOfWeek;
+        const bDays = b.daysOfWeek.length === 0 ? ['every'] : b.daysOfWeek;
+        const commonDays = aDays.filter((d) => bDays.includes(d) || d === 'every' || bDays.includes('every'));
+        if (commonDays.length > 0) {
+          overlaps.push({ scheduleIds: [a.id, b.id], time: a.time, day: commonDays[0] });
+        }
+      }
+    }
+    return overlaps;
+  }
+
+  /**
+   * 2つの時間が近すぎないかチェック（デフォルト15分以内）
+   */
+  static hasTimeConflict(time1: string, time2: string, thresholdMinutes: number = 15): boolean {
+    return ScheduleEntity.getTimeDiffMinutes(time1, time2) <= thresholdMinutes;
+  }
+
+  /**
+   * 重複検知時のメッセージを生成
+   */
+  static getConflictMessage(medicationNameA: string, medicationNameB: string, time: string): string {
+    return `${medicationNameA}と${medicationNameB}が${time}に重複しています`;
+  }
 }


### PR DESCRIPTION
## Summary
- findOverlappingSchedules: 同時間・同曜日のスケジュール重複を検知
- hasTimeConflict: 2つの時間が指定閾値以内かチェック（デフォルト15分）
- getConflictMessage: 重複検知時のユーザー向けメッセージ生成

## Test plan
- [x] TDDテスト11件追加・全パス
- [x] 全1486テストパス
- [x] ビルド成功

closes #331