### PR TITLE
AppointmentEntityに予約種別バリデーションメソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentTypeValidation.test.ts
+++ b/src/__tests__/domain/entities/AppointmentTypeValidation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity 予約種別バリデーション', () => {
+  describe('validateAppointmentType', () => {
+    it('checkupは有効', () => {
+      expect(AppointmentEntity.validateAppointmentType('checkup')).toBe(true);
+    });
+
+    it('treatmentは有効', () => {
+      expect(AppointmentEntity.validateAppointmentType('treatment')).toBe(true);
+    });
+
+    it('vaccinationは有効', () => {
+      expect(AppointmentEntity.validateAppointmentType('vaccination')).toBe(true);
+    });
+
+    it('unknownは無効', () => {
+      expect(AppointmentEntity.validateAppointmentType('unknown')).toBe(false);
+    });
+
+    it('空文字は無効', () => {
+      expect(AppointmentEntity.validateAppointmentType('')).toBe(false);
+    });
+  });
+
+  describe('getAllAppointmentTypes', () => {
+    it('全種別を返す', () => {
+      const types = AppointmentEntity.getAllAppointmentTypes();
+      expect(types.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('各種別にidとlabelがある', () => {
+      const types = AppointmentEntity.getAllAppointmentTypes();
+      for (const t of types) {
+        expect(t.id).toBeTruthy();
+        expect(t.label).toBeTruthy();
+      }
+    });
+
+    it('checkupを含む', () => {
+      const types = AppointmentEntity.getAllAppointmentTypes();
+      expect(types.some((t) => t.id === 'checkup')).toBe(true);
+    });
+  });
+
+  describe('getTypeDisplayInfo', () => {
+    it('checkupの表示情報を返す', () => {
+      const info = AppointmentEntity.getTypeDisplayInfo('checkup');
+      expect(info.label).toBe('定期検診');
+      expect(info.isValid).toBe(true);
+    });
+
+    it('未知の種別のisValidはfalse', () => {
+      const info = AppointmentEntity.getTypeDisplayInfo('unknown');
+      expect(info.isValid).toBe(false);
+    });
+
+    it('未知の種別のlabelはそのまま返す', () => {
+      const info = AppointmentEntity.getTypeDisplayInfo('custom');
+      expect(info.label).toBe('custom');
+    });
+
+    it('undefinedの場合は空ラベルを返す', () => {
+      const info = AppointmentEntity.getTypeDisplayInfo(undefined);
+      expect(info.label).toBe('');
+      expect(info.isValid).toBe(true);
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -278,4 +278,33 @@ export class AppointmentEntity {
       })
       .sort((a, b) => new Date(a.appointmentDate).getTime() - new Date(b.appointmentDate).getTime());
   }
+
+  /**
+   * 予約種別が有効か検証する
+   */
+  static validateAppointmentType(type: string): boolean {
+    return type in AppointmentEntity.typeLabels;
+  }
+
+  /**
+   * 全予約種別の一覧を返す
+   */
+  static getAllAppointmentTypes(): Array<{ id: string; label: string }> {
+    return Object.entries(AppointmentEntity.typeLabels).map(([id, label]) => ({
+      id,
+      label,
+    }));
+  }
+
+  /**
+   * 予約種別の表示情報を返す
+   */
+  static getTypeDisplayInfo(type?: string): { label: string; isValid: boolean } {
+    if (!type) return { label: '', isValid: true };
+    const label = AppointmentEntity.typeLabels[type];
+    return {
+      label: label || type,
+      isValid: !!label,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- validateAppointmentType: 予約種別の妥当性検証
- getAllAppointmentTypes: 全種別の一覧取得
- getTypeDisplayInfo: 種別の表示情報取得

## Test plan
- [ ] 新規12テスト含め全2238テストがパスすること