### PR TITLE
test: Cycle 29 Phase 1 機能のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangeBusinessDays.edge.test.ts
+++ b/src/__tests__/domain/entities/DateRangeBusinessDays.edge.test.ts
@@ -1,0 +1,58 @@
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper - Business Days Edge Cases', () => {
+  describe('countBusinessDays 境界値', () => {
+    it('同一日(月曜)は1営業日', () => {
+      const mon = new Date('2025-06-16');
+      expect(DateRangeHelper.countBusinessDays(mon, mon)).toBe(1);
+    });
+
+    it('同一日(土曜)は0営業日', () => {
+      const sat = new Date('2025-06-14');
+      expect(DateRangeHelper.countBusinessDays(sat, sat)).toBe(0);
+    });
+
+    it('金曜から月曜は2営業日(金・月)', () => {
+      const fri = new Date('2025-06-13');
+      const mon = new Date('2025-06-16');
+      expect(DateRangeHelper.countBusinessDays(fri, mon)).toBe(2);
+    });
+
+    it('1週間(月-日)は5営業日', () => {
+      const mon = new Date('2025-06-16');
+      const sun = new Date('2025-06-22');
+      expect(DateRangeHelper.countBusinessDays(mon, sun)).toBe(5);
+    });
+  });
+
+  describe('addBusinessDays 境界値', () => {
+    it('0営業日追加は同じ日', () => {
+      const mon = new Date('2025-06-16');
+      const result = DateRangeHelper.addBusinessDays(mon, 0);
+      expect(result.getDate()).toBe(16);
+    });
+
+    it('金曜に1営業日追加は翌月曜', () => {
+      const fri = new Date('2025-06-13');
+      const result = DateRangeHelper.addBusinessDays(fri, 1);
+      expect(result.getDay()).toBe(1); // Monday
+      expect(result.getDate()).toBe(16);
+    });
+
+    it('5営業日追加で1週間後(土日スキップ)', () => {
+      const mon = new Date('2025-06-16');
+      const result = DateRangeHelper.addBusinessDays(mon, 5);
+      expect(result.getDate()).toBe(23); // 次の月曜
+    });
+  });
+
+  describe('isBusinessDay 境界値', () => {
+    it('金曜は営業日', () => {
+      expect(DateRangeHelper.isBusinessDay(new Date('2025-06-13'))).toBe(true);
+    });
+
+    it('日曜は非営業日', () => {
+      expect(DateRangeHelper.isBusinessDay(new Date('2025-06-15'))).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HospitalVisitInfo.edge.test.ts
+++ b/src/__tests__/domain/entities/HospitalVisitInfo.edge.test.ts
@@ -1,0 +1,56 @@
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity - Visit Info Edge Cases', () => {
+  describe('getLastVisitLabel 境界値', () => {
+    const today = new Date('2025-06-15');
+
+    it('27日前は「27日前」を返す', () => {
+      const visit = new Date('2025-05-19');
+      expect(HospitalEntity.getLastVisitLabel(visit, today)).toBe('27日前');
+    });
+
+    it('28日前は「1ヶ月前」を返す', () => {
+      const visit = new Date('2025-05-18');
+      expect(HospitalEntity.getLastVisitLabel(visit, today)).toBe('1ヶ月前');
+    });
+
+    it('31日前は「1ヶ月前」を返す', () => {
+      const visit = new Date('2025-05-15');
+      expect(HospitalEntity.getLastVisitLabel(visit, today)).toBe('1ヶ月前');
+    });
+
+    it('32日前は月数表示になる', () => {
+      const visit = new Date('2025-05-14');
+      expect(HospitalEntity.getLastVisitLabel(visit, today)).toBe('1ヶ月前');
+    });
+
+    it('365日前は「12ヶ月前」を返す', () => {
+      const visit = new Date('2024-06-16');
+      expect(HospitalEntity.getLastVisitLabel(visit, today)).toBe('12ヶ月前');
+    });
+  });
+
+  describe('formatVisitFrequency 境界値', () => {
+    it('非常に多い回数でも月X回形式', () => {
+      expect(HospitalEntity.formatVisitFrequency(30)).toBe('月30回');
+    });
+  });
+
+  describe('getVisitStatusLevel 境界値', () => {
+    it('30日はgood', () => {
+      expect(HospitalEntity.getVisitStatusLevel(30)).toBe('good');
+    });
+
+    it('31日はwarning', () => {
+      expect(HospitalEntity.getVisitStatusLevel(31)).toBe('warning');
+    });
+
+    it('90日はwarning', () => {
+      expect(HospitalEntity.getVisitStatusLevel(90)).toBe('warning');
+    });
+
+    it('91日はalert', () => {
+      expect(HospitalEntity.getVisitStatusLevel(91)).toBe('alert');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationRecordDurationCalc.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationRecordDurationCalc.edge.test.ts
@@ -1,0 +1,77 @@
+import { MedicationRecordEntity, MedicationRecord } from '@/domain/entities/MedicationRecord';
+
+const createRecord = (takenAt: string): MedicationRecord => ({
+  id: '1',
+  memberId: 'm1',
+  memberName: 'テスト',
+  medicationId: 'med1',
+  medicationName: '薬A',
+  userId: 'u1',
+  takenAt: new Date(takenAt),
+});
+
+describe('MedicationRecordEntity - Duration Calc Edge Cases', () => {
+  describe('getTimeSinceLastDose 境界値', () => {
+    it('0分前(同時刻)は「0分前」を返す', () => {
+      const now = new Date('2025-06-15T10:00:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('0分前');
+    });
+
+    it('59分前は「59分前」を返す', () => {
+      const now = new Date('2025-06-15T10:59:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('59分前');
+    });
+
+    it('60分前は「1時間前」を返す', () => {
+      const now = new Date('2025-06-15T11:00:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('1時間前');
+    });
+
+    it('23時間59分前は「23時間前」を返す', () => {
+      const now = new Date('2025-06-16T09:59:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('23時間前');
+    });
+
+    it('24時間前は「1日前」を返す', () => {
+      const now = new Date('2025-06-16T10:00:00');
+      const records = [createRecord('2025-06-15T10:00:00')];
+      expect(MedicationRecordEntity.getTimeSinceLastDose(records, now)).toBe('1日前');
+    });
+  });
+
+  describe('getDoseIntervalStats 境界値', () => {
+    it('同時刻の2記録で間隔0分', () => {
+      const records = [
+        createRecord('2025-06-15T10:00:00'),
+        createRecord('2025-06-15T10:00:00'),
+      ];
+      const stats = MedicationRecordEntity.getDoseIntervalStats(records);
+      expect(stats).toEqual({ averageMinutes: 0, minMinutes: 0, maxMinutes: 0 });
+    });
+
+    it('1分間隔の記録', () => {
+      const records = [
+        createRecord('2025-06-15T10:00:00'),
+        createRecord('2025-06-15T10:01:00'),
+      ];
+      const stats = MedicationRecordEntity.getDoseIntervalStats(records);
+      expect(stats).toEqual({ averageMinutes: 1, minMinutes: 1, maxMinutes: 1 });
+    });
+  });
+
+  describe('getNextDoseEstimate 境界値', () => {
+    it('日付を跨ぐ推定', () => {
+      const records = [
+        createRecord('2025-06-15T20:00:00'),
+        createRecord('2025-06-15T23:00:00'),
+      ];
+      // interval: 180min → next: 23:00 + 3h = 翌02:00
+      const result = MedicationRecordEntity.getNextDoseEstimate(records);
+      expect(result).toEqual(new Date('2025-06-16T02:00:00'));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- HospitalVisitInfo: 境界値(27/28/31/32日、365日)、高頻度通院、ステータス境界(10テスト)
- DateRangeBusinessDays: 同一日、週末跨ぎ、金曜+1営業日、5営業日追加(9テスト)
- MedicationRecordDurationCalc: 0分/59分/60分/24時間境界、同時刻、日付跨ぎ(8テスト)

## Test plan
- [x] 新規27テスト全パス
- [x] 既存含む全2522テストパス

closes #541