### PR TITLE
feat: Appointment 予約重複検出メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentConflictDetection.test.ts
+++ b/src/__tests__/domain/entities/AppointmentConflictDetection.test.ts
@@ -1,0 +1,69 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Conflict Detection', () => {
+  describe('hasConflict', () => {
+    it('同日の予約は重複と判定する', () => {
+      const date1 = new Date('2025-06-15T10:00:00');
+      const date2 = new Date('2025-06-15T14:00:00');
+      expect(AppointmentEntity.hasConflict(date1, date2)).toBe(true);
+    });
+
+    it('異日の予約は重複しない', () => {
+      const date1 = new Date('2025-06-15T10:00:00');
+      const date2 = new Date('2025-06-16T10:00:00');
+      expect(AppointmentEntity.hasConflict(date1, date2)).toBe(false);
+    });
+
+    it('同日の深夜と朝でも重複', () => {
+      const date1 = new Date('2025-06-15T01:00:00');
+      const date2 = new Date('2025-06-15T23:59:00');
+      expect(AppointmentEntity.hasConflict(date1, date2)).toBe(true);
+    });
+  });
+
+  describe('findConflicts', () => {
+    const appointments = [
+      { appointmentDate: new Date('2025-06-15T10:00:00'), hospitalName: '東京病院' },
+      { appointmentDate: new Date('2025-06-16T10:00:00'), hospitalName: '大阪クリニック' },
+      { appointmentDate: new Date('2025-06-15T14:00:00'), hospitalName: '名古屋医院' },
+    ];
+
+    it('指定日と重複する予約を検出する', () => {
+      const conflicts = AppointmentEntity.findConflicts(
+        appointments,
+        new Date('2025-06-15T09:00:00'),
+      );
+      expect(conflicts).toHaveLength(2);
+    });
+
+    it('重複がない場合は空配列を返す', () => {
+      const conflicts = AppointmentEntity.findConflicts(
+        appointments,
+        new Date('2025-06-17T09:00:00'),
+      );
+      expect(conflicts).toHaveLength(0);
+    });
+
+    it('空配列に対しては空配列を返す', () => {
+      const conflicts = AppointmentEntity.findConflicts(
+        [],
+        new Date('2025-06-15T09:00:00'),
+      );
+      expect(conflicts).toHaveLength(0);
+    });
+  });
+
+  describe('getConflictMessage', () => {
+    it('0件の場合はnullを返す', () => {
+      expect(AppointmentEntity.getConflictMessage(0)).toBeNull();
+    });
+
+    it('1件の場合は単数メッセージを返す', () => {
+      expect(AppointmentEntity.getConflictMessage(1)).toBe('同日に1件の予約があります');
+    });
+
+    it('複数件の場合は複数メッセージを返す', () => {
+      expect(AppointmentEntity.getConflictMessage(3)).toBe('同日に3件の予約があります');
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -334,4 +334,29 @@ export class AppointmentEntity {
       isValid: !!label,
     };
   }
+
+  /**
+   * 2つの予約日が同日かどうかを判定する
+   */
+  static hasConflict(date1: Date, date2: Date): boolean {
+    return DateRangeHelper.toDateKey(date1) === DateRangeHelper.toDateKey(date2);
+  }
+
+  /**
+   * 予約リストから指定日と重複する予約を検出する
+   */
+  static findConflicts<T extends { appointmentDate: Date }>(
+    appointments: T[],
+    targetDate: Date,
+  ): T[] {
+    return appointments.filter((a) => AppointmentEntity.hasConflict(a.appointmentDate, targetDate));
+  }
+
+  /**
+   * 重複件数に応じた警告メッセージを返す(0件はnull)
+   */
+  static getConflictMessage(conflictCount: number): string | null {
+    if (conflictCount === 0) return null;
+    return `同日に${conflictCount}件の予約があります`;
+  }
 }


### PR DESCRIPTION
## Summary
- `hasConflict`: 2つの予約日が同日かどうかを判定
- `findConflicts`: 予約リストから指定日と重複する予約を検出
- `getConflictMessage`: 重複件数に応じた警告メッセージ

## Test plan
- [x] hasConflict: 同日/異日/深夜-朝(3テスト)
- [x] findConflicts: 重複あり/なし/空配列(3テスト)
- [x] getConflictMessage: 0件/1件/複数件(3テスト)

closes #559