### PR TITLE
feat: AdherenceTrend トレンド分析・予測メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceTrendForecast.test.ts
+++ b/src/__tests__/domain/entities/AdherenceTrendForecast.test.ts
@@ -1,0 +1,74 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Forecast', () => {
+  describe('calculateTrendDirection', () => {
+    it('遵守率が上昇傾向の場合upを返す', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([50, 60, 70])).toBe('up');
+    });
+
+    it('遵守率が下降傾向の場合downを返す', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([80, 70, 60])).toBe('down');
+    });
+
+    it('遵守率が安定している場合stableを返す', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([70, 72, 68])).toBe('stable');
+    });
+
+    it('2値で上昇', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([50, 70])).toBe('up');
+    });
+
+    it('2値で下降', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([70, 50])).toBe('down');
+    });
+
+    it('1値はstable', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([70])).toBe('stable');
+    });
+
+    it('空配列はstable', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([])).toBe('stable');
+    });
+  });
+
+  describe('predictNextPeriodRate', () => {
+    it('上昇傾向から次期間を予測する', () => {
+      const result = AdherenceTrendEntity.predictNextPeriodRate(60, 70);
+      expect(result).toBe(80);
+    });
+
+    it('下降傾向から次期間を予測する', () => {
+      const result = AdherenceTrendEntity.predictNextPeriodRate(70, 60);
+      expect(result).toBe(50);
+    });
+
+    it('100を超える場合は100に制限する', () => {
+      const result = AdherenceTrendEntity.predictNextPeriodRate(90, 95);
+      expect(result).toBe(100);
+    });
+
+    it('0を下回る場合は0に制限する', () => {
+      const result = AdherenceTrendEntity.predictNextPeriodRate(10, 3);
+      expect(result).toBe(0);
+    });
+
+    it('変化なしの場合は同じ値を返す', () => {
+      const result = AdherenceTrendEntity.predictNextPeriodRate(70, 70);
+      expect(result).toBe(70);
+    });
+  });
+
+  describe('getTrendSummaryMessage', () => {
+    it('上昇トレンドのメッセージ', () => {
+      expect(AdherenceTrendEntity.getTrendSummaryMessage('up')).toBe('服薬率が改善傾向にあります');
+    });
+
+    it('下降トレンドのメッセージ', () => {
+      expect(AdherenceTrendEntity.getTrendSummaryMessage('down')).toBe('服薬率が低下傾向にあります');
+    });
+
+    it('安定トレンドのメッセージ', () => {
+      expect(AdherenceTrendEntity.getTrendSummaryMessage('stable')).toBe('服薬率は安定しています');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -46,4 +46,38 @@ export class AdherenceTrendEntity {
   static getDayLabel(day: number): string {
     return DAY_LABELS[day] ?? '';
   }
+
+  /**
+   * 複数期間の遵守率から改善/悪化/安定を判定する
+   */
+  static calculateTrendDirection(rates: number[]): 'up' | 'down' | 'stable' {
+    if (rates.length < 2) return 'stable';
+    const first = rates[0];
+    const last = rates[rates.length - 1];
+    const diff = last - first;
+    if (diff > 5) return 'up';
+    if (diff < -5) return 'down';
+    return 'stable';
+  }
+
+  /**
+   * 直近の変化率から次期間の遵守率を予測する(0-100制約)
+   */
+  static predictNextPeriodRate(previousRate: number, currentRate: number): number {
+    const change = currentRate - previousRate;
+    const predicted = currentRate + change;
+    return Math.max(0, Math.min(100, predicted));
+  }
+
+  /**
+   * トレンド方向に応じた日本語サマリーを返す
+   */
+  static getTrendSummaryMessage(direction: 'up' | 'down' | 'stable'): string {
+    const messages: Record<string, string> = {
+      up: '服薬率が改善傾向にあります',
+      down: '服薬率が低下傾向にあります',
+      stable: '服薬率は安定しています',
+    };
+    return messages[direction];
+  }
 }


### PR DESCRIPTION
## Summary
- `calculateTrendDirection`: 複数期間の遵守率から改善/悪化/安定を判定
- `predictNextPeriodRate`: 直近の変化率から次期間の遵守率を予測(0-100制約)
- `getTrendSummaryMessage`: トレンド方向に応じた日本語サマリー

## Test plan
- [x] calculateTrendDirection: 上昇/下降/安定/2値/1値/空(7テスト)
- [x] predictNextPeriodRate: 上昇/下降/上限/下限/変化なし(5テスト)
- [x] getTrendSummaryMessage: up/down/stable(3テスト)

closes #549