### PR TITLE
refactor: getDisplayInfoでgetCategoryLabelメソッドを使用

### DIFF
--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -121,7 +121,7 @@ export class MedicationEntity {
   getDisplayInfo(): { name: string; categoryLabel: string; dosageInfo: string } {
     return {
       name: this.medication.name,
-      categoryLabel: MedicationEntity.categoryLabels[this.medication.category],
+      categoryLabel: MedicationEntity.getCategoryLabel(this.medication.category),
       dosageInfo: this.getDosageSummary(),
     };
   }


### PR DESCRIPTION
## Summary
- getDisplayInfoのcategoryLabels直接参照をgetCategoryLabelメソッド経由に変更
- カテゴリラベル取得ロジックの一元化

## Test plan
- [x] 全1999テストパス

closes #443