### PR TITLE
refactor: getWeekSummaryの平均計算をMathHelper.calculateAverageに統合

### DIFF
--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -143,9 +143,9 @@ export class CalendarEntity {
     const daysWithRecords = days.filter((d) => d.recordCount > 0).length;
     const averageCondition =
       daysWithCondition.length > 0
-        ? Math.round(
-            daysWithCondition.reduce((sum, d) => sum + (d.averageCondition as number), 0) /
-              daysWithCondition.length,
+        ? MathHelper.calculateAverage(
+            daysWithCondition.map((d) => d.averageCondition as number),
+            0,
           )
         : null;
     return { totalRecords, averageCondition, daysWithRecords };


### PR DESCRIPTION
## Summary
- CalendarEntity.getWeekSummaryの手動Math.round計算をMathHelper.calculateAverageに置き換え
- ドメインヘルパーの再利用を促進

## Test plan
- [x] 全1950テストパス

closes #431