### PR TITLE
refactor: isActiveOnDayのdayMapをDAY_MAPに統一

### DIFF
--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -71,17 +71,7 @@ export class ScheduleEntity {
       return true;
     }
 
-    const dayMap: Record<number, DayOfWeek> = {
-      0: 'sun',
-      1: 'mon',
-      2: 'tue',
-      3: 'wed',
-      4: 'thu',
-      5: 'fri',
-      6: 'sat',
-    };
-
-    const dayOfWeek = dayMap[date.getDay()];
+    const dayOfWeek = ScheduleEntity.DAY_MAP[date.getDay()];
     return this.schedule.daysOfWeek.includes(dayOfWeek);
   }
 


### PR DESCRIPTION
## Summary
- isActiveOnDay内のローカルdayMap定義を削除
- Phase 1で追加したstaticなDAY_MAPプロパティに委譲
- 重複した曜日マッピング定義を解消

## Test plan
- [x] 既存テスト2313件全パス
- [x] isActiveOnDayの動作に変更なし

closes #503