### PR TITLE
fix: ダッシュボード系GETルートにレート制限を追加

### DIFF
--- a/src/app/api/medications/alerts/route.ts
+++ b/src/app/api/medications/alerts/route.ts
@@ -1,10 +1,13 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { StockAlertEntity } from '@/domain/entities/StockAlert';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`medications-alerts-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
 
   const [medications, schedules] = await Promise.all([

--- a/src/app/api/members/summary/route.ts
+++ b/src/app/api/members/summary/route.ts
@@ -1,9 +1,12 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`members-summary-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const [members, medications, appointments] = await Promise.all([
     prisma.member.findMany({
       where: { userId },

--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -1,9 +1,12 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`schedules-today-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
   const todayStart = new Date(now);
   todayStart.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- /api/schedules/today GETにレート制限（30req/min）を追加
- /api/medications/alerts GETにレート制限（30req/min）を追加
- /api/members/summary GETにレート制限（30req/min）を追加
- ダッシュボード表示時の過剰リクエストを防止

## Test plan
- [x] 2409件全テストパス
- [x] 既存動作への影響なし

closes #519