### PR TITLE
スケジュールAPI PUT/DELETEにレート制限を追加

### DIFF
--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { updateScheduleSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 const findSchedule = (id: string) => prisma.schedule.findUnique({ where: { id } });
 
@@ -10,6 +11,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ sche
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`schedules-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
     const { scheduleId } = await params;
     return withOwnershipCheck({
       userId,
@@ -33,6 +37,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ sche
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ scheduleId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`schedules-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { scheduleId } = await params;
     return withOwnershipCheck({
       userId,


### PR DESCRIPTION
## Summary
- スケジュールAPI（/api/schedules/[scheduleId]）のPUT・DELETEにレート制限追加
- PUT: 20回/分、DELETE: 10回/分

## Test plan
- [ ] 全2155テストがパスすること