### PR TITLE
在庫アラートの一括分析ユーティリティを追加

### DIFF
--- a/src/__tests__/domain/entities/StockAlertBatch.test.ts
+++ b/src/__tests__/domain/entities/StockAlertBatch.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity, StockAlert } from '@/domain/entities/StockAlert';
+
+const createAlert = (overrides: Partial<StockAlert> = {}): StockAlert => ({
+  medicationId: 'med-1',
+  medicationName: '薬A',
+  memberId: 'member-1',
+  memberName: '太郎',
+  stockQuantity: 10,
+  stockAlertDate: '2026-03-10',
+  daysUntilAlert: 5,
+  isOverdue: false,
+  ...overrides,
+});
+
+describe('StockAlertEntity 一括分析', () => {
+  describe('getAlertSummary', () => {
+    it('空配列は全て0を返す', () => {
+      const result = StockAlertEntity.getAlertSummary([]);
+      expect(result).toEqual({ urgent: 0, warning: 0, normal: 0 });
+    });
+
+    it('緊急度別に集計する', () => {
+      const alerts = [
+        createAlert({ daysUntilAlert: 1, isOverdue: false }),
+        createAlert({ daysUntilAlert: 5, isOverdue: false }),
+        createAlert({ daysUntilAlert: 10, isOverdue: false }),
+        createAlert({ daysUntilAlert: -1, isOverdue: true }),
+      ];
+      const result = StockAlertEntity.getAlertSummary(alerts);
+      expect(result.urgent).toBe(2); // 1日 + 期限超過
+      expect(result.warning).toBe(1); // 5日
+      expect(result.normal).toBe(1); // 10日
+    });
+  });
+
+  describe('getNextAlertDate', () => {
+    it('空配列はnullを返す', () => {
+      expect(StockAlertEntity.getNextAlertDate([])).toBeNull();
+    });
+
+    it('最も近い未来のアラート日を返す', () => {
+      const alerts = [
+        createAlert({ stockAlertDate: '2026-03-10', isOverdue: false }),
+        createAlert({ stockAlertDate: '2026-03-05', isOverdue: false }),
+        createAlert({ stockAlertDate: '2026-03-15', isOverdue: false }),
+      ];
+      expect(StockAlertEntity.getNextAlertDate(alerts)).toBe('2026-03-05');
+    });
+
+    it('期限超過のアラートは除外しない', () => {
+      const alerts = [
+        createAlert({ stockAlertDate: '2026-03-01', isOverdue: true }),
+        createAlert({ stockAlertDate: '2026-03-10', isOverdue: false }),
+      ];
+      expect(StockAlertEntity.getNextAlertDate(alerts)).toBe('2026-03-01');
+    });
+  });
+
+  describe('formatRemainingDays', () => {
+    it('0日は今日を返す', () => {
+      expect(StockAlertEntity.formatRemainingDays(0)).toBe('今日');
+    });
+
+    it('1日はあと1日を返す', () => {
+      expect(StockAlertEntity.formatRemainingDays(1)).toBe('あと1日');
+    });
+
+    it('7日はあと1週間を返す', () => {
+      expect(StockAlertEntity.formatRemainingDays(7)).toBe('あと1週間');
+    });
+
+    it('14日はあと2週間を返す', () => {
+      expect(StockAlertEntity.formatRemainingDays(14)).toBe('あと2週間');
+    });
+
+    it('30日はあと1ヶ月を返す', () => {
+      expect(StockAlertEntity.formatRemainingDays(30)).toBe('あと1ヶ月');
+    });
+
+    it('負の値は期限超過を返す', () => {
+      expect(StockAlertEntity.formatRemainingDays(-3)).toBe('3日超過');
+    });
+  });
+});

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -159,4 +159,41 @@ export class StockAlertEntity {
     const needed = Math.ceil(dailyConsumption * targetDays);
     return Math.max(0, needed - currentStock);
   }
+
+  /**
+   * 緊急度別のアラート件数を集計する
+   */
+  static getAlertSummary(alerts: StockAlert[]): { urgent: number; warning: number; normal: number } {
+    const summary = { urgent: 0, warning: 0, normal: 0 };
+    for (const alert of alerts) {
+      if (alert.isOverdue || alert.daysUntilAlert <= 3) {
+        summary.urgent++;
+      } else if (alert.daysUntilAlert <= 7) {
+        summary.warning++;
+      } else {
+        summary.normal++;
+      }
+    }
+    return summary;
+  }
+
+  /**
+   * 最も近いアラート日を返す
+   */
+  static getNextAlertDate(alerts: StockAlert[]): string | null {
+    if (alerts.length === 0) return null;
+    const sorted = [...alerts].sort((a, b) => a.stockAlertDate.localeCompare(b.stockAlertDate));
+    return sorted[0].stockAlertDate;
+  }
+
+  /**
+   * 残日数の日本語表示を返す
+   */
+  static formatRemainingDays(days: number): string {
+    if (days < 0) return `${Math.abs(days)}日超過`;
+    if (days === 0) return '今日';
+    if (days % 30 === 0 && days >= 30) return `あと${days / 30}ヶ月`;
+    if (days % 7 === 0 && days >= 7) return `あと${days / 7}週間`;
+    return `あと${days}日`;
+  }
 }


### PR DESCRIPTION
## Summary
- StockAlertEntityにgetAlertSummary, getNextAlertDate, formatRemainingDaysを追加
- 緊急度別集計、最近接アラート日取得、残日数の日本語表示
- テスト11件追加（計1809件）

## Test plan
- [x] getAlertSummaryが緊急度別に正しく集計する
- [x] getNextAlertDateが最も近いアラート日を返す
- [x] formatRemainingDaysが日数に応じた日本語表示を返す
- [x] 全テスト通過・ビルド成功

closes #401