### PR TITLE
在庫消費トレンド分析ユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/StockConsumptionTrend.test.ts
+++ b/src/__tests__/domain/entities/StockConsumptionTrend.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity 在庫消費トレンド分析', () => {
+  describe('getConsumptionRate', () => {
+    it('消費量と日数から1日あたりの消費量を返す', () => {
+      expect(StockAlertEntity.getConsumptionRate(30, 10)).toBe(3);
+    });
+
+    it('日数0はnullを返す', () => {
+      expect(StockAlertEntity.getConsumptionRate(30, 0)).toBeNull();
+    });
+
+    it('消費量0は0を返す', () => {
+      expect(StockAlertEntity.getConsumptionRate(0, 10)).toBe(0);
+    });
+
+    it('小数点以下は2桁に丸める', () => {
+      expect(StockAlertEntity.getConsumptionRate(10, 3)).toBe(3.33);
+    });
+
+    it('負の日数はnullを返す', () => {
+      expect(StockAlertEntity.getConsumptionRate(10, -1)).toBeNull();
+    });
+  });
+
+  describe('getConsumptionTrend', () => {
+    it('現在の消費量が前期より多い場合increasingを返す', () => {
+      expect(StockAlertEntity.getConsumptionTrend(5, 3)).toBe('increasing');
+    });
+
+    it('現在の消費量が前期より少ない場合decreasingを返す', () => {
+      expect(StockAlertEntity.getConsumptionTrend(2, 4)).toBe('decreasing');
+    });
+
+    it('同じ消費量はstableを返す', () => {
+      expect(StockAlertEntity.getConsumptionTrend(3, 3)).toBe('stable');
+    });
+
+    it('10%以内の差はstableを返す', () => {
+      expect(StockAlertEntity.getConsumptionTrend(3.0, 3.2)).toBe('stable');
+    });
+
+    it('前期0で現在0はstableを返す', () => {
+      expect(StockAlertEntity.getConsumptionTrend(0, 0)).toBe('stable');
+    });
+  });
+
+  describe('getOptimalOrderQuantity', () => {
+    it('目標日数と消費量から発注量を返す', () => {
+      expect(StockAlertEntity.getOptimalOrderQuantity(2, 30, 10)).toBe(50);
+    });
+
+    it('在庫が十分な場合は0を返す', () => {
+      expect(StockAlertEntity.getOptimalOrderQuantity(2, 30, 100)).toBe(0);
+    });
+
+    it('消費量0は0を返す', () => {
+      expect(StockAlertEntity.getOptimalOrderQuantity(0, 30, 5)).toBe(0);
+    });
+
+    it('目標日数0は現在の在庫不足分を返す', () => {
+      expect(StockAlertEntity.getOptimalOrderQuantity(2, 0, 0)).toBe(0);
+    });
+  });
+});

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -124,4 +124,39 @@ export class StockAlertEntity {
     if (rate >= 40) return 'やや不足';
     return '不足';
   }
+
+  /**
+   * 期間内の1日あたりの消費量を算出する
+   */
+  static getConsumptionRate(consumed: number, days: number): number | null {
+    if (days <= 0) return null;
+    return Math.round((consumed / days) * 100) / 100;
+  }
+
+  /**
+   * 消費量の増減傾向を判定する（10%以内はstable）
+   */
+  static getConsumptionTrend(
+    currentRate: number,
+    previousRate: number,
+  ): 'increasing' | 'decreasing' | 'stable' {
+    if (previousRate === 0 && currentRate === 0) return 'stable';
+    if (previousRate === 0) return 'increasing';
+    const changeRate = Math.abs(currentRate - previousRate) / previousRate;
+    if (changeRate <= 0.1) return 'stable';
+    return currentRate > previousRate ? 'increasing' : 'decreasing';
+  }
+
+  /**
+   * 目標日数に対する最適発注量を算出する
+   */
+  static getOptimalOrderQuantity(
+    dailyConsumption: number,
+    targetDays: number,
+    currentStock: number,
+  ): number {
+    if (dailyConsumption <= 0) return 0;
+    const needed = Math.ceil(dailyConsumption * targetDays);
+    return Math.max(0, needed - currentStock);
+  }
 }


### PR DESCRIPTION
## Summary
- StockAlertEntityにgetConsumptionRate, getConsumptionTrend, getOptimalOrderQuantityを追加
- 1日あたりの消費量算出、増減傾向判定、最適発注量算出
- テスト14件追加（計1653件）

## Test plan
- [x] getConsumptionRateが消費量と日数から正しい値を返す
- [x] getConsumptionTrendが10%閾値で傾向を判定する
- [x] getOptimalOrderQuantityが必要発注量を算出する
- [x] 全テスト通過・ビルド成功

closes #367