### PR TITLE
MathHelperに標準偏差・最頻値計算メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/MathHelperStatsExt.test.ts
+++ b/src/__tests__/domain/entities/MathHelperStatsExt.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper 統計拡張', () => {
+  describe('calculateStdDev', () => {
+    it('空配列は0を返す', () => {
+      expect(MathHelper.calculateStdDev([])).toBe(0);
+    });
+
+    it('1要素は0を返す', () => {
+      expect(MathHelper.calculateStdDev([5])).toBe(0);
+    });
+
+    it('同じ値の配列は0を返す', () => {
+      expect(MathHelper.calculateStdDev([3, 3, 3])).toBe(0);
+    });
+
+    it('[2, 4, 4, 4, 5, 5, 7, 9]の標準偏差を計算する', () => {
+      const result = MathHelper.calculateStdDev([2, 4, 4, 4, 5, 5, 7, 9]);
+      expect(result).toBeGreaterThan(1.5);
+      expect(result).toBeLessThan(2.5);
+    });
+
+    it('[1, 2, 3, 4, 5]の標準偏差を計算する', () => {
+      const result = MathHelper.calculateStdDev([1, 2, 3, 4, 5]);
+      expect(result).toBeGreaterThan(1);
+      expect(result).toBeLessThan(2);
+    });
+  });
+
+  describe('calculateMode', () => {
+    it('空配列はnullを返す', () => {
+      expect(MathHelper.calculateMode([])).toBeNull();
+    });
+
+    it('1要素はその値を返す', () => {
+      expect(MathHelper.calculateMode([5])).toBe(5);
+    });
+
+    it('最頻値を正しく返す', () => {
+      expect(MathHelper.calculateMode([1, 2, 2, 3, 3, 3])).toBe(3);
+    });
+
+    it('全て同じ頻度の場合は最初の値を返す', () => {
+      expect(MathHelper.calculateMode([1, 2, 3])).toBe(1);
+    });
+
+    it('2つの最頻値がある場合は最初に出現した方を返す', () => {
+      expect(MathHelper.calculateMode([1, 1, 2, 2, 3])).toBe(1);
+    });
+  });
+
+  describe('getVariabilityLabel', () => {
+    it('標準偏差0は安定を返す', () => {
+      expect(MathHelper.getVariabilityLabel(0)).toBe('安定');
+    });
+
+    it('標準偏差1以下は安定を返す', () => {
+      expect(MathHelper.getVariabilityLabel(1)).toBe('安定');
+    });
+
+    it('標準偏差2はやや不安定を返す', () => {
+      expect(MathHelper.getVariabilityLabel(2)).toBe('やや不安定');
+    });
+
+    it('標準偏差3以上は不安定を返す', () => {
+      expect(MathHelper.getVariabilityLabel(3)).toBe('不安定');
+    });
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -43,4 +43,43 @@ export class MathHelper {
   static clamp(value: number, min: number, max: number): number {
     return Math.min(Math.max(value, min), max);
   }
+
+  /**
+   * 標準偏差を算出する（母集団標準偏差）
+   */
+  static calculateStdDev(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    const variance = values.reduce((sum, v) => sum + (v - avg) ** 2, 0) / values.length;
+    return Math.round(Math.sqrt(variance) * 100) / 100;
+  }
+
+  /**
+   * 最頻値を算出する（同頻度の場合は最初の値）
+   */
+  static calculateMode(values: number[]): number | null {
+    if (values.length === 0) return null;
+    const counts = new Map<number, number>();
+    for (const v of values) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+    let maxCount = 0;
+    let mode = values[0];
+    for (const [value, count] of counts) {
+      if (count > maxCount) {
+        maxCount = count;
+        mode = value;
+      }
+    }
+    return mode;
+  }
+
+  /**
+   * ばらつき度合いのラベルを返す
+   */
+  static getVariabilityLabel(stdDev: number): string {
+    if (stdDev <= 1) return '安定';
+    if (stdDev < 3) return 'やや不安定';
+    return '不安定';
+  }
 }


### PR DESCRIPTION
## Summary
- calculateStdDev: 母集団標準偏差の計算
- calculateMode: 最頻値の計算
- getVariabilityLabel: ばらつき度合いのラベル

## Test plan
- [ ] 新規14テスト含め全2226テストがパスすること