### PR TITLE
RecordStreak・CalendarWeek・ComplianceGradeのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarWeekAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarWeekAnalysis.edge.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity, CalendarDay } from '@/domain/entities/Calendar';
+
+const createDay = (date: Date, recordCount: number = 0): CalendarDay => ({
+  date,
+  isCurrentMonth: true,
+  isToday: false,
+  recordCount,
+  averageCondition: null,
+});
+
+describe('CalendarWeekAnalysis エッジケース', () => {
+  describe('getWeeksInMonth エッジケース', () => {
+    it('14日は2週に分割される', () => {
+      const days = Array.from({ length: 14 }, (_, i) =>
+        createDay(new Date(2026, 2, i + 1)),
+      );
+      expect(CalendarEntity.getWeeksInMonth(days)).toHaveLength(2);
+    });
+
+    it('8日は2週に分割される（2週目は1日のみ）', () => {
+      const days = Array.from({ length: 8 }, (_, i) =>
+        createDay(new Date(2026, 2, i + 1)),
+      );
+      const weeks = CalendarEntity.getWeeksInMonth(days);
+      expect(weeks).toHaveLength(2);
+      expect(weeks[1]).toHaveLength(1);
+    });
+  });
+
+  describe('getWeekLabel エッジケース', () => {
+    it('月をまたぐ場合の表示', () => {
+      const days = [
+        createDay(new Date(2026, 2, 30)),
+        createDay(new Date(2026, 2, 31)),
+        createDay(new Date(2026, 3, 1)),
+      ];
+      expect(CalendarEntity.getWeekLabel(days)).toBe('3/30 - 4/1');
+    });
+  });
+
+  describe('getMonthlyTrend エッジケース', () => {
+    it('全週に記録がある場合の推移', () => {
+      const days = Array.from({ length: 21 }, (_, i) =>
+        createDay(new Date(2026, 2, i + 1), i % 7 === 0 ? 3 : 1),
+      );
+      const trend = CalendarEntity.getMonthlyTrend(days);
+      expect(trend).toHaveLength(3);
+      expect(trend[0]).toBe(9); // 3 + 1*6
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ComplianceGrade.edge.test.ts
+++ b/src/__tests__/domain/entities/ComplianceGrade.edge.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('ComplianceGrade エッジケース', () => {
+  describe('getComplianceGrade 境界値', () => {
+    it('正確な境界値で正しいグレードを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(89)).toBe('B');
+      expect(AdherenceStatsEntity.getComplianceGrade(90)).toBe('A');
+      expect(AdherenceStatsEntity.getComplianceGrade(79)).toBe('C');
+      expect(AdherenceStatsEntity.getComplianceGrade(80)).toBe('B');
+      expect(AdherenceStatsEntity.getComplianceGrade(59)).toBe('D');
+      expect(AdherenceStatsEntity.getComplianceGrade(60)).toBe('C');
+      expect(AdherenceStatsEntity.getComplianceGrade(39)).toBe('F');
+      expect(AdherenceStatsEntity.getComplianceGrade(40)).toBe('D');
+    });
+
+    it('100%はAを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(100)).toBe('A');
+    });
+
+    it('0%はFを返す', () => {
+      expect(AdherenceStatsEntity.getComplianceGrade(0)).toBe('F');
+    });
+  });
+
+  describe('全グレードの色とメッセージの一貫性', () => {
+    const grades = ['A', 'B', 'C', 'D', 'F'] as const;
+
+    it('全グレードにメッセージが定義されている', () => {
+      for (const grade of grades) {
+        const message = AdherenceStatsEntity.getComplianceMessage(grade);
+        expect(message).toBeTruthy();
+        expect(typeof message).toBe('string');
+      }
+    });
+
+    it('全グレードに色クラスが定義されている', () => {
+      for (const grade of grades) {
+        const color = AdherenceStatsEntity.getComplianceColor(grade);
+        expect(color).toMatch(/^text-\w+-\d+$/);
+      }
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RecordStreakAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/RecordStreakAnalysis.edge.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (takenAt: Date): MedicationRecord => ({
+  id: `rec-${Math.random()}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  medicationId: 'med-1',
+  medicationName: '薬A',
+  userId: 'user-1',
+  takenAt,
+});
+
+describe('RecordStreakAnalysis エッジケース', () => {
+  describe('getCurrentStreak エッジケース', () => {
+    it('昨日の記録のみの場合は0を返す', () => {
+      const records = [createRecord(new Date('2026-03-04'))];
+      expect(MedicationRecordEntity.getCurrentStreak(records, new Date('2026-03-05'))).toBe(0);
+    });
+
+    it('同日に複数記録があっても1日としてカウント', () => {
+      const records = [
+        createRecord(new Date('2026-03-05T08:00:00')),
+        createRecord(new Date('2026-03-05T12:00:00')),
+        createRecord(new Date('2026-03-05T18:00:00')),
+      ];
+      expect(MedicationRecordEntity.getCurrentStreak(records, new Date('2026-03-05'))).toBe(1);
+    });
+
+    it('5日連続は5を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-05')),
+        createRecord(new Date('2026-03-04')),
+        createRecord(new Date('2026-03-03')),
+        createRecord(new Date('2026-03-02')),
+        createRecord(new Date('2026-03-01')),
+      ];
+      expect(MedicationRecordEntity.getCurrentStreak(records, new Date('2026-03-05'))).toBe(5);
+    });
+  });
+
+  describe('getLongestStreak エッジケース', () => {
+    it('全て同日の記録は1を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-01T08:00:00')),
+        createRecord(new Date('2026-03-01T12:00:00')),
+        createRecord(new Date('2026-03-01T18:00:00')),
+      ];
+      expect(MedicationRecordEntity.getLongestStreak(records)).toBe(1);
+    });
+
+    it('2つの連続期間で長い方を返す', () => {
+      const records = [
+        createRecord(new Date('2026-03-01')),
+        createRecord(new Date('2026-03-02')),
+        createRecord(new Date('2026-03-05')),
+        createRecord(new Date('2026-03-06')),
+        createRecord(new Date('2026-03-07')),
+      ];
+      expect(MedicationRecordEntity.getLongestStreak(records)).toBe(3);
+    });
+  });
+
+  describe('getStreakMessage エッジケース', () => {
+    it('2日は連続メッセージを返す', () => {
+      expect(MedicationRecordEntity.getStreakMessage(2)).toBe('2日連続です');
+    });
+
+    it('6日はまだ週間メッセージではない', () => {
+      expect(MedicationRecordEntity.getStreakMessage(6)).toBe('6日連続です');
+    });
+
+    it('14日は順調メッセージを返す', () => {
+      expect(MedicationRecordEntity.getStreakMessage(14)).toBe('順調に継続しています');
+    });
+
+    it('29日はまだ月間メッセージではない', () => {
+      expect(MedicationRecordEntity.getStreakMessage(29)).toBe('順調に継続しています');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- RecordStreakAnalysis.edge.test.ts: 昨日のみ・同日複数・5日連続等9件
- CalendarWeekAnalysis.edge.test.ts: 14日分割・月跨ぎ・推移計算等4件
- ComplianceGrade.edge.test.ts: 全境界値・全グレード一貫性等5件
- テスト18件追加（計1734件）

## Test plan
- [x] 全1734テスト通過
- [x] ビルド成功

closes #383