### PR TITLE
refactor: getConditionChangeRateをMathHelper.calculateChangeRateに委譲

### DIFF
--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -298,8 +298,7 @@ export class HealthLogEntity {
    * 前週との体調変化率を算出(%)
    */
   static getConditionChangeRate(currentAvg: number, previousAvg: number): number {
-    if (previousAvg === 0) return 0;
-    return Math.round(((currentAvg - previousAvg) / previousAvg) * 100);
+    return MathHelper.calculateChangeRate(previousAvg, currentAvg);
   }
 
   /**


### PR DESCRIPTION
## Summary
- HealthLogEntity.getConditionChangeRateの変化率計算をMathHelper.calculateChangeRateに委譲
- 重複した変化率計算ロジックを解消

## Test plan
- [x] 既存テスト2385件全パス
- [x] getConditionChangeRateの動作に変更なし

closes #515