### PR TITLE
feat: 体調ログの期間別分析機能を追加

### DIFF
--- a/src/__tests__/domain/entities/HealthLogPeriodAnalysis.test.ts
+++ b/src/__tests__/domain/entities/HealthLogPeriodAnalysis.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity, HealthLog, ConditionLevel } from '@/domain/entities/HealthLog';
+
+const createLog = (conditionLevel: ConditionLevel): HealthLog => ({
+  id: `log-${Math.random()}`,
+  memberId: 'member-1',
+  memberName: '太郎',
+  userId: 'user-1',
+  conditionLevel,
+  symptoms: [],
+  notes: '',
+  recordedAt: new Date('2026-03-01'),
+});
+
+describe('HealthLogEntity 期間別分析', () => {
+  describe('getConditionDistribution', () => {
+    it('空配列は全レベル0を返す', () => {
+      const result = HealthLogEntity.getConditionDistribution([]);
+      expect(result).toEqual({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 });
+    });
+
+    it('各レベルの件数を正しくカウントする', () => {
+      const logs = [
+        createLog(1), createLog(3), createLog(3), createLog(5),
+      ];
+      const result = HealthLogEntity.getConditionDistribution(logs);
+      expect(result[1]).toBe(1);
+      expect(result[2]).toBe(0);
+      expect(result[3]).toBe(2);
+      expect(result[4]).toBe(0);
+      expect(result[5]).toBe(1);
+    });
+
+    it('全て同じレベルの場合', () => {
+      const logs = [createLog(4), createLog(4), createLog(4)];
+      const result = HealthLogEntity.getConditionDistribution(logs);
+      expect(result[4]).toBe(3);
+    });
+  });
+
+  describe('getPeriodSummaryMessage', () => {
+    it('空配列は記録なしメッセージを返す', () => {
+      expect(HealthLogEntity.getPeriodSummaryMessage([])).toBe('この期間の記録はありません');
+    });
+
+    it('平均4以上は良好メッセージを返す', () => {
+      const logs = [createLog(4), createLog(5), createLog(4)];
+      const msg = HealthLogEntity.getPeriodSummaryMessage(logs);
+      expect(msg).toContain('良好');
+    });
+
+    it('平均3以上は普通メッセージを返す', () => {
+      const logs = [createLog(3), createLog(3), createLog(4)];
+      const msg = HealthLogEntity.getPeriodSummaryMessage(logs);
+      expect(msg).toContain('普通');
+    });
+
+    it('平均3未満は注意メッセージを返す', () => {
+      const logs = [createLog(1), createLog(2), createLog(2)];
+      const msg = HealthLogEntity.getPeriodSummaryMessage(logs);
+      expect(msg).toContain('注意');
+    });
+
+    it('件数を含むメッセージを返す', () => {
+      const logs = [createLog(5), createLog(5)];
+      const msg = HealthLogEntity.getPeriodSummaryMessage(logs);
+      expect(msg).toContain('2');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -425,4 +425,26 @@ export class HealthLogEntity {
     const symptomLabels = HealthLogEntity.getSymptomLabels(symptoms);
     return `体調: ${condLabel} / ${symptomLabels.join(', ')}`;
   }
+
+  /**
+   * 体調レベル別の分布を返す
+   */
+  static getConditionDistribution(logs: HealthLog[]): Record<ConditionLevel, number> {
+    const dist: Record<ConditionLevel, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+    for (const log of logs) {
+      dist[log.conditionLevel]++;
+    }
+    return dist;
+  }
+
+  /**
+   * 期間の体調サマリーメッセージを返す
+   */
+  static getPeriodSummaryMessage(logs: HealthLog[]): string {
+    if (logs.length === 0) return 'この期間の記録はありません';
+    const avg = HealthLogEntity.getAverageCondition(logs);
+    if (avg >= 4) return `${logs.length}件の記録があり、体調は良好です`;
+    if (avg >= 3) return `${logs.length}件の記録があり、体調は普通です`;
+    return `${logs.length}件の記録があり、体調に注意が必要です`;
+  }
 }


### PR DESCRIPTION
## Summary
- getConditionDistribution: 体調レベル1-5別の件数分布を返す
- getPeriodSummaryMessage: 平均体調レベルに基づくサマリーメッセージ生成

## Test plan
- [x] getConditionDistribution: 空配列、各レベルカウント、全同一レベル
- [x] getPeriodSummaryMessage: 空配列、良好(4以上)、普通(3以上)、注意(3未満)、件数含む
- [x] 全1982テストパス

closes #437