### PR TITLE
calculateLongestStreakの日付差分計算をDateRangeHelper.diffDaysに統一

### DIFF
--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -137,8 +137,7 @@ export class AdherenceStatsEntity {
     for (let i = 1; i < uniqueDays.length; i++) {
       const prevDate = new Date(uniqueDays[i - 1] + 'T00:00:00');
       const currDate = new Date(uniqueDays[i] + 'T00:00:00');
-      const diffMs = prevDate.getTime() - currDate.getTime();
-      const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+      const diffDays = DateRangeHelper.diffDays(currDate, prevDate);
 
       if (diffDays === 1) {
         current++;


### PR DESCRIPTION
## Summary
- AdherenceStats.calculateLongestStreakの手動ミリ秒差分計算をDateRangeHelper.diffDaysに置き換え
- 日付差分計算の一貫性を向上

## Test plan
- [x] 全1544テストパス
- [x] ビルド成功

closes #345