### PR TITLE
test: Cycle 30 Phase 1 機能のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceTrendForecast.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceTrendForecast.edge.test.ts
@@ -1,0 +1,61 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Forecast Edge Cases', () => {
+  describe('calculateTrendDirection 境界値', () => {
+    it('差が+5の場合はstable', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([50, 55])).toBe('stable');
+    });
+
+    it('差が+6の場合はup', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([50, 56])).toBe('up');
+    });
+
+    it('差が-5の場合はstable', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([55, 50])).toBe('stable');
+    });
+
+    it('差が-6の場合はdown', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([56, 50])).toBe('down');
+    });
+
+    it('長い配列でも最初と最後で判定', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([50, 30, 20, 80])).toBe('up');
+    });
+
+    it('全て同じ値はstable', () => {
+      expect(AdherenceTrendEntity.calculateTrendDirection([70, 70, 70, 70])).toBe('stable');
+    });
+  });
+
+  describe('predictNextPeriodRate 境界値', () => {
+    it('0から0は0を返す', () => {
+      expect(AdherenceTrendEntity.predictNextPeriodRate(0, 0)).toBe(0);
+    });
+
+    it('100から100は100を返す', () => {
+      expect(AdherenceTrendEntity.predictNextPeriodRate(100, 100)).toBe(100);
+    });
+
+    it('大きな上昇でも100に制限', () => {
+      expect(AdherenceTrendEntity.predictNextPeriodRate(50, 90)).toBe(100);
+    });
+
+    it('大きな下降でも0に制限', () => {
+      expect(AdherenceTrendEntity.predictNextPeriodRate(50, 10)).toBe(0);
+    });
+  });
+
+  describe('formatRateChange 境界値', () => {
+    it('大きな正の値', () => {
+      expect(AdherenceTrendEntity.formatRateChange(100)).toBe('+100%');
+    });
+
+    it('大きな負の値', () => {
+      expect(AdherenceTrendEntity.formatRateChange(-100)).toBe('-100%');
+    });
+
+    it('小数点を含む値', () => {
+      expect(AdherenceTrendEntity.formatRateChange(0.5)).toBe('+0.5%');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/GreetingSeasonalStreak.edge.test.ts
+++ b/src/__tests__/domain/entities/GreetingSeasonalStreak.edge.test.ts
@@ -1,0 +1,54 @@
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity - Seasonal & Streak Edge Cases', () => {
+  describe('getSeasonalGreeting 境界値', () => {
+    it('2月(冬の最後)は冬の挨拶', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(2)).toBe('寒い日が続きますがお体ご自愛ください');
+    });
+
+    it('6月(春→夏の境界)は夏の挨拶', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(6)).toBe('暑い日が続きますが体調にお気をつけて');
+    });
+
+    it('8月(夏の最後)は夏の挨拶', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(8)).toBe('暑い日が続きますが体調にお気をつけて');
+    });
+
+    it('9月(夏→秋の境界)は秋の挨拶', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(9)).toBe('過ごしやすい季節になりましたね');
+    });
+
+    it('11月(秋の最後)は秋の挨拶', () => {
+      expect(GreetingMessageEntity.getSeasonalGreeting(11)).toBe('過ごしやすい季節になりましたね');
+    });
+  });
+
+  describe('getStreakEncouragement 境界値', () => {
+    it('1日は序盤メッセージ', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(1)).toBe('1日連続です。良い調子です');
+    });
+
+    it('6日は序盤メッセージ', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(6)).toBe('6日連続です。良い調子です');
+    });
+
+    it('8日は中盤メッセージ', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(8)).toBe('8日連続です。素晴らしい継続力です');
+    });
+
+    it('29日は中盤メッセージ', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(29)).toBe('29日連続です。素晴らしい継続力です');
+    });
+
+    it('365日は長期メッセージ', () => {
+      expect(GreetingMessageEntity.getStreakEncouragement(365)).toBe('365日連続達成です。立派な習慣です');
+    });
+  });
+
+  describe('formatGreetingWithName 境界値', () => {
+    it('長い名前でも正しくフォーマット', () => {
+      const name = 'あ'.repeat(50);
+      expect(GreetingMessageEntity.formatGreetingWithName('おはよう', name)).toBe(`${name}さん、おはよう`);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberSummaryComparison.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberSummaryComparison.edge.test.ts
@@ -1,0 +1,74 @@
+import { MemberSummaryEntity, MemberSummary } from '@/domain/entities/MemberSummary';
+
+const createSummary = (overrides: Partial<MemberSummary> = {}): MemberSummary => ({
+  memberId: 'm1',
+  memberName: 'テスト',
+  memberType: 'human',
+  medicationCount: 0,
+  nextAppointmentDate: null,
+  ...overrides,
+});
+
+describe('MemberSummaryEntity - Comparison Edge Cases', () => {
+  describe('rankByMedicationCount 境界値', () => {
+    it('全員薬0件の場合は元の順序を維持', () => {
+      const members = [
+        createSummary({ memberId: 'a' }),
+        createSummary({ memberId: 'b' }),
+      ];
+      const ranked = MemberSummaryEntity.rankByMedicationCount(members);
+      expect(ranked.map(m => m.memberId)).toEqual(['a', 'b']);
+    });
+
+    it('1人だけの配列', () => {
+      const members = [createSummary({ memberId: 'a', medicationCount: 5 })];
+      const ranked = MemberSummaryEntity.rankByMedicationCount(members);
+      expect(ranked).toHaveLength(1);
+    });
+
+    it('大量メンバーでも正しくソート', () => {
+      const members = Array.from({ length: 100 }, (_, i) =>
+        createSummary({ memberId: `m${i}`, medicationCount: i })
+      );
+      const ranked = MemberSummaryEntity.rankByMedicationCount(members);
+      expect(ranked[0].medicationCount).toBe(99);
+      expect(ranked[99].medicationCount).toBe(0);
+    });
+  });
+
+  describe('filterByType 境界値', () => {
+    it('空配列に対するフィルタ', () => {
+      expect(MemberSummaryEntity.filterByType([], 'human')).toEqual([]);
+    });
+
+    it('全員同じ種別', () => {
+      const members = [
+        createSummary({ memberId: 'a', memberType: 'pet' }),
+        createSummary({ memberId: 'b', memberType: 'pet' }),
+      ];
+      const result = MemberSummaryEntity.filterByType(members, 'pet');
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getGroupActivitySummary 境界値', () => {
+    it('全員薬なし・予約なし', () => {
+      const members = [
+        createSummary(),
+        createSummary(),
+      ];
+      const summary = MemberSummaryEntity.getGroupActivitySummary(members);
+      expect(summary.withMedications).toBe(0);
+      expect(summary.withAppointments).toBe(0);
+      expect(summary.totalMedications).toBe(0);
+    });
+
+    it('大量の薬登録', () => {
+      const members = [
+        createSummary({ medicationCount: 999 }),
+      ];
+      const summary = MemberSummaryEntity.getGroupActivitySummary(members);
+      expect(summary.totalMedications).toBe(999);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MemberSummaryComparison: 全員薬0件、1人、大量(100人)、空配列(7テスト)
- GreetingSeasonalStreak: 月境界(2/6/8/9/11月)、ストリーク境界(1/6/8/29/365日)、長い名前(11テスト)
- AdherenceTrendForecast: 差境界(+5/+6/-5/-6)、長配列、0-100制約、formatRateChange(13テスト)

## Test plan
- [x] 新規31テスト全パス
- [x] 既存含む全2593テストパス

closes #553