### PR TITLE
fix: /api/users/me GETにレート制限追加

### DIFF
--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -13,6 +13,8 @@ const USER_SELECT = {
 } as const;
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`users-me-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: USER_SELECT,


### PR DESCRIPTION
## Summary
- /api/users/me GET: 30req/minのレート制限を追加

## Test plan
- [x] 既存2593テスト全パス

closes #555