### PR TITLE
getTypeLabelをgetTypeDisplayInfoに委譲

### DIFF
--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -78,8 +78,7 @@ export class AppointmentEntity {
   };
 
   getTypeLabel(): string {
-    if (!this.appointment.appointmentType) return '';
-    return AppointmentEntity.typeLabels[this.appointment.appointmentType] || this.appointment.appointmentType;
+    return AppointmentEntity.getTypeDisplayInfo(this.appointment.appointmentType).label;
   }
 
   /**


### PR DESCRIPTION
## Summary
- AppointmentEntity.getTypeLabel内の直接参照をgetTypeDisplayInfo().labelに委譲

## Test plan
- [ ] 全2248テストがパスすること