### PR TITLE
feat: 通院予約リマインダー日時計算メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentReminderCalc.test.ts
+++ b/src/__tests__/domain/entities/AppointmentReminderCalc.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity リマインダー日時計算', () => {
+  describe('getReminderDate', () => {
+    it('予約3日前のリマインダー日を返す', () => {
+      const appointmentDate = new Date(2026, 2, 10);
+      const result = AppointmentEntity.getReminderDate(appointmentDate, 3);
+      expect(result.getFullYear()).toBe(2026);
+      expect(result.getMonth()).toBe(2);
+      expect(result.getDate()).toBe(7);
+    });
+
+    it('予約当日のリマインダーは同日を返す', () => {
+      const appointmentDate = new Date(2026, 2, 10);
+      const result = AppointmentEntity.getReminderDate(appointmentDate, 0);
+      expect(result.getDate()).toBe(10);
+    });
+
+    it('1週間前のリマインダーを返す', () => {
+      const appointmentDate = new Date(2026, 2, 15);
+      const result = AppointmentEntity.getReminderDate(appointmentDate, 7);
+      expect(result.getDate()).toBe(8);
+    });
+
+    it('月をまたぐリマインダー日を正しく算出する', () => {
+      const appointmentDate = new Date(2026, 2, 2);
+      const result = AppointmentEntity.getReminderDate(appointmentDate, 5);
+      expect(result.getMonth()).toBe(1); // 2月
+      expect(result.getDate()).toBe(25);
+    });
+  });
+
+  describe('formatReminderTiming', () => {
+    it('当日は当日を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(0)).toBe('当日');
+    });
+
+    it('1日前は前日を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(1)).toBe('前日');
+    });
+
+    it('3日前は3日前を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(3)).toBe('3日前');
+    });
+
+    it('7日前は1週間前を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(7)).toBe('1週間前');
+    });
+
+    it('14日前は2週間前を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(14)).toBe('2週間前');
+    });
+
+    it('5日前は5日前を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(5)).toBe('5日前');
+    });
+  });
+
+  describe('isReminderOverdue', () => {
+    it('リマインダー日が過去なら遅延', () => {
+      const today = new Date(2026, 2, 10);
+      const reminderDate = new Date(2026, 2, 8);
+      expect(AppointmentEntity.isReminderOverdue(reminderDate, today)).toBe(true);
+    });
+
+    it('リマインダー日が今日なら遅延ではない', () => {
+      const today = new Date(2026, 2, 10);
+      const reminderDate = new Date(2026, 2, 10);
+      expect(AppointmentEntity.isReminderOverdue(reminderDate, today)).toBe(false);
+    });
+
+    it('リマインダー日が未来なら遅延ではない', () => {
+      const today = new Date(2026, 2, 10);
+      const reminderDate = new Date(2026, 2, 12);
+      expect(AppointmentEntity.isReminderOverdue(reminderDate, today)).toBe(false);
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -298,6 +298,34 @@ export class AppointmentEntity {
   /**
    * 予約種別の表示情報を返す
    */
+  /**
+   * リマインダー送信日を算出する
+   */
+  static getReminderDate(appointmentDate: Date, daysBefore: number): Date {
+    const date = new Date(appointmentDate);
+    date.setDate(date.getDate() - daysBefore);
+    return date;
+  }
+
+  /**
+   * リマインダータイミングを日本語で表示する
+   */
+  static formatReminderTiming(daysBefore: number): string {
+    if (daysBefore === 0) return '当日';
+    if (daysBefore === 1) return '前日';
+    if (daysBefore % 7 === 0) return `${daysBefore / 7}週間前`;
+    return `${daysBefore}日前`;
+  }
+
+  /**
+   * リマインダーが遅延しているか判定する
+   */
+  static isReminderOverdue(reminderDate: Date, today: Date): boolean {
+    const reminderStart = DateRangeHelper.toStartOfDay(reminderDate);
+    const todayStart = DateRangeHelper.toStartOfDay(today);
+    return reminderStart.getTime() < todayStart.getTime();
+  }
+
   static getTypeDisplayInfo(type?: string): { label: string; isValid: boolean } {
     if (!type) return { label: '', isValid: true };
     const label = AppointmentEntity.typeLabels[type];


### PR DESCRIPTION
## Summary
- AppointmentEntityにリマインダー送信日を算出するgetReminderDateを追加
- リマインダータイミング表示のformatReminderTimingを追加
- リマインダー遅延判定のisReminderOverdueを追加
- テスト13件追加（2352件全パス）

## Test plan
- [x] 予約N日前のリマインダー日が正しく算出される
- [x] 月またぎでも正しく動作する
- [x] 当日/前日/N日前/N週間前の表示が正しい
- [x] 遅延判定が正しく動作する

closes #509