### PR TITLE
Phase24エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarDateAttribute.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarDateAttribute.edge.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity 日付選択ヘルパー エッジケース', () => {
+  describe('getDateAttribute', () => {
+    it('年末と年始は異なる日と判定する', () => {
+      const dec31 = new Date('2025-12-31');
+      const jan1 = new Date('2026-01-01');
+      expect(CalendarEntity.getDateAttribute(dec31, jan1)).toBe('past');
+    });
+
+    it('同日の異なる時刻はtodayを返す', () => {
+      const morning = new Date('2025-06-15T08:00:00');
+      const evening = new Date('2025-06-15T20:00:00');
+      expect(CalendarEntity.getDateAttribute(morning, evening)).toBe('today');
+    });
+  });
+
+  describe('isDateInCurrentMonth', () => {
+    it('うるう年2月29日は2月に含まれる', () => {
+      expect(CalendarEntity.isDateInCurrentMonth(new Date('2024-02-29'), 2024, 1)).toBe(true);
+    });
+
+    it('異なる年の同月はfalseを返す', () => {
+      expect(CalendarEntity.isDateInCurrentMonth(new Date('2024-06-15'), 2025, 5)).toBe(false);
+    });
+  });
+
+  describe('getDateStatusLabel', () => {
+    it('全属性にラベルが返る', () => {
+      const attrs: ('today' | 'past' | 'future')[] = ['today', 'past', 'future'];
+      for (const a of attrs) {
+        expect(CalendarEntity.getDateStatusLabel(a)).toBeTruthy();
+      }
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HealthLogSymptomTrend.edge.test.ts
+++ b/src/__tests__/domain/entities/HealthLogSymptomTrend.edge.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity 症状トレンド エッジケース', () => {
+  describe('getSymptomTrendMessage', () => {
+    it('差が2の場合は増加と判定する', () => {
+      const msg = HealthLogEntity.getSymptomTrendMessage(4, 2);
+      expect(msg).toContain('増加');
+    });
+
+    it('差が-2の場合は減少と判定する', () => {
+      const msg = HealthLogEntity.getSymptomTrendMessage(1, 3);
+      expect(msg).toContain('減少');
+    });
+
+    it('両方0の場合は変化なし', () => {
+      const msg = HealthLogEntity.getSymptomTrendMessage(0, 0);
+      expect(msg).toContain('変化');
+    });
+  });
+
+  describe('getConditionImprovementRate', () => {
+    it('5から1への悪化は-4を返す', () => {
+      expect(HealthLogEntity.getConditionImprovementRate(1, 5)).toBe(-4);
+    });
+
+    it('1から5への改善は4を返す', () => {
+      expect(HealthLogEntity.getConditionImprovementRate(5, 1)).toBe(4);
+    });
+  });
+
+  describe('getRecordFrequencyMessage', () => {
+    it('30日中15日は順調', () => {
+      const msg = HealthLogEntity.getRecordFrequencyMessage(15, 30);
+      expect(msg).toContain('順調');
+    });
+
+    it('30日中30日は毎日', () => {
+      const msg = HealthLogEntity.getRecordFrequencyMessage(30, 30);
+      expect(msg).toContain('毎日');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationFrequencyValidation.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationFrequencyValidation.edge.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity 頻度バリデーション エッジケース', () => {
+  describe('validateFrequency', () => {
+    it('大文字のDAILYは無効', () => {
+      expect(MedicationEntity.validateFrequency('DAILY')).toBe(false);
+    });
+
+    it('スペース付きは無効', () => {
+      expect(MedicationEntity.validateFrequency(' daily ')).toBe(false);
+    });
+  });
+
+  describe('getAllFrequencies', () => {
+    it('as_neededを含む', () => {
+      const freqs = MedicationEntity.getAllFrequencies();
+      expect(freqs.some((f) => f.id === 'as_needed')).toBe(true);
+    });
+
+    it('各ラベルが空でない', () => {
+      const freqs = MedicationEntity.getAllFrequencies();
+      for (const f of freqs) {
+        expect(f.label.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('getFrequencySummary', () => {
+    it('未知の頻度コードはそのまま表示する', () => {
+      const result = MedicationEntity.getFrequencySummary('custom_freq', '1錠');
+      expect(result).toContain('custom_freq');
+    });
+
+    it('用量が空文字の場合は頻度のみ返す', () => {
+      const result = MedicationEntity.getFrequencySummary('daily', '');
+      expect(result).toBe('毎日');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MedicationFrequencyValidation.edge.test.ts (6テスト)
- CalendarDateAttribute.edge.test.ts (5テスト)
- HealthLogSymptomTrend.edge.test.ts (7テスト)

## Test plan
- [ ] 新規18テスト含め全2212テストがパスすること