### PR TITLE
服薬記録作成APIにレート制限を追加

### DIFF
--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { createRecordSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
@@ -25,6 +26,11 @@ export async function POST(request: Request) {
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const rateLimit = checkRateLimit(`records:${userId}`, { maxAttempts: 30, windowMs: 60 * 1000 });
+    if (!rateLimit.allowed) {
+      return errorResponse('記録回数の上限に達しました。しばらくしてから再試行してください。', 429);
+    }
+
     const body = await request.json();
     const parsed = createRecordSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);


### PR DESCRIPTION
## Summary
- POST /api/recordsに1分あたり30回のレート制限を追加
- 服薬記録は頻繁に作成されるためやや高めの閾値を設定

## Test plan
- [x] 全1734テスト通過
- [x] ビルド成功

closes #385