### PR TITLE
メンバー年齢計算・プロフィールユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/MemberProfileUtils.test.ts
+++ b/src/__tests__/domain/entities/MemberProfileUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity プロフィールユーティリティ', () => {
+  describe('calculateAge', () => {
+    it('正確な年齢を返す', () => {
+      expect(MemberEntity.calculateAge(new Date('2020-01-01'), new Date('2026-03-05'))).toBe(6);
+    });
+
+    it('誕生日前は年齢-1を返す', () => {
+      expect(MemberEntity.calculateAge(new Date('2020-06-01'), new Date('2026-03-05'))).toBe(5);
+    });
+
+    it('誕生日当日は年齢を返す', () => {
+      expect(MemberEntity.calculateAge(new Date('2020-03-05'), new Date('2026-03-05'))).toBe(6);
+    });
+
+    it('nullの場合はnullを返す', () => {
+      expect(MemberEntity.calculateAge(null, new Date('2026-03-05'))).toBeNull();
+    });
+
+    it('undefinedの場合はnullを返す', () => {
+      expect(MemberEntity.calculateAge(undefined, new Date('2026-03-05'))).toBeNull();
+    });
+  });
+
+  describe('getMemberTypeLabel', () => {
+    it('humanは家族を返す', () => {
+      expect(MemberEntity.getMemberTypeLabel('human')).toBe('家族');
+    });
+
+    it('petはペットを返す', () => {
+      expect(MemberEntity.getMemberTypeLabel('pet')).toBe('ペット');
+    });
+  });
+
+  describe('getPetTypeLabel', () => {
+    it('dogは犬を返す', () => {
+      expect(MemberEntity.getPetTypeLabel('dog')).toBe('犬');
+    });
+
+    it('catは猫を返す', () => {
+      expect(MemberEntity.getPetTypeLabel('cat')).toBe('猫');
+    });
+
+    it('rabbitはうさぎを返す', () => {
+      expect(MemberEntity.getPetTypeLabel('rabbit')).toBe('うさぎ');
+    });
+
+    it('birdは鳥を返す', () => {
+      expect(MemberEntity.getPetTypeLabel('bird')).toBe('鳥');
+    });
+
+    it('otherはその他を返す', () => {
+      expect(MemberEntity.getPetTypeLabel('other')).toBe('その他');
+    });
+
+    it('undefinedは空文字を返す', () => {
+      expect(MemberEntity.getPetTypeLabel(undefined)).toBe('');
+    });
+  });
+
+  describe('getProfileSummary', () => {
+    it('人間メンバーの要約', () => {
+      expect(MemberEntity.getProfileSummary('human', 30)).toBe('家族 (30歳)');
+    });
+
+    it('年齢なしの人間メンバー', () => {
+      expect(MemberEntity.getProfileSummary('human', null)).toBe('家族');
+    });
+
+    it('ペットメンバーの要約', () => {
+      expect(MemberEntity.getProfileSummary('pet', 3, 'dog')).toBe('ペット - 犬 (3歳)');
+    });
+
+    it('年齢なしのペットメンバー', () => {
+      expect(MemberEntity.getProfileSummary('pet', null, 'cat')).toBe('ペット - 猫');
+    });
+
+    it('ペットタイプなしのペット', () => {
+      expect(MemberEntity.getProfileSummary('pet', 2)).toBe('ペット (2歳)');
+    });
+  });
+});

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -135,4 +135,64 @@ export class MemberEntity {
     if (trimmed.length === 0) return '?';
     return trimmed[0].toUpperCase();
   }
+
+  /**
+   * 生年月日から年齢を計算する（staticバージョン）
+   */
+  static calculateAge(birthDate: Date | null | undefined, today: Date): number | null {
+    if (!birthDate) return null;
+    const birth = new Date(birthDate);
+    let age = today.getFullYear() - birth.getFullYear();
+    const monthDiff = today.getMonth() - birth.getMonth();
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+      age--;
+    }
+    return age;
+  }
+
+  private static readonly memberTypeLabels: Record<MemberType, string> = {
+    human: '家族',
+    pet: 'ペット',
+  };
+
+  /**
+   * メンバータイプの日本語ラベルを返す
+   */
+  static getMemberTypeLabel(type: MemberType): string {
+    return MemberEntity.memberTypeLabels[type];
+  }
+
+  private static readonly petTypeLabels: Record<PetType, string> = {
+    dog: '犬',
+    cat: '猫',
+    rabbit: 'うさぎ',
+    bird: '鳥',
+    other: 'その他',
+  };
+
+  /**
+   * ペットタイプの日本語ラベルを返す
+   */
+  static getPetTypeLabel(type: PetType | undefined): string {
+    if (!type) return '';
+    return MemberEntity.petTypeLabels[type];
+  }
+
+  /**
+   * プロフィール要約テキストを返す
+   */
+  static getProfileSummary(
+    memberType: MemberType,
+    age: number | null,
+    petType?: PetType,
+  ): string {
+    const typeLabel = MemberEntity.getMemberTypeLabel(memberType);
+    const petLabel = petType ? MemberEntity.getPetTypeLabel(petType) : '';
+    const ageLabel = age !== null ? ` (${age}歳)` : '';
+
+    if (memberType === 'pet' && petLabel) {
+      return `${typeLabel} - ${petLabel}${ageLabel}`;
+    }
+    return `${typeLabel}${ageLabel}`;
+  }
 }


### PR DESCRIPTION
## Summary
- MemberEntityにcalculateAge, getMemberTypeLabel, getPetTypeLabel, getProfileSummaryを追加
- 生年月日からの年齢計算、タイプラベル日本語化、プロフィール要約生成
- テスト18件追加（計1752件）

## Test plan
- [x] calculateAgeが誕生日前後で正しい年齢を返す
- [x] getMemberTypeLabelがタイプ別ラベルを返す
- [x] getPetTypeLabelがペットタイプ別ラベルを返す
- [x] getProfileSummaryが人間/ペット別の要約を返す
- [x] 全テスト通過・ビルド成功

closes #387