### PR TITLE
fix: スケジュールAPI POSTにレートリミットを追加

### DIFF
--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -4,6 +4,7 @@ import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
 import { ScheduleEntity, Schedule } from '@/domain/entities/Schedule';
 import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
 
 export const GET = withAuth(async (userId) => {
   const schedules = await prisma.schedule.findMany({ where: { userId }, take: QUERY_LIMITS.SCHEDULES });
@@ -15,6 +16,9 @@ export async function POST(request: Request) {
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const rateLimitError = checkRateLimit(userId, 'schedules-post', 15);
+    if (rateLimitError) return rateLimitError;
+
     const body = await request.json();
     const parsed = createScheduleSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);


### PR DESCRIPTION
## Summary
- POST /api/schedules に15回/分/ユーザーのレートリミットを追加
- checkRateLimitを使用し、既存のセキュリティパターンに準拠

## Test plan
- [x] 全1850テストパス

closes #409