### PR TITLE
手動パーセント計算をMathHelper.calculatePercentageに統一

### DIFF
--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -235,7 +235,7 @@ export class AdherenceStatsEntity {
     }
     return expected.map((exp, i) => {
       if (exp === 0) return 0;
-      return Math.min(100, Math.round((counts[i] / exp) * 100));
+      return MathHelper.calculatePercentage(counts[i], exp, true);
     });
   }
 

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -3,6 +3,7 @@
  */
 
 import { DateRangeHelper } from './DateRange';
+import { MathHelper } from './MathHelper';
 
 export interface Appointment {
   readonly id: string;
@@ -218,7 +219,7 @@ export class AppointmentEntity {
         type,
         label: AppointmentEntity.typeLabels[type] || type,
         count,
-        percentage: Math.round((count / appointments.length) * 100),
+        percentage: MathHelper.calculatePercentage(count, appointments.length),
       }))
       .sort((a, b) => b.count - a.count);
   }
@@ -240,6 +241,6 @@ export class AppointmentEntity {
   static getTypePercentage(appointments: Appointment[], type: string): number {
     if (appointments.length === 0) return 0;
     const count = appointments.filter((a) => (a.appointmentType || 'other') === type).length;
-    return Math.round((count / appointments.length) * 100);
+    return MathHelper.calculatePercentage(count, appointments.length);
   }
 }

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -3,6 +3,7 @@
  */
 
 import { DateRangeHelper } from './DateRange';
+import { MathHelper } from './MathHelper';
 
 export interface CalendarDay {
   date: Date;
@@ -184,7 +185,7 @@ export class CalendarEntity {
     const currentMonthDays = days.filter((d) => d.isCurrentMonth);
     if (currentMonthDays.length === 0) return 0;
     const daysWithRecords = currentMonthDays.filter((d) => d.recordCount > 0).length;
-    return Math.round((daysWithRecords / currentMonthDays.length) * 100);
+    return MathHelper.calculatePercentage(daysWithRecords, currentMonthDays.length);
   }
 
   /**

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -3,6 +3,7 @@
  */
 
 import { DateRangeHelper } from './DateRange';
+import { MathHelper } from './MathHelper';
 
 export interface StockAlert {
   readonly medicationId: string;
@@ -112,7 +113,7 @@ export class StockAlertEntity {
     if (stockQuantity === null) return 0;
     if (dailyConsumption <= 0 || targetDays <= 0) return 100;
     const needed = dailyConsumption * targetDays;
-    return Math.min(100, Math.round((stockQuantity / needed) * 100));
+    return MathHelper.calculatePercentage(stockQuantity, needed, true);
   }
 
   /**


### PR DESCRIPTION
## Summary
- StockAlert, Calendar, Appointment, AdherenceStatsの手動パーセント計算をMathHelper.calculatePercentageに置き換え
- 4ファイルの計算ロジックを共通ヘルパーに統一し一貫性を向上
- 機能的な変更なし

## Test plan
- [x] 全1593テスト通過
- [x] ビルド成功

closes #357