### PR TITLE
AdherenceStatsにマイルストーン計算メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceMilestoneCalc.test.ts
+++ b/src/__tests__/domain/entities/AdherenceMilestoneCalc.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStats マイルストーン計算', () => {
+  describe('getNextMilestone', () => {
+    it('0日の場合は7を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(0)).toBe(7);
+    });
+
+    it('5日の場合は7を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(5)).toBe(7);
+    });
+
+    it('7日の場合は14を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(7)).toBe(14);
+    });
+
+    it('14日の場合は30を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(14)).toBe(30);
+    });
+
+    it('30日の場合は60を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(30)).toBe(60);
+    });
+
+    it('90日の場合は100を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(90)).toBe(100);
+    });
+
+    it('100日の場合は180を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(100)).toBe(180);
+    });
+
+    it('180日の場合は365を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(180)).toBe(365);
+    });
+
+    it('365日以上の場合はnullを返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(365)).toBeNull();
+    });
+
+    it('400日の場合はnullを返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(400)).toBeNull();
+    });
+  });
+
+  describe('getDaysUntilMilestone', () => {
+    it('0日の場合は7を返す', () => {
+      expect(AdherenceStatsEntity.getDaysUntilMilestone(0)).toBe(7);
+    });
+
+    it('5日の場合は2を返す', () => {
+      expect(AdherenceStatsEntity.getDaysUntilMilestone(5)).toBe(2);
+    });
+
+    it('7日ちょうどの場合は次のマイルストーンまでの日数を返す', () => {
+      expect(AdherenceStatsEntity.getDaysUntilMilestone(7)).toBe(7);
+    });
+
+    it('365日以上の場合はnullを返す', () => {
+      expect(AdherenceStatsEntity.getDaysUntilMilestone(365)).toBeNull();
+    });
+  });
+
+  describe('getMilestoneAchievementMessage', () => {
+    it('7日達成メッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMilestoneAchievementMessage(7);
+      expect(msg).toContain('1週間');
+    });
+
+    it('14日達成メッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMilestoneAchievementMessage(14);
+      expect(msg).toContain('2週間');
+    });
+
+    it('30日達成メッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMilestoneAchievementMessage(30);
+      expect(msg).toContain('1ヶ月');
+    });
+
+    it('365日達成メッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMilestoneAchievementMessage(365);
+      expect(msg).toContain('1年');
+    });
+
+    it('マイルストーンでない日数はnullを返す', () => {
+      expect(AdherenceStatsEntity.getMilestoneAchievementMessage(5)).toBeNull();
+    });
+
+    it('10日はマイルストーンでないのでnullを返す', () => {
+      expect(AdherenceStatsEntity.getMilestoneAchievementMessage(10)).toBeNull();
+    });
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -331,4 +331,40 @@ export class AdherenceStatsEntity {
     if (rate >= 50) return '少しずつ習慣にしていきましょう';
     return '一回でも記録をつけることが大切です';
   }
+
+  private static readonly MILESTONES = [7, 14, 30, 60, 90, 100, 180, 365];
+
+  /**
+   * 現在の連続日数から次のマイルストーンを取得する
+   */
+  static getNextMilestone(currentStreak: number): number | null {
+    return AdherenceStatsEntity.MILESTONES.find((m) => m > currentStreak) ?? null;
+  }
+
+  /**
+   * 次のマイルストーンまでの残り日数を返す
+   */
+  static getDaysUntilMilestone(currentStreak: number): number | null {
+    const next = AdherenceStatsEntity.getNextMilestone(currentStreak);
+    if (next === null) return null;
+    return next - currentStreak;
+  }
+
+  private static readonly milestoneMessages: Record<number, string> = {
+    7: '1週間連続達成です',
+    14: '2週間連続達成です',
+    30: '1ヶ月連続達成です',
+    60: '2ヶ月連続達成です',
+    90: '3ヶ月連続達成です',
+    100: '100日連続達成です',
+    180: '半年連続達成です',
+    365: '1年連続達成です',
+  };
+
+  /**
+   * マイルストーン達成時のメッセージを返す（マイルストーンでない場合はnull）
+   */
+  static getMilestoneAchievementMessage(streak: number): string | null {
+    return AdherenceStatsEntity.milestoneMessages[streak] ?? null;
+  }
 }


### PR DESCRIPTION
## Summary
- getNextMilestone: 現在の連続日数から次のマイルストーンを取得
- getDaysUntilMilestone: マイルストーンまでの残り日数計算
- getMilestoneAchievementMessage: マイルストーン達成メッセージ生成

## Test plan
- [ ] 新規20テスト含め全2064テストがパスすること