### PR TITLE
feat: 用量フォーマット・日数換算メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationDosageFormat.test.ts
+++ b/src/__tests__/domain/entities/MedicationDosageFormat.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity 用量フォーマット', () => {
+  describe('formatDosageWithUnit', () => {
+    it('用量と単位を結合する', () => {
+      expect(MedicationEntity.formatDosageWithUnit(1, '錠')).toBe('1錠');
+    });
+
+    it('小数を含む用量を表示する', () => {
+      expect(MedicationEntity.formatDosageWithUnit(0.5, '錠')).toBe('0.5錠');
+    });
+
+    it('用量0の場合は0を表示する', () => {
+      expect(MedicationEntity.formatDosageWithUnit(0, '錠')).toBe('0錠');
+    });
+
+    it('ml単位の場合', () => {
+      expect(MedicationEntity.formatDosageWithUnit(5, 'ml')).toBe('5ml');
+    });
+  });
+
+  describe('getDailyDosageTotal', () => {
+    it('1回2錠x3回で6を返す', () => {
+      expect(MedicationEntity.getDailyDosageTotal(2, 3)).toBe(6);
+    });
+
+    it('1回0.5錠x2回で1を返す', () => {
+      expect(MedicationEntity.getDailyDosageTotal(0.5, 2)).toBe(1);
+    });
+
+    it('回数0の場合は0を返す', () => {
+      expect(MedicationEntity.getDailyDosageTotal(2, 0)).toBe(0);
+    });
+
+    it('用量0の場合は0を返す', () => {
+      expect(MedicationEntity.getDailyDosageTotal(0, 3)).toBe(0);
+    });
+  });
+
+  describe('getDosageWarningLevel', () => {
+    it('日用量10以上はhighを返す', () => {
+      expect(MedicationEntity.getDosageWarningLevel(12)).toBe('high');
+    });
+
+    it('日用量5以上10未満はmediumを返す', () => {
+      expect(MedicationEntity.getDosageWarningLevel(7)).toBe('medium');
+    });
+
+    it('日用量5未満はnormalを返す', () => {
+      expect(MedicationEntity.getDosageWarningLevel(3)).toBe('normal');
+    });
+
+    it('日用量0はnormalを返す', () => {
+      expect(MedicationEntity.getDosageWarningLevel(0)).toBe('normal');
+    });
+  });
+});

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -241,6 +241,29 @@ export class MedicationEntity {
   /**
    * 頻度と用量のサマリーテキストを返す
    */
+  /**
+   * 用量と単位を結合してフォーマットする
+   */
+  static formatDosageWithUnit(amount: number, unit: string): string {
+    return `${amount}${unit}`;
+  }
+
+  /**
+   * 1回の用量と1日の回数から日あたり総用量を算出する
+   */
+  static getDailyDosageTotal(dosagePerTime: number, timesPerDay: number): number {
+    return dosagePerTime * timesPerDay;
+  }
+
+  /**
+   * 日用量の注意レベルを判定する
+   */
+  static getDosageWarningLevel(dailyTotal: number): 'normal' | 'medium' | 'high' {
+    if (dailyTotal >= 10) return 'high';
+    if (dailyTotal >= 5) return 'medium';
+    return 'normal';
+  }
+
   static getFrequencySummary(frequency?: string, dosage?: string): string {
     const parts: string[] = [];
     if (frequency) {


### PR DESCRIPTION
## Summary
- MedicationEntityに用量フォーマットのformatDosageWithUnitを追加
- 日あたり総用量算出のgetDailyDosageTotalを追加
- 用量注意レベル判定のgetDosageWarningLevelを追加
- テスト12件追加（2435件全パス）

## Test plan
- [x] 用量と単位が正しく結合される
- [x] 日あたり総用量が正しく算出される
- [x] 注意レベルが閾値に応じて正しく判定される

closes #525