### PR TITLE
feat: MemberSummary メンバー比較・ランキングメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MemberSummaryComparison.test.ts
+++ b/src/__tests__/domain/entities/MemberSummaryComparison.test.ts
@@ -1,0 +1,102 @@
+import { MemberSummaryEntity, MemberSummary } from '@/domain/entities/MemberSummary';
+
+const createSummary = (overrides: Partial<MemberSummary> = {}): MemberSummary => ({
+  memberId: 'm1',
+  memberName: 'テスト太郎',
+  memberType: 'human',
+  medicationCount: 3,
+  nextAppointmentDate: '2025-06-20',
+  ...overrides,
+});
+
+describe('MemberSummaryEntity - Comparison', () => {
+  describe('rankByMedicationCount', () => {
+    it('薬の登録数で降順ソートする', () => {
+      const members = [
+        createSummary({ memberId: 'a', medicationCount: 1 }),
+        createSummary({ memberId: 'b', medicationCount: 5 }),
+        createSummary({ memberId: 'c', medicationCount: 3 }),
+      ];
+      const ranked = MemberSummaryEntity.rankByMedicationCount(members);
+      expect(ranked.map(m => m.memberId)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('空配列は空配列を返す', () => {
+      expect(MemberSummaryEntity.rankByMedicationCount([])).toEqual([]);
+    });
+
+    it('同数の場合は元の順序を維持する', () => {
+      const members = [
+        createSummary({ memberId: 'a', medicationCount: 3 }),
+        createSummary({ memberId: 'b', medicationCount: 3 }),
+      ];
+      const ranked = MemberSummaryEntity.rankByMedicationCount(members);
+      expect(ranked.map(m => m.memberId)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('filterByType', () => {
+    const members = [
+      createSummary({ memberId: 'h1', memberType: 'human' }),
+      createSummary({ memberId: 'p1', memberType: 'pet' }),
+      createSummary({ memberId: 'h2', memberType: 'human' }),
+    ];
+
+    it('humanでフィルタする', () => {
+      const result = MemberSummaryEntity.filterByType(members, 'human');
+      expect(result).toHaveLength(2);
+      expect(result.every(m => m.memberType === 'human')).toBe(true);
+    });
+
+    it('petでフィルタする', () => {
+      const result = MemberSummaryEntity.filterByType(members, 'pet');
+      expect(result).toHaveLength(1);
+      expect(result[0].memberId).toBe('p1');
+    });
+
+    it('該当なしの種別は空配列を返す', () => {
+      expect(MemberSummaryEntity.filterByType(members, 'robot')).toEqual([]);
+    });
+  });
+
+  describe('getGroupActivitySummary', () => {
+    it('全メンバーのアクティビティ集計を返す', () => {
+      const members = [
+        createSummary({ medicationCount: 3, nextAppointmentDate: '2025-06-20' }),
+        createSummary({ medicationCount: 0, nextAppointmentDate: null }),
+        createSummary({ medicationCount: 2, nextAppointmentDate: null }),
+      ];
+      const summary = MemberSummaryEntity.getGroupActivitySummary(members);
+      expect(summary).toEqual({
+        totalMembers: 3,
+        withMedications: 2,
+        withAppointments: 1,
+        totalMedications: 5,
+      });
+    });
+
+    it('空配列は全て0を返す', () => {
+      const summary = MemberSummaryEntity.getGroupActivitySummary([]);
+      expect(summary).toEqual({
+        totalMembers: 0,
+        withMedications: 0,
+        withAppointments: 0,
+        totalMedications: 0,
+      });
+    });
+
+    it('全員アクティブな場合', () => {
+      const members = [
+        createSummary({ medicationCount: 2, nextAppointmentDate: '2025-06-20' }),
+        createSummary({ medicationCount: 1, nextAppointmentDate: '2025-07-01' }),
+      ];
+      const summary = MemberSummaryEntity.getGroupActivitySummary(members);
+      expect(summary).toEqual({
+        totalMembers: 2,
+        withMedications: 2,
+        withAppointments: 2,
+        totalMedications: 3,
+      });
+    });
+  });
+});

--- a/src/domain/entities/MemberSummary.ts
+++ b/src/domain/entities/MemberSummary.ts
@@ -64,4 +64,35 @@ export class MemberSummaryEntity {
     };
     return labels[memberType] ?? memberType;
   }
+
+  /**
+   * 薬の登録数で降順ソートする
+   */
+  static rankByMedicationCount(members: MemberSummary[]): MemberSummary[] {
+    return [...members].sort((a, b) => b.medicationCount - a.medicationCount);
+  }
+
+  /**
+   * メンバー種別でフィルタする
+   */
+  static filterByType(members: MemberSummary[], type: string): MemberSummary[] {
+    return members.filter((m) => m.memberType === type);
+  }
+
+  /**
+   * グループ全体のアクティビティ集計を返す
+   */
+  static getGroupActivitySummary(members: MemberSummary[]): {
+    totalMembers: number;
+    withMedications: number;
+    withAppointments: number;
+    totalMedications: number;
+  } {
+    return {
+      totalMembers: members.length,
+      withMedications: members.filter((m) => m.medicationCount > 0).length,
+      withAppointments: members.filter((m) => m.nextAppointmentDate !== null).length,
+      totalMedications: members.reduce((sum, m) => sum + m.medicationCount, 0),
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- `rankByMedicationCount`: 薬の登録数で降順ソート
- `filterByType`: メンバー種別(human/pet)でフィルタ
- `getGroupActivitySummary`: グループ全体のアクティビティ集計

## Test plan
- [x] rankByMedicationCount: 正常系・空配列・同数(3テスト)
- [x] filterByType: human/pet/該当なし(3テスト)
- [x] getGroupActivitySummary: 複合・空・全員アクティブ(3テスト)

closes #545