### PR TITLE
スケジュール週間完了パターン分析を追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleWeeklyPattern.test.ts
+++ b/src/__tests__/domain/entities/ScheduleWeeklyPattern.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity, DayOfWeek } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 週間完了パターン分析', () => {
+  describe('getDayCompletionRates', () => {
+    it('空の完了・予定は全曜日0を返す', () => {
+      const result = ScheduleEntity.getDayCompletionRates([], []);
+      expect(result).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('予定がない曜日は0を返す', () => {
+      const completed: DayOfWeek[] = ['mon'];
+      const scheduled: DayOfWeek[] = [];
+      const result = ScheduleEntity.getDayCompletionRates(completed, scheduled);
+      expect(result).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    });
+
+    it('全曜日完了は100を返す', () => {
+      const days: DayOfWeek[] = ['mon', 'tue', 'wed'];
+      const result = ScheduleEntity.getDayCompletionRates(days, days);
+      expect(result[1]).toBe(100); // mon
+      expect(result[2]).toBe(100); // tue
+      expect(result[3]).toBe(100); // wed
+    });
+
+    it('半分完了は50を返す', () => {
+      const completed: DayOfWeek[] = ['mon'];
+      const scheduled: DayOfWeek[] = ['mon', 'mon'];
+      const result = ScheduleEntity.getDayCompletionRates(completed, scheduled);
+      expect(result[1]).toBe(50);
+    });
+
+    it('複数曜日の混合パターン', () => {
+      const completed: DayOfWeek[] = ['mon', 'mon', 'fri'];
+      const scheduled: DayOfWeek[] = ['mon', 'mon', 'mon', 'fri', 'fri'];
+      const result = ScheduleEntity.getDayCompletionRates(completed, scheduled);
+      expect(result[1]).toBe(67); // mon: 2/3
+      expect(result[5]).toBe(50); // fri: 1/2
+    });
+  });
+
+  describe('getWeakestDay', () => {
+    it('全て0の場合はnullを返す', () => {
+      expect(ScheduleEntity.getWeakestDay([0, 0, 0, 0, 0, 0, 0])).toBeNull();
+    });
+
+    it('最も低い曜日のインデックスを返す', () => {
+      const rates = [0, 80, 60, 100, 0, 40, 0];
+      expect(ScheduleEntity.getWeakestDay(rates)).toBe(5); // fri: 40
+    });
+
+    it('0%の曜日は除外する', () => {
+      const rates = [0, 50, 0, 100, 0, 0, 0];
+      expect(ScheduleEntity.getWeakestDay(rates)).toBe(1); // mon: 50
+    });
+  });
+
+  describe('getStrongestDay', () => {
+    it('全て0の場合はnullを返す', () => {
+      expect(ScheduleEntity.getStrongestDay([0, 0, 0, 0, 0, 0, 0])).toBeNull();
+    });
+
+    it('最も高い曜日のインデックスを返す', () => {
+      const rates = [0, 80, 60, 100, 0, 40, 0];
+      expect(ScheduleEntity.getStrongestDay(rates)).toBe(3); // wed: 100
+    });
+
+    it('同率の場合は最初の曜日を返す', () => {
+      const rates = [0, 50, 50, 0, 0, 0, 0];
+      expect(ScheduleEntity.getStrongestDay(rates)).toBe(1);
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -338,4 +338,44 @@ export class ScheduleEntity {
   static getConflictMessage(medicationNameA: string, medicationNameB: string, time: string): string {
     return `${medicationNameA}と${medicationNameB}が${time}に重複しています`;
   }
+
+  private static readonly DAY_INDEX: Record<DayOfWeek, number> = {
+    sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6,
+  };
+
+  /**
+   * 曜日別の完了率を算出する
+   * 返り値: [日, 月, 火, 水, 木, 金, 土] の完了率(0-100)
+   */
+  static getDayCompletionRates(completed: DayOfWeek[], scheduled: DayOfWeek[]): number[] {
+    const completedCounts = new Array(7).fill(0);
+    const scheduledCounts = new Array(7).fill(0);
+    for (const day of completed) {
+      completedCounts[ScheduleEntity.DAY_INDEX[day]]++;
+    }
+    for (const day of scheduled) {
+      scheduledCounts[ScheduleEntity.DAY_INDEX[day]]++;
+    }
+    return scheduledCounts.map((total, i) =>
+      total === 0 ? 0 : MathHelper.calculatePercentage(completedCounts[i], total),
+    );
+  }
+
+  /**
+   * 最も完了率が低い曜日インデックスを返す（0%の曜日は除外）
+   */
+  static getWeakestDay(rates: number[]): number | null {
+    const nonZero = rates.map((r, i) => ({ rate: r, index: i })).filter((r) => r.rate > 0);
+    if (nonZero.length === 0) return null;
+    return nonZero.reduce((min, r) => (r.rate < min.rate ? r : min)).index;
+  }
+
+  /**
+   * 最も完了率が高い曜日インデックスを返す
+   */
+  static getStrongestDay(rates: number[]): number | null {
+    const max = Math.max(...rates);
+    if (max === 0) return null;
+    return rates.indexOf(max);
+  }
 }


### PR DESCRIPTION
## Summary
- ScheduleEntityにgetDayCompletionRates, getWeakestDay, getStrongestDayを追加
- 曜日別の完了率算出と最強/最弱曜日の特定
- テスト11件追加（計1639件）

## Test plan
- [x] getDayCompletionRatesが曜日別の完了率を正しく算出する
- [x] getWeakestDayが最も低い曜日を返す
- [x] getStrongestDayが最も高い曜日を返す
- [x] 全テスト通過・ビルド成功

closes #365