### PR TITLE
feat: Character 検証・取得ユーティリティメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/CharacterValidation.test.ts
+++ b/src/__tests__/domain/entities/CharacterValidation.test.ts
@@ -1,0 +1,61 @@
+import { CharacterEntity } from '@/domain/entities/Character';
+
+describe('CharacterEntity - Validation', () => {
+  describe('isValidCharacterType', () => {
+    it('dogは有効', () => {
+      expect(CharacterEntity.isValidCharacterType('dog')).toBe(true);
+    });
+
+    it('catは有効', () => {
+      expect(CharacterEntity.isValidCharacterType('cat')).toBe(true);
+    });
+
+    it('rabbitは有効', () => {
+      expect(CharacterEntity.isValidCharacterType('rabbit')).toBe(true);
+    });
+
+    it('birdは有効', () => {
+      expect(CharacterEntity.isValidCharacterType('bird')).toBe(true);
+    });
+
+    it('unknownは無効', () => {
+      expect(CharacterEntity.isValidCharacterType('unknown')).toBe(false);
+    });
+
+    it('空文字は無効', () => {
+      expect(CharacterEntity.isValidCharacterType('')).toBe(false);
+    });
+  });
+
+  describe('getCharacterConfig', () => {
+    it('dogのConfigを返す', () => {
+      const config = CharacterEntity.getCharacterConfig('dog');
+      expect(config.name).toBe('いぬ');
+    });
+
+    it('catのConfigを返す', () => {
+      const config = CharacterEntity.getCharacterConfig('cat');
+      expect(config.name).toBe('ねこ');
+    });
+
+    it('無効タイプはdogのConfigを返す', () => {
+      const config = CharacterEntity.getCharacterConfig('invalid');
+      expect(config.name).toBe('いぬ');
+    });
+  });
+
+  describe('getAllCharacterTypes', () => {
+    it('4つのタイプを返す', () => {
+      const types = CharacterEntity.getAllCharacterTypes();
+      expect(types).toHaveLength(4);
+    });
+
+    it('全タイプを含む', () => {
+      const types = CharacterEntity.getAllCharacterTypes();
+      expect(types).toContain('dog');
+      expect(types).toContain('cat');
+      expect(types).toContain('rabbit');
+      expect(types).toContain('bird');
+    });
+  });
+});

--- a/src/domain/entities/Character.ts
+++ b/src/domain/entities/Character.ts
@@ -31,6 +31,34 @@ export interface CharacterConfig {
   };
 }
 
+const VALID_TYPES: CharacterType[] = ['dog', 'cat', 'rabbit', 'bird'];
+
+export class CharacterEntity {
+  /**
+   * 文字列がCharacterTypeか検証する
+   */
+  static isValidCharacterType(type: string): type is CharacterType {
+    return VALID_TYPES.includes(type as CharacterType);
+  }
+
+  /**
+   * タイプからConfigを取得する(無効時はdogをデフォルトで返す)
+   */
+  static getCharacterConfig(type: string): CharacterConfig {
+    if (CharacterEntity.isValidCharacterType(type)) {
+      return CHARACTER_CONFIGS[type];
+    }
+    return CHARACTER_CONFIGS.dog;
+  }
+
+  /**
+   * 全キャラクタータイプのリストを返す
+   */
+  static getAllCharacterTypes(): CharacterType[] {
+    return [...VALID_TYPES];
+  }
+}
+
 export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {
   dog: {
     type: 'dog',


### PR DESCRIPTION
## Summary
- CharacterEntityクラスを新設
- `isValidCharacterType`: 文字列がCharacterTypeか検証
- `getCharacterConfig`: タイプからConfigを取得(無効時はdog)
- `getAllCharacterTypes`: 全タイプのリストを返す

## Test plan
- [x] isValidCharacterType: dog/cat/rabbit/bird有効、unknown/空文字無効(6テスト)
- [x] getCharacterConfig: dog/cat/invalid(3テスト)
- [x] getAllCharacterTypes: 4件・全タイプ含む(2テスト)

closes #557