### PR TITLE
test: Cycle26エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/MemberPetAge.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberPetAge.edge.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberPetAge エッジケース', () => {
+  describe('getHumanEquivalentAge', () => {
+    it('年齢0は0を返す', () => {
+      expect(MemberEntity.getHumanEquivalentAge(0, 'dog')).toBe(0);
+    });
+
+    it('年齢20の犬は人間換算96歳', () => {
+      // 24 + (20-2)*4 = 24 + 72 = 96
+      expect(MemberEntity.getHumanEquivalentAge(20, 'dog')).toBe(96);
+    });
+
+    it('birdタイプはnullを返す', () => {
+      expect(MemberEntity.getHumanEquivalentAge(5, 'bird')).toBeNull();
+    });
+
+    it('otherタイプはnullを返す', () => {
+      expect(MemberEntity.getHumanEquivalentAge(3, 'other')).toBeNull();
+    });
+  });
+
+  describe('getPetLifeStage', () => {
+    it('犬6歳は成犬（境界値）', () => {
+      expect(MemberEntity.getPetLifeStage(6, 'dog')).toBe('成犬');
+    });
+
+    it('犬7歳はシニア犬（境界値）', () => {
+      expect(MemberEntity.getPetLifeStage(7, 'dog')).toBe('シニア犬');
+    });
+
+    it('猫1歳は成猫（境界値）', () => {
+      expect(MemberEntity.getPetLifeStage(1, 'cat')).toBe('成猫');
+    });
+
+    it('birdの年齢指定はペットを返す', () => {
+      expect(MemberEntity.getPetLifeStage(5, 'bird')).toBe('ペット');
+    });
+  });
+
+  describe('getPetAgeLabel', () => {
+    it('猫0歳は人間換算0歳', () => {
+      const label = MemberEntity.getPetAgeLabel(0, 'cat');
+      expect(label).toContain('0歳');
+      expect(label).toContain('人間換算');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/NextScheduleCalc.edge.test.ts
+++ b/src/__tests__/domain/entities/NextScheduleCalc.edge.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity, DayOfWeek } from '@/domain/entities/Schedule';
+
+describe('NextScheduleCalc エッジケース', () => {
+  describe('getNextScheduledDay', () => {
+    it('今日と同じ曜日のみ対象なら翌週の同じ曜日を返す', () => {
+      // 2026-03-02 月曜 → 月曜のみ → 翌週月曜
+      const today = new Date(2026, 2, 2);
+      const days: DayOfWeek[] = ['mon'];
+      expect(ScheduleEntity.getNextScheduledDay(today, days)).toBe('mon');
+    });
+
+    it('年またぎでも正しく動作する', () => {
+      // 2025-12-31 水曜 → 木曜のみ → 2026-01-01 木曜
+      const today = new Date(2025, 11, 31);
+      const days: DayOfWeek[] = ['thu'];
+      expect(ScheduleEntity.getNextScheduledDay(today, days)).toBe('thu');
+    });
+
+    it('月またぎでも正しく動作する', () => {
+      // 2026-02-28 土曜 → 日曜 → 2026-03-01
+      const today = new Date(2026, 1, 28);
+      const days: DayOfWeek[] = ['sun'];
+      expect(ScheduleEntity.getNextScheduledDay(today, days)).toBe('sun');
+    });
+  });
+
+  describe('getNextScheduledDateTime', () => {
+    it('年またぎで正しい日時を返す', () => {
+      const today = new Date(2025, 11, 31);
+      const result = ScheduleEntity.getNextScheduledDateTime(today, '10:00', []);
+      expect(result.getFullYear()).toBe(2026);
+      expect(result.getMonth()).toBe(0);
+      expect(result.getDate()).toBe(1);
+    });
+
+    it('深夜の時刻でも正しく設定される', () => {
+      const today = new Date(2026, 2, 5);
+      const result = ScheduleEntity.getNextScheduledDateTime(today, '23:59', []);
+      expect(result.getHours()).toBe(23);
+      expect(result.getMinutes()).toBe(59);
+    });
+  });
+
+  describe('getDaysUntilNextSchedule', () => {
+    it('全曜日指定なら常に1', () => {
+      const today = new Date(2026, 2, 5);
+      const allDays: DayOfWeek[] = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+      expect(ScheduleEntity.getDaysUntilNextSchedule(today, allDays)).toBe(1);
+    });
+
+    it('翌日のみ対象なら1を返す', () => {
+      // 2026-03-05 木曜 → 金曜のみ
+      const today = new Date(2026, 2, 5);
+      const days: DayOfWeek[] = ['fri'];
+      expect(ScheduleEntity.getDaysUntilNextSchedule(today, days)).toBe(1);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockCostCalc.edge.test.ts
+++ b/src/__tests__/domain/entities/StockCostCalc.edge.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockCostCalc エッジケース', () => {
+  describe('estimateRefillCost', () => {
+    it('極大値でも計算できる', () => {
+      expect(StockAlertEntity.estimateRefillCost(10000, 100)).toBe(1000000);
+    });
+
+    it('小数の単価で切り上げされる', () => {
+      // 3 * 33.3 = 99.9 → 切り上げ100
+      expect(StockAlertEntity.estimateRefillCost(3, 33.3)).toBe(100);
+    });
+
+    it('両方負の場合は0を返す', () => {
+      expect(StockAlertEntity.estimateRefillCost(-1, -1)).toBe(0);
+    });
+  });
+
+  describe('getMonthlyConsumptionCost', () => {
+    it('極小消費量でも計算できる', () => {
+      // 0.1 * 30 * 50 = 150
+      expect(StockAlertEntity.getMonthlyConsumptionCost(0.1, 50)).toBe(150);
+    });
+
+    it('大量消費の場合', () => {
+      // 10 * 30 * 1000 = 300000
+      expect(StockAlertEntity.getMonthlyConsumptionCost(10, 1000)).toBe(300000);
+    });
+  });
+
+  describe('getCostEfficiencyLabel', () => {
+    it('999円は低コスト（境界値）', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(999)).toBe('低コスト');
+    });
+
+    it('1000円は標準（境界値）', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(1000)).toBe('標準');
+    });
+
+    it('4999円は標準（境界値）', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(4999)).toBe('標準');
+    });
+
+    it('5000円はやや高額（境界値）', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(5000)).toBe('やや高額');
+    });
+
+    it('10000円は高額（境界値）', () => {
+      expect(StockAlertEntity.getCostEfficiencyLabel(10000)).toBe('高額');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MemberPetAge: 年齢0、極大値、非対応ペットタイプの境界値テスト9件追加
- StockCostCalc: 極大値、小数精度、境界値テスト10件追加
- NextScheduleCalc: 年またぎ、月またぎ、全曜日指定のエッジケーステスト7件追加
- テスト合計2339件全パス

## Test plan
- [x] 全エッジケーステスト26件パス
- [x] 既存テストへの影響なし

closes #505