### PR TITLE
MedicationRecordEntityに記録バッチサマリーメソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/RecordBatchSummary.test.ts
+++ b/src/__tests__/domain/entities/RecordBatchSummary.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (overrides: Partial<MedicationRecord> = {}): MedicationRecord => ({
+  id: '1',
+  memberId: 'm1',
+  memberName: 'テスト太郎',
+  medicationId: 'med1',
+  medicationName: 'テスト薬',
+  userId: 'u1',
+  takenAt: new Date('2025-06-15T08:00:00'),
+  ...overrides,
+});
+
+describe('MedicationRecordEntity 記録バッチサマリー', () => {
+  describe('getBatchSummary', () => {
+    it('0件の場合は記録なしメッセージを返す', () => {
+      expect(MedicationRecordEntity.getBatchSummary(0, 0)).toContain('記録はありません');
+    });
+
+    it('全件完了の場合は完了メッセージを返す', () => {
+      const msg = MedicationRecordEntity.getBatchSummary(5, 5);
+      expect(msg).toContain('全');
+      expect(msg).toContain('完了');
+    });
+
+    it('一部完了の場合は件数を含むメッセージを返す', () => {
+      const msg = MedicationRecordEntity.getBatchSummary(3, 5);
+      expect(msg).toContain('3');
+      expect(msg).toContain('5');
+    });
+  });
+
+  describe('getMemberRecordCounts', () => {
+    it('空配列は空オブジェクトを返す', () => {
+      expect(MedicationRecordEntity.getMemberRecordCounts([])).toEqual({});
+    });
+
+    it('メンバー別に集計する', () => {
+      const records = [
+        createRecord({ memberId: 'm1', memberName: '太郎' }),
+        createRecord({ memberId: 'm1', memberName: '太郎' }),
+        createRecord({ memberId: 'm2', memberName: '花子' }),
+      ];
+      const counts = MedicationRecordEntity.getMemberRecordCounts(records);
+      expect(counts['太郎']).toBe(2);
+      expect(counts['花子']).toBe(1);
+    });
+
+    it('1メンバーのみの場合', () => {
+      const records = [
+        createRecord({ memberName: '太郎' }),
+        createRecord({ memberName: '太郎' }),
+      ];
+      const counts = MedicationRecordEntity.getMemberRecordCounts(records);
+      expect(counts['太郎']).toBe(2);
+    });
+  });
+
+  describe('getCompletionRateMessage', () => {
+    it('100%は完璧メッセージを返す', () => {
+      const msg = MedicationRecordEntity.getCompletionRateMessage(100);
+      expect(msg).toContain('完璧');
+    });
+
+    it('80%以上は良好メッセージを返す', () => {
+      const msg = MedicationRecordEntity.getCompletionRateMessage(85);
+      expect(msg).toContain('良');
+    });
+
+    it('50%以上は頑張りメッセージを返す', () => {
+      const msg = MedicationRecordEntity.getCompletionRateMessage(60);
+      expect(msg).toContain('もう少し');
+    });
+
+    it('50%未満は励ましメッセージを返す', () => {
+      const msg = MedicationRecordEntity.getCompletionRateMessage(30);
+      expect(msg).toContain('少しずつ');
+    });
+  });
+});

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -341,4 +341,34 @@ export class MedicationRecordEntity {
     const label = hours > 0 ? (mins > 0 ? `${hours}時間${mins}分` : `${hours}時間`) : `${mins}分`;
     return `前回の服薬から${label}以上空けてください`;
   }
+
+  /**
+   * 複数記録のバッチサマリーテキストを返す
+   */
+  static getBatchSummary(completed: number, total: number): string {
+    if (total === 0) return '記録はありません';
+    if (completed === total) return `全${total}件の服薬が完了しました`;
+    return `${total}件中${completed}件が完了しています`;
+  }
+
+  /**
+   * メンバー別の記録件数を集計する
+   */
+  static getMemberRecordCounts(records: MedicationRecord[]): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const r of records) {
+      counts[r.memberName] = (counts[r.memberName] || 0) + 1;
+    }
+    return counts;
+  }
+
+  /**
+   * 完了率に応じたメッセージを返す
+   */
+  static getCompletionRateMessage(rate: number): string {
+    if (rate >= 100) return '完璧です';
+    if (rate >= 80) return '良い調子です';
+    if (rate >= 50) return 'もう少しで達成です';
+    return '少しずつ頑張りましょう';
+  }
 }


### PR DESCRIPTION
## Summary
- getBatchSummary: 複数記録のバッチサマリーテキスト
- getMemberRecordCounts: メンバー別記録件数集計
- getCompletionRateMessage: 完了率に応じたメッセージ

## Test plan
- [ ] 新規10テスト含め全2248テストがパスすること