### PR TITLE
feat: アドヒアランス週間比較メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceWeeklyCompare.test.ts
+++ b/src/__tests__/domain/entities/AdherenceWeeklyCompare.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity 週間比較', () => {
+  describe('getWeeklyComparison', () => {
+    it('改善の場合は正の差分を返す', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparison(80, 60);
+      expect(result.diff).toBe(20);
+      expect(result.direction).toBe('up');
+    });
+
+    it('悪化の場合は負の差分を返す', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparison(50, 70);
+      expect(result.diff).toBe(-20);
+      expect(result.direction).toBe('down');
+    });
+
+    it('変化なしの場合は0を返す', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparison(80, 80);
+      expect(result.diff).toBe(0);
+      expect(result.direction).toBe('stable');
+    });
+
+    it('5%以内の変化はstableとする', () => {
+      const result = AdherenceStatsEntity.getWeeklyComparison(83, 80);
+      expect(result.direction).toBe('stable');
+    });
+  });
+
+  describe('getWeeklyTrendLabel', () => {
+    it('upは改善を返す', () => {
+      expect(AdherenceStatsEntity.getWeeklyTrendLabel('up')).toBe('改善');
+    });
+
+    it('downは低下を返す', () => {
+      expect(AdherenceStatsEntity.getWeeklyTrendLabel('down')).toBe('低下');
+    });
+
+    it('stableは維持を返す', () => {
+      expect(AdherenceStatsEntity.getWeeklyTrendLabel('stable')).toBe('維持');
+    });
+  });
+
+  describe('getImprovementSuggestion', () => {
+    it('90%以上は維持メッセージ', () => {
+      const msg = AdherenceStatsEntity.getImprovementSuggestion(95);
+      expect(msg).toContain('維持');
+    });
+
+    it('70%以上はもう少しメッセージ', () => {
+      const msg = AdherenceStatsEntity.getImprovementSuggestion(75);
+      expect(msg).toContain('あと少し');
+    });
+
+    it('50%以上は習慣化メッセージ', () => {
+      const msg = AdherenceStatsEntity.getImprovementSuggestion(55);
+      expect(msg).toContain('習慣');
+    });
+
+    it('50%未満はリマインダーメッセージ', () => {
+      const msg = AdherenceStatsEntity.getImprovementSuggestion(30);
+      expect(msg).toContain('リマインダー');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -366,4 +366,38 @@ export class AdherenceStatsEntity {
   static getMilestoneAchievementMessage(streak: number): string | null {
     return AdherenceStatsEntity.milestoneMessages[streak] ?? null;
   }
+
+  /**
+   * 今週と先週の服薬率を比較する
+   */
+  static getWeeklyComparison(
+    currentRate: number,
+    previousRate: number,
+  ): { diff: number; direction: 'up' | 'down' | 'stable' } {
+    const diff = currentRate - previousRate;
+    if (Math.abs(diff) <= 5) return { diff, direction: 'stable' };
+    return { diff, direction: diff > 0 ? 'up' : 'down' };
+  }
+
+  /**
+   * 週間トレンドのラベルを返す
+   */
+  static getWeeklyTrendLabel(direction: 'up' | 'down' | 'stable'): string {
+    const labels: Record<string, string> = {
+      up: '改善',
+      down: '低下',
+      stable: '維持',
+    };
+    return labels[direction];
+  }
+
+  /**
+   * 服薬率に応じた改善提案メッセージを返す
+   */
+  static getImprovementSuggestion(rate: number): string {
+    if (rate >= 90) return 'この調子を維持しましょう';
+    if (rate >= 70) return 'あと少しで目標達成です';
+    if (rate >= 50) return '服薬を習慣化していきましょう';
+    return 'リマインダーを活用してみましょう';
+  }
 }


### PR DESCRIPTION
## Summary
- AdherenceStatsEntityに今週/先週比較のgetWeeklyComparisonを追加
- 週間トレンドラベルgetWeeklyTrendLabelを追加
- 改善提案メッセージgetImprovementSuggestionを追加
- テスト11件追加（2423件全パス）

## Test plan
- [x] 差分5%以内はstable判定される
- [x] 改善/悪化が正しく検出される
- [x] 服薬率に応じた適切なメッセージが返される

closes #523