### PR TITLE
症状の深刻度スコアリングユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/SymptomSeverityScoring.test.ts
+++ b/src/__tests__/domain/entities/SymptomSeverityScoring.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, HealthLog, ConditionLevel, SymptomType } from '@/domain/entities/HealthLog';
+
+const createLog = (
+  conditionLevel: ConditionLevel,
+  symptoms: SymptomType[],
+  overrides: Partial<HealthLog> = {},
+): HealthLog => ({
+  id: `log-${Math.random()}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  userId: 'user-1',
+  conditionLevel,
+  symptoms,
+  notes: '',
+  recordedAt: new Date('2026-03-01'),
+  ...overrides,
+});
+
+describe('HealthLogEntity 症状深刻度スコアリング', () => {
+  describe('getSymptomSeverityScore', () => {
+    it('空配列は0を返す', () => {
+      expect(HealthLogEntity.getSymptomSeverityScore([], 'headache')).toBe(0);
+    });
+
+    it('該当症状がない場合は0を返す', () => {
+      const logs = [createLog(1, ['fever']), createLog(2, ['fatigue'])];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(0);
+    });
+
+    it('低体調時のみに出現する症状は100を返す', () => {
+      const logs = [
+        createLog(1, ['headache']),
+        createLog(2, ['headache']),
+        createLog(4, ['fatigue']),
+        createLog(5, []),
+      ];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(100);
+    });
+
+    it('高体調時のみに出現する症状は0を返す', () => {
+      const logs = [
+        createLog(4, ['headache']),
+        createLog(5, ['headache']),
+        createLog(1, ['fever']),
+      ];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(0);
+    });
+
+    it('半分が低体調時の場合50を返す', () => {
+      const logs = [
+        createLog(1, ['headache']),
+        createLog(4, ['headache']),
+      ];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(50);
+    });
+  });
+
+  describe('getSymptomRiskLevel', () => {
+    it('スコア0はlowを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(0)).toBe('low');
+    });
+
+    it('スコア30はlowを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(30)).toBe('low');
+    });
+
+    it('スコア50はmediumを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(50)).toBe('medium');
+    });
+
+    it('スコア70はmediumを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(70)).toBe('medium');
+    });
+
+    it('スコア80はhighを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(80)).toBe('high');
+    });
+
+    it('スコア100はhighを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(100)).toBe('high');
+    });
+  });
+
+  describe('getMostSevereSymptom', () => {
+    it('空配列はnullを返す', () => {
+      expect(HealthLogEntity.getMostSevereSymptom([])).toBeNull();
+    });
+
+    it('最も深刻度が高い症状を返す', () => {
+      const logs = [
+        createLog(1, ['headache', 'fever']),
+        createLog(2, ['headache']),
+        createLog(4, ['fever']),
+        createLog(5, ['fatigue']),
+      ];
+      const result = HealthLogEntity.getMostSevereSymptom(logs);
+      expect(result!.symptom).toBe('headache');
+      expect(result!.score).toBe(100);
+    });
+
+    it('症状がない場合はnullを返す', () => {
+      const logs = [createLog(3, []), createLog(4, [])];
+      expect(HealthLogEntity.getMostSevereSymptom(logs)).toBeNull();
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -344,4 +344,47 @@ export class HealthLogEntity {
     if (logs.length === 0) return null;
     return logs.reduce((worst, log) => (log.conditionLevel < worst.conditionLevel ? log : worst));
   }
+
+  /**
+   * 特定症状の深刻度スコア(0-100)を算出する
+   * 症状が体調レベル1-2の時に出現する割合
+   */
+  static getSymptomSeverityScore(logs: HealthLog[], symptom: SymptomType): number {
+    const logsWithSymptom = logs.filter((l) => l.symptoms.includes(symptom));
+    if (logsWithSymptom.length === 0) return 0;
+    const lowConditionCount = logsWithSymptom.filter((l) => l.conditionLevel <= 2).length;
+    return MathHelper.calculatePercentage(lowConditionCount, logsWithSymptom.length);
+  }
+
+  /**
+   * 深刻度スコアに応じたリスクレベルを返す
+   */
+  static getSymptomRiskLevel(score: number): 'low' | 'medium' | 'high' {
+    if (score >= 80) return 'high';
+    if (score >= 50) return 'medium';
+    return 'low';
+  }
+
+  /**
+   * 最も深刻度が高い症状を返す
+   */
+  static getMostSevereSymptom(
+    logs: HealthLog[],
+  ): { symptom: SymptomType; score: number } | null {
+    const allSymptoms = new Set<SymptomType>();
+    for (const log of logs) {
+      for (const s of log.symptoms) {
+        allSymptoms.add(s);
+      }
+    }
+    if (allSymptoms.size === 0) return null;
+    let best: { symptom: SymptomType; score: number } | null = null;
+    for (const symptom of allSymptoms) {
+      const score = HealthLogEntity.getSymptomSeverityScore(logs, symptom);
+      if (!best || score > best.score) {
+        best = { symptom, score };
+      }
+    }
+    return best;
+  }
 }


### PR DESCRIPTION
## Summary
- HealthLogEntityにgetSymptomSeverityScore, getSymptomRiskLevel, getMostSevereSymptomを追加
- 症状が低体調時（レベル1-2）に出現する割合をスコア化
- スコアに応じたリスクレベル判定と最も深刻な症状の特定
- テスト14件追加（計1628件）

## Test plan
- [x] getSymptomSeverityScoreが低体調時の出現率を正しく算出する
- [x] getSymptomRiskLevelがスコアに応じたレベルを返す
- [x] getMostSevereSymptomが最も深刻な症状を返す
- [x] 全テスト通過・ビルド成功

closes #363