### PR TITLE
お薬API PUT/DELETEにレート制限を追加

### DIFF
--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { updateMedicationSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 const findMedication = (id: string) => prisma.medication.findUnique({ where: { id } });
 
@@ -23,6 +24,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medications-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({
       userId,
@@ -58,6 +61,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medications-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({
       userId,


### PR DESCRIPTION
## Summary
- お薬API（/api/medications/[medicationId]）のPUT・DELETEハンドラにレート制限を追加
- PUT: 20回/分、DELETE: 10回/分

## Test plan
- [ ] 全2091テストがパスすること