### PR TITLE
test: Cycle 31 Phase 1 機能のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentConflictDetection.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentConflictDetection.edge.test.ts
@@ -1,0 +1,45 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Conflict Detection Edge Cases', () => {
+  describe('hasConflict 境界値', () => {
+    it('年跨ぎの同日は重複', () => {
+      const d1 = new Date('2025-12-31T10:00:00');
+      const d2 = new Date('2025-12-31T23:59:00');
+      expect(AppointmentEntity.hasConflict(d1, d2)).toBe(true);
+    });
+
+    it('年跨ぎの前日と翌日は非重複', () => {
+      const d1 = new Date('2025-12-31T23:59:00');
+      const d2 = new Date('2026-01-01T00:01:00');
+      expect(AppointmentEntity.hasConflict(d1, d2)).toBe(false);
+    });
+
+    it('月末と翌月初は非重複', () => {
+      const d1 = new Date('2025-06-30T23:00:00');
+      const d2 = new Date('2025-07-01T01:00:00');
+      expect(AppointmentEntity.hasConflict(d1, d2)).toBe(false);
+    });
+
+    it('同じDateオブジェクトは重複', () => {
+      const d = new Date('2025-06-15T10:00:00');
+      expect(AppointmentEntity.hasConflict(d, d)).toBe(true);
+    });
+  });
+
+  describe('findConflicts 境界値', () => {
+    it('全て同日の場合全件返す', () => {
+      const appointments = Array.from({ length: 5 }, (_, i) => ({
+        appointmentDate: new Date(`2025-06-15T${10 + i}:00:00`),
+        hospitalName: `病院${i}`,
+      }));
+      const conflicts = AppointmentEntity.findConflicts(appointments, new Date('2025-06-15'));
+      expect(conflicts).toHaveLength(5);
+    });
+  });
+
+  describe('getConflictMessage 境界値', () => {
+    it('大きな数でも正しいメッセージ', () => {
+      expect(AppointmentEntity.getConflictMessage(99)).toBe('同日に99件の予約があります');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/CharacterValidation.edge.test.ts
+++ b/src/__tests__/domain/entities/CharacterValidation.edge.test.ts
@@ -1,0 +1,49 @@
+import { CharacterEntity } from '@/domain/entities/Character';
+
+describe('CharacterEntity - Validation Edge Cases', () => {
+  describe('isValidCharacterType 境界値', () => {
+    it('大文字DOGは無効', () => {
+      expect(CharacterEntity.isValidCharacterType('DOG')).toBe(false);
+    });
+
+    it('数字は無効', () => {
+      expect(CharacterEntity.isValidCharacterType('123')).toBe(false);
+    });
+
+    it('スペース付きは無効', () => {
+      expect(CharacterEntity.isValidCharacterType(' dog ')).toBe(false);
+    });
+
+    it('nullっぽい文字列は無効', () => {
+      expect(CharacterEntity.isValidCharacterType('null')).toBe(false);
+    });
+  });
+
+  describe('getCharacterConfig 境界値', () => {
+    it('全4タイプのConfigが正しい名前を持つ', () => {
+      expect(CharacterEntity.getCharacterConfig('dog').name).toBe('いぬ');
+      expect(CharacterEntity.getCharacterConfig('cat').name).toBe('ねこ');
+      expect(CharacterEntity.getCharacterConfig('rabbit').name).toBe('うさぎ');
+      expect(CharacterEntity.getCharacterConfig('bird').name).toBe('インコ');
+    });
+
+    it('空文字はデフォルト(dog)を返す', () => {
+      expect(CharacterEntity.getCharacterConfig('').name).toBe('いぬ');
+    });
+
+    it('Configにmessagesが含まれる', () => {
+      const config = CharacterEntity.getCharacterConfig('cat');
+      expect(config.messages).toBeDefined();
+      expect(config.messages.medicationReminder).toBeTruthy();
+    });
+  });
+
+  describe('getAllCharacterTypes 境界値', () => {
+    it('返り値は元配列と独立したコピー', () => {
+      const types1 = CharacterEntity.getAllCharacterTypes();
+      const types2 = CharacterEntity.getAllCharacterTypes();
+      expect(types1).not.toBe(types2);
+      expect(types1).toEqual(types2);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationCategoryCheck.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationCategoryCheck.edge.test.ts
@@ -1,0 +1,50 @@
+import { MedicationEntity } from '@/domain/entities/Medication';
+import type { MedicationCategory } from '@/domain/entities/Medication';
+
+describe('MedicationEntity - Category Check Edge Cases', () => {
+  describe('isSameCategory 境界値', () => {
+    it('空文字同士は同じ', () => {
+      expect(MedicationEntity.isSameCategory('', '')).toBe(true);
+    });
+
+    it('片方空文字は異なる', () => {
+      expect(MedicationEntity.isSameCategory('regular', '')).toBe(false);
+    });
+
+    it('未知カテゴリ同士でも同じなら一致', () => {
+      expect(MedicationEntity.isSameCategory('custom', 'custom')).toBe(true);
+    });
+  });
+
+  describe('groupByCategory 境界値', () => {
+    it('1件のみの場合1グループ', () => {
+      const meds = [{ name: '薬A', category: 'regular' }];
+      const groups = MedicationEntity.groupByCategory(meds);
+      expect(Object.keys(groups)).toHaveLength(1);
+    });
+
+    it('未知カテゴリもグループ化される', () => {
+      const meds = [
+        { name: '薬A', category: 'custom1' },
+        { name: '薬B', category: 'custom1' },
+      ];
+      const groups = MedicationEntity.groupByCategory(meds);
+      expect(groups['custom1']).toHaveLength(2);
+    });
+  });
+
+  describe('getCategoryCountSummary 境界値', () => {
+    it('全カテゴリが含まれる場合', () => {
+      const meds = [
+        { name: '薬A', category: 'regular' as MedicationCategory },
+        { name: '薬B', category: 'supplement' as MedicationCategory },
+        { name: '薬C', category: 'prn' as MedicationCategory },
+        { name: '薬D', category: 'external' as MedicationCategory },
+        { name: '薬E', category: 'heartworm' as MedicationCategory },
+      ];
+      const summary = MedicationEntity.getCategoryCountSummary(meds);
+      expect(summary).toHaveLength(5);
+      expect(summary.every(s => s.count === 1)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- CharacterValidation: 大文字/数字/スペース/null文字列、全Config確認、コピー独立性(8テスト)
- AppointmentConflictDetection: 年跨ぎ/月末/同オブジェクト、全件同日、大件数(6テスト)
- MedicationCategoryCheck: 空文字/未知カテゴリ、全カテゴリ含む(6テスト)

## Test plan
- [x] 新規20テスト全パス
- [x] 既存含む全2642テストパス

closes #565