### PR TITLE
fix: forgot-password にメールアドレスベースのレート制限追加

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -18,8 +18,12 @@ export async function POST(request: NextRequest) {
     const email = parsed.data.email;
 
     const ip = request.headers.get('x-forwarded-for') ?? 'unknown';
-    const rateLimit = checkRateLimit(`forgot:${ip}`, { maxAttempts: 5, windowMs: 60 * 1000 });
-    if (!rateLimit.allowed) {
+    const ipLimit = checkRateLimit(`forgot:${ip}`, { maxAttempts: 5, windowMs: 60 * 1000 });
+    if (!ipLimit.allowed) {
+      return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    }
+    const emailLimit = checkRateLimit(`forgot-email:${email}`, { maxAttempts: 3, windowMs: 60 * 1000 });
+    if (!emailLimit.allowed) {
       return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     }
 


### PR DESCRIPTION
## Summary
- 既存のIPベースレート制限(5回/分)に加え、メールアドレスベース(3回/分)のレート制限を追加
- 同一メールアドレスへの連続パスワードリセット要求を防止

## Test plan
- [x] 既存2642テスト全パス

closes #567