### PR TITLE
users/me PUTにレートリミットを追加

### DIFF
--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { updateUserProfileSchema } from '@/lib/schemas';
 import { success, errorResponse, notFound } from '@/lib/auth-helpers';
 import { withAuth, validateBodySize } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 const USER_SELECT = {
   id: true,
@@ -26,6 +27,11 @@ export async function PUT(request: Request) {
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const rateLimit = checkRateLimit(`profile:${userId}`, { maxAttempts: 10, windowMs: 60 * 1000 });
+    if (!rateLimit.allowed) {
+      return errorResponse('更新回数の上限に達しました。しばらくしてから再試行してください。', 429);
+    }
+
     const body = await request.json();
     const parsed = updateUserProfileSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);


### PR DESCRIPTION
## Summary
- users/me PUTにユーザーIDベースのレートリミットを追加（10回/分）
- プロフィール更新の乱用を防止
- 429レスポンスで日本語エラーメッセージを返却

## Test plan
- [x] 全1556テストパス
- [x] ビルド成功

closes #349