### PR TITLE
feat: 服薬遵守率の週次比較メッセージ生成機能を追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceWeeklyComparison.test.ts
+++ b/src/__tests__/domain/entities/AdherenceWeeklyComparison.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity 週次比較', () => {
+  describe('getWeeklyComparisonDetail', () => {
+    it('改善時は改善メッセージとプラスの差を返す', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparisonDetail(90, 70);
+      expect(result.direction).toBe('up');
+      expect(result.diff).toBe(20);
+      expect(result.message).toContain('改善');
+    });
+
+    it('悪化時は悪化メッセージとマイナスの差を返す', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparisonDetail(50, 80);
+      expect(result.direction).toBe('down');
+      expect(result.diff).toBe(30);
+      expect(result.message).toContain('低下');
+    });
+
+    it('差5以内は維持メッセージを返す', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparisonDetail(75, 72);
+      expect(result.direction).toBe('stable');
+      expect(result.message).toContain('維持');
+    });
+
+    it('同値は維持メッセージを返す', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparisonDetail(80, 80);
+      expect(result.direction).toBe('stable');
+    });
+  });
+
+  describe('getRateChangeLabel', () => {
+    it('正の変化はプラス表記を返す', () => {
+      expect(AdherenceStatsEntity.getRateChangeLabel(15)).toBe('+15%');
+    });
+
+    it('負の変化はマイナス表記を返す', () => {
+      expect(AdherenceStatsEntity.getRateChangeLabel(-10)).toBe('-10%');
+    });
+
+    it('0は変化なしを返す', () => {
+      expect(AdherenceStatsEntity.getRateChangeLabel(0)).toBe('変化なし');
+    });
+  });
+
+  describe('getMotivationMessage', () => {
+    it('90%以上は最高のメッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMotivationMessage(95);
+      expect(msg.length).toBeGreaterThan(0);
+    });
+
+    it('70%以上は良好のメッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMotivationMessage(75);
+      expect(msg.length).toBeGreaterThan(0);
+    });
+
+    it('50%以上は励ましのメッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMotivationMessage(55);
+      expect(msg.length).toBeGreaterThan(0);
+    });
+
+    it('50%未満は改善提案のメッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMotivationMessage(30);
+      expect(msg.length).toBeGreaterThan(0);
+    });
+
+    it('各レベルで異なるメッセージを返す', () => {
+      const msgs = [95, 75, 55, 30].map((r) => AdherenceStatsEntity.getMotivationMessage(r));
+      const unique = new Set(msgs);
+      expect(unique.size).toBe(4);
+    });
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -295,4 +295,40 @@ export class AdherenceStatsEntity {
     };
     return colors[grade];
   }
+
+  /**
+   * 今週と先週の遵守率を比較し詳細情報を返す
+   */
+  static getWeeklyComparisonDetail(
+    currentRate: number,
+    previousRate: number,
+  ): { direction: 'up' | 'down' | 'stable'; diff: number; message: string } {
+    const diff = Math.abs(currentRate - previousRate);
+    if (diff <= 5) {
+      return { direction: 'stable', diff, message: '先週と同水準を維持しています' };
+    }
+    if (currentRate > previousRate) {
+      return { direction: 'up', diff, message: `先週より${diff}%改善しました` };
+    }
+    return { direction: 'down', diff, message: `先週より${diff}%低下しています` };
+  }
+
+  /**
+   * 遵守率の変化量をラベルで返す
+   */
+  static getRateChangeLabel(change: number): string {
+    if (change === 0) return '変化なし';
+    if (change > 0) return `+${change}%`;
+    return `${change}%`;
+  }
+
+  /**
+   * 遵守率に基づいた動機付けメッセージを返す
+   */
+  static getMotivationMessage(rate: number): string {
+    if (rate >= 90) return 'この調子で続けましょう';
+    if (rate >= 70) return '良いペースです。あと少しで最高評価です';
+    if (rate >= 50) return '少しずつ習慣にしていきましょう';
+    return '一回でも記録をつけることが大切です';
+  }
 }


### PR DESCRIPTION
## Summary
- getWeeklyComparisonDetail: 今週と先週の遵守率比較の詳細情報を返す
- getRateChangeLabel: 変化量をプラス/マイナス表記のラベルに変換
- getMotivationMessage: 遵守率に応じた4段階の動機付けメッセージ

## Test plan
- [x] getWeeklyComparisonDetail: 改善、悪化、維持(差5以内)、同値
- [x] getRateChangeLabel: 正、負、0
- [x] getMotivationMessage: 90%以上、70%以上、50%以上、50%未満、各レベル異なること
- [x] 全1926テストパス

closes #424