### PR TITLE
feat: 営業日計算メソッドを追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangeBusinessDays.test.ts
+++ b/src/__tests__/domain/entities/DateRangeBusinessDays.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper 営業日計算', () => {
+  describe('isBusinessDay', () => {
+    it('月曜日は営業日', () => {
+      expect(DateRangeHelper.isBusinessDay(new Date(2026, 2, 2))).toBe(true);
+    });
+
+    it('土曜日は営業日ではない', () => {
+      expect(DateRangeHelper.isBusinessDay(new Date(2026, 2, 7))).toBe(false);
+    });
+
+    it('日曜日は営業日ではない', () => {
+      expect(DateRangeHelper.isBusinessDay(new Date(2026, 2, 1))).toBe(false);
+    });
+
+    it('金曜日は営業日', () => {
+      expect(DateRangeHelper.isBusinessDay(new Date(2026, 2, 6))).toBe(true);
+    });
+  });
+
+  describe('countBusinessDays', () => {
+    it('月-金の1週間は5営業日', () => {
+      const from = new Date(2026, 2, 2); // 月
+      const to = new Date(2026, 2, 6); // 金
+      expect(DateRangeHelper.countBusinessDays(from, to)).toBe(5);
+    });
+
+    it('月-日の1週間は5営業日', () => {
+      const from = new Date(2026, 2, 2); // 月
+      const to = new Date(2026, 2, 8); // 日
+      expect(DateRangeHelper.countBusinessDays(from, to)).toBe(5);
+    });
+
+    it('同じ日は営業日なら1を返す', () => {
+      const date = new Date(2026, 2, 2); // 月
+      expect(DateRangeHelper.countBusinessDays(date, date)).toBe(1);
+    });
+
+    it('同じ日が土曜なら0を返す', () => {
+      const date = new Date(2026, 2, 7); // 土
+      expect(DateRangeHelper.countBusinessDays(date, date)).toBe(0);
+    });
+
+    it('2週間は10営業日', () => {
+      const from = new Date(2026, 2, 2); // 月
+      const to = new Date(2026, 2, 13); // 金
+      expect(DateRangeHelper.countBusinessDays(from, to)).toBe(10);
+    });
+  });
+
+  describe('addBusinessDays', () => {
+    it('月曜に3営業日加算すると木曜', () => {
+      const result = DateRangeHelper.addBusinessDays(new Date(2026, 2, 2), 3);
+      expect(result.getDate()).toBe(5); // 木曜
+    });
+
+    it('金曜に1営業日加算すると月曜', () => {
+      const result = DateRangeHelper.addBusinessDays(new Date(2026, 2, 6), 1);
+      expect(result.getDate()).toBe(9); // 月曜
+    });
+
+    it('0営業日加算は同日を返す', () => {
+      const date = new Date(2026, 2, 2);
+      const result = DateRangeHelper.addBusinessDays(date, 0);
+      expect(result.getDate()).toBe(2);
+    });
+
+    it('5営業日加算で翌週金曜', () => {
+      const result = DateRangeHelper.addBusinessDays(new Date(2026, 2, 2), 5);
+      expect(result.getDate()).toBe(9); // 翌月曜
+    });
+  });
+});

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -163,6 +163,41 @@ export class DateRangeHelper {
   /**
    * 相対日付を日本語で表示する
    */
+  /**
+   * 営業日（月-金）かどうかを判定する
+   */
+  static isBusinessDay(date: Date): boolean {
+    return !DateRangeHelper.isWeekend(date);
+  }
+
+  /**
+   * 期間内の営業日数を算出する（from/to含む）
+   */
+  static countBusinessDays(from: Date, to: Date): number {
+    let count = 0;
+    const current = DateRangeHelper.toStartOfDay(from);
+    const end = DateRangeHelper.toStartOfDay(to);
+    while (current <= end) {
+      if (DateRangeHelper.isBusinessDay(current)) count++;
+      current.setDate(current.getDate() + 1);
+    }
+    return count;
+  }
+
+  /**
+   * 営業日数を加算した日付を返す
+   */
+  static addBusinessDays(from: Date, days: number): Date {
+    const result = new Date(from);
+    let added = 0;
+    if (days === 0) return result;
+    while (added < days) {
+      result.setDate(result.getDate() + 1);
+      if (DateRangeHelper.isBusinessDay(result)) added++;
+    }
+    return result;
+  }
+
   static formatRelativeDate(date: Date, today: Date): string {
     const startOfDate = DateRangeHelper.toStartOfDay(date);
     const startOfToday = DateRangeHelper.toStartOfDay(today);


### PR DESCRIPTION
## Summary
- DateRangeHelperに営業日判定のisBusinessDayを追加
- 期間内営業日数算出のcountBusinessDaysを追加
- 営業日加算のaddBusinessDaysを追加
- テスト13件追加（2480件全パス）

## Test plan
- [x] 月-金が営業日として判定される
- [x] 1週間で5営業日が算出される
- [x] 金曜+1営業日で翌月曜が返される

closes #535