### PR TITLE
CalendarEntityに日付選択ヘルパーメソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarDateAttribute.test.ts
+++ b/src/__tests__/domain/entities/CalendarDateAttribute.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity 日付選択ヘルパー', () => {
+  describe('getDateAttribute', () => {
+    const today = new Date('2025-06-15');
+
+    it('今日はtodayを返す', () => {
+      expect(CalendarEntity.getDateAttribute(new Date('2025-06-15'), today)).toBe('today');
+    });
+
+    it('昨日はpastを返す', () => {
+      expect(CalendarEntity.getDateAttribute(new Date('2025-06-14'), today)).toBe('past');
+    });
+
+    it('明日はfutureを返す', () => {
+      expect(CalendarEntity.getDateAttribute(new Date('2025-06-16'), today)).toBe('future');
+    });
+
+    it('1週間前はpastを返す', () => {
+      expect(CalendarEntity.getDateAttribute(new Date('2025-06-08'), today)).toBe('past');
+    });
+  });
+
+  describe('isDateInCurrentMonth', () => {
+    it('同月の日付はtrueを返す', () => {
+      expect(CalendarEntity.isDateInCurrentMonth(new Date('2025-06-15'), 2025, 5)).toBe(true);
+    });
+
+    it('前月の日付はfalseを返す', () => {
+      expect(CalendarEntity.isDateInCurrentMonth(new Date('2025-05-31'), 2025, 5)).toBe(false);
+    });
+
+    it('翌月の日付はfalseを返す', () => {
+      expect(CalendarEntity.isDateInCurrentMonth(new Date('2025-07-01'), 2025, 5)).toBe(false);
+    });
+
+    it('1月の判定（monthは0-indexed）', () => {
+      expect(CalendarEntity.isDateInCurrentMonth(new Date('2025-01-15'), 2025, 0)).toBe(true);
+    });
+
+    it('12月の判定', () => {
+      expect(CalendarEntity.isDateInCurrentMonth(new Date('2025-12-25'), 2025, 11)).toBe(true);
+    });
+  });
+
+  describe('getDateStatusLabel', () => {
+    const today = new Date('2025-06-15');
+
+    it('todayは今日を返す', () => {
+      expect(CalendarEntity.getDateStatusLabel('today')).toBe('今日');
+    });
+
+    it('pastは過去を返す', () => {
+      expect(CalendarEntity.getDateStatusLabel('past')).toBe('過去');
+    });
+
+    it('futureは未来を返す', () => {
+      expect(CalendarEntity.getDateStatusLabel('future')).toBe('未来');
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -259,4 +259,33 @@ export class CalendarEntity {
     if (recordDays === totalDays) return '毎日記録がつけられています';
     return `${totalDays}日中${recordDays}日記録がつけられています`;
   }
+
+  /**
+   * 日付が今日・過去・未来のいずれかを判定する
+   */
+  static getDateAttribute(date: Date, today: Date): 'today' | 'past' | 'future' {
+    const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const t = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    if (d.getTime() === t.getTime()) return 'today';
+    return d.getTime() < t.getTime() ? 'past' : 'future';
+  }
+
+  /**
+   * 日付が指定月内かチェックする（monthは0-indexed）
+   */
+  static isDateInCurrentMonth(date: Date, year: number, month: number): boolean {
+    return date.getFullYear() === year && date.getMonth() === month;
+  }
+
+  /**
+   * 日付属性の日本語ラベルを返す
+   */
+  static getDateStatusLabel(attribute: 'today' | 'past' | 'future'): string {
+    const labels: Record<string, string> = {
+      today: '今日',
+      past: '過去',
+      future: '未来',
+    };
+    return labels[attribute];
+  }
 }


### PR DESCRIPTION
## Summary
- getDateAttribute: 日付が今日・過去・未来のいずれかを判定
- isDateInCurrentMonth: 日付が指定月内かチェック
- getDateStatusLabel: 日付属性の日本語ラベル

## Test plan
- [ ] 新規12テスト含め全2182テストがパスすること