### PR TITLE
体調記録の症状サマリーユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/SymptomSummaryUtils.test.ts
+++ b/src/__tests__/domain/entities/SymptomSummaryUtils.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, HealthLog, ConditionLevel, SymptomType } from '@/domain/entities/HealthLog';
+
+const createLog = (
+  conditionLevel: ConditionLevel,
+  symptoms: SymptomType[],
+): HealthLog => ({
+  id: `log-${Math.random()}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  userId: 'user-1',
+  conditionLevel,
+  symptoms,
+  notes: '',
+  recordedAt: new Date('2026-03-01'),
+});
+
+describe('HealthLogEntity 症状サマリーユーティリティ', () => {
+  describe('getSymptomCountSummary', () => {
+    it('空配列は空配列を返す', () => {
+      expect(HealthLogEntity.getSymptomCountSummary([])).toEqual([]);
+    });
+
+    it('全症状の出現回数を多い順に返す', () => {
+      const logs = [
+        createLog(3, ['headache', 'fever']),
+        createLog(2, ['headache', 'fatigue']),
+        createLog(4, ['headache']),
+      ];
+      const result = HealthLogEntity.getSymptomCountSummary(logs);
+      expect(result[0]).toEqual({ symptom: 'headache', label: '頭痛', count: 3 });
+      expect(result[1].count).toBe(1);
+    });
+
+    it('症状がないログは集計に含まれない', () => {
+      const logs = [createLog(5, []), createLog(3, ['fever'])];
+      const result = HealthLogEntity.getSymptomCountSummary(logs);
+      expect(result).toHaveLength(1);
+      expect(result[0].symptom).toBe('fever');
+    });
+  });
+
+  describe('getSymptomLabels', () => {
+    it('空配列は空配列を返す', () => {
+      expect(HealthLogEntity.getSymptomLabels([])).toEqual([]);
+    });
+
+    it('症状コードを日本語ラベルに変換する', () => {
+      const result = HealthLogEntity.getSymptomLabels(['headache', 'fever', 'fatigue']);
+      expect(result).toEqual(['頭痛', '発熱', '倦怠感']);
+    });
+
+    it('全ての症状コードを変換できる', () => {
+      const all: SymptomType[] = [
+        'headache', 'fever', 'fatigue', 'nausea', 'stomachache',
+        'dizziness', 'cough', 'runny_nose', 'joint_pain', 'insomnia',
+      ];
+      const result = HealthLogEntity.getSymptomLabels(all);
+      expect(result).toHaveLength(10);
+      expect(result.every((l) => typeof l === 'string' && l.length > 0)).toBe(true);
+    });
+  });
+
+  describe('formatConditionSummary', () => {
+    it('症状なしの場合は体調のみ', () => {
+      expect(HealthLogEntity.formatConditionSummary(4, [])).toBe('体調: 良い');
+    });
+
+    it('症状ありの場合は体調と症状', () => {
+      expect(HealthLogEntity.formatConditionSummary(2, ['headache', 'fever'])).toBe(
+        '体調: 悪い / 頭痛, 発熱',
+      );
+    });
+
+    it('体調レベル5は最高', () => {
+      expect(HealthLogEntity.formatConditionSummary(5, [])).toBe('体調: とても良い');
+    });
+
+    it('体調レベル1は最悪', () => {
+      expect(HealthLogEntity.formatConditionSummary(1, [])).toBe('体調: とても悪い');
+    });
+
+    it('体調レベル3は普通', () => {
+      expect(HealthLogEntity.formatConditionSummary(3, [])).toBe('体調: 普通');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -387,4 +387,42 @@ export class HealthLogEntity {
     }
     return best;
   }
+
+  /**
+   * 全症状の出現回数を多い順に返す
+   */
+  static getSymptomCountSummary(
+    logs: HealthLog[],
+  ): { symptom: SymptomType; label: string; count: number }[] {
+    const counts: Record<string, number> = {};
+    for (const log of logs) {
+      for (const s of log.symptoms) {
+        counts[s] = (counts[s] || 0) + 1;
+      }
+    }
+    return Object.entries(counts)
+      .map(([symptom, count]) => ({
+        symptom: symptom as SymptomType,
+        label: SYMPTOM_LABELS[symptom as SymptomType],
+        count,
+      }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  /**
+   * 症状コード配列を日本語ラベル配列に変換する
+   */
+  static getSymptomLabels(symptoms: SymptomType[]): string[] {
+    return symptoms.map((s) => SYMPTOM_LABELS[s]);
+  }
+
+  /**
+   * 体調レベルと症状の要約テキストを生成する
+   */
+  static formatConditionSummary(level: ConditionLevel, symptoms: SymptomType[]): string {
+    const condLabel = HealthLogEntity.getConditionLabel(level);
+    if (symptoms.length === 0) return `体調: ${condLabel}`;
+    const symptomLabels = HealthLogEntity.getSymptomLabels(symptoms);
+    return `体調: ${condLabel} / ${symptomLabels.join(', ')}`;
+  }
 }


### PR DESCRIPTION
## Summary
- HealthLogEntityにgetSymptomCountSummary, getSymptomLabels, formatConditionSummaryを追加
- 症状出現回数集計、コードのラベル変換、体調+症状の要約テキスト生成
- テスト11件追加（計1763件）

## Test plan
- [x] getSymptomCountSummaryが出現回数を多い順に返す
- [x] getSymptomLabelsが全コードを正しく変換する
- [x] formatConditionSummaryが体調レベル別に適切な要約を返す
- [x] 全テスト通過・ビルド成功

closes #389