### PR TITLE
SymptomSeverity・ScheduleWeeklyPattern・StockConsumptionのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleWeeklyPattern.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleWeeklyPattern.edge.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity, DayOfWeek } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 週間完了パターン エッジケース', () => {
+  describe('getDayCompletionRates エッジケース', () => {
+    it('全曜日に予定がある場合', () => {
+      const all: DayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+      const result = ScheduleEntity.getDayCompletionRates(all, all);
+      expect(result.every((r) => r === 100)).toBe(true);
+    });
+
+    it('完了が予定より多くても100%を超える', () => {
+      const completed: DayOfWeek[] = ['mon', 'mon', 'mon'];
+      const scheduled: DayOfWeek[] = ['mon', 'mon'];
+      const result = ScheduleEntity.getDayCompletionRates(completed, scheduled);
+      expect(result[1]).toBe(150);
+    });
+
+    it('週末のみの予定', () => {
+      const completed: DayOfWeek[] = ['sat'];
+      const scheduled: DayOfWeek[] = ['sat', 'sun'];
+      const result = ScheduleEntity.getDayCompletionRates(completed, scheduled);
+      expect(result[0]).toBe(0); // sun
+      expect(result[6]).toBe(100); // sat
+    });
+  });
+
+  describe('getWeakestDay エッジケース', () => {
+    it('全曜日100%の場合は日曜を返す', () => {
+      const rates = [100, 100, 100, 100, 100, 100, 100];
+      expect(ScheduleEntity.getWeakestDay(rates)).toBe(0);
+    });
+
+    it('1曜日のみ記録がある場合はその曜日を返す', () => {
+      const rates = [0, 0, 0, 50, 0, 0, 0];
+      expect(ScheduleEntity.getWeakestDay(rates)).toBe(3);
+    });
+  });
+
+  describe('getStrongestDay エッジケース', () => {
+    it('全曜日100%の場合は日曜を返す', () => {
+      const rates = [100, 100, 100, 100, 100, 100, 100];
+      expect(ScheduleEntity.getStrongestDay(rates)).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockConsumptionTrend.edge.test.ts
+++ b/src/__tests__/domain/entities/StockConsumptionTrend.edge.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockConsumptionTrend エッジケース', () => {
+  describe('getConsumptionRate エッジケース', () => {
+    it('1日1消費は1を返す', () => {
+      expect(StockAlertEntity.getConsumptionRate(1, 1)).toBe(1);
+    });
+
+    it('大きな消費量と日数', () => {
+      expect(StockAlertEntity.getConsumptionRate(1000, 365)).toBe(2.74);
+    });
+
+    it('割り切れる場合は整数を返す', () => {
+      expect(StockAlertEntity.getConsumptionRate(100, 10)).toBe(10);
+    });
+  });
+
+  describe('getConsumptionTrend エッジケース', () => {
+    it('前期0で現在正の値はincreasingを返す', () => {
+      expect(StockAlertEntity.getConsumptionTrend(5, 0)).toBe('increasing');
+    });
+
+    it('前期10で現在9はstableを返す（10%以内）', () => {
+      expect(StockAlertEntity.getConsumptionTrend(9, 10)).toBe('stable');
+    });
+
+    it('前期10で現在8はdecreasingを返す（20%減）', () => {
+      expect(StockAlertEntity.getConsumptionTrend(8, 10)).toBe('decreasing');
+    });
+
+    it('前期10で現在11はstableを返す（10%以内）', () => {
+      expect(StockAlertEntity.getConsumptionTrend(11, 10)).toBe('stable');
+    });
+
+    it('前期10で現在12はincreasingを返す（20%増）', () => {
+      expect(StockAlertEntity.getConsumptionTrend(12, 10)).toBe('increasing');
+    });
+  });
+
+  describe('getOptimalOrderQuantity エッジケース', () => {
+    it('在庫が目標量と一致する場合は0を返す', () => {
+      expect(StockAlertEntity.getOptimalOrderQuantity(2, 30, 60)).toBe(0);
+    });
+
+    it('在庫が目標量を超える場合は0を返す', () => {
+      expect(StockAlertEntity.getOptimalOrderQuantity(2, 30, 100)).toBe(0);
+    });
+
+    it('小数の消費量は切り上げる', () => {
+      expect(StockAlertEntity.getOptimalOrderQuantity(1.5, 10, 0)).toBe(15);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/SymptomSeverityScoring.edge.test.ts
+++ b/src/__tests__/domain/entities/SymptomSeverityScoring.edge.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, HealthLog, ConditionLevel, SymptomType } from '@/domain/entities/HealthLog';
+
+const createLog = (
+  conditionLevel: ConditionLevel,
+  symptoms: SymptomType[],
+): HealthLog => ({
+  id: `log-${Math.random()}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  userId: 'user-1',
+  conditionLevel,
+  symptoms,
+  notes: '',
+  recordedAt: new Date('2026-03-01'),
+});
+
+describe('SymptomSeverityScoring エッジケース', () => {
+  describe('getSymptomSeverityScore エッジケース', () => {
+    it('体調レベル3は低体調に含まれない', () => {
+      const logs = [createLog(3, ['headache'])];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(0);
+    });
+
+    it('体調レベル2は低体調に含まれる', () => {
+      const logs = [createLog(2, ['headache'])];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(100);
+    });
+
+    it('複数症状を持つログも正しくカウントされる', () => {
+      const logs = [
+        createLog(1, ['headache', 'fever', 'fatigue']),
+        createLog(5, ['headache']),
+      ];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(50);
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'fever')).toBe(100);
+    });
+
+    it('全体調レベルで出現する症状の正確なスコア', () => {
+      const logs = [
+        createLog(1, ['headache']),
+        createLog(2, ['headache']),
+        createLog(3, ['headache']),
+        createLog(4, ['headache']),
+        createLog(5, ['headache']),
+      ];
+      expect(HealthLogEntity.getSymptomSeverityScore(logs, 'headache')).toBe(40);
+    });
+  });
+
+  describe('getSymptomRiskLevel 境界値', () => {
+    it('スコア49はlowを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(49)).toBe('low');
+    });
+
+    it('スコア79はmediumを返す', () => {
+      expect(HealthLogEntity.getSymptomRiskLevel(79)).toBe('medium');
+    });
+  });
+
+  describe('getMostSevereSymptom エッジケース', () => {
+    it('全症状が同スコアの場合いずれかを返す', () => {
+      const logs = [
+        createLog(1, ['headache', 'fever']),
+      ];
+      const result = HealthLogEntity.getMostSevereSymptom(logs);
+      expect(result).not.toBeNull();
+      expect(result!.score).toBe(100);
+    });
+
+    it('1件のログの全症状を分析する', () => {
+      const logs = [createLog(4, ['headache', 'fever', 'fatigue'])];
+      const result = HealthLogEntity.getMostSevereSymptom(logs);
+      expect(result!.score).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- SymptomSeverityScoring.edge.test.ts: 体調レベル境界・複数症状・全レベル等8件
- ScheduleWeeklyPattern.edge.test.ts: 全曜日完了・超過完了・週末パターン等6件
- StockConsumptionTrend.edge.test.ts: 消費率境界・10%閾値・切り上げ等11件
- テスト25件追加（計1678件）

## Test plan
- [x] 全1678テスト通過
- [x] ビルド成功

closes #371