### PR TITLE
feat: GreetingMessage 季節・ストリーク挨拶メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/GreetingSeasonalStreak.test.ts
+++ b/src/__tests__/domain/entities/GreetingSeasonalStreak.test.ts
@@ -1,0 +1,73 @@
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity - Seasonal & Streak', () => {
+  describe('getSeasonalGreeting', () => {
+    it('3月は春の挨拶を返す', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(3)).toBe('春の陽気が気持ちいい季節ですね');
+    });
+
+    it('4月は春の挨拶を返す', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(4)).toBe('春の陽気が気持ちいい季節ですね');
+    });
+
+    it('5月は春の挨拶を返す', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(5)).toBe('春の陽気が気持ちいい季節ですね');
+    });
+
+    it('7月は夏の挨拶を返す', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(7)).toBe('暑い日が続きますが体調にお気をつけて');
+    });
+
+    it('10月は秋の挨拶を返す', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(10)).toBe('過ごしやすい季節になりましたね');
+    });
+
+    it('1月は冬の挨拶を返す', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(1)).toBe('寒い日が続きますがお体ご自愛ください');
+    });
+
+    it('12月は冬の挨拶を返す', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(12)).toBe('寒い日が続きますがお体ご自愛ください');
+    });
+  });
+
+  describe('getStreakEncouragement', () => {
+    it('0日は開始メッセージを返す', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(0)).toBe('今日から記録を始めましょう');
+    });
+
+    it('3日は序盤メッセージを返す', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(3)).toBe('3日連続です。良い調子です');
+    });
+
+    it('7日は週間メッセージを返す', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(7)).toBe('1週間達成です。習慣になってきましたね');
+    });
+
+    it('14日は2週間メッセージを返す', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(14)).toBe('14日連続です。素晴らしい継続力です');
+    });
+
+    it('30日は1ヶ月メッセージを返す', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(30)).toBe('30日連続達成です。立派な習慣です');
+    });
+
+    it('100日は大台メッセージを返す', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(100)).toBe('100日連続達成です。立派な習慣です');
+    });
+  });
+
+  describe('formatGreetingWithName', () => {
+    it('名前付きの挨拶を返す', () => {
+      expect(GreetingMessageEntity.formatGreetingWithName('おはよう', '太郎')).toBe('太郎さん、おはよう');
+    });
+
+    it('名前なしの場合はそのまま返す', () => {
+      expect(GreetingMessageEntity.formatGreetingWithName('こんにちは', null)).toBe('こんにちは');
+    });
+
+    it('空文字名の場合はそのまま返す', () => {
+      expect(GreetingMessageEntity.formatGreetingWithName('こんばんは', '')).toBe('こんばんは');
+    });
+  });
+});

--- a/src/domain/entities/GreetingMessage.ts
+++ b/src/domain/entities/GreetingMessage.ts
@@ -36,4 +36,33 @@ export class GreetingMessageEntity {
       default: return '今日も頑張りましょう';
     }
   }
+
+  /**
+   * 月に基づく季節の挨拶を返す
+   */
+  static getSeasonalGreeting(month: number): string {
+    if (month >= 3 && month <= 5) return '春の陽気が気持ちいい季節ですね';
+    if (month >= 6 && month <= 8) return '暑い日が続きますが体調にお気をつけて';
+    if (month >= 9 && month <= 11) return '過ごしやすい季節になりましたね';
+    return '寒い日が続きますがお体ご自愛ください';
+  }
+
+  /**
+   * 連続日数に応じた励ましメッセージを返す
+   */
+  static getStreakEncouragement(streak: number): string {
+    if (streak === 0) return '今日から記録を始めましょう';
+    if (streak === 7) return '1週間達成です。習慣になってきましたね';
+    if (streak < 7) return `${streak}日連続です。良い調子です`;
+    if (streak < 30) return `${streak}日連続です。素晴らしい継続力です`;
+    return `${streak}日連続達成です。立派な習慣です`;
+  }
+
+  /**
+   * 名前付きの挨拶文を生成する
+   */
+  static formatGreetingWithName(greeting: string, name: string | null): string {
+    if (!name || name === '') return greeting;
+    return `${name}さん、${greeting}`;
+  }
 }


### PR DESCRIPTION
## Summary
- `getSeasonalGreeting`: 月に基づく季節の挨拶(春夏秋冬)
- `getStreakEncouragement`: 連続日数に応じた励ましメッセージ
- `formatGreetingWithName`: 名前付きの挨拶文生成

## Test plan
- [x] getSeasonalGreeting: 春夏秋冬の各月(7テスト)
- [x] getStreakEncouragement: 0/3/7/14/30/100日(6テスト)
- [x] formatGreetingWithName: 名前あり/null/空文字(3テスト)

closes #547