### PR TITLE
通院予約の種別分布分析ユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentTypeDistribution.test.ts
+++ b/src/__tests__/domain/entities/AppointmentTypeDistribution.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity, Appointment } from '@/domain/entities/Appointment';
+
+const createAppointment = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: `apt-${Math.random()}`,
+  userId: 'user-1',
+  memberId: 'member-1',
+  appointmentDate: new Date('2026-03-01'),
+  reminderEnabled: false,
+  reminderDaysBefore: 1,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+describe('AppointmentEntity 種別分布分析', () => {
+  describe('getTypeDistribution', () => {
+    it('空配列は空配列を返す', () => {
+      expect(AppointmentEntity.getTypeDistribution([])).toEqual([]);
+    });
+
+    it('種別ごとの件数と割合を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'treatment' }),
+        createAppointment({ appointmentType: 'vaccination' }),
+      ];
+      const result = AppointmentEntity.getTypeDistribution(appointments);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({ type: 'checkup', label: '定期検診', count: 2, percentage: 50 });
+      expect(result[1].count).toBe(1);
+    });
+
+    it('件数が多い順にソートされる', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'vaccination' }),
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'vaccination' }),
+      ];
+      const result = AppointmentEntity.getTypeDistribution(appointments);
+      expect(result[0].type).toBe('checkup');
+      expect(result[1].type).toBe('vaccination');
+    });
+
+    it('種別未設定はotherとして集計する', () => {
+      const appointments = [
+        createAppointment({}),
+        createAppointment({ appointmentType: 'checkup' }),
+      ];
+      const result = AppointmentEntity.getTypeDistribution(appointments);
+      const other = result.find((r) => r.type === 'other');
+      expect(other).toBeDefined();
+      expect(other!.count).toBe(1);
+    });
+  });
+
+  describe('getMostFrequentType', () => {
+    it('空配列はnullを返す', () => {
+      expect(AppointmentEntity.getMostFrequentType([])).toBeNull();
+    });
+
+    it('最も多い種別を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'treatment' }),
+        createAppointment({ appointmentType: 'checkup' }),
+      ];
+      const result = AppointmentEntity.getMostFrequentType(appointments);
+      expect(result!.type).toBe('checkup');
+      expect(result!.count).toBe(2);
+    });
+
+    it('ラベル付きで返す', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'vaccination' }),
+      ];
+      const result = AppointmentEntity.getMostFrequentType(appointments);
+      expect(result!.label).toBe('予防接種');
+    });
+  });
+
+  describe('getTypePercentage', () => {
+    it('空配列は0を返す', () => {
+      expect(AppointmentEntity.getTypePercentage([], 'checkup')).toBe(0);
+    });
+
+    it('特定種別の割合を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'treatment' }),
+        createAppointment({ appointmentType: 'vaccination' }),
+      ];
+      expect(AppointmentEntity.getTypePercentage(appointments, 'checkup')).toBe(50);
+    });
+
+    it('該当種別がない場合は0を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+      ];
+      expect(AppointmentEntity.getTypePercentage(appointments, 'surgery')).toBe(0);
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -200,4 +200,46 @@ export class AppointmentEntity {
       to: DateRangeHelper.toDateKey(new Date(maxTo.appointmentDate)),
     };
   }
+
+  /**
+   * 予約種別ごとの件数と割合を算出する（多い順）
+   */
+  static getTypeDistribution(
+    appointments: Appointment[],
+  ): { type: string; label: string; count: number; percentage: number }[] {
+    if (appointments.length === 0) return [];
+    const counts: Record<string, number> = {};
+    for (const apt of appointments) {
+      const type = apt.appointmentType || 'other';
+      counts[type] = (counts[type] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([type, count]) => ({
+        type,
+        label: AppointmentEntity.typeLabels[type] || type,
+        count,
+        percentage: Math.round((count / appointments.length) * 100),
+      }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  /**
+   * 最も多い予約種別を返す
+   */
+  static getMostFrequentType(
+    appointments: Appointment[],
+  ): { type: string; label: string; count: number } | null {
+    const dist = AppointmentEntity.getTypeDistribution(appointments);
+    if (dist.length === 0) return null;
+    return { type: dist[0].type, label: dist[0].label, count: dist[0].count };
+  }
+
+  /**
+   * 特定種別の割合を算出する
+   */
+  static getTypePercentage(appointments: Appointment[], type: string): number {
+    if (appointments.length === 0) return 0;
+    const count = appointments.filter((a) => (a.appointmentType || 'other') === type).length;
+    return Math.round((count / appointments.length) * 100);
+  }
 }


### PR DESCRIPTION
## Summary
- AppointmentEntityにgetTypeDistribution, getMostFrequentType, getTypePercentageを追加
- 予約種別ごとの件数・割合の算出と最頻種別の取得
- テスト10件追加（計1593件）

## Test plan
- [x] getTypeDistributionが種別ごとの件数と割合を正しく算出する
- [x] getMostFrequentTypeが最頻種別を返す
- [x] getTypePercentageが特定種別の割合を返す
- [x] 全テスト通過・ビルド成功

closes #355