### PR TITLE
在庫予測・体調変化検知のエッジケーステストを追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionChangeDetection.edge.test.ts
+++ b/src/__tests__/domain/entities/ConditionChangeDetection.edge.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, HealthLog, ConditionLevel } from '@/domain/entities/HealthLog';
+
+const createLog = (conditionLevel: ConditionLevel, recordedAt: string): HealthLog => ({
+  id: `log-${recordedAt}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  userId: 'user-1',
+  conditionLevel,
+  symptoms: [],
+  recordedAt: new Date(recordedAt),
+});
+
+describe('HealthLogEntity 体調変化検知 エッジケース', () => {
+  describe('detectConditionChange 追加テスト', () => {
+    it('全て同じ体調レベルは空配列を返す', () => {
+      const logs = [
+        createLog(3, '2026-03-05'),
+        createLog(3, '2026-03-04'),
+        createLog(3, '2026-03-03'),
+        createLog(3, '2026-03-02'),
+      ];
+      expect(HealthLogEntity.detectConditionChange(logs)).toEqual([]);
+    });
+
+    it('1→5の急激な変化を検知する', () => {
+      const logs = [
+        createLog(5, '2026-03-05'),
+        createLog(1, '2026-03-04'),
+      ];
+      const result = HealthLogEntity.detectConditionChange(logs);
+      expect(result).toHaveLength(1);
+      expect(result[0].from).toBe(1);
+      expect(result[0].to).toBe(5);
+    });
+
+    it('5→1の急激な悪化を検知する', () => {
+      const logs = [
+        createLog(1, '2026-03-05'),
+        createLog(5, '2026-03-04'),
+      ];
+      const result = HealthLogEntity.detectConditionChange(logs);
+      expect(result).toHaveLength(1);
+      expect(result[0].from).toBe(5);
+      expect(result[0].to).toBe(1);
+    });
+
+    it('複数箇所で変化を検知する', () => {
+      const logs = [
+        createLog(5, '2026-03-05'),
+        createLog(1, '2026-03-04'),
+        createLog(4, '2026-03-03'),
+        createLog(2, '2026-03-02'),
+      ];
+      const result = HealthLogEntity.detectConditionChange(logs);
+      expect(result).toHaveLength(3);
+    });
+
+    it('閾値3で検知する', () => {
+      const logs = [
+        createLog(5, '2026-03-05'),
+        createLog(2, '2026-03-04'),
+      ];
+      const result = HealthLogEntity.detectConditionChange(logs, 3);
+      expect(result).toHaveLength(1);
+    });
+
+    it('閾値3で差が2の場合は検知しない', () => {
+      const logs = [
+        createLog(4, '2026-03-05'),
+        createLog(2, '2026-03-04'),
+      ];
+      expect(HealthLogEntity.detectConditionChange(logs, 3)).toEqual([]);
+    });
+  });
+
+  describe('getConditionTrend 追加テスト', () => {
+    it('2件で改善', () => {
+      const logs = [createLog(4, '2026-03-05'), createLog(2, '2026-03-04')];
+      expect(HealthLogEntity.getConditionTrend(logs)).toBe('improving');
+    });
+
+    it('2件で悪化', () => {
+      const logs = [createLog(2, '2026-03-05'), createLog(4, '2026-03-04')];
+      expect(HealthLogEntity.getConditionTrend(logs)).toBe('declining');
+    });
+
+    it('途中で上下しても最新と最古で判定する', () => {
+      const logs = [
+        createLog(5, '2026-03-05'),
+        createLog(1, '2026-03-04'),
+        createLog(5, '2026-03-03'),
+        createLog(3, '2026-03-02'),
+      ];
+      expect(HealthLogEntity.getConditionTrend(logs)).toBe('improving');
+    });
+  });
+
+  describe('getWorstDay 追加テスト', () => {
+    it('全てレベル5の場合は最初の要素を返す', () => {
+      const logs = [
+        createLog(5, '2026-03-05'),
+        createLog(5, '2026-03-04'),
+      ];
+      const result = HealthLogEntity.getWorstDay(logs);
+      expect(result!.id).toBe('log-2026-03-05');
+    });
+
+    it('レベル1が最後にある場合も正しく検知する', () => {
+      const logs = [
+        createLog(3, '2026-03-05'),
+        createLog(4, '2026-03-04'),
+        createLog(1, '2026-03-03'),
+      ];
+      expect(HealthLogEntity.getWorstDay(logs)!.conditionLevel).toBe(1);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockPrediction.edge.test.ts
+++ b/src/__tests__/domain/entities/StockPrediction.edge.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity 在庫予測エッジケース', () => {
+  describe('predictStockoutDate 追加境界値', () => {
+    it('在庫1・消費1の場合は1日後', () => {
+      const result = StockAlertEntity.predictStockoutDate(1, 1, new Date('2026-03-05'));
+      expect(result).toBe('2026-03-06');
+    });
+
+    it('在庫が消費量より小さい場合は当日', () => {
+      const result = StockAlertEntity.predictStockoutDate(1, 3, new Date('2026-03-05'));
+      expect(result).toBe('2026-03-05');
+    });
+
+    it('大量在庫の場合も正しく計算する', () => {
+      const result = StockAlertEntity.predictStockoutDate(365, 1, new Date('2026-01-01'));
+      expect(result).toBe('2027-01-01');
+    });
+
+    it('小数の消費量も正しく処理する', () => {
+      const result = StockAlertEntity.predictStockoutDate(10, 0.5, new Date('2026-03-05'));
+      expect(result).toBe('2026-03-25');
+    });
+  });
+
+  describe('getStockSufficiencyRate 追加境界値', () => {
+    it('在庫が必要量ちょうどの場合は100', () => {
+      expect(StockAlertEntity.getStockSufficiencyRate(7, 1, 7)).toBe(100);
+    });
+
+    it('在庫が必要量の2倍でも100を超えない', () => {
+      expect(StockAlertEntity.getStockSufficiencyRate(14, 1, 7)).toBe(100);
+    });
+
+    it('消費量が負の場合は100を返す', () => {
+      expect(StockAlertEntity.getStockSufficiencyRate(5, -1, 7)).toBe(100);
+    });
+
+    it('目標日数が負の場合は100を返す', () => {
+      expect(StockAlertEntity.getStockSufficiencyRate(5, 1, -1)).toBe(100);
+    });
+  });
+
+  describe('getStockSufficiencyLabel 境界値', () => {
+    it('ちょうど70は"十分"', () => {
+      expect(StockAlertEntity.getStockSufficiencyLabel(70)).toBe('十分');
+    });
+
+    it('69は"やや不足"', () => {
+      expect(StockAlertEntity.getStockSufficiencyLabel(69)).toBe('やや不足');
+    });
+
+    it('ちょうど40は"やや不足"', () => {
+      expect(StockAlertEntity.getStockSufficiencyLabel(40)).toBe('やや不足');
+    });
+
+    it('39は"不足"', () => {
+      expect(StockAlertEntity.getStockSufficiencyLabel(39)).toBe('不足');
+    });
+  });
+
+  describe('calculateRemainingDays 追加テスト', () => {
+    it('在庫7・消費2の場合は3日', () => {
+      expect(StockAlertEntity.calculateRemainingDays(7, 2)).toBe(3);
+    });
+
+    it('在庫1・消費1の場合は1日', () => {
+      expect(StockAlertEntity.calculateRemainingDays(1, 1)).toBe(1);
+    });
+
+    it('在庫0の場合は0日', () => {
+      expect(StockAlertEntity.calculateRemainingDays(0, 1)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- StockPrediction: predictStockoutDate境界値（在庫1、大量在庫、小数消費量）、getStockSufficiencyRate/Label境界値、calculateRemainingDays追加
- ConditionChangeDetection: 急激な変化（1→5,5→1）、複数箇所検知、閾値カスタマイズ、getConditionTrend追加パターン、getWorstDay追加

## Test plan
- [x] 26件のテスト追加・全パス
- [x] 全1512テストパス
- [x] ビルド成功

closes #335