### PR TITLE
feat: MedicationRecord 服薬間隔計算メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationRecordDurationCalc.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordDurationCalc.test.ts
@@ -1,0 +1,127 @@
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (takenAt: string | Date): MedicationRecord => ({
+  id: '1',
+  memberId: 'm1',
+  memberName: 'テスト',
+  medicationId: 'med1',
+  medicationName: '薬A',
+  userId: 'u1',
+  takenAt: new Date(takenAt),
+});
+
+describe('MedicationRecordEntity - Duration Calc', () => {
+  describe('getTimeSinceLastDose', () => {
+    it('記録なしの場合nullを返す', () => {
+      const now = new Date('2025-06-15T10:00:00');
+      expect(MedicationRecordEntity.getTimeSinceLastDose([], now)).toBeNull();
+    });
+
+    it('30分前の服薬で「30分前」を返す', () => {
+      const now = new Date('2025-06-15T10:30:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('30分前');
+    });
+
+    it('2時間前の服薬で「2時間前」を返す', () => {
+      const now = new Date('2025-06-15T12:00:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('2時間前');
+    });
+
+    it('1時間30分前の服薬で「1時間前」を返す', () => {
+      const now = new Date('2025-06-15T11:30:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('1時間前');
+    });
+
+    it('2日前の服薬で「2日前」を返す', () => {
+      const now = new Date('2025-06-17T10:00:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('2日前');
+    });
+
+    it('複数記録がある場合最新の記録を基準にする', () => {
+      const now = new Date('2025-06-15T11:00:00');
+      const records = [
+        createRecord('2025-06-15T10:00:00'),
+        createRecord('2025-06-15T10:30:00'),
+        createRecord('2025-06-15T09:00:00'),
+      ];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('30分前');
+    });
+  });
+
+  describe('getDoseIntervalStats', () => {
+    it('記録なしの場合nullを返す', () => {
+      expect(MedicationRecordEntity.getDoseIntervalStats([])).toBeNull();
+    });
+
+    it('1件の記録の場合nullを返す', () => {
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getDoseIntervalStats(records)).toBeNull();
+    });
+
+    it('2件の記録で正しい統計を返す', () => {
+      const records = [
+        createRecord('2025-06-15T10:00:00'),
+        createRecord('2025-06-15T14:00:00'),
+      ];
+      const stats = MedicationRecordEntity.getDoseIntervalStats(records);
+      expect(stats).toEqual({ averageMinutes: 240, minMinutes: 240, maxMinutes: 240 });
+    });
+
+    it('3件の記録で正しい統計を返す', () => {
+      const records = [
+        createRecord('2025-06-15T08:00:00'),
+        createRecord('2025-06-15T12:00:00'),
+        createRecord('2025-06-15T18:00:00'),
+      ];
+      const stats = MedicationRecordEntity.getDoseIntervalStats(records);
+      expect(stats).toEqual({ averageMinutes: 300, minMinutes: 240, maxMinutes: 360 });
+    });
+
+    it('順序がバラバラでもソートして正しく計算する', () => {
+      const records = [
+        createRecord('2025-06-15T18:00:00'),
+        createRecord('2025-06-15T08:00:00'),
+        createRecord('2025-06-15T12:00:00'),
+      ];
+      const stats = MedicationRecordEntity.getDoseIntervalStats(records);
+      expect(stats).toEqual({ averageMinutes: 300, minMinutes: 240, maxMinutes: 360 });
+    });
+  });
+
+  describe('getNextDoseEstimate', () => {
+    it('記録なしの場合nullを返す', () => {
+      expect(MedicationRecordEntity.getNextDoseEstimate([])).toBeNull();
+    });
+
+    it('1件の記録の場合nullを返す', () => {
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getNextDoseEstimate(records)).toBeNull();
+    });
+
+    it('平均間隔に基づいた次回予定時刻を返す', () => {
+      const records = [
+        createRecord('2025-06-15T08:00:00'),
+        createRecord('2025-06-15T12:00:00'),
+        createRecord('2025-06-15T16:00:00'),
+      ];
+      const result = MedicationRecordEntity.getNextDoseEstimate(records);
+      expect(result).toEqual(new Date('2025-06-15T20:00:00'));
+    });
+
+    it('異なる間隔でも平均を使って推定する', () => {
+      const records = [
+        createRecord('2025-06-15T06:00:00'),
+        createRecord('2025-06-15T10:00:00'),
+        createRecord('2025-06-15T16:00:00'),
+      ];
+      // intervals: 240min, 360min → avg 300min = 5h
+      // last: 16:00 + 5h = 21:00
+      const result = MedicationRecordEntity.getNextDoseEstimate(records);
+      expect(result).toEqual(new Date('2025-06-15T21:00:00'));
+    });
+  });
+});

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -371,4 +371,59 @@ export class MedicationRecordEntity {
     if (rate >= 50) return 'もう少しで達成です';
     return '少しずつ頑張りましょう';
   }
+
+  /**
+   * 最後の服薬からの経過時間を日本語文字列で返す
+   */
+  static getTimeSinceLastDose(records: MedicationRecord[], now: Date): string | null {
+    if (records.length === 0) return null;
+    const latest = records.reduce((a, b) =>
+      new Date(a.takenAt).getTime() > new Date(b.takenAt).getTime() ? a : b,
+    );
+    const diffMs = now.getTime() - new Date(latest.takenAt).getTime();
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    if (diffMinutes < 60) return `${diffMinutes}分前`;
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) return `${diffHours}時間前`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}日前`;
+  }
+
+  /**
+   * 服薬記録間隔の統計(平均・最小・最大)を算出
+   */
+  static getDoseIntervalStats(
+    records: MedicationRecord[],
+  ): { averageMinutes: number; minMinutes: number; maxMinutes: number } | null {
+    if (records.length < 2) return null;
+    const sorted = [...records].sort(
+      (a, b) => new Date(a.takenAt).getTime() - new Date(b.takenAt).getTime(),
+    );
+    const intervals: number[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+      const diff =
+        (new Date(sorted[i].takenAt).getTime() - new Date(sorted[i - 1].takenAt).getTime()) /
+        (1000 * 60);
+      intervals.push(diff);
+    }
+    const sum = intervals.reduce((a, b) => a + b, 0);
+    return {
+      averageMinutes: Math.round(sum / intervals.length),
+      minMinutes: Math.min(...intervals),
+      maxMinutes: Math.max(...intervals),
+    };
+  }
+
+  /**
+   * 平均間隔に基づく次回服薬予定時刻を推定
+   */
+  static getNextDoseEstimate(records: MedicationRecord[]): Date | null {
+    const stats = MedicationRecordEntity.getDoseIntervalStats(records);
+    if (!stats) return null;
+    const sorted = [...records].sort(
+      (a, b) => new Date(a.takenAt).getTime() - new Date(b.takenAt).getTime(),
+    );
+    const lastTime = new Date(sorted[sorted.length - 1].takenAt).getTime();
+    return new Date(lastTime + stats.averageMinutes * 60 * 1000);
+  }
 }


### PR DESCRIPTION
## Summary
- `getTimeSinceLastDose`: 最後の服薬からの経過時間を日本語文字列で返す
- `getDoseIntervalStats`: 服薬記録間隔の統計(平均・最小・最大)を算出
- `getNextDoseEstimate`: 平均間隔に基づく次回服薬予定時刻を推定

## Test plan
- [x] getTimeSinceLastDose: 記録なし/分/時間/日の各パターン(6テスト)
- [x] getDoseIntervalStats: 空/単一/2件/3件/順序バラバラ(5テスト)
- [x] getNextDoseEstimate: 空/単一/正常系2パターン(4テスト)

closes #537