### PR TITLE
getDisplayInfoのインラインラベルをgetMemberTypeLabelに統合

### DIFF
--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -88,7 +88,7 @@ export class MemberEntity {
       memberType: this.member.memberType,
       petType: this.member.petType,
       name: this.member.name,
-      typeLabel: this.isPet() ? 'ペット' : '家族',
+      typeLabel: MemberEntity.getMemberTypeLabel(this.member.memberType),
     };
   }
 


### PR DESCRIPTION
## Summary
- getDisplayInfo内のインラインタイプラベル（三項演算子）をgetMemberTypeLabelに委譲
- ラベル管理の一元化により保守性を向上

## Test plan
- [x] 全1775テスト通過
- [x] ビルド成功

closes #393