### PR TITLE
feat: Medication カテゴリ分類・注意チェックメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationCategoryCheck.test.ts
+++ b/src/__tests__/domain/entities/MedicationCategoryCheck.test.ts
@@ -1,0 +1,76 @@
+import { MedicationEntity } from '@/domain/entities/Medication';
+import type { MedicationCategory } from '@/domain/entities/Medication';
+
+describe('MedicationEntity - Category Check', () => {
+  describe('isSameCategory', () => {
+    it('同じカテゴリの場合trueを返す', () => {
+      expect(MedicationEntity.isSameCategory('regular', 'regular')).toBe(true);
+    });
+
+    it('異なるカテゴリの場合falseを返す', () => {
+      expect(MedicationEntity.isSameCategory('regular', 'supplement')).toBe(false);
+    });
+
+    it('prnとprnは同じ', () => {
+      expect(MedicationEntity.isSameCategory('prn', 'prn')).toBe(true);
+    });
+  });
+
+  describe('groupByCategory', () => {
+    it('カテゴリ別にグループ化する', () => {
+      const meds = [
+        { name: '薬A', category: 'regular' as MedicationCategory },
+        { name: '薬B', category: 'supplement' as MedicationCategory },
+        { name: '薬C', category: 'regular' as MedicationCategory },
+      ];
+      const groups = MedicationEntity.groupByCategory(meds);
+      expect(Object.keys(groups)).toHaveLength(2);
+      expect(groups['regular']).toHaveLength(2);
+      expect(groups['supplement']).toHaveLength(1);
+    });
+
+    it('空配列は空オブジェクトを返す', () => {
+      const groups = MedicationEntity.groupByCategory([]);
+      expect(Object.keys(groups)).toHaveLength(0);
+    });
+
+    it('全て同じカテゴリの場合1グループ', () => {
+      const meds = [
+        { name: '薬A', category: 'prn' as MedicationCategory },
+        { name: '薬B', category: 'prn' as MedicationCategory },
+      ];
+      const groups = MedicationEntity.groupByCategory(meds);
+      expect(Object.keys(groups)).toHaveLength(1);
+      expect(groups['prn']).toHaveLength(2);
+    });
+
+    it('全て異なるカテゴリの場合各1グループ', () => {
+      const meds = [
+        { name: '薬A', category: 'regular' as MedicationCategory },
+        { name: '薬B', category: 'supplement' as MedicationCategory },
+        { name: '薬C', category: 'prn' as MedicationCategory },
+      ];
+      const groups = MedicationEntity.groupByCategory(meds);
+      expect(Object.keys(groups)).toHaveLength(3);
+    });
+  });
+
+  describe('getCategoryCountSummary', () => {
+    it('カテゴリ別の件数サマリーを返す', () => {
+      const meds = [
+        { name: '薬A', category: 'regular' as MedicationCategory },
+        { name: '薬B', category: 'regular' as MedicationCategory },
+        { name: '薬C', category: 'supplement' as MedicationCategory },
+      ];
+      const summary = MedicationEntity.getCategoryCountSummary(meds);
+      expect(summary).toEqual([
+        { category: 'regular', label: '常用薬', count: 2 },
+        { category: 'supplement', label: 'サプリメント', count: 1 },
+      ]);
+    });
+
+    it('空配列は空配列を返す', () => {
+      expect(MedicationEntity.getCategoryCountSummary([])).toEqual([]);
+    });
+  });
+});

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -274,4 +274,39 @@ export class MedicationEntity {
     }
     return parts.join(' / ');
   }
+
+  /**
+   * 2つの薬が同カテゴリかチェックする
+   */
+  static isSameCategory(cat1: string, cat2: string): boolean {
+    return cat1 === cat2;
+  }
+
+  /**
+   * 薬リストをカテゴリ別にグループ化する
+   */
+  static groupByCategory<T extends { category: string }>(medications: T[]): Record<string, T[]> {
+    const groups: Record<string, T[]> = {};
+    for (const med of medications) {
+      if (!groups[med.category]) {
+        groups[med.category] = [];
+      }
+      groups[med.category].push(med);
+    }
+    return groups;
+  }
+
+  /**
+   * カテゴリ別の件数サマリーを返す
+   */
+  static getCategoryCountSummary<T extends { category: MedicationCategory }>(
+    medications: T[],
+  ): Array<{ category: MedicationCategory; label: string; count: number }> {
+    const groups = MedicationEntity.groupByCategory(medications);
+    return Object.entries(groups).map(([category, meds]) => ({
+      category: category as MedicationCategory,
+      label: MedicationEntity.getCategoryLabel(category as MedicationCategory),
+      count: meds.length,
+    }));
+  }
 }


### PR DESCRIPTION
## Summary
- `isSameCategory`: 2つの薬が同カテゴリかチェック
- `groupByCategory`: 薬リストをカテゴリ別にグループ化
- `getCategoryCountSummary`: カテゴリ別の件数サマリー

## Test plan
- [x] isSameCategory: 同カテゴリ/異カテゴリ(3テスト)
- [x] groupByCategory: 複合/空/同一/全異なる(4テスト)
- [x] getCategoryCountSummary: 複合/空(2テスト)

closes #561