### PR TITLE
スケジュール時間フォーマットユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleTimeFormat.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimeFormat.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity, DayOfWeek } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 時間フォーマットユーティリティ', () => {
+  describe('formatTimeRange', () => {
+    it('開始時刻と分数から範囲を返す', () => {
+      expect(ScheduleEntity.formatTimeRange('08:00', 30)).toBe('08:00 - 08:30');
+    });
+
+    it('時間をまたぐ場合', () => {
+      expect(ScheduleEntity.formatTimeRange('23:30', 60)).toBe('23:30 - 00:30');
+    });
+
+    it('0分の場合は開始時刻のみ', () => {
+      expect(ScheduleEntity.formatTimeRange('12:00', 0)).toBe('12:00');
+    });
+  });
+
+  describe('getTimeUntilLabel', () => {
+    it('0分はまもなくを返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(0)).toBe('まもなく');
+    });
+
+    it('30分は30分後を返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(30)).toBe('30分後');
+    });
+
+    it('60分は1時間後を返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(60)).toBe('1時間後');
+    });
+
+    it('90分は1時間30分後を返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(90)).toBe('1時間30分後');
+    });
+
+    it('120分は2時間後を返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(120)).toBe('2時間後');
+    });
+
+    it('負の値は過ぎていますを返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(-10)).toBe('予定時刻を過ぎています');
+    });
+  });
+
+  describe('getDaysOfWeekLabels', () => {
+    it('空配列は空配列を返す', () => {
+      expect(ScheduleEntity.getDaysOfWeekLabels([])).toEqual([]);
+    });
+
+    it('曜日コードを日本語に変換する', () => {
+      const days: DayOfWeek[] = ['mon', 'wed', 'fri'];
+      expect(ScheduleEntity.getDaysOfWeekLabels(days)).toEqual(['月', '水', '金']);
+    });
+
+    it('全曜日を変換できる', () => {
+      const days: DayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+      expect(ScheduleEntity.getDaysOfWeekLabels(days)).toEqual(['日', '月', '火', '水', '木', '金', '土']);
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -378,4 +378,41 @@ export class ScheduleEntity {
     if (max === 0) return null;
     return rates.indexOf(max);
   }
+
+  /**
+   * 開始時刻と分数から時間範囲の文字列を生成する
+   */
+  static formatTimeRange(startTime: string, durationMinutes: number): string {
+    if (durationMinutes === 0) return startTime;
+    const [h, m] = startTime.split(':').map(Number);
+    const totalMinutes = h * 60 + m + durationMinutes;
+    const endH = Math.floor(totalMinutes / 60) % 24;
+    const endM = totalMinutes % 60;
+    const endTime = `${endH.toString().padStart(2, '0')}:${endM.toString().padStart(2, '0')}`;
+    return `${startTime} - ${endTime}`;
+  }
+
+  /**
+   * 予定までの残り時間を日本語で表示する
+   */
+  static getTimeUntilLabel(minutes: number): string {
+    if (minutes < 0) return '予定時刻を過ぎています';
+    if (minutes === 0) return 'まもなく';
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    if (h === 0) return `${m}分後`;
+    if (m === 0) return `${h}時間後`;
+    return `${h}時間${m}分後`;
+  }
+
+  private static readonly DAY_LABELS: Record<DayOfWeek, string> = {
+    sun: '日', mon: '月', tue: '火', wed: '水', thu: '木', fri: '金', sat: '土',
+  };
+
+  /**
+   * 曜日コード配列を日本語ラベルに変換する
+   */
+  static getDaysOfWeekLabels(days: DayOfWeek[]): string[] {
+    return days.map((d) => ScheduleEntity.DAY_LABELS[d]);
+  }
 }


### PR DESCRIPTION
## Summary
- ScheduleEntityにformatTimeRange, getTimeUntilLabel, getDaysOfWeekLabelsを追加
- 時間範囲文字列生成、残り時間の日本語表示、曜日コードのラベル変換
- テスト12件追加（計1775件）

## Test plan
- [x] formatTimeRangeが正しい時間範囲を返す
- [x] getTimeUntilLabelが分数に応じた日本語表示を返す
- [x] getDaysOfWeekLabelsが全曜日を変換できる
- [x] 全テスト通過・ビルド成功

closes #391