### PR TITLE
Phase22エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceMilestoneCalc.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceMilestoneCalc.edge.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStats マイルストーン エッジケース', () => {
+  describe('getNextMilestone', () => {
+    it('6日の場合は7を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(6)).toBe(7);
+    });
+
+    it('59日の場合は60を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(59)).toBe(60);
+    });
+
+    it('99日の場合は100を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(99)).toBe(100);
+    });
+
+    it('364日の場合は365を返す', () => {
+      expect(AdherenceStatsEntity.getNextMilestone(364)).toBe(365);
+    });
+  });
+
+  describe('getDaysUntilMilestone', () => {
+    it('6日の場合は残り1日', () => {
+      expect(AdherenceStatsEntity.getDaysUntilMilestone(6)).toBe(1);
+    });
+
+    it('13日の場合は残り1日', () => {
+      expect(AdherenceStatsEntity.getDaysUntilMilestone(13)).toBe(1);
+    });
+
+    it('29日の場合は残り1日', () => {
+      expect(AdherenceStatsEntity.getDaysUntilMilestone(29)).toBe(1);
+    });
+  });
+
+  describe('getMilestoneAchievementMessage', () => {
+    it('60日達成メッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMilestoneAchievementMessage(60);
+      expect(msg).toContain('2ヶ月');
+    });
+
+    it('90日達成メッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMilestoneAchievementMessage(90);
+      expect(msg).toContain('3ヶ月');
+    });
+
+    it('180日達成メッセージを返す', () => {
+      const msg = AdherenceStatsEntity.getMilestoneAchievementMessage(180);
+      expect(msg).toContain('半年');
+    });
+
+    it('1日はマイルストーンでない', () => {
+      expect(AdherenceStatsEntity.getMilestoneAchievementMessage(1)).toBeNull();
+    });
+
+    it('0日はマイルストーンでない', () => {
+      expect(AdherenceStatsEntity.getMilestoneAchievementMessage(0)).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HospitalEntityHelpers.edge.test.ts
+++ b/src/__tests__/domain/entities/HospitalEntityHelpers.edge.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity 表示ヘルパー エッジケース', () => {
+  describe('getHospitalTypeLabel', () => {
+    it('空文字はそのまま返す', () => {
+      expect(HospitalEntity.getHospitalTypeLabel('')).toBe('');
+    });
+  });
+
+  describe('getDisplayInfo', () => {
+    it('全項目が未設定の場合は空文字を返す', () => {
+      const info = HospitalEntity.getDisplayInfo({ name: '' });
+      expect(info.name).toBe('');
+      expect(info.typeLabel).toBe('');
+      expect(info.address).toBe('');
+      expect(info.phoneNumber).toBe('');
+    });
+
+    it('空文字のhospitalTypeはラベル変換される', () => {
+      const info = HospitalEntity.getDisplayInfo({ name: 'テスト', hospitalType: '' });
+      expect(info.typeLabel).toBe('');
+    });
+  });
+
+  describe('formatPhoneNumber', () => {
+    it('undefinedはハイフンを返す', () => {
+      expect(HospitalEntity.formatPhoneNumber(undefined)).toBe('-');
+    });
+
+    it('空白のみはハイフンを返す', () => {
+      expect(HospitalEntity.formatPhoneNumber('   ')).toBe('-');
+    });
+
+    it('9桁の番号はそのまま返す', () => {
+      expect(HospitalEntity.formatPhoneNumber('123456789')).toBe('123456789');
+    });
+
+    it('12桁の番号はそのまま返す', () => {
+      expect(HospitalEntity.formatPhoneNumber('123456789012')).toBe('123456789012');
+    });
+
+    it('既にハイフン付き11桁はそのまま返す', () => {
+      expect(HospitalEntity.formatPhoneNumber('090-1234-5678')).toBe('090-1234-5678');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberAgeGroup.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberAgeGroup.edge.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity 年齢グループ エッジケース', () => {
+  describe('getAgeGroup', () => {
+    it('境界値6歳はchildを返す', () => {
+      expect(MemberEntity.getAgeGroup(6)).toBe('child');
+    });
+
+    it('境界値18歳はadultを返す', () => {
+      expect(MemberEntity.getAgeGroup(18)).toBe('adult');
+    });
+
+    it('境界値65歳はseniorを返す', () => {
+      expect(MemberEntity.getAgeGroup(65)).toBe('senior');
+    });
+
+    it('非常に高齢（120歳）はseniorを返す', () => {
+      expect(MemberEntity.getAgeGroup(120)).toBe('senior');
+    });
+  });
+
+  describe('getAgeDisplayLabel', () => {
+    it('100歳は100歳を返す', () => {
+      expect(MemberEntity.getAgeDisplayLabel(100)).toBe('100歳');
+    });
+  });
+
+  describe('validateBirthDate', () => {
+    it('1日後の未来日は無効', () => {
+      const tomorrow = new Date('2025-06-16');
+      const today = new Date('2025-06-15');
+      const result = MemberEntity.validateBirthDate(tomorrow, today);
+      expect(result.valid).toBe(false);
+    });
+
+    it('100年以上前の日付も有効', () => {
+      const oldDate = new Date('1900-01-01');
+      const result = MemberEntity.validateBirthDate(oldDate, new Date('2025-01-01'));
+      expect(result.valid).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- HospitalEntityHelpers.edge.test.ts (8テスト)
- MemberAgeGroup.edge.test.ts (7テスト)
- AdherenceMilestoneCalc.edge.test.ts (12テスト)

## Test plan
- [ ] 新規27テスト含め全2091テストがパスすること