### PR TITLE
MemberEntityに年齢グループ判定メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/MemberAgeGroup.test.ts
+++ b/src/__tests__/domain/entities/MemberAgeGroup.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity 年齢グループ判定', () => {
+  describe('getAgeGroup', () => {
+    it('0歳は乳幼児を返す', () => {
+      expect(MemberEntity.getAgeGroup(0)).toBe('infant');
+    });
+
+    it('5歳は乳幼児を返す', () => {
+      expect(MemberEntity.getAgeGroup(5)).toBe('infant');
+    });
+
+    it('6歳は子供を返す', () => {
+      expect(MemberEntity.getAgeGroup(6)).toBe('child');
+    });
+
+    it('17歳は子供を返す', () => {
+      expect(MemberEntity.getAgeGroup(17)).toBe('child');
+    });
+
+    it('18歳は大人を返す', () => {
+      expect(MemberEntity.getAgeGroup(18)).toBe('adult');
+    });
+
+    it('64歳は大人を返す', () => {
+      expect(MemberEntity.getAgeGroup(64)).toBe('adult');
+    });
+
+    it('65歳はシニアを返す', () => {
+      expect(MemberEntity.getAgeGroup(65)).toBe('senior');
+    });
+
+    it('nullはunknownを返す', () => {
+      expect(MemberEntity.getAgeGroup(null)).toBe('unknown');
+    });
+  });
+
+  describe('getAgeGroupLabel', () => {
+    it('infantは乳幼児を返す', () => {
+      expect(MemberEntity.getAgeGroupLabel('infant')).toBe('乳幼児');
+    });
+
+    it('childは子供を返す', () => {
+      expect(MemberEntity.getAgeGroupLabel('child')).toBe('子供');
+    });
+
+    it('adultは大人を返す', () => {
+      expect(MemberEntity.getAgeGroupLabel('adult')).toBe('大人');
+    });
+
+    it('seniorはシニアを返す', () => {
+      expect(MemberEntity.getAgeGroupLabel('senior')).toBe('シニア');
+    });
+
+    it('unknownは不明を返す', () => {
+      expect(MemberEntity.getAgeGroupLabel('unknown')).toBe('不明');
+    });
+  });
+
+  describe('getAgeDisplayLabel', () => {
+    it('年齢ありの場合は歳付きで返す', () => {
+      expect(MemberEntity.getAgeDisplayLabel(25)).toBe('25歳');
+    });
+
+    it('0歳の場合は0歳を返す', () => {
+      expect(MemberEntity.getAgeDisplayLabel(0)).toBe('0歳');
+    });
+
+    it('nullの場合は年齢不明を返す', () => {
+      expect(MemberEntity.getAgeDisplayLabel(null)).toBe('年齢不明');
+    });
+  });
+
+  describe('validateBirthDate', () => {
+    it('過去の日付は有効', () => {
+      const result = MemberEntity.validateBirthDate(new Date('2000-01-01'), new Date('2025-01-01'));
+      expect(result.valid).toBe(true);
+    });
+
+    it('未来の日付は無効', () => {
+      const result = MemberEntity.validateBirthDate(new Date('2030-01-01'), new Date('2025-01-01'));
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('今日の日付は有効', () => {
+      const today = new Date('2025-06-15');
+      const result = MemberEntity.validateBirthDate(today, today);
+      expect(result.valid).toBe(true);
+    });
+
+    it('nullは有効（任意項目）', () => {
+      const result = MemberEntity.validateBirthDate(null, new Date('2025-01-01'));
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -179,6 +179,54 @@ export class MemberEntity {
   }
 
   /**
+   * 年齢からグループを判定する
+   */
+  static getAgeGroup(age: number | null): 'infant' | 'child' | 'adult' | 'senior' | 'unknown' {
+    if (age === null) return 'unknown';
+    if (age < 6) return 'infant';
+    if (age < 18) return 'child';
+    if (age < 65) return 'adult';
+    return 'senior';
+  }
+
+  private static readonly ageGroupLabels: Record<string, string> = {
+    infant: '乳幼児',
+    child: '子供',
+    adult: '大人',
+    senior: 'シニア',
+    unknown: '不明',
+  };
+
+  /**
+   * 年齢グループの日本語ラベルを返す
+   */
+  static getAgeGroupLabel(group: 'infant' | 'child' | 'adult' | 'senior' | 'unknown'): string {
+    return MemberEntity.ageGroupLabels[group];
+  }
+
+  /**
+   * 年齢の表示用ラベルを返す
+   */
+  static getAgeDisplayLabel(age: number | null): string {
+    if (age === null) return '年齢不明';
+    return `${age}歳`;
+  }
+
+  /**
+   * 生年月日のバリデーション
+   */
+  static validateBirthDate(
+    birthDate: Date | null,
+    today: Date,
+  ): { valid: boolean; error?: string } {
+    if (birthDate === null) return { valid: true };
+    if (birthDate.getTime() > today.getTime()) {
+      return { valid: false, error: '生年月日は今日以前の日付を入力してください' };
+    }
+    return { valid: true };
+  }
+
+  /**
    * プロフィール要約テキストを返す
    */
   static getProfileSummary(


### PR DESCRIPTION
## Summary
- getAgeGroup: 年齢を乳幼児/子供/大人/シニアに分類
- getAgeGroupLabel: 年齢グループの日本語ラベル
- getAgeDisplayLabel: 年齢の表示用ラベル
- validateBirthDate: 生年月日の妥当性検証

## Test plan
- [ ] 新規20テスト含め全2044テストがパスすること