### PR TITLE
feat: 病院の通院情報表示メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/HospitalVisitInfo.test.ts
+++ b/src/__tests__/domain/entities/HospitalVisitInfo.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity 通院情報表示', () => {
+  describe('formatVisitFrequency', () => {
+    it('月1回は毎月を返す', () => {
+      expect(HospitalEntity.formatVisitFrequency(1)).toBe('毎月');
+    });
+
+    it('月2回は月2回を返す', () => {
+      expect(HospitalEntity.formatVisitFrequency(2)).toBe('月2回');
+    });
+
+    it('月0回は不定期を返す', () => {
+      expect(HospitalEntity.formatVisitFrequency(0)).toBe('不定期');
+    });
+
+    it('月4回は週1回を返す', () => {
+      expect(HospitalEntity.formatVisitFrequency(4)).toBe('週1回');
+    });
+  });
+
+  describe('getLastVisitLabel', () => {
+    it('今日の場合は今日を返す', () => {
+      const today = new Date(2026, 2, 5);
+      expect(HospitalEntity.getLastVisitLabel(today, today)).toBe('今日');
+    });
+
+    it('1日前は昨日を返す', () => {
+      const today = new Date(2026, 2, 5);
+      const lastVisit = new Date(2026, 2, 4);
+      expect(HospitalEntity.getLastVisitLabel(lastVisit, today)).toBe('昨日');
+    });
+
+    it('7日前は1週間前を返す', () => {
+      const today = new Date(2026, 2, 10);
+      const lastVisit = new Date(2026, 2, 3);
+      expect(HospitalEntity.getLastVisitLabel(lastVisit, today)).toBe('1週間前');
+    });
+
+    it('30日前は1ヶ月前を返す', () => {
+      const today = new Date(2026, 2, 10);
+      const lastVisit = new Date(2026, 1, 8);
+      expect(HospitalEntity.getLastVisitLabel(lastVisit, today)).toBe('1ヶ月前');
+    });
+
+    it('3日前は3日前を返す', () => {
+      const today = new Date(2026, 2, 10);
+      const lastVisit = new Date(2026, 2, 7);
+      expect(HospitalEntity.getLastVisitLabel(lastVisit, today)).toBe('3日前');
+    });
+  });
+
+  describe('getVisitStatusLevel', () => {
+    it('30日以内はgoodを返す', () => {
+      expect(HospitalEntity.getVisitStatusLevel(15)).toBe('good');
+    });
+
+    it('90日以内はwarningを返す', () => {
+      expect(HospitalEntity.getVisitStatusLevel(60)).toBe('warning');
+    });
+
+    it('90日超はalertを返す', () => {
+      expect(HospitalEntity.getVisitStatusLevel(120)).toBe('alert');
+    });
+
+    it('0日はgoodを返す', () => {
+      expect(HospitalEntity.getVisitStatusLevel(0)).toBe('good');
+    });
+  });
+});

--- a/src/domain/entities/Hospital.ts
+++ b/src/domain/entities/Hospital.ts
@@ -66,4 +66,39 @@ export class HospitalEntity {
     }
     return phone;
   }
+
+  /**
+   * 月間通院回数から通院頻度ラベルを返す
+   */
+  static formatVisitFrequency(timesPerMonth: number): string {
+    if (timesPerMonth === 0) return '不定期';
+    if (timesPerMonth === 1) return '毎月';
+    if (timesPerMonth === 4) return '週1回';
+    return `月${timesPerMonth}回`;
+  }
+
+  /**
+   * 最終通院日からのラベルを生成する
+   */
+  static getLastVisitLabel(lastVisit: Date, today: Date): string {
+    const lastStart = new Date(lastVisit.getFullYear(), lastVisit.getMonth(), lastVisit.getDate());
+    const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const diffMs = todayStart.getTime() - lastStart.getTime();
+    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays === 0) return '今日';
+    if (diffDays === 1) return '昨日';
+    if (diffDays === 7) return '1週間前';
+    if (diffDays >= 28 && diffDays <= 31) return '1ヶ月前';
+    if (diffDays > 31) return `${Math.round(diffDays / 30)}ヶ月前`;
+    return `${diffDays}日前`;
+  }
+
+  /**
+   * 最終通院からの日数に応じたステータスレベルを返す
+   */
+  static getVisitStatusLevel(daysSinceLastVisit: number): 'good' | 'warning' | 'alert' {
+    if (daysSinceLastVisit <= 30) return 'good';
+    if (daysSinceLastVisit <= 90) return 'warning';
+    return 'alert';
+  }
 }


### PR DESCRIPTION
## Summary
- HospitalEntityに通院頻度表示のformatVisitFrequencyを追加
- 最終通院日ラベルのgetLastVisitLabelを追加
- 通院状況レベル判定のgetVisitStatusLevelを追加
- テスト13件追加（2467件全パス）

## Test plan
- [x] 通院頻度が正しくフォーマットされる
- [x] 最終通院日からのラベルが正しく生成される
- [x] 通院状況レベルが日数に応じて正しく判定される

closes #533