### PR TITLE
fix: records/health-logs/stockルートにレート制限を追加

### DIFF
--- a/src/app/api/health-logs/[logId]/route.ts
+++ b/src/app/api/health-logs/[logId]/route.ts
@@ -1,9 +1,12 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ logId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`health-logs-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { logId } = await params;
     return withOwnershipCheck({
       userId,

--- a/src/app/api/medications/[medicationId]/stock/route.ts
+++ b/src/app/api/medications/[medicationId]/stock/route.ts
@@ -3,6 +3,7 @@ import { updateStockSchema } from '@/lib/schemas';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 const findMedicationWithMember = (id: string) =>
   prisma.medication.findUnique({ where: { id }, include: { member: true } });
@@ -12,6 +13,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`stock-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({
       userId,

--- a/src/app/api/records/[recordId]/route.ts
+++ b/src/app/api/records/[recordId]/route.ts
@@ -1,11 +1,14 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 
 const findRecord = (id: string) => prisma.medicationRecord.findUnique({ where: { id } });
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ recordId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`records-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { recordId } = await params;
     return withOwnershipCheck({
       userId,


### PR DESCRIPTION
## Summary
- /api/records/[recordId] DELETEにレート制限（10req/min）を追加
- /api/health-logs/[logId] DELETEにレート制限（10req/min）を追加
- /api/medications/[medicationId]/stock PUTにレート制限（20req/min）を追加
- 全書き込み系APIルートのレート制限が完了

## Test plan
- [x] 2339件全テストパス
- [x] 既存動作への影響なし

closes #507