### PR TITLE
fix: データ取得系GETルートにレート制限を追加

### DIFF
--- a/src/app/api/medications/search/route.ts
+++ b/src/app/api/medications/search/route.ts
@@ -2,10 +2,13 @@ import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(request: NextRequest) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medications-search-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const q = request.nextUrl.searchParams.get('q')?.trim() ?? '';
     if (!q) {
       return errorResponse('検索キーワードを入力してください');

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -1,11 +1,14 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
 import { DateRangeHelper } from '@/domain/entities/DateRange';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`records-stats-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
   const sevenDaysAgo = DateRangeHelper.daysAgo(7, now);
   const thirtyDaysAgo = DateRangeHelper.daysAgo(30, now);

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -1,11 +1,14 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
 import { DateRangeHelper } from '@/domain/entities/DateRange';
 import { DAY_LABELS_JP, QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`records-trends-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
   const fourteenDaysAgo = DateRangeHelper.daysAgo(14, now);
   const sevenDaysAgo = DateRangeHelper.daysAgo(7, now);


### PR DESCRIPTION
## Summary
- /api/records/trends GETにレート制限（30req/min）を追加
- /api/records/stats GETにレート制限（30req/min）を追加
- /api/medications/search GETにレート制限（30req/min）を追加

## Test plan
- [x] 2454件全テストパス
- [x] 既存動作への影響なし

closes #531