### PR TITLE
feat: 予約リマインダーメッセージ生成機能を追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentReminderMessage.test.ts
+++ b/src/__tests__/domain/entities/AppointmentReminderMessage.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity, Appointment } from '@/domain/entities/Appointment';
+
+const createAppointment = (overrides: Partial<Appointment> = {}): Appointment => ({
+  id: 'apt-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  hospitalName: '東京病院',
+  appointmentType: 'checkup',
+  appointmentDate: new Date('2026-03-10'),
+  reminderEnabled: true,
+  reminderDaysBefore: 3,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+describe('AppointmentEntity リマインダーメッセージ', () => {
+  describe('getReminderMessage', () => {
+    it('当日は本日の予約メッセージを返す', () => {
+      expect(AppointmentEntity.getReminderMessage(0)).toBe('本日の予約があります');
+    });
+
+    it('明日は明日の予約メッセージを返す', () => {
+      expect(AppointmentEntity.getReminderMessage(1)).toBe('明日の予約があります');
+    });
+
+    it('2日以上は残り日数を含むメッセージを返す', () => {
+      expect(AppointmentEntity.getReminderMessage(3)).toBe('3日後に予約があります');
+    });
+
+    it('7日はちょうど1週間のメッセージを返す', () => {
+      expect(AppointmentEntity.getReminderMessage(7)).toBe('1週間後に予約があります');
+    });
+
+    it('負の値は予約日を過ぎたメッセージを返す', () => {
+      expect(AppointmentEntity.getReminderMessage(-1)).toBe('予約日を過ぎています');
+    });
+  });
+
+  describe('formatAppointmentSummary', () => {
+    it('全ての情報がある場合のサマリーを返す', () => {
+      const apt = createAppointment();
+      const result = AppointmentEntity.formatAppointmentSummary(apt);
+      expect(result).toContain('太郎');
+      expect(result).toContain('東京病院');
+      expect(result).toContain('定期検診');
+    });
+
+    it('病院名がない場合は省略される', () => {
+      const apt = createAppointment({ hospitalName: undefined });
+      const result = AppointmentEntity.formatAppointmentSummary(apt);
+      expect(result).not.toContain('東京病院');
+      expect(result).toContain('太郎');
+    });
+
+    it('種別がない場合は省略される', () => {
+      const apt = createAppointment({ appointmentType: undefined });
+      const result = AppointmentEntity.formatAppointmentSummary(apt);
+      expect(result).not.toContain('定期検診');
+    });
+  });
+
+  describe('getUpcomingAppointments', () => {
+    it('空配列は空配列を返す', () => {
+      const result = AppointmentEntity.getUpcomingAppointments([], new Date('2026-03-05'), 7);
+      expect(result).toEqual([]);
+    });
+
+    it('指定日数以内の予約のみ返す', () => {
+      const today = new Date('2026-03-05');
+      const appointments = [
+        createAppointment({ appointmentDate: new Date('2026-03-06') }),
+        createAppointment({ appointmentDate: new Date('2026-03-10') }),
+        createAppointment({ appointmentDate: new Date('2026-03-20') }),
+      ];
+      const result = AppointmentEntity.getUpcomingAppointments(appointments, today, 7);
+      expect(result).toHaveLength(2);
+    });
+
+    it('過去の予約は含めない', () => {
+      const today = new Date('2026-03-05');
+      const appointments = [
+        createAppointment({ appointmentDate: new Date('2026-03-01') }),
+        createAppointment({ appointmentDate: new Date('2026-03-06') }),
+      ];
+      const result = AppointmentEntity.getUpcomingAppointments(appointments, today, 7);
+      expect(result).toHaveLength(1);
+    });
+
+    it('当日の予約は含む', () => {
+      const today = new Date('2026-03-05');
+      const appointments = [
+        createAppointment({ appointmentDate: new Date('2026-03-05') }),
+      ];
+      const result = AppointmentEntity.getUpcomingAppointments(appointments, today, 7);
+      expect(result).toHaveLength(1);
+    });
+
+    it('日付順にソートされる', () => {
+      const today = new Date('2026-03-05');
+      const appointments = [
+        createAppointment({ id: 'apt-2', appointmentDate: new Date('2026-03-10') }),
+        createAppointment({ id: 'apt-1', appointmentDate: new Date('2026-03-06') }),
+      ];
+      const result = AppointmentEntity.getUpcomingAppointments(appointments, today, 7);
+      expect(result[0].id).toBe('apt-1');
+      expect(result[1].id).toBe('apt-2');
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -239,4 +239,43 @@ export class AppointmentEntity {
     const count = appointments.filter((a) => (a.appointmentType || 'other') === type).length;
     return MathHelper.calculatePercentage(count, appointments.length);
   }
+
+  /**
+   * 残り日数に応じたリマインダーメッセージを返す
+   */
+  static getReminderMessage(daysUntil: number): string {
+    if (daysUntil < 0) return '予約日を過ぎています';
+    if (daysUntil === 0) return '本日の予約があります';
+    if (daysUntil === 1) return '明日の予約があります';
+    if (daysUntil === 7) return '1週間後に予約があります';
+    return `${daysUntil}日後に予約があります`;
+  }
+
+  /**
+   * 予約情報のサマリーテキストを生成する
+   */
+  static formatAppointmentSummary(appointment: Appointment): string {
+    const parts: string[] = [];
+    if (appointment.memberName) parts.push(appointment.memberName);
+    if (appointment.appointmentType) {
+      const label = AppointmentEntity.typeLabels[appointment.appointmentType] || appointment.appointmentType;
+      parts.push(label);
+    }
+    if (appointment.hospitalName) parts.push(appointment.hospitalName);
+    return parts.join(' / ');
+  }
+
+  /**
+   * 指定日数以内の予約を日付順で返す
+   */
+  static getUpcomingAppointments(appointments: Appointment[], today: Date, withinDays: number): Appointment[] {
+    const todayStart = DateRangeHelper.toStartOfDay(today);
+    return appointments
+      .filter((apt) => {
+        const aptDate = DateRangeHelper.toStartOfDay(new Date(apt.appointmentDate));
+        const diff = DateRangeHelper.diffDays(todayStart, aptDate);
+        return diff >= 0 && diff <= withinDays;
+      })
+      .sort((a, b) => new Date(a.appointmentDate).getTime() - new Date(b.appointmentDate).getTime());
+  }
 }


### PR DESCRIPTION
## Summary
- getReminderMessage: 残り日数に応じたリマインダーメッセージ生成
- formatAppointmentSummary: 予約情報のサマリーテキスト生成
- getUpcomingAppointments: 指定日数以内の予約を日付順に抽出

## Test plan
- [x] getReminderMessage: 当日、明日、2日以上、1週間、過去
- [x] formatAppointmentSummary: 全情報あり、病院なし、種別なし
- [x] getUpcomingAppointments: 空配列、日数内、過去除外、当日含む、ソート
- [x] 全1863テストパス

closes #411