### PR TITLE
ScheduleEntityに曜日バリデーションメソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleDayValidation.test.ts
+++ b/src/__tests__/domain/entities/ScheduleDayValidation.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 曜日バリデーション', () => {
+  describe('validateDaysOfWeek', () => {
+    it('有効な曜日配列は有効と判定する', () => {
+      const result = ScheduleEntity.validateDaysOfWeek(['mon', 'tue', 'wed']);
+      expect(result.valid).toBe(true);
+    });
+
+    it('空配列は有効（毎日を意味する）', () => {
+      const result = ScheduleEntity.validateDaysOfWeek([]);
+      expect(result.valid).toBe(true);
+    });
+
+    it('無効な曜日を含む場合は無効と判定する', () => {
+      const result = ScheduleEntity.validateDaysOfWeek(['mon', 'invalid' as never]);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('全7曜日は有効', () => {
+      const result = ScheduleEntity.validateDaysOfWeek(['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('normalizeDaysOfWeek', () => {
+    it('重複を除去する', () => {
+      const result = ScheduleEntity.normalizeDaysOfWeek(['mon', 'mon', 'tue']);
+      expect(result).toEqual(['mon', 'tue']);
+    });
+
+    it('曜日順にソートする', () => {
+      const result = ScheduleEntity.normalizeDaysOfWeek(['sat', 'mon', 'sun']);
+      expect(result).toEqual(['sun', 'mon', 'sat']);
+    });
+
+    it('空配列はそのまま返す', () => {
+      const result = ScheduleEntity.normalizeDaysOfWeek([]);
+      expect(result).toEqual([]);
+    });
+
+    it('既にソート済みの場合はそのまま返す', () => {
+      const result = ScheduleEntity.normalizeDaysOfWeek(['sun', 'mon', 'tue']);
+      expect(result).toEqual(['sun', 'mon', 'tue']);
+    });
+  });
+
+  describe('formatDaysOfWeekSummary', () => {
+    it('空配列は毎日を返す', () => {
+      expect(ScheduleEntity.formatDaysOfWeekSummary([])).toBe('毎日');
+    });
+
+    it('全7曜日は毎日を返す', () => {
+      expect(ScheduleEntity.formatDaysOfWeekSummary(['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'])).toBe('毎日');
+    });
+
+    it('月〜金は平日を返す', () => {
+      expect(ScheduleEntity.formatDaysOfWeekSummary(['mon', 'tue', 'wed', 'thu', 'fri'])).toBe('平日');
+    });
+
+    it('土日は週末を返す', () => {
+      expect(ScheduleEntity.formatDaysOfWeekSummary(['sat', 'sun'])).toBe('週末');
+    });
+
+    it('個別の曜日はラベルをカンマ区切りで返す', () => {
+      const result = ScheduleEntity.formatDaysOfWeekSummary(['mon', 'wed', 'fri']);
+      expect(result).toBe('月, 水, 金');
+    });
+
+    it('1曜日のみの場合はその曜日ラベルを返す', () => {
+      expect(ScheduleEntity.formatDaysOfWeekSummary(['tue'])).toBe('火');
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -438,4 +438,44 @@ export class ScheduleEntity {
   static hasAnyOverlap(overlaps: { scheduleIds: string[]; time: string; day: string }[]): boolean {
     return overlaps.length > 0;
   }
+
+  private static readonly VALID_DAYS: readonly DayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+  /**
+   * 曜日配列のバリデーション
+   */
+  static validateDaysOfWeek(days: string[]): { valid: boolean; error?: string } {
+    for (const day of days) {
+      if (!ScheduleEntity.VALID_DAYS.includes(day as DayOfWeek)) {
+        return { valid: false, error: `無効な曜日が含まれています: ${day}` };
+      }
+    }
+    return { valid: true };
+  }
+
+  /**
+   * 曜日配列の正規化（重複除去・曜日順ソート）
+   */
+  static normalizeDaysOfWeek(days: DayOfWeek[]): DayOfWeek[] {
+    const unique = [...new Set(days)];
+    return unique.sort((a, b) =>
+      ScheduleEntity.VALID_DAYS.indexOf(a) - ScheduleEntity.VALID_DAYS.indexOf(b),
+    );
+  }
+
+  /**
+   * 曜日配列をサマリーテキストにフォーマットする
+   */
+  static formatDaysOfWeekSummary(days: DayOfWeek[]): string {
+    if (days.length === 0 || days.length === 7) return '毎日';
+
+    const sorted = ScheduleEntity.normalizeDaysOfWeek(days);
+    const weekdays: DayOfWeek[] = ['mon', 'tue', 'wed', 'thu', 'fri'];
+    const weekend: DayOfWeek[] = ['sat', 'sun'];
+
+    if (sorted.length === 5 && weekdays.every((d) => sorted.includes(d))) return '平日';
+    if (sorted.length === 2 && weekend.every((d) => sorted.includes(d))) return '週末';
+
+    return sorted.map((d) => ScheduleEntity.DAY_LABELS[d]).join(', ');
+  }
 }


### PR DESCRIPTION
## Summary
- validateDaysOfWeek: 曜日配列のバリデーション
- normalizeDaysOfWeek: 重複除去・曜日順ソート
- formatDaysOfWeekSummary: 毎日/平日/週末等のサマリーテキスト生成

## Test plan
- [ ] 新規14テスト含め全2105テストがパスすること