### PR TITLE
feat: スケジュール重複検知の詳細メッセージ生成機能を追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleOverlapMessage.test.ts
+++ b/src/__tests__/domain/entities/ScheduleOverlapMessage.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 重複検知メッセージ', () => {
+  describe('getOverlapSummary', () => {
+    it('0件は重複なしメッセージを返す', () => {
+      expect(ScheduleEntity.getOverlapSummary(0)).toBe('重複するスケジュールはありません');
+    });
+
+    it('1件は単数メッセージを返す', () => {
+      expect(ScheduleEntity.getOverlapSummary(1)).toBe('1件の重複があります');
+    });
+
+    it('複数件は複数メッセージを返す', () => {
+      expect(ScheduleEntity.getOverlapSummary(3)).toBe('3件の重複があります');
+    });
+  });
+
+  describe('formatOverlapDetail', () => {
+    it('時刻と曜日を含むメッセージを返す', () => {
+      const result = ScheduleEntity.formatOverlapDetail('08:00', 'mon');
+      expect(result).toContain('08:00');
+      expect(result).toContain('月');
+    });
+
+    it('every曜日は毎日を表示する', () => {
+      const result = ScheduleEntity.formatOverlapDetail('12:00', 'every');
+      expect(result).toContain('毎日');
+    });
+
+    it('各曜日を正しく変換する', () => {
+      expect(ScheduleEntity.formatOverlapDetail('09:00', 'sun')).toContain('日');
+      expect(ScheduleEntity.formatOverlapDetail('09:00', 'sat')).toContain('土');
+    });
+  });
+
+  describe('hasAnyOverlap', () => {
+    it('空配列はfalseを返す', () => {
+      expect(ScheduleEntity.hasAnyOverlap([])).toBe(false);
+    });
+
+    it('1件以上はtrueを返す', () => {
+      expect(ScheduleEntity.hasAnyOverlap([{ scheduleIds: ['a', 'b'], time: '08:00', day: 'mon' }])).toBe(true);
+    });
+
+    it('複数件もtrueを返す', () => {
+      const overlaps = [
+        { scheduleIds: ['a', 'b'], time: '08:00', day: 'mon' },
+        { scheduleIds: ['c', 'd'], time: '12:00', day: 'tue' },
+      ];
+      expect(ScheduleEntity.hasAnyOverlap(overlaps)).toBe(true);
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -415,4 +415,27 @@ export class ScheduleEntity {
   static getDaysOfWeekLabels(days: DayOfWeek[]): string[] {
     return days.map((d) => ScheduleEntity.DAY_LABELS[d]);
   }
+
+  /**
+   * 重複件数に応じたサマリーメッセージを返す
+   */
+  static getOverlapSummary(overlapCount: number): string {
+    if (overlapCount === 0) return '重複するスケジュールはありません';
+    return `${overlapCount}件の重複があります`;
+  }
+
+  /**
+   * 個別の重複情報をテキスト化する
+   */
+  static formatOverlapDetail(time: string, day: string): string {
+    const dayLabel = day === 'every' ? '毎日' : (ScheduleEntity.DAY_LABELS[day as DayOfWeek] || day);
+    return `${dayLabel} ${time}に重複`;
+  }
+
+  /**
+   * 重複が1件以上あるかを判定する
+   */
+  static hasAnyOverlap(overlaps: { scheduleIds: string[]; time: string; day: string }[]): boolean {
+    return overlaps.length > 0;
+  }
 }


### PR DESCRIPTION
## Summary
- getOverlapSummary: 重複件数に応じたサマリーメッセージ
- formatOverlapDetail: 時刻と曜日の重複情報テキスト化
- hasAnyOverlap: 重複が1件以上あるかの判定

## Test plan
- [x] getOverlapSummary: 0件、1件、複数件
- [x] formatOverlapDetail: 通常曜日、every、各曜日変換
- [x] hasAnyOverlap: 空配列、1件、複数件
- [x] 全1991テストパス

closes #439