### PR TITLE
MedicationDosageText・AppointmentTypeDistributionのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentTypeDistribution.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentTypeDistribution.edge.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity, Appointment } from '@/domain/entities/Appointment';
+
+const createAppointment = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: `apt-${Math.random()}`,
+  userId: 'user-1',
+  memberId: 'member-1',
+  appointmentDate: new Date('2026-03-01'),
+  reminderEnabled: false,
+  reminderDaysBefore: 1,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+describe('AppointmentEntity 種別分布 エッジケース', () => {
+  describe('getTypeDistribution エッジケース', () => {
+    it('全て同じ種別は100%を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+      ];
+      const result = AppointmentEntity.getTypeDistribution(appointments);
+      expect(result).toHaveLength(1);
+      expect(result[0].percentage).toBe(100);
+    });
+
+    it('1件のみは100%を返す', () => {
+      const appointments = [createAppointment({ appointmentType: 'treatment' })];
+      const result = AppointmentEntity.getTypeDistribution(appointments);
+      expect(result[0].percentage).toBe(100);
+      expect(result[0].label).toBe('治療');
+    });
+
+    it('未知の種別はそのまま表示する', () => {
+      const appointments = [createAppointment({ appointmentType: 'custom_type' })];
+      const result = AppointmentEntity.getTypeDistribution(appointments);
+      expect(result[0].label).toBe('custom_type');
+    });
+
+    it('3種別が均等な場合の割合', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'treatment' }),
+        createAppointment({ appointmentType: 'vaccination' }),
+      ];
+      const result = AppointmentEntity.getTypeDistribution(appointments);
+      expect(result.every((r) => r.percentage === 33)).toBe(true);
+    });
+  });
+
+  describe('getMostFrequentType エッジケース', () => {
+    it('1件のみでもnullではない', () => {
+      const appointments = [createAppointment({ appointmentType: 'surgery' })];
+      const result = AppointmentEntity.getMostFrequentType(appointments);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('surgery');
+      expect(result!.label).toBe('手術');
+    });
+
+    it('種別未設定のみの場合otherを返す', () => {
+      const appointments = [createAppointment({}), createAppointment({})];
+      const result = AppointmentEntity.getMostFrequentType(appointments);
+      expect(result!.type).toBe('other');
+      expect(result!.label).toBe('その他');
+    });
+  });
+
+  describe('getTypePercentage エッジケース', () => {
+    it('全て同じ種別は100を返す', () => {
+      const appointments = [
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+        createAppointment({ appointmentType: 'checkup' }),
+      ];
+      expect(AppointmentEntity.getTypePercentage(appointments, 'checkup')).toBe(100);
+    });
+
+    it('種別未設定はotherとして計算される', () => {
+      const appointments = [createAppointment({})];
+      expect(AppointmentEntity.getTypePercentage(appointments, 'other')).toBe(100);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationDosageText.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationDosageText.edge.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity 用法用量テキスト エッジケース', () => {
+  describe('getFrequencyLabel エッジケース', () => {
+    it('空文字はそのまま返す', () => {
+      expect(MedicationEntity.getFrequencyLabel('')).toBe('');
+    });
+
+    it('大文字の頻度コードはマッチしない', () => {
+      expect(MedicationEntity.getFrequencyLabel('DAILY')).toBe('DAILY');
+    });
+
+    it('スペース付きの頻度コードはマッチしない', () => {
+      expect(MedicationEntity.getFrequencyLabel(' daily ')).toBe(' daily ');
+    });
+
+    it('全ての定義済みラベルが取得可能', () => {
+      const expected: Record<string, string> = {
+        daily: '毎日',
+        twice_daily: '1日2回',
+        three_times_daily: '1日3回',
+        weekly: '週1回',
+        as_needed: '必要時',
+      };
+      for (const [code, label] of Object.entries(expected)) {
+        expect(MedicationEntity.getFrequencyLabel(code)).toBe(label);
+      }
+    });
+  });
+
+  describe('isExpiringSoon エッジケース', () => {
+    it('負の在庫はtrueを返す', () => {
+      expect(MedicationEntity.isExpiringSoon(-1)).toBe(true);
+    });
+
+    it('閾値0で在庫0はtrueを返す', () => {
+      expect(MedicationEntity.isExpiringSoon(0, 0)).toBe(true);
+    });
+
+    it('閾値0で在庫1はfalseを返す', () => {
+      expect(MedicationEntity.isExpiringSoon(1, 0)).toBe(false);
+    });
+
+    it('大きな在庫は閾値以下でなければfalse', () => {
+      expect(MedicationEntity.isExpiringSoon(1000, 999)).toBe(false);
+      expect(MedicationEntity.isExpiringSoon(999, 999)).toBe(true);
+    });
+  });
+
+  describe('getRefillRecommendation エッジケース', () => {
+    it('境界値5は早めの補充を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(5)).toBe('早めの補充をおすすめします');
+    });
+
+    it('境界値6はそろそろ補充を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(6)).toBe('そろそろ補充を検討してください');
+    });
+
+    it('境界値10はそろそろ補充を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(10)).toBe('そろそろ補充を検討してください');
+    });
+
+    it('境界値11は十分な在庫を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(11)).toBe('十分な在庫があります');
+    });
+
+    it('非常に大きな在庫は十分な在庫を返す', () => {
+      expect(MedicationEntity.getRefillRecommendation(99999)).toBe('十分な在庫があります');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MedicationDosageText.edge.test.ts: 境界値・空文字・大文字・負値等13件
- AppointmentTypeDistribution.edge.test.ts: 均等分布・未知種別・単一種別等8件
- テスト21件追加（計1614件）

## Test plan
- [x] 全1614テスト通過
- [x] ビルド成功

closes #359