### PR TITLE
feat: カレンダー月間比較分析機能を追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarMonthComparison.test.ts
+++ b/src/__tests__/domain/entities/CalendarMonthComparison.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity 月間比較分析', () => {
+  describe('getMonthComparisonMessage', () => {
+    it('改善時は改善メッセージを返す', () => {
+      const msg = CalendarEntity.getMonthComparisonMessage(80, 60);
+      expect(msg).toContain('改善');
+    });
+
+    it('悪化時は低下メッセージを返す', () => {
+      const msg = CalendarEntity.getMonthComparisonMessage(40, 70);
+      expect(msg).toContain('低下');
+    });
+
+    it('差5%以内は維持メッセージを返す', () => {
+      const msg = CalendarEntity.getMonthComparisonMessage(73, 70);
+      expect(msg).toContain('維持');
+    });
+
+    it('同値は維持メッセージを返す', () => {
+      const msg = CalendarEntity.getMonthComparisonMessage(80, 80);
+      expect(msg).toContain('維持');
+    });
+  });
+
+  describe('getRecordDensity', () => {
+    it('80%以上は高密度を返す', () => {
+      expect(CalendarEntity.getRecordDensity(85)).toBe('高');
+    });
+
+    it('50%以上は中密度を返す', () => {
+      expect(CalendarEntity.getRecordDensity(60)).toBe('中');
+    });
+
+    it('50%未満は低密度を返す', () => {
+      expect(CalendarEntity.getRecordDensity(30)).toBe('低');
+    });
+
+    it('0%は低密度を返す', () => {
+      expect(CalendarEntity.getRecordDensity(0)).toBe('低');
+    });
+
+    it('100%は高密度を返す', () => {
+      expect(CalendarEntity.getRecordDensity(100)).toBe('高');
+    });
+  });
+
+  describe('getMonthlyRecordSummary', () => {
+    it('記録なしの場合はなしメッセージを返す', () => {
+      expect(CalendarEntity.getMonthlyRecordSummary(0, 30)).toBe('今月の記録はありません');
+    });
+
+    it('全日記録ありの場合は完璧メッセージを返す', () => {
+      expect(CalendarEntity.getMonthlyRecordSummary(30, 30)).toBe('毎日記録がつけられています');
+    });
+
+    it('一部記録ありの場合は日数を含むメッセージを返す', () => {
+      const msg = CalendarEntity.getMonthlyRecordSummary(15, 30);
+      expect(msg).toContain('15');
+      expect(msg).toContain('30');
+    });
+
+    it('totalDays 0は記録なしメッセージを返す', () => {
+      expect(CalendarEntity.getMonthlyRecordSummary(0, 0)).toBe('今月の記録はありません');
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -231,4 +231,32 @@ export class CalendarEntity {
     const weeks = CalendarEntity.getWeeksInMonth(days);
     return weeks.map((week) => week.reduce((sum, d) => sum + d.recordCount, 0));
   }
+
+  /**
+   * 今月と先月の記録率を比較しメッセージを返す
+   */
+  static getMonthComparisonMessage(currentRate: number, previousRate: number): string {
+    const diff = currentRate - previousRate;
+    if (Math.abs(diff) <= 5) return '先月と同水準を維持しています';
+    if (diff > 0) return `先月より${diff}%改善しました`;
+    return `先月より${Math.abs(diff)}%低下しています`;
+  }
+
+  /**
+   * 記録密度のラベルを返す
+   */
+  static getRecordDensity(rate: number): string {
+    if (rate >= 80) return '高';
+    if (rate >= 50) return '中';
+    return '低';
+  }
+
+  /**
+   * 月間の記録サマリーテキストを生成する
+   */
+  static getMonthlyRecordSummary(recordDays: number, totalDays: number): string {
+    if (recordDays === 0 || totalDays === 0) return '今月の記録はありません';
+    if (recordDays === totalDays) return '毎日記録がつけられています';
+    return `${totalDays}日中${recordDays}日記録がつけられています`;
+  }
 }


### PR DESCRIPTION
## Summary
- getMonthComparisonMessage: 今月と先月の記録率比較メッセージ(差5%以内は維持)
- getRecordDensity: 記録率に応じた密度ラベル(高/中/低)
- getMonthlyRecordSummary: 月間記録のサマリーテキスト生成

## Test plan
- [x] getMonthComparisonMessage: 改善、悪化、維持、同値
- [x] getRecordDensity: 80%以上、50%以上、50%未満、0%、100%
- [x] getMonthlyRecordSummary: 0日、全日、一部、totalDays 0
- [x] 全1950テストパス

closes #428