### PR TITLE
feat: 在庫予測メッセージ生成機能を追加

### DIFF
--- a/src/__tests__/domain/entities/StockForecastMessage.test.ts
+++ b/src/__tests__/domain/entities/StockForecastMessage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity 在庫予測メッセージ', () => {
+  describe('getStockForecastMessage', () => {
+    it('残日数nullは在庫不明メッセージを返す', () => {
+      expect(StockAlertEntity.getStockForecastMessage(null)).toBe('在庫数が不明です');
+    });
+
+    it('0日は即補充メッセージを返す', () => {
+      expect(StockAlertEntity.getStockForecastMessage(0)).toBe('在庫がありません');
+    });
+
+    it('3日以内は緊急メッセージを返す', () => {
+      expect(StockAlertEntity.getStockForecastMessage(2)).toBe('あと2日分の在庫です。早急に補充してください');
+    });
+
+    it('7日以内は注意メッセージを返す', () => {
+      expect(StockAlertEntity.getStockForecastMessage(5)).toBe('あと5日分の在庫です。補充を検討してください');
+    });
+
+    it('7日超は余裕メッセージを返す', () => {
+      expect(StockAlertEntity.getStockForecastMessage(14)).toBe('あと14日分の在庫があります');
+    });
+  });
+
+  describe('getRefillUrgency', () => {
+    it('nullはunknownを返す', () => {
+      expect(StockAlertEntity.getRefillUrgency(null)).toBe('unknown');
+    });
+
+    it('0日はcriticalを返す', () => {
+      expect(StockAlertEntity.getRefillUrgency(0)).toBe('critical');
+    });
+
+    it('3日以内はurgentを返す', () => {
+      expect(StockAlertEntity.getRefillUrgency(3)).toBe('urgent');
+    });
+
+    it('7日以内はwarningを返す', () => {
+      expect(StockAlertEntity.getRefillUrgency(7)).toBe('warning');
+    });
+
+    it('7日超はnormalを返す', () => {
+      expect(StockAlertEntity.getRefillUrgency(8)).toBe('normal');
+    });
+  });
+
+  describe('getDaysUntilStockout', () => {
+    it('在庫nullはnullを返す', () => {
+      expect(StockAlertEntity.getDaysUntilStockout(null, 2)).toBeNull();
+    });
+
+    it('消費量0はnullを返す', () => {
+      expect(StockAlertEntity.getDaysUntilStockout(10, 0)).toBeNull();
+    });
+
+    it('在庫10で1日2消費は5日を返す', () => {
+      expect(StockAlertEntity.getDaysUntilStockout(10, 2)).toBe(5);
+    });
+
+    it('端数は切り捨てる', () => {
+      expect(StockAlertEntity.getDaysUntilStockout(7, 2)).toBe(3);
+    });
+
+    it('在庫0は0日を返す', () => {
+      expect(StockAlertEntity.getDaysUntilStockout(0, 2)).toBe(0);
+    });
+  });
+});

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -196,4 +196,34 @@ export class StockAlertEntity {
     if (days % 7 === 0 && days >= 7) return `あと${days / 7}週間`;
     return `あと${days}日`;
   }
+
+  /**
+   * 残日数に応じた在庫予測メッセージを返す
+   */
+  static getStockForecastMessage(remainingDays: number | null): string {
+    if (remainingDays === null) return '在庫数が不明です';
+    if (remainingDays === 0) return '在庫がありません';
+    if (remainingDays <= 3) return `あと${remainingDays}日分の在庫です。早急に補充してください`;
+    if (remainingDays <= 7) return `あと${remainingDays}日分の在庫です。補充を検討してください`;
+    return `あと${remainingDays}日分の在庫があります`;
+  }
+
+  /**
+   * 補充の緊急度を判定する
+   */
+  static getRefillUrgency(remainingDays: number | null): 'critical' | 'urgent' | 'warning' | 'normal' | 'unknown' {
+    if (remainingDays === null) return 'unknown';
+    if (remainingDays === 0) return 'critical';
+    if (remainingDays <= 3) return 'urgent';
+    if (remainingDays <= 7) return 'warning';
+    return 'normal';
+  }
+
+  /**
+   * 在庫切れまでの日数を算出する（切り捨て）
+   */
+  static getDaysUntilStockout(stockQuantity: number | null, dailyConsumption: number): number | null {
+    if (stockQuantity === null || dailyConsumption <= 0) return null;
+    return Math.floor(stockQuantity / dailyConsumption);
+  }
 }


### PR DESCRIPTION
## Summary
- getStockForecastMessage: 残日数に応じた在庫予測メッセージ生成
- getRefillUrgency: 補充の緊急度を5段階で判定
- getDaysUntilStockout: 在庫と消費量から在庫切れまでの日数を算出

## Test plan
- [x] getStockForecastMessage: null、0日、3日以内、7日以内、7日超
- [x] getRefillUrgency: null、0日、3日以内、7日以内、8日以上
- [x] getDaysUntilStockout: null在庫、0消費、正常計算、端数切捨、0在庫
- [x] 全1891テストパス

closes #416