### PR TITLE
fix: 病院API POSTにレートリミットを追加

### DIFF
--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -3,6 +3,7 @@ import { createHospitalSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, validateBodySize } from '@/lib/api-helpers';
 import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
 
 export const GET = withAuth(async (userId) => {
   const hospitals = await prisma.hospital.findMany({ where: { userId }, take: QUERY_LIMITS.DEFAULT });
@@ -14,6 +15,9 @@ export async function POST(request: Request) {
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const rateLimitError = checkRateLimit(userId, 'hospitals-post', 10);
+    if (rateLimitError) return rateLimitError;
+
     const body = await request.json();
     const parsed = createHospitalSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);


### PR DESCRIPTION
## Summary
- POST /api/hospitals に10回/分/ユーザーのレートリミットを追加
- checkRateLimitを使用し、既存のセキュリティパターンに準拠

## Test plan
- [x] 全1974テストパス

closes #435