### PR TITLE
CalendarEntityに月間統計機能を追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarMonthlyStats.test.ts
+++ b/src/__tests__/domain/entities/CalendarMonthlyStats.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity, CalendarDay } from '@/domain/entities/Calendar';
+
+const createDay = (date: string, recordCount: number = 0): CalendarDay => ({
+  date: new Date(date),
+  isCurrentMonth: true,
+  isToday: false,
+  recordCount,
+});
+
+describe('CalendarEntity 月間統計', () => {
+  describe('getMonthlyRecordRate', () => {
+    it('空配列は0を返す', () => {
+      expect(CalendarEntity.getMonthlyRecordRate([])).toBe(0);
+    });
+
+    it('全日記録ありの場合は100を返す', () => {
+      const days = [
+        createDay('2026-03-01', 1),
+        createDay('2026-03-02', 2),
+        createDay('2026-03-03', 1),
+      ];
+      expect(CalendarEntity.getMonthlyRecordRate(days)).toBe(100);
+    });
+
+    it('半分記録ありの場合は50を返す', () => {
+      const days = [
+        createDay('2026-03-01', 1),
+        createDay('2026-03-02', 0),
+      ];
+      expect(CalendarEntity.getMonthlyRecordRate(days)).toBe(50);
+    });
+
+    it('記録なしの場合は0を返す', () => {
+      const days = [
+        createDay('2026-03-01', 0),
+        createDay('2026-03-02', 0),
+      ];
+      expect(CalendarEntity.getMonthlyRecordRate(days)).toBe(0);
+    });
+
+    it('当月以外の日は除外する', () => {
+      const days = [
+        createDay('2026-03-01', 1),
+        { ...createDay('2026-02-28', 1), isCurrentMonth: false },
+      ];
+      expect(CalendarEntity.getMonthlyRecordRate(days)).toBe(100);
+    });
+  });
+
+  describe('getActiveWeeks', () => {
+    it('空配列は0を返す', () => {
+      expect(CalendarEntity.getActiveWeeks([])).toBe(0);
+    });
+
+    it('1週間に記録ありの場合は1を返す', () => {
+      const days = [
+        createDay('2026-03-02', 1), // 月
+        createDay('2026-03-03', 0), // 火
+      ];
+      expect(CalendarEntity.getActiveWeeks(days)).toBe(1);
+    });
+
+    it('異なる週に記録がある場合は週数を返す', () => {
+      const days = [
+        createDay('2026-03-02', 1), // 第1週月
+        createDay('2026-03-09', 1), // 第2週月
+      ];
+      expect(CalendarEntity.getActiveWeeks(days)).toBe(2);
+    });
+
+    it('記録なしの日のみの場合は0を返す', () => {
+      const days = [
+        createDay('2026-03-01', 0),
+        createDay('2026-03-02', 0),
+      ];
+      expect(CalendarEntity.getActiveWeeks(days)).toBe(0);
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -176,4 +176,27 @@ export class CalendarEntity {
   static formatDateKey(date: Date): string {
     return DateRangeHelper.toDateKey(date);
   }
+
+  /**
+   * 月間の記録日数率(0-100)を返す（当月の日のみ対象）
+   */
+  static getMonthlyRecordRate(days: CalendarDay[]): number {
+    const currentMonthDays = days.filter((d) => d.isCurrentMonth);
+    if (currentMonthDays.length === 0) return 0;
+    const daysWithRecords = currentMonthDays.filter((d) => d.recordCount > 0).length;
+    return Math.round((daysWithRecords / currentMonthDays.length) * 100);
+  }
+
+  /**
+   * 記録がある週の数を返す
+   */
+  static getActiveWeeks(days: CalendarDay[]): number {
+    const weeks = new Set<number>();
+    for (const day of days) {
+      if (day.recordCount > 0) {
+        weeks.add(DateRangeHelper.getWeekNumber(day.date));
+      }
+    }
+    return weeks.size;
+  }
 }


### PR DESCRIPTION
## Summary
- getMonthlyRecordRate: 月間の記録日数率(0-100)を算出（当月の日のみ対象）
- getActiveWeeks: 月内で記録がある週数を返す

## Test plan
- [x] TDDテスト9件追加・全パス
- [x] 全1544テストパス
- [x] ビルド成功

closes #343