### PR TITLE
feat: 薬の在庫ステータスラベル生成機能を追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationStockStatus.test.ts
+++ b/src/__tests__/domain/entities/MedicationStockStatus.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity 在庫ステータス', () => {
+  describe('getStockStatusColor', () => {
+    it('safeは緑色クラスを返す', () => {
+      const result = MedicationEntity.getStockStatusColor('safe');
+      expect(result).toContain('green');
+    });
+
+    it('lowはオレンジ色クラスを返す', () => {
+      const result = MedicationEntity.getStockStatusColor('low');
+      expect(result).toContain('orange');
+    });
+
+    it('criticalは赤色クラスを返す', () => {
+      const result = MedicationEntity.getStockStatusColor('critical');
+      expect(result).toContain('red');
+    });
+
+    it('unknownはグレー色クラスを返す', () => {
+      const result = MedicationEntity.getStockStatusColor('unknown');
+      expect(result).toContain('gray');
+    });
+  });
+
+  describe('getMedicationSummary', () => {
+    it('カテゴリと在庫状態を含むサマリーを返す', () => {
+      const result = MedicationEntity.getMedicationSummary('regular', 10);
+      expect(result).toContain('常用薬');
+      expect(result).toContain('10');
+    });
+
+    it('在庫未設定の場合は未設定を含む', () => {
+      const result = MedicationEntity.getMedicationSummary('supplement', undefined);
+      expect(result).toContain('サプリメント');
+      expect(result).toContain('未設定');
+    });
+
+    it('在庫0の場合は在庫切れを含む', () => {
+      const result = MedicationEntity.getMedicationSummary('prn', 0);
+      expect(result).toContain('在庫切れ');
+    });
+  });
+
+  describe('isActive check', () => {
+    it('アクティブフラグの判定', () => {
+      expect(MedicationEntity.getActiveStatusLabel(true)).toBe('有効');
+      expect(MedicationEntity.getActiveStatusLabel(false)).toBe('無効');
+    });
+  });
+});

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -190,4 +190,34 @@ export class MedicationEntity {
     if (quantity <= 10) return 'そろそろ補充を検討してください';
     return '十分な在庫があります';
   }
+
+  /**
+   * 在庫ステータスに応じたスタイルクラスを返す
+   */
+  static getStockStatusColor(status: 'safe' | 'low' | 'critical' | 'unknown'): string {
+    const colors: Record<string, string> = {
+      safe: 'text-green-600',
+      low: 'text-orange-600',
+      critical: 'text-red-600',
+      unknown: 'text-gray-400',
+    };
+    return colors[status];
+  }
+
+  /**
+   * カテゴリと在庫数からサマリーテキストを生成する
+   */
+  static getMedicationSummary(category: MedicationCategory, stockQuantity: number | undefined): string {
+    const catLabel = MedicationEntity.getCategoryLabel(category);
+    if (stockQuantity === undefined) return `${catLabel} / 在庫: 未設定`;
+    if (stockQuantity === 0) return `${catLabel} / 在庫切れ`;
+    return `${catLabel} / 在庫: ${stockQuantity}`;
+  }
+
+  /**
+   * アクティブフラグの日本語ラベルを返す
+   */
+  static getActiveStatusLabel(isActive: boolean): string {
+    return isActive ? '有効' : '無効';
+  }
 }


### PR DESCRIPTION
## Summary
- getStockStatusColor: 在庫ステータスに応じたTailwindスタイルクラス
- getMedicationSummary: カテゴリと在庫数のサマリーテキスト
- getActiveStatusLabel: アクティブフラグの日本語ラベル

## Test plan
- [x] getStockStatusColor: safe/low/critical/unknown
- [x] getMedicationSummary: 在庫あり、未設定、0
- [x] getActiveStatusLabel: true/false
- [x] 全1999テストパス

closes #441