### PR TITLE
通院間隔分析・月間統計のエッジケーステストを追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentInterval.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentInterval.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity, Appointment } from '@/domain/entities/Appointment';
+
+const createAppointment = (date: string): Appointment => ({
+  id: `apt-${date}`,
+  userId: 'user-1',
+  memberId: 'member-1',
+  appointmentDate: new Date(date),
+  reminderEnabled: false,
+  reminderDaysBefore: 1,
+  createdAt: new Date(),
+});
+
+describe('AppointmentEntity 通院間隔エッジケース', () => {
+  describe('getAverageInterval 追加テスト', () => {
+    it('同日の2件は間隔0を返す', () => {
+      const apts = [
+        createAppointment('2026-03-05'),
+        createAppointment('2026-03-05'),
+      ];
+      expect(AppointmentEntity.getAverageInterval(apts)).toBe(0);
+    });
+
+    it('4件の等間隔は正しく平均を返す', () => {
+      const apts = [
+        createAppointment('2026-03-01'),
+        createAppointment('2026-03-08'),
+        createAppointment('2026-03-15'),
+        createAppointment('2026-03-22'),
+      ];
+      expect(AppointmentEntity.getAverageInterval(apts)).toBe(7);
+    });
+
+    it('不等間隔の平均を正しく計算する', () => {
+      const apts = [
+        createAppointment('2026-03-01'),
+        createAppointment('2026-03-04'), // 3日
+        createAppointment('2026-03-14'), // 10日
+      ];
+      // 平均: (3+10)/2 = 6.5 → 7
+      expect(AppointmentEntity.getAverageInterval(apts)).toBe(7);
+    });
+  });
+
+  describe('getNextRecommendedDate 追加テスト', () => {
+    it('年をまたぐ場合も正しく計算する', () => {
+      expect(AppointmentEntity.getNextRecommendedDate(new Date('2026-12-25'), 14)).toBe('2027-01-08');
+    });
+
+    it('大きな間隔も計算する', () => {
+      expect(AppointmentEntity.getNextRecommendedDate(new Date('2026-01-01'), 90)).toBe('2026-04-01');
+    });
+  });
+
+  describe('getLongestGap 追加テスト', () => {
+    it('同日の2件は間隔0を返す', () => {
+      const apts = [
+        createAppointment('2026-03-05'),
+        createAppointment('2026-03-05'),
+      ];
+      const result = AppointmentEntity.getLongestGap(apts);
+      expect(result!.days).toBe(0);
+    });
+
+    it('3件で最も長い間隔を正しく特定する', () => {
+      const apts = [
+        createAppointment('2026-03-01'),
+        createAppointment('2026-03-05'),  // 4日
+        createAppointment('2026-03-20'),  // 15日
+      ];
+      const result = AppointmentEntity.getLongestGap(apts);
+      expect(result!.days).toBe(15);
+      expect(result!.from).toBe('2026-03-05');
+      expect(result!.to).toBe('2026-03-20');
+    });
+
+    it('等間隔の場合は最初のペアを返す', () => {
+      const apts = [
+        createAppointment('2026-03-01'),
+        createAppointment('2026-03-08'),
+        createAppointment('2026-03-15'),
+      ];
+      const result = AppointmentEntity.getLongestGap(apts);
+      expect(result!.days).toBe(7);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/CalendarMonthlyStats.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarMonthlyStats.edge.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity, CalendarDay } from '@/domain/entities/Calendar';
+
+const createDay = (date: string, recordCount: number = 0, isCurrentMonth: boolean = true): CalendarDay => ({
+  date: new Date(date),
+  isCurrentMonth,
+  isToday: false,
+  recordCount,
+});
+
+describe('CalendarEntity 月間統計エッジケース', () => {
+  describe('getMonthlyRecordRate 追加テスト', () => {
+    it('1日だけ記録ありの31日間', () => {
+      const days = Array.from({ length: 31 }, (_, i) =>
+        createDay(`2026-03-${String(i + 1).padStart(2, '0')}`, i === 0 ? 1 : 0),
+      );
+      const rate = CalendarEntity.getMonthlyRecordRate(days);
+      expect(rate).toBe(3); // 1/31 = 3.2% → 3
+    });
+
+    it('全て前月の日は0を返す', () => {
+      const days = [
+        createDay('2026-02-28', 1, false),
+        createDay('2026-02-27', 1, false),
+      ];
+      expect(CalendarEntity.getMonthlyRecordRate(days)).toBe(0);
+    });
+  });
+
+  describe('getActiveWeeks 追加テスト', () => {
+    it('同じ週の複数日は1を返す', () => {
+      const days = [
+        createDay('2026-03-02', 1), // 月
+        createDay('2026-03-03', 1), // 火
+        createDay('2026-03-04', 1), // 水
+      ];
+      expect(CalendarEntity.getActiveWeeks(days)).toBe(1);
+    });
+
+    it('4週間全てに記録ありは4を返す', () => {
+      const days = [
+        createDay('2026-03-02', 1),
+        createDay('2026-03-09', 1),
+        createDay('2026-03-16', 1),
+        createDay('2026-03-23', 1),
+      ];
+      expect(CalendarEntity.getActiveWeeks(days)).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- AppointmentInterval: 同日2件・等間隔・不等間隔・年またぎ・大間隔のエッジケース
- CalendarMonthlyStats: 1日記録/31日間・前月除外・同週複数日・4週間のエッジケース

## Test plan
- [x] 12件のテスト追加・全パス
- [x] 全1556テストパス
- [x] ビルド成功

closes #347