### PR TITLE
feat: 数値計算ヘルパーの統計関数を追加

### DIFF
--- a/src/__tests__/domain/entities/MathHelperStatistics.test.ts
+++ b/src/__tests__/domain/entities/MathHelperStatistics.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper 統計関数', () => {
+  describe('calculateAverage', () => {
+    it('空配列は0を返す', () => {
+      expect(MathHelper.calculateAverage([])).toBe(0);
+    });
+
+    it('単一要素はその値を返す', () => {
+      expect(MathHelper.calculateAverage([5])).toBe(5);
+    });
+
+    it('複数要素の平均を算出する', () => {
+      expect(MathHelper.calculateAverage([10, 20, 30])).toBe(20);
+    });
+
+    it('小数点以下を指定桁数で丸める', () => {
+      expect(MathHelper.calculateAverage([1, 2, 3], 2)).toBe(2);
+      expect(MathHelper.calculateAverage([1, 2], 2)).toBe(1.5);
+    });
+
+    it('デフォルトは小数点以下1桁', () => {
+      expect(MathHelper.calculateAverage([1, 2, 4])).toBe(2.3);
+    });
+
+    it('全て0の場合は0を返す', () => {
+      expect(MathHelper.calculateAverage([0, 0, 0])).toBe(0);
+    });
+  });
+
+  describe('calculateMedian', () => {
+    it('空配列は0を返す', () => {
+      expect(MathHelper.calculateMedian([])).toBe(0);
+    });
+
+    it('単一要素はその値を返す', () => {
+      expect(MathHelper.calculateMedian([7])).toBe(7);
+    });
+
+    it('奇数個の中央値を返す', () => {
+      expect(MathHelper.calculateMedian([3, 1, 2])).toBe(2);
+    });
+
+    it('偶数個の中央2値の平均を返す', () => {
+      expect(MathHelper.calculateMedian([1, 2, 3, 4])).toBe(2.5);
+    });
+
+    it('ソートされていない配列でも正しく算出する', () => {
+      expect(MathHelper.calculateMedian([5, 1, 3, 2, 4])).toBe(3);
+    });
+
+    it('同一値の配列はその値を返す', () => {
+      expect(MathHelper.calculateMedian([3, 3, 3])).toBe(3);
+    });
+  });
+
+  describe('clamp', () => {
+    it('範囲内の値はそのまま返す', () => {
+      expect(MathHelper.clamp(5, 0, 10)).toBe(5);
+    });
+
+    it('最小値未満は最小値を返す', () => {
+      expect(MathHelper.clamp(-5, 0, 10)).toBe(0);
+    });
+
+    it('最大値超過は最大値を返す', () => {
+      expect(MathHelper.clamp(15, 0, 10)).toBe(10);
+    });
+
+    it('境界値はそのまま返す', () => {
+      expect(MathHelper.clamp(0, 0, 10)).toBe(0);
+      expect(MathHelper.clamp(10, 0, 10)).toBe(10);
+    });
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -13,4 +13,34 @@ export class MathHelper {
     const result = Math.round((numerator / denominator) * 100);
     return cap ? Math.min(100, result) : result;
   }
+
+  /**
+   * 数値配列の平均値を算出する
+   * @param values 数値配列
+   * @param decimals 小数点以下の桁数（デフォルト1）
+   */
+  static calculateAverage(values: number[], decimals: number = 1): number {
+    if (values.length === 0) return 0;
+    const sum = values.reduce((a, b) => a + b, 0);
+    const factor = Math.pow(10, decimals);
+    return Math.round((sum / values.length) * factor) / factor;
+  }
+
+  /**
+   * 数値配列の中央値を算出する
+   */
+  static calculateMedian(values: number[]): number {
+    if (values.length === 0) return 0;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    if (sorted.length % 2 === 1) return sorted[mid];
+    return (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+
+  /**
+   * 数値を指定範囲内に制約する
+   */
+  static clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+  }
 }


### PR DESCRIPTION
## Summary
- MathHelperにcalculateAverage, calculateMedian, clampの3メソッドを追加
- 数値配列の平均値・中央値算出と数値の範囲制約機能を提供
- TDDで16件のテストを作成

## Test plan
- [x] calculateAverage: 空配列、単一要素、複数要素、丸め桁数指定
- [x] calculateMedian: 空配列、奇数個、偶数個、未ソート配列
- [x] clamp: 範囲内、最小値未満、最大値超過、境界値
- [x] 全1825テストパス

closes #403