### PR TITLE
MemberProfile・ScheduleTimeFormatのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/MemberProfileUtils.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberProfileUtils.edge.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberProfileUtils エッジケース', () => {
+  describe('calculateAge エッジケース', () => {
+    it('生まれた日は0歳', () => {
+      expect(MemberEntity.calculateAge(new Date('2026-03-05'), new Date('2026-03-05'))).toBe(0);
+    });
+
+    it('翌日は0歳', () => {
+      expect(MemberEntity.calculateAge(new Date('2026-03-04'), new Date('2026-03-05'))).toBe(0);
+    });
+
+    it('1年後の誕生日前日は0歳', () => {
+      expect(MemberEntity.calculateAge(new Date('2025-03-06'), new Date('2026-03-05'))).toBe(0);
+    });
+
+    it('閏年の2月29日生まれ', () => {
+      expect(MemberEntity.calculateAge(new Date('2024-02-29'), new Date('2026-03-01'))).toBe(2);
+    });
+  });
+
+  describe('getProfileSummary エッジケース', () => {
+    it('年齢0歳の表示', () => {
+      expect(MemberEntity.getProfileSummary('human', 0)).toBe('家族 (0歳)');
+    });
+
+    it('ペットタイプotherの表示', () => {
+      expect(MemberEntity.getProfileSummary('pet', 5, 'other')).toBe('ペット - その他 (5歳)');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleTimeFormat.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimeFormat.edge.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleTimeFormat エッジケース', () => {
+  describe('formatTimeRange エッジケース', () => {
+    it('深夜0時開始', () => {
+      expect(ScheduleEntity.formatTimeRange('00:00', 15)).toBe('00:00 - 00:15');
+    });
+
+    it('120分（2時間）の範囲', () => {
+      expect(ScheduleEntity.formatTimeRange('10:00', 120)).toBe('10:00 - 12:00');
+    });
+  });
+
+  describe('getTimeUntilLabel エッジケース', () => {
+    it('1分は1分後を返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(1)).toBe('1分後');
+    });
+
+    it('59分は59分後を返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(59)).toBe('59分後');
+    });
+
+    it('大きな値も正しく表示', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(180)).toBe('3時間後');
+    });
+
+    it('-1分は過ぎていますを返す', () => {
+      expect(ScheduleEntity.getTimeUntilLabel(-1)).toBe('予定時刻を過ぎています');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MemberProfileUtils.edge.test.ts: 0歳・閏年・誕生日前日等6件
- ScheduleTimeFormat.edge.test.ts: 深夜0時・2時間範囲・59分等6件
- テスト12件追加（計1787件）

## Test plan
- [x] 全1787テスト通過
- [x] ビルド成功

closes #395