### PR TITLE
薬の用法用量テキスト生成ユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationDosageText.test.ts
+++ b/src/__tests__/domain/entities/MedicationDosageText.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity 用法用量テキスト生成', () => {
+  describe('getFrequencyLabel', () => {
+    it('"daily"は"毎日"を返す', () => {
+      expect(MedicationEntity.getFrequencyLabel('daily')).toBe('毎日');
+    });
+
+    it('"twice_daily"は"1日2回"を返す', () => {
+      expect(MedicationEntity.getFrequencyLabel('twice_daily')).toBe('1日2回');
+    });
+
+    it('"three_times_daily"は"1日3回"を返す', () => {
+      expect(MedicationEntity.getFrequencyLabel('three_times_daily')).toBe('1日3回');
+    });
+
+    it('"weekly"は"週1回"を返す', () => {
+      expect(MedicationEntity.getFrequencyLabel('weekly')).toBe('週1回');
+    });
+
+    it('"as_needed"は"必要時"を返す', () => {
+      expect(MedicationEntity.getFrequencyLabel('as_needed')).toBe('必要時');
+    });
+
+    it('未知の頻度はそのまま返す', () => {
+      expect(MedicationEntity.getFrequencyLabel('custom_freq')).toBe('custom_freq');
+    });
+  });
+
+  describe('isExpiringSoon', () => {
+    it('在庫5以下はtrueを返す', () => {
+      expect(MedicationEntity.isExpiringSoon(5)).toBe(true);
+    });
+
+    it('在庫0はtrueを返す', () => {
+      expect(MedicationEntity.isExpiringSoon(0)).toBe(true);
+    });
+
+    it('在庫6はfalseを返す', () => {
+      expect(MedicationEntity.isExpiringSoon(6)).toBe(false);
+    });
+
+    it('在庫nullはfalseを返す', () => {
+      expect(MedicationEntity.isExpiringSoon(null)).toBe(false);
+    });
+
+    it('カスタム閾値で判定する', () => {
+      expect(MedicationEntity.isExpiringSoon(10, 10)).toBe(true);
+      expect(MedicationEntity.isExpiringSoon(11, 10)).toBe(false);
+    });
+  });
+
+  describe('getRefillRecommendation', () => {
+    it('在庫0は"今すぐ補充が必要です"を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(0)).toBe('今すぐ補充が必要です');
+    });
+
+    it('在庫3は"早めの補充をおすすめします"を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(3)).toBe('早めの補充をおすすめします');
+    });
+
+    it('在庫7は"そろそろ補充を検討してください"を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(7)).toBe('そろそろ補充を検討してください');
+    });
+
+    it('在庫15は"十分な在庫があります"を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(15)).toBe('十分な在庫があります');
+    });
+
+    it('在庫nullは"在庫数が未設定です"を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(null)).toBe('在庫数が未設定です');
+    });
+  });
+});

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -156,4 +156,38 @@ export class MedicationEntity {
     };
     return labels[status];
   }
+
+  private static readonly frequencyLabels: Record<string, string> = {
+    daily: '毎日',
+    twice_daily: '1日2回',
+    three_times_daily: '1日3回',
+    weekly: '週1回',
+    as_needed: '必要時',
+  };
+
+  /**
+   * 服薬頻度コードを日本語ラベルに変換する
+   */
+  static getFrequencyLabel(frequency: string): string {
+    return MedicationEntity.frequencyLabels[frequency] ?? frequency;
+  }
+
+  /**
+   * 在庫が補充推奨レベルかどうかを判定する
+   */
+  static isExpiringSoon(quantity: number | null, threshold: number = 5): boolean {
+    if (quantity === null) return false;
+    return quantity <= threshold;
+  }
+
+  /**
+   * 在庫数に応じた補充推奨メッセージを返す
+   */
+  static getRefillRecommendation(quantity: number | null): string {
+    if (quantity === null) return '在庫数が未設定です';
+    if (quantity === 0) return '今すぐ補充が必要です';
+    if (quantity <= 5) return '早めの補充をおすすめします';
+    if (quantity <= 10) return 'そろそろ補充を検討してください';
+    return '十分な在庫があります';
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationEntityにgetFrequencyLabel, isExpiringSoon, getRefillRecommendationを追加
- 頻度コードの日本語ラベル変換（daily→毎日、twice_daily→1日2回 等）
- 在庫数に応じた補充推奨判定とメッセージ生成
- テスト16件追加（計1583件）

## Test plan
- [x] getFrequencyLabelが全頻度コードを正しく変換する
- [x] isExpiringSoonが閾値に基づき正しく判定する
- [x] getRefillRecommendationが在庫レベル別に適切なメッセージを返す
- [x] 全テスト通過・ビルド成功

closes #353