### PR TITLE
test: Cycle27エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentReminderCalc.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentReminderCalc.edge.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentReminderCalc エッジケース', () => {
+  describe('getReminderDate', () => {
+    it('年またぎのリマインダー日を正しく算出する', () => {
+      const appointmentDate = new Date(2026, 0, 2); // 1月2日
+      const result = AppointmentEntity.getReminderDate(appointmentDate, 5);
+      expect(result.getFullYear()).toBe(2025);
+      expect(result.getMonth()).toBe(11); // 12月
+      expect(result.getDate()).toBe(28);
+    });
+
+    it('30日前のリマインダーを正しく算出する', () => {
+      const appointmentDate = new Date(2026, 2, 15);
+      const result = AppointmentEntity.getReminderDate(appointmentDate, 30);
+      expect(result.getMonth()).toBe(1); // 2月
+      expect(result.getDate()).toBe(13);
+    });
+  });
+
+  describe('formatReminderTiming', () => {
+    it('21日前は3週間前を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(21)).toBe('3週間前');
+    });
+
+    it('10日前は10日前を返す', () => {
+      expect(AppointmentEntity.formatReminderTiming(10)).toBe('10日前');
+    });
+  });
+
+  describe('isReminderOverdue', () => {
+    it('1ヶ月前のリマインダーは遅延', () => {
+      const today = new Date(2026, 2, 10);
+      const reminderDate = new Date(2026, 1, 10);
+      expect(AppointmentEntity.isReminderOverdue(reminderDate, today)).toBe(true);
+    });
+
+    it('同日の異なる時刻は遅延ではない', () => {
+      const today = new Date(2026, 2, 10, 15, 0);
+      const reminderDate = new Date(2026, 2, 10, 8, 0);
+      expect(AppointmentEntity.isReminderOverdue(reminderDate, today)).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HealthLogTemperatureClass.edge.test.ts
+++ b/src/__tests__/domain/entities/HealthLogTemperatureClass.edge.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogTemperatureClass エッジケース', () => {
+  describe('classifyTemperature', () => {
+    it('35.0度ちょうどは平熱（境界値）', () => {
+      expect(HealthLogEntity.classifyTemperature(35.0)).toBe('normal');
+    });
+
+    it('34.9度は低体温（境界値）', () => {
+      expect(HealthLogEntity.classifyTemperature(34.9)).toBe('hypothermia');
+    });
+
+    it('37.49度は平熱（境界値）', () => {
+      expect(HealthLogEntity.classifyTemperature(37.49)).toBe('normal');
+    });
+
+    it('38.99度は発熱（境界値）', () => {
+      expect(HealthLogEntity.classifyTemperature(38.99)).toBe('fever');
+    });
+
+    it('42.0度の高温は高熱', () => {
+      expect(HealthLogEntity.classifyTemperature(42.0)).toBe('high_fever');
+    });
+  });
+
+  describe('calculateHealthScore', () => {
+    it('体調レベル2で症状5なら0点（下限クランプ）', () => {
+      // 2/5*100=40, 5*10=50, 40-50=-10 → 0
+      expect(HealthLogEntity.calculateHealthScore(2, 5)).toBe(0);
+    });
+
+    it('体調レベル4で症状1なら70点', () => {
+      // 4/5*100=80, 1*10=10, 80-10=70
+      expect(HealthLogEntity.calculateHealthScore(4, 1)).toBe(70);
+    });
+
+    it('体調レベル1で症状5なら0点', () => {
+      // 1/5*100=20, 5*10=50, 20-50=-30 → 0
+      expect(HealthLogEntity.calculateHealthScore(1, 5)).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MathMovingAverage.edge.test.ts
+++ b/src/__tests__/domain/entities/MathMovingAverage.edge.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathMovingAverage エッジケース', () => {
+  describe('calculateMovingAverage', () => {
+    it('ウィンドウ1は元の配列を返す', () => {
+      expect(MathHelper.calculateMovingAverage([3, 5, 7], 1)).toEqual([3, 5, 7]);
+    });
+
+    it('全て同じ値なら移動平均も同じ値', () => {
+      expect(MathHelper.calculateMovingAverage([4, 4, 4, 4], 2)).toEqual([4, 4, 4]);
+    });
+
+    it('1要素の配列でウィンドウ1なら1要素を返す', () => {
+      expect(MathHelper.calculateMovingAverage([10], 1)).toEqual([10]);
+    });
+  });
+
+  describe('calculateChangeRate', () => {
+    it('0から0は変化率0', () => {
+      expect(MathHelper.calculateChangeRate(0, 0)).toBe(0);
+    });
+
+    it('大きな減少は-100に近い値', () => {
+      expect(MathHelper.calculateChangeRate(1000, 1)).toBe(-100);
+    });
+
+    it('微小な変化は丸められる', () => {
+      expect(MathHelper.calculateChangeRate(100, 101)).toBe(1);
+    });
+  });
+
+  describe('getChangeRateLabel', () => {
+    it('9%は横ばい（境界値）', () => {
+      expect(MathHelper.getChangeRateLabel(9)).toBe('横ばい');
+    });
+
+    it('10%は上昇（境界値）', () => {
+      expect(MathHelper.getChangeRateLabel(10)).toBe('上昇');
+    });
+
+    it('-10%は下降（境界値）', () => {
+      expect(MathHelper.getChangeRateLabel(-10)).toBe('下降');
+    });
+
+    it('-9%は横ばい（境界値）', () => {
+      expect(MathHelper.getChangeRateLabel(-9)).toBe('横ばい');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- AppointmentReminderCalc: 年またぎ、30日前、同日異時刻等6件追加
- HealthLogTemperatureClass: 体温境界値、スコア下限クランプ等8件追加
- MathMovingAverage: ウィンドウ1、全同値、変化率境界値等10件追加
- テスト合計2409件全パス

## Test plan
- [x] 全エッジケーステスト24件パス
- [x] 既存テストへの影響なし

closes #517