### PR TITLE
服薬遵守率のグレード判定ユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/ComplianceGrade.test.ts
+++ b/src/__tests__/domain/entities/ComplianceGrade.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity 遵守率グレード判定', () => {
+  describe('getComplianceGrade', () => {
+    it('90%以上はAを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(90)).toBe('A');
+      expect(AdherenceStatsEntity.getComplianceGrade(100)).toBe('A');
+    });
+
+    it('80-89%はBを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(80)).toBe('B');
+      expect(AdherenceStatsEntity.getComplianceGrade(89)).toBe('B');
+    });
+
+    it('60-79%はCを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(60)).toBe('C');
+      expect(AdherenceStatsEntity.getComplianceGrade(79)).toBe('C');
+    });
+
+    it('40-59%はDを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(40)).toBe('D');
+      expect(AdherenceStatsEntity.getComplianceGrade(59)).toBe('D');
+    });
+
+    it('40%未満はFを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(39)).toBe('F');
+      expect(AdherenceStatsEntity.getComplianceGrade(0)).toBe('F');
+    });
+  });
+
+  describe('getComplianceMessage', () => {
+    it('グレードAは褒めるメッセージ', () => {
+      expect(AdherenceStatsEntity.getComplianceMessage('A')).toBe('とても良い服薬管理です');
+    });
+
+    it('グレードBは良好メッセージ', () => {
+      expect(AdherenceStatsEntity.getComplianceMessage('B')).toBe('良好な服薬管理です');
+    });
+
+    it('グレードCは改善提案', () => {
+      expect(AdherenceStatsEntity.getComplianceMessage('C')).toBe('もう少し改善できます');
+    });
+
+    it('グレードDは注意メッセージ', () => {
+      expect(AdherenceStatsEntity.getComplianceMessage('D')).toBe('服薬の見直しが必要です');
+    });
+
+    it('グレードFは警告メッセージ', () => {
+      expect(AdherenceStatsEntity.getComplianceMessage('F')).toBe('服薬管理を始めましょう');
+    });
+  });
+
+  describe('getComplianceColor', () => {
+    it('グレードAは緑', () => {
+      expect(AdherenceStatsEntity.getComplianceColor('A')).toBe('text-green-600');
+    });
+
+    it('グレードBは青', () => {
+      expect(AdherenceStatsEntity.getComplianceColor('B')).toBe('text-blue-600');
+    });
+
+    it('グレードCは黄', () => {
+      expect(AdherenceStatsEntity.getComplianceColor('C')).toBe('text-yellow-600');
+    });
+
+    it('グレードDはオレンジ', () => {
+      expect(AdherenceStatsEntity.getComplianceColor('D')).toBe('text-orange-600');
+    });
+
+    it('グレードFは赤', () => {
+      expect(AdherenceStatsEntity.getComplianceColor('F')).toBe('text-red-600');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -256,4 +256,43 @@ export class AdherenceStatsEntity {
     if (nonZeroRates.length === 0) return null;
     return nonZeroRates.reduce((min, r) => (r.rate < min.rate ? r : min)).index;
   }
+
+  /**
+   * 遵守率に応じたグレードを返す
+   */
+  static getComplianceGrade(rate: number): 'A' | 'B' | 'C' | 'D' | 'F' {
+    if (rate >= 90) return 'A';
+    if (rate >= 80) return 'B';
+    if (rate >= 60) return 'C';
+    if (rate >= 40) return 'D';
+    return 'F';
+  }
+
+  /**
+   * グレードに応じたメッセージを返す
+   */
+  static getComplianceMessage(grade: 'A' | 'B' | 'C' | 'D' | 'F'): string {
+    const messages: Record<string, string> = {
+      A: 'とても良い服薬管理です',
+      B: '良好な服薬管理です',
+      C: 'もう少し改善できます',
+      D: '服薬の見直しが必要です',
+      F: '服薬管理を始めましょう',
+    };
+    return messages[grade];
+  }
+
+  /**
+   * グレードに応じた色クラスを返す
+   */
+  static getComplianceColor(grade: 'A' | 'B' | 'C' | 'D' | 'F'): string {
+    const colors: Record<string, string> = {
+      A: 'text-green-600',
+      B: 'text-blue-600',
+      C: 'text-yellow-600',
+      D: 'text-orange-600',
+      F: 'text-red-600',
+    };
+    return colors[grade];
+  }
 }


### PR DESCRIPTION
## Summary
- AdherenceStatsEntityにgetComplianceGrade, getComplianceMessage, getComplianceColorを追加
- 遵守率のA-Fグレード判定、メッセージ、Tailwind色クラスの返却
- テスト15件追加（計1716件）

## Test plan
- [x] getComplianceGradeが境界値で正しいグレードを返す
- [x] getComplianceMessageがグレード別メッセージを返す
- [x] getComplianceColorがグレード別色クラスを返す
- [x] 全テスト通過・ビルド成功

closes #379