### PR TITLE
feat: 服薬記録の日別サマリー機能を追加

### DIFF
--- a/src/__tests__/domain/entities/RecordDailySummary.test.ts
+++ b/src/__tests__/domain/entities/RecordDailySummary.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (overrides: Partial<MedicationRecord> = {}): MedicationRecord => ({
+  id: `rec-${Math.random()}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  medicationId: 'med-1',
+  medicationName: '薬A',
+  userId: 'user-1',
+  takenAt: new Date('2026-03-05T08:00:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity 日別サマリー', () => {
+  describe('getDailySummaryText', () => {
+    it('0件は服薬なしメッセージを返す', () => {
+      expect(MedicationRecordEntity.getDailySummaryText(0, 0)).toBe('今日の服薬はありません');
+    });
+
+    it('全て完了の場合は完了メッセージを返す', () => {
+      expect(MedicationRecordEntity.getDailySummaryText(3, 3)).toBe('全3件の服薬が完了しました');
+    });
+
+    it('一部完了の場合は進捗メッセージを返す', () => {
+      expect(MedicationRecordEntity.getDailySummaryText(2, 5)).toBe('5件中2件の服薬が完了しています');
+    });
+
+    it('0件完了で予定がある場合は未完了メッセージを返す', () => {
+      expect(MedicationRecordEntity.getDailySummaryText(0, 3)).toBe('5件中0件の服薬が完了しています'.replace('5', '3').replace('0', '0'));
+    });
+  });
+
+  describe('getWeeklyRecordCount', () => {
+    it('空配列は0を返す', () => {
+      expect(MedicationRecordEntity.getWeeklyRecordCount([], new Date('2026-03-05'))).toBe(0);
+    });
+
+    it('過去7日間の記録数を返す', () => {
+      const today = new Date('2026-03-05');
+      const records = [
+        createRecord({ takenAt: new Date('2026-03-05T08:00:00') }),
+        createRecord({ takenAt: new Date('2026-03-03T08:00:00') }),
+        createRecord({ takenAt: new Date('2026-03-01T08:00:00') }),
+        createRecord({ takenAt: new Date('2026-02-25T08:00:00') }),
+      ];
+      expect(MedicationRecordEntity.getWeeklyRecordCount(records, today)).toBe(3);
+    });
+
+    it('ちょうど7日前の記録は含む', () => {
+      const today = new Date('2026-03-08');
+      const records = [
+        createRecord({ takenAt: new Date('2026-03-01T08:00:00') }),
+      ];
+      expect(MedicationRecordEntity.getWeeklyRecordCount(records, today)).toBe(1);
+    });
+
+    it('8日前の記録は含まない', () => {
+      const today = new Date('2026-03-09');
+      const records = [
+        createRecord({ takenAt: new Date('2026-03-01T08:00:00') }),
+      ];
+      expect(MedicationRecordEntity.getWeeklyRecordCount(records, today)).toBe(0);
+    });
+  });
+
+  describe('getRecordTrendLabel', () => {
+    it('増加傾向は増加ラベルを返す', () => {
+      expect(MedicationRecordEntity.getRecordTrendLabel(10, 5)).toBe('増加傾向');
+    });
+
+    it('減少傾向は減少ラベルを返す', () => {
+      expect(MedicationRecordEntity.getRecordTrendLabel(3, 8)).toBe('減少傾向');
+    });
+
+    it('同数は横ばいラベルを返す', () => {
+      expect(MedicationRecordEntity.getRecordTrendLabel(5, 5)).toBe('横ばい');
+    });
+
+    it('差が1以内は横ばいとする', () => {
+      expect(MedicationRecordEntity.getRecordTrendLabel(5, 6)).toBe('横ばい');
+      expect(MedicationRecordEntity.getRecordTrendLabel(6, 5)).toBe('横ばい');
+    });
+
+    it('前期間0で今期間があれば増加', () => {
+      expect(MedicationRecordEntity.getRecordTrendLabel(5, 0)).toBe('増加傾向');
+    });
+  });
+});

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -287,4 +287,33 @@ export class MedicationRecordEntity {
     if (days < 30) return '順調に継続しています';
     return '素晴らしい継続力です';
   }
+
+  /**
+   * 日別の服薬サマリーテキストを生成する
+   */
+  static getDailySummaryText(completed: number, total: number): string {
+    if (total === 0) return '今日の服薬はありません';
+    if (completed === total) return `全${total}件の服薬が完了しました`;
+    return `${total}件中${completed}件の服薬が完了しています`;
+  }
+
+  /**
+   * 過去7日間の記録数を算出する
+   */
+  static getWeeklyRecordCount(records: MedicationRecord[], today: Date): number {
+    const weekAgo = DateRangeHelper.daysAgo(7, today);
+    return records.filter((r) => {
+      const takenDate = DateRangeHelper.toStartOfDay(new Date(r.takenAt));
+      return takenDate.getTime() >= weekAgo.getTime();
+    }).length;
+  }
+
+  /**
+   * 記録の増減傾向ラベルを返す（差が1以内は横ばい）
+   */
+  static getRecordTrendLabel(currentCount: number, previousCount: number): string {
+    const diff = currentCount - previousCount;
+    if (Math.abs(diff) <= 1) return '横ばい';
+    return diff > 0 ? '増加傾向' : '減少傾向';
+  }
 }


### PR DESCRIPTION
## Summary
- getDailySummaryText: 完了数と予定数に応じたサマリーテキスト生成
- getWeeklyRecordCount: 過去7日間の記録数を算出
- getRecordTrendLabel: 記録の増減傾向を判定(差1以内は横ばい)

## Test plan
- [x] getDailySummaryText: 0件、全完了、一部完了、未完了
- [x] getWeeklyRecordCount: 空配列、7日以内、境界値7日/8日
- [x] getRecordTrendLabel: 増加、減少、同数、差1以内、前期間0
- [x] 全1876テストパス

closes #413