### PR TITLE
AdherenceStatsに曜日別服薬率分析機能を追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceDayAnalysis.test.ts
+++ b/src/__tests__/domain/entities/AdherenceDayAnalysis.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity 曜日別服薬率分析', () => {
+  describe('getDayOfWeekRates', () => {
+    it('空の記録・期待値は全曜日0%を返す', () => {
+      const result = AdherenceStatsEntity.getDayOfWeekRates([], [0, 0, 0, 0, 0, 0, 0]);
+      expect(result).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('期待値が0の曜日は0%を返す', () => {
+      const records = [new Date('2026-03-02')]; // 月曜
+      const expected = [0, 0, 0, 0, 0, 0, 0]; // 期待値0
+      const result = AdherenceStatsEntity.getDayOfWeekRates(records, expected);
+      expect(result[1]).toBe(0);
+    });
+
+    it('月曜に1回記録・月曜の期待値1で100%を返す', () => {
+      const records = [new Date('2026-03-02')]; // 月曜
+      const expected = [0, 1, 0, 0, 0, 0, 0];
+      const result = AdherenceStatsEntity.getDayOfWeekRates(records, expected);
+      expect(result[1]).toBe(100);
+    });
+
+    it('月曜に1回記録・月曜の期待値2で50%を返す', () => {
+      const records = [new Date('2026-03-02')]; // 月曜
+      const expected = [0, 2, 0, 0, 0, 0, 0];
+      const result = AdherenceStatsEntity.getDayOfWeekRates(records, expected);
+      expect(result[1]).toBe(50);
+    });
+
+    it('複数曜日の記録を正しく集計する', () => {
+      const records = [
+        new Date('2026-03-02'), // 月
+        new Date('2026-03-04'), // 水
+        new Date('2026-03-04'), // 水（2回目）
+      ];
+      const expected = [0, 1, 0, 2, 0, 0, 0];
+      const result = AdherenceStatsEntity.getDayOfWeekRates(records, expected);
+      expect(result[1]).toBe(100); // 月: 1/1
+      expect(result[3]).toBe(100); // 水: 2/2
+    });
+  });
+
+  describe('getBestDay', () => {
+    it('全曜日0%の場合はnullを返す', () => {
+      expect(AdherenceStatsEntity.getBestDay([0, 0, 0, 0, 0, 0, 0])).toBeNull();
+    });
+
+    it('最も高い率の曜日インデックスを返す', () => {
+      expect(AdherenceStatsEntity.getBestDay([50, 80, 70, 100, 60, 90, 40])).toBe(3); // 水
+    });
+
+    it('同率の場合は最初のインデックスを返す', () => {
+      expect(AdherenceStatsEntity.getBestDay([100, 100, 0, 0, 0, 0, 0])).toBe(0); // 日
+    });
+  });
+
+  describe('getWorstDay', () => {
+    it('全曜日0%の場合はnullを返す', () => {
+      expect(AdherenceStatsEntity.getWorstDay([0, 0, 0, 0, 0, 0, 0])).toBeNull();
+    });
+
+    it('最も低い率の曜日インデックスを返す（0%以外の中で）', () => {
+      expect(AdherenceStatsEntity.getWorstDay([0, 80, 70, 100, 60, 90, 40])).toBe(6); // 土
+    });
+
+    it('0%の曜日は除外する', () => {
+      expect(AdherenceStatsEntity.getWorstDay([0, 50, 30, 0, 0, 0, 0])).toBe(2); // 火
+    });
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -224,4 +224,37 @@ export class AdherenceStatsEntity {
     const milestones = [7, 14, 30, 60, 90, 100, 180, 365];
     return milestones.includes(streak);
   }
+
+  /**
+   * 曜日別の服薬率を算出する
+   * 返り値: [日, 月, 火, 水, 木, 金, 土] の服薬率(0-100)
+   */
+  static getDayOfWeekRates(recordDates: Date[], expected: number[]): number[] {
+    const counts = new Array(7).fill(0);
+    for (const date of recordDates) {
+      counts[date.getDay()]++;
+    }
+    return expected.map((exp, i) => {
+      if (exp === 0) return 0;
+      return Math.min(100, Math.round((counts[i] / exp) * 100));
+    });
+  }
+
+  /**
+   * 最も服薬率が高い曜日インデックスを返す
+   */
+  static getBestDay(rates: number[]): number | null {
+    const max = Math.max(...rates);
+    if (max === 0) return null;
+    return rates.indexOf(max);
+  }
+
+  /**
+   * 最も服薬率が低い曜日インデックスを返す（0%の曜日は除外）
+   */
+  static getWorstDay(rates: number[]): number | null {
+    const nonZeroRates = rates.map((r, i) => ({ rate: r, index: i })).filter((r) => r.rate > 0);
+    if (nonZeroRates.length === 0) return null;
+    return nonZeroRates.reduce((min, r) => (r.rate < min.rate ? r : min)).index;
+  }
 }


### PR DESCRIPTION
## Summary
- getDayOfWeekRates: 曜日別の服薬率(0-100)を算出
- getBestDay: 最も服薬率が高い曜日インデックスを返す
- getWorstDay: 最も服薬率が低い曜日インデックスを返す（0%除外）

## Test plan
- [x] TDDテスト11件追加・全パス
- [x] 全1535テストパス
- [x] ビルド成功

closes #341