### PR TITLE
日付範囲バリデーションユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangeValidation.test.ts
+++ b/src/__tests__/domain/entities/DateRangeValidation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper バリデーションユーティリティ', () => {
+  describe('isValidDateRange', () => {
+    it('開始日が終了日より前ならtrue', () => {
+      expect(DateRangeHelper.isValidDateRange(
+        new Date('2026-03-01'), new Date('2026-03-05'),
+      )).toBe(true);
+    });
+
+    it('開始日と終了日が同じならtrue', () => {
+      expect(DateRangeHelper.isValidDateRange(
+        new Date('2026-03-01'), new Date('2026-03-01'),
+      )).toBe(true);
+    });
+
+    it('開始日が終了日より後ならfalse', () => {
+      expect(DateRangeHelper.isValidDateRange(
+        new Date('2026-03-05'), new Date('2026-03-01'),
+      )).toBe(false);
+    });
+  });
+
+  describe('clampDate', () => {
+    it('範囲内の日付はそのまま返す', () => {
+      const date = new Date('2026-03-03');
+      const min = new Date('2026-03-01');
+      const max = new Date('2026-03-05');
+      expect(DateRangeHelper.clampDate(date, min, max).getTime()).toBe(date.getTime());
+    });
+
+    it('最小値より前の日付は最小値を返す', () => {
+      const date = new Date('2026-02-28');
+      const min = new Date('2026-03-01');
+      const max = new Date('2026-03-05');
+      expect(DateRangeHelper.clampDate(date, min, max).getTime()).toBe(min.getTime());
+    });
+
+    it('最大値より後の日付は最大値を返す', () => {
+      const date = new Date('2026-03-10');
+      const min = new Date('2026-03-01');
+      const max = new Date('2026-03-05');
+      expect(DateRangeHelper.clampDate(date, min, max).getTime()).toBe(max.getTime());
+    });
+
+    it('境界値と同じ日付はそのまま返す', () => {
+      const min = new Date('2026-03-01');
+      const max = new Date('2026-03-05');
+      expect(DateRangeHelper.clampDate(min, min, max).getTime()).toBe(min.getTime());
+      expect(DateRangeHelper.clampDate(max, min, max).getTime()).toBe(max.getTime());
+    });
+  });
+
+  describe('getMonthRange', () => {
+    it('3月の範囲を返す', () => {
+      const range = DateRangeHelper.getMonthRange(2026, 2);
+      expect(DateRangeHelper.toDateKey(range.start)).toBe('2026-03-01');
+      expect(DateRangeHelper.toDateKey(range.end)).toBe('2026-03-31');
+    });
+
+    it('2月の範囲を返す（閏年）', () => {
+      const range = DateRangeHelper.getMonthRange(2024, 1);
+      expect(DateRangeHelper.toDateKey(range.start)).toBe('2024-02-01');
+      expect(DateRangeHelper.toDateKey(range.end)).toBe('2024-02-29');
+    });
+
+    it('2月の範囲を返す（平年）', () => {
+      const range = DateRangeHelper.getMonthRange(2026, 1);
+      expect(DateRangeHelper.toDateKey(range.start)).toBe('2026-02-01');
+      expect(DateRangeHelper.toDateKey(range.end)).toBe('2026-02-28');
+    });
+
+    it('12月の範囲を返す', () => {
+      const range = DateRangeHelper.getMonthRange(2026, 11);
+      expect(DateRangeHelper.toDateKey(range.start)).toBe('2026-12-01');
+      expect(DateRangeHelper.toDateKey(range.end)).toBe('2026-12-31');
+    });
+  });
+});

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -124,4 +124,29 @@ export class DateRangeHelper {
     const days = Math.floor(diff / (1000 * 60 * 60 * 24));
     return Math.ceil((days + 1) / 7);
   }
+
+  /**
+   * 開始日が終了日以前であることを検証する
+   */
+  static isValidDateRange(from: Date, to: Date): boolean {
+    return from.getTime() <= to.getTime();
+  }
+
+  /**
+   * 日付を指定範囲内に制約する
+   */
+  static clampDate(date: Date, min: Date, max: Date): Date {
+    if (date.getTime() < min.getTime()) return min;
+    if (date.getTime() > max.getTime()) return max;
+    return date;
+  }
+
+  /**
+   * 指定月の開始日と終了日を返す（monthは0-indexed）
+   */
+  static getMonthRange(year: number, month: number): { start: Date; end: Date } {
+    const start = new Date(year, month, 1);
+    const end = new Date(year, month + 1, 0);
+    return { start, end };
+  }
 }


### PR DESCRIPTION
## Summary
- DateRangeHelperにisValidDateRange, clampDate, getMonthRangeを追加
- 日付範囲の検証、日付の範囲制約、月の開始・終了日取得
- テスト11件追加（計1798件）

## Test plan
- [x] isValidDateRangeが開始日・終了日の順序を正しく検証する
- [x] clampDateが範囲外の日付を制約する
- [x] getMonthRangeが閏年を含む各月の範囲を正しく返す
- [x] 全テスト通過・ビルド成功

closes #399