### PR TITLE
薬登録APIにレート制限を追加

### DIFF
--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -2,12 +2,18 @@ import { prisma } from '@/lib/prisma';
 import { createMedicationSchema } from '@/lib/schemas';
 import { created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 export async function POST(request: Request) {
   const sizeError = validateBodySize(request);
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const rateLimit = checkRateLimit(`medications:${userId}`, { maxAttempts: 10, windowMs: 60 * 1000 });
+    if (!rateLimit.allowed) {
+      return errorResponse('作成回数の上限に達しました。しばらくしてから再試行してください。', 429);
+    }
+
     const body = await request.json();
     const parsed = createMedicationSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);


### PR DESCRIPTION
## Summary
- POST /api/medicationsに1分あたり10回のレート制限を追加
- 過剰な薬登録リクエストによるDB負荷を防止

## Test plan
- [x] 全1678テスト通過
- [x] ビルド成功

closes #373