### PR TITLE
refactor: AdherenceTrend.getRateChangeLabel をstaticメソッドに抽出

### DIFF
--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -37,7 +37,13 @@ export class AdherenceTrendEntity {
   }
 
   getRateChangeLabel(): string {
-    const change = this.trend.rateChange;
+    return AdherenceTrendEntity.formatRateChange(this.trend.rateChange);
+  }
+
+  /**
+   * 変化率を+X%/-X%/0%形式でフォーマットする
+   */
+  static formatRateChange(change: number): string {
     if (change > 0) return `+${change}%`;
     if (change < 0) return `${change}%`;
     return '0%';


### PR DESCRIPTION
## Summary
- インスタンスメソッドgetRateChangeLabelのロジックをstatic formatRateChangeに抽出
- getRateChangeLabelはformatRateChangeに委譲する形に変更

## Test plan
- [x] 既存テスト2562件が全パス

closes #551