### PR TITLE
fix: メンバー別API GETルートにレート制限追加

### DIFF
--- a/src/app/api/medications/member/[memberId]/route.ts
+++ b/src/app/api/medications/member/[memberId]/route.ts
@@ -1,10 +1,13 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, validateParamId } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medications-member-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     const idError = validateParamId(memberId);
     if (idError) return idError;

--- a/src/app/api/members/[memberId]/profile/route.ts
+++ b/src/app/api/members/[memberId]/profile/route.ts
@@ -1,10 +1,13 @@
 import { prisma } from '@/lib/prisma';
-import { success, notFound } from '@/lib/auth-helpers';
+import { success, notFound, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, validateParamId } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { DateRangeHelper } from '@/domain/entities/DateRange';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`member-profile-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     const idError = validateParamId(memberId);
     if (idError) return idError;

--- a/src/app/api/records/member/[memberId]/route.ts
+++ b/src/app/api/records/member/[memberId]/route.ts
@@ -1,10 +1,13 @@
 import { prisma } from '@/lib/prisma';
-import { success } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, validateParamId } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`records-member-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     const idError = validateParamId(memberId);
     if (idError) return idError;


### PR DESCRIPTION
## Summary
- /api/members/[memberId]/profile GET: 30req/min
- /api/medications/member/[memberId] GET: 30req/min
- /api/records/member/[memberId] GET: 30req/min

## Test plan
- [x] 既存2522テスト全パス

closes #543