### PR TITLE
Phase23エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangeFormat.edge.test.ts
+++ b/src/__tests__/domain/entities/DateRangeFormat.edge.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper 期間フォーマット エッジケース', () => {
+  describe('formatDateRange', () => {
+    it('年をまたぐ範囲をフォーマットする', () => {
+      const start = new Date('2025-12-25');
+      const end = new Date('2026-01-05');
+      expect(DateRangeHelper.formatDateRange(start, end)).toBe('12月25日〜1月5日');
+    });
+
+    it('1月1日同士は1日だけ表示する', () => {
+      const date = new Date('2025-01-01');
+      expect(DateRangeHelper.formatDateRange(date, date)).toBe('1月1日');
+    });
+  });
+
+  describe('formatRelativeDate', () => {
+    const today = new Date('2025-06-15');
+
+    it('1日前は昨日を返す', () => {
+      expect(DateRangeHelper.formatRelativeDate(new Date('2025-06-14'), today)).toBe('昨日');
+    });
+
+    it('ちょうど7日前は7日前を返す', () => {
+      expect(DateRangeHelper.formatRelativeDate(new Date('2025-06-08'), today)).toBe('7日前');
+    });
+  });
+
+  describe('getDateRangeDescription', () => {
+    it('2日間は2日間を返す', () => {
+      expect(DateRangeHelper.getDateRangeDescription(2)).toBe('2日間');
+    });
+
+    it('21日間は3週間を返す', () => {
+      expect(DateRangeHelper.getDateRangeDescription(21)).toBe('3週間');
+    });
+
+    it('60日間は約2ヶ月を返す', () => {
+      expect(DateRangeHelper.getDateRangeDescription(60)).toBe('約2ヶ月');
+    });
+
+    it('730日間は約2年を返す', () => {
+      expect(DateRangeHelper.getDateRangeDescription(730)).toBe('約2年');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleDayValidation.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleDayValidation.edge.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity 曜日バリデーション エッジケース', () => {
+  describe('validateDaysOfWeek', () => {
+    it('重複した曜日を含む配列も有効', () => {
+      const result = ScheduleEntity.validateDaysOfWeek(['mon', 'mon']);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('normalizeDaysOfWeek', () => {
+    it('全7曜日の重複をソート・除去する', () => {
+      const result = ScheduleEntity.normalizeDaysOfWeek(['sat', 'sun', 'sat', 'mon', 'fri', 'tue', 'wed', 'thu']);
+      expect(result).toEqual(['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']);
+    });
+
+    it('1曜日のみの場合はそのまま返す', () => {
+      expect(ScheduleEntity.normalizeDaysOfWeek(['wed'])).toEqual(['wed']);
+    });
+  });
+
+  describe('formatDaysOfWeekSummary', () => {
+    it('月水金のみの場合はカンマ区切りで返す', () => {
+      expect(ScheduleEntity.formatDaysOfWeekSummary(['mon', 'wed', 'fri'])).toBe('月, 水, 金');
+    });
+
+    it('土のみの場合は土を返す', () => {
+      expect(ScheduleEntity.formatDaysOfWeekSummary(['sat'])).toBe('土');
+    });
+
+    it('平日+土は平日とはみなさない', () => {
+      const result = ScheduleEntity.formatDaysOfWeekSummary(['mon', 'tue', 'wed', 'thu', 'fri', 'sat']);
+      expect(result).not.toBe('平日');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockOverallSummary.edge.test.ts
+++ b/src/__tests__/domain/entities/StockOverallSummary.edge.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity 在庫全体サマリー エッジケース', () => {
+  describe('getOverallStockMessage', () => {
+    it('全カテゴリにアラートがある場合は緊急を優先する', () => {
+      const msg = StockAlertEntity.getOverallStockMessage(1, 1, 1);
+      expect(msg).toContain('緊急');
+    });
+
+    it('警告と注意のみの場合は注意を返す', () => {
+      const msg = StockAlertEntity.getOverallStockMessage(0, 1, 1);
+      expect(msg).toContain('注意');
+    });
+  });
+
+  describe('getCriticalAlertCount', () => {
+    it('全て0日の場合は全件カウントする', () => {
+      expect(StockAlertEntity.getCriticalAlertCount([0, 0, 0])).toBe(3);
+    });
+
+    it('境界値4日はカウントしない', () => {
+      expect(StockAlertEntity.getCriticalAlertCount([4])).toBe(0);
+    });
+
+    it('境界値3日はカウントする', () => {
+      expect(StockAlertEntity.getCriticalAlertCount([3])).toBe(1);
+    });
+  });
+
+  describe('getAlertPriorityMessage', () => {
+    it('全ての優先度でメッセージが返る', () => {
+      const priorities: ('critical' | 'urgent' | 'warning' | 'normal')[] = ['critical', 'urgent', 'warning', 'normal'];
+      for (const p of priorities) {
+        expect(StockAlertEntity.getAlertPriorityMessage(p)).toBeTruthy();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ScheduleDayValidation.edge.test.ts (6テスト)
- DateRangeFormat.edge.test.ts (8テスト)
- StockOverallSummary.edge.test.ts (6テスト)

## Test plan
- [ ] 新規20テスト含め全2155テストがパスすること