### PR TITLE
服薬記録の連続記録分析ユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/RecordStreakAnalysis.test.ts
+++ b/src/__tests__/domain/entities/RecordStreakAnalysis.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (takenAt: Date): MedicationRecord => ({
+  id: `rec-${Math.random()}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  medicationId: 'med-1',
+  medicationName: '薬A',
+  userId: 'user-1',
+  takenAt,
+});
+
+describe('MedicationRecordEntity 連続記録分析', () => {
+  describe('getCurrentStreak', () => {
+    it('空配列は0を返す', () => {
+      expect(MedicationRecordEntity.getCurrentStreak([], new Date('2026-03-05'))).toBe(0);
+    });
+
+    it('今日の記録がない場合は0を返す', () => {
+      const records = [createRecord(new Date('2026-03-03'))];
+      expect(MedicationRecordEntity.getCurrentStreak(records, new Date('2026-03-05'))).toBe(0);
+    });
+
+    it('今日のみの記録は1を返す', () => {
+      const records = [createRecord(new Date('2026-03-05'))];
+      expect(MedicationRecordEntity.getCurrentStreak(records, new Date('2026-03-05'))).toBe(1);
+    });
+
+    it('3日連続は3を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-05')),
+        createRecord(new Date('2026-03-04')),
+        createRecord(new Date('2026-03-03')),
+      ];
+      expect(MedicationRecordEntity.getCurrentStreak(records, new Date('2026-03-05'))).toBe(3);
+    });
+
+    it('途切れた場合は途切れるまでの日数を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-05')),
+        createRecord(new Date('2026-03-04')),
+        createRecord(new Date('2026-03-02')),
+      ];
+      expect(MedicationRecordEntity.getCurrentStreak(records, new Date('2026-03-05'))).toBe(2);
+    });
+  });
+
+  describe('getLongestStreak', () => {
+    it('空配列は0を返す', () => {
+      expect(MedicationRecordEntity.getLongestStreak([])).toBe(0);
+    });
+
+    it('1件のみは1を返す', () => {
+      const records = [createRecord(new Date('2026-03-01'))];
+      expect(MedicationRecordEntity.getLongestStreak(records)).toBe(1);
+    });
+
+    it('最長連続期間を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-01')),
+        createRecord(new Date('2026-03-02')),
+        createRecord(new Date('2026-03-03')),
+        createRecord(new Date('2026-03-05')),
+        createRecord(new Date('2026-03-06')),
+      ];
+      expect(MedicationRecordEntity.getLongestStreak(records)).toBe(3);
+    });
+
+    it('同日に複数記録があっても1日としてカウント', () => {
+      const records = [
+        createRecord(new Date('2026-03-01T08:00:00')),
+        createRecord(new Date('2026-03-01T12:00:00')),
+        createRecord(new Date('2026-03-02T08:00:00')),
+      ];
+      expect(MedicationRecordEntity.getLongestStreak(records)).toBe(2);
+    });
+  });
+
+  describe('getStreakMessage', () => {
+    it('0日は開始メッセージを返す', () => {
+      expect(MedicationRecordEntity.getStreakMessage(0)).toBe('今日から始めましょう');
+    });
+
+    it('1日は継続メッセージを返す', () => {
+      expect(MedicationRecordEntity.getStreakMessage(1)).toBe('記録を始めました');
+    });
+
+    it('3日は短期メッセージを返す', () => {
+      expect(MedicationRecordEntity.getStreakMessage(3)).toBe('3日連続です');
+    });
+
+    it('7日は週間メッセージを返す', () => {
+      expect(MedicationRecordEntity.getStreakMessage(7)).toBe('1週間継続中です');
+    });
+
+    it('30日は月間メッセージを返す', () => {
+      expect(MedicationRecordEntity.getStreakMessage(30)).toBe('素晴らしい継続力です');
+    });
+  });
+});

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -242,4 +242,62 @@ export class MedicationRecordEntity {
     }
     return gaps;
   }
+
+  /**
+   * 現在の連続記録日数を返す（今日から遡って連続する日数）
+   */
+  static getCurrentStreak(records: MedicationRecord[], today: Date): number {
+    if (records.length === 0) return 0;
+    const uniqueDates = [
+      ...new Set(records.map((r) => DateRangeHelper.toDateKey(new Date(r.takenAt)))),
+    ].sort((a, b) => b.localeCompare(a));
+    const todayKey = DateRangeHelper.toDateKey(today);
+    if (uniqueDates[0] !== todayKey) return 0;
+    let streak = 1;
+    for (let i = 1; i < uniqueDates.length; i++) {
+      const prev = new Date(uniqueDates[i - 1] + 'T00:00:00');
+      const curr = new Date(uniqueDates[i] + 'T00:00:00');
+      if (DateRangeHelper.diffDays(curr, prev) === 1) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  /**
+   * 最長の連続記録日数を返す
+   */
+  static getLongestStreak(records: MedicationRecord[]): number {
+    if (records.length === 0) return 0;
+    const uniqueDates = [
+      ...new Set(records.map((r) => DateRangeHelper.toDateKey(new Date(r.takenAt)))),
+    ].sort();
+    let longest = 1;
+    let current = 1;
+    for (let i = 1; i < uniqueDates.length; i++) {
+      const prev = new Date(uniqueDates[i - 1] + 'T00:00:00');
+      const curr = new Date(uniqueDates[i] + 'T00:00:00');
+      if (DateRangeHelper.diffDays(prev, curr) === 1) {
+        current++;
+        longest = Math.max(longest, current);
+      } else {
+        current = 1;
+      }
+    }
+    return longest;
+  }
+
+  /**
+   * 連続日数に応じた励ましメッセージを返す
+   */
+  static getStreakMessage(days: number): string {
+    if (days === 0) return '今日から始めましょう';
+    if (days === 1) return '記録を始めました';
+    if (days < 7) return `${days}日連続です`;
+    if (days < 14) return '1週間継続中です';
+    if (days < 30) return '順調に継続しています';
+    return '素晴らしい継続力です';
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityにgetCurrentStreak, getLongestStreak, getStreakMessageを追加
- 連続服薬日数の追跡と励ましメッセージの生成
- テスト14件追加（計1692件）

## Test plan
- [x] getCurrentStreakが今日からの連続日数を返す
- [x] getLongestStreakが最長連続日数を返す
- [x] getStreakMessageが日数に応じた適切なメッセージを返す
- [x] 全テスト通過・ビルド成功

closes #375