### PR TITLE
feat: 在庫コスト計算メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/StockCostCalc.test.ts
+++ b/src/__tests__/domain/entities/StockCostCalc.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity 在庫コスト計算', () => {
+  describe('estimateRefillCost', () => {
+    it('必要量と単価からコストを算出する', () => {
+      expect(StockAlertEntity.estimateRefillCost(30, 50)).toBe(1500);
+    });
+
+    it('必要量が0ならコストは0', () => {
+      expect(StockAlertEntity.estimateRefillCost(0, 50)).toBe(0);
+    });
+
+    it('単価が0ならコストは0', () => {
+      expect(StockAlertEntity.estimateRefillCost(30, 0)).toBe(0);
+    });
+
+    it('負の必要量は0を返す', () => {
+      expect(StockAlertEntity.estimateRefillCost(-5, 50)).toBe(0);
+    });
+
+    it('小数を含む場合は切り上げる', () => {
+      expect(StockAlertEntity.estimateRefillCost(3, 33)).toBe(99);
+    });
+  });
+
+  describe('getMonthlyConsumptionCost', () => {
+    it('日消費量と単価から月間コストを算出する', () => {
+      // 1日2個 x 30日 x 10円 = 600円
+      expect(StockAlertEntity.getMonthlyConsumptionCost(2, 10)).toBe(600);
+    });
+
+    it('日消費量が0なら0を返す', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(0, 10)).toBe(0);
+    });
+
+    it('単価が0なら0を返す', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(2, 0)).toBe(0);
+    });
+
+    it('小数の日消費量でも計算できる', () => {
+      // 0.5 x 30 x 100 = 1500
+      expect(StockAlertEntity.getMonthlyConsumptionCost(0.5, 100)).toBe(1500);
+    });
+
+    it('負の日消費量は0を返す', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(-1, 10)).toBe(0);
+    });
+  });
+
+  describe('getCostEfficiencyLabel', () => {
+    it('月間コストが1000円未満は低コスト', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(500)).toBe('低コスト');
+    });
+
+    it('月間コストが1000円以上5000円未満は標準', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(3000)).toBe('標準');
+    });
+
+    it('月間コストが5000円以上10000円未満はやや高額', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(7000)).toBe('やや高額');
+    });
+
+    it('月間コストが10000円以上は高額', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(15000)).toBe('高額');
+    });
+
+    it('0円は低コスト', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(0)).toBe('低コスト');
+    });
+  });
+});

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -261,4 +261,30 @@ export class StockAlertEntity {
     };
     return messages[urgency];
   }
+
+  /**
+   * 補充コストの概算を返す（必要量 x 単価）
+   */
+  static estimateRefillCost(quantity: number, unitPrice: number): number {
+    if (quantity <= 0 || unitPrice <= 0) return 0;
+    return Math.ceil(quantity * unitPrice);
+  }
+
+  /**
+   * 月間消費コストを算出する（日消費量 x 30日 x 単価）
+   */
+  static getMonthlyConsumptionCost(dailyConsumption: number, unitPrice: number): number {
+    if (dailyConsumption <= 0 || unitPrice <= 0) return 0;
+    return Math.round(dailyConsumption * 30 * unitPrice);
+  }
+
+  /**
+   * 月間コストに応じた効率ラベルを返す
+   */
+  static getCostEfficiencyLabel(monthlyCost: number): string {
+    if (monthlyCost < 1000) return '低コスト';
+    if (monthlyCost < 5000) return '標準';
+    if (monthlyCost < 10000) return 'やや高額';
+    return '高額';
+  }
 }


### PR DESCRIPTION
## Summary
- StockAlertEntityに補充コスト概算のestimateRefillCostを追加
- 月間消費コスト算出のgetMonthlyConsumptionCostを追加
- コスト効率ラベル返却のgetCostEfficiencyLabelを追加
- テスト15件追加（2301件全パス）

## Test plan
- [x] 必要量と単価から正しくコスト算出される
- [x] 月間消費コストが日消費量x30日x単価で算出される
- [x] コスト効率ラベルが閾値に応じて正しく返される
- [x] 境界値（0、負数）が正しく処理される

closes #499