### PR TITLE
予約API PUT/DELETEにレート制限を追加

### DIFF
--- a/src/app/api/appointments/[appointmentId]/route.ts
+++ b/src/app/api/appointments/[appointmentId]/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { updateAppointmentSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 const findAppointment = (id: string) => prisma.appointment.findUnique({ where: { id } });
 
@@ -10,6 +11,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ appo
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`appointments-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
     const { appointmentId } = await params;
     return withOwnershipCheck({
       userId,
@@ -39,6 +43,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ appo
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ appointmentId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`appointments-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { appointmentId } = await params;
     return withOwnershipCheck({
       userId,


### PR DESCRIPTION
## Summary
- 予約API（/api/appointments/[appointmentId]）のPUT・DELETEにレート制限追加
- PUT: 20回/分、DELETE: 10回/分

## Test plan
- [ ] 全2212テストがパスすること