### PR TITLE
feat: Member プロフィール完成度チェックメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MemberProfileCompleteness.test.ts
+++ b/src/__tests__/domain/entities/MemberProfileCompleteness.test.ts
@@ -1,0 +1,86 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Profile Completeness', () => {
+  describe('getProfileCompleteness', () => {
+    it('全フィールド入力で100%を返す', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+        birthDate: new Date('1990-01-01'),
+        photoUrl: 'https://example.com/photo.jpg',
+        notes: 'メモ',
+      };
+      expect(MemberEntity.getProfileCompleteness(member)).toBe(100);
+    });
+
+    it('名前とタイプのみで最低限の完成度を返す', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+      };
+      expect(MemberEntity.getProfileCompleteness(member)).toBe(40);
+    });
+
+    it('一部入力で中間の完成度を返す', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+        birthDate: new Date('1990-01-01'),
+      };
+      expect(MemberEntity.getProfileCompleteness(member)).toBe(60);
+    });
+
+    it('ペットでpetType入力ありの場合', () => {
+      const member = {
+        name: 'ポチ',
+        memberType: 'pet' as const,
+        petType: 'dog' as const,
+        birthDate: new Date('2020-01-01'),
+        photoUrl: 'https://example.com/pochi.jpg',
+      };
+      expect(MemberEntity.getProfileCompleteness(member)).toBe(80);
+    });
+  });
+
+  describe('getMissingFields', () => {
+    it('全フィールド入力で空配列を返す', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+        birthDate: new Date('1990-01-01'),
+        photoUrl: 'https://example.com/photo.jpg',
+        notes: 'メモ',
+      };
+      expect(MemberEntity.getMissingFields(member)).toEqual([]);
+    });
+
+    it('未入力フィールドを返す', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+      };
+      const missing = MemberEntity.getMissingFields(member);
+      expect(missing).toContain('生年月日');
+      expect(missing).toContain('写真');
+      expect(missing).toContain('メモ');
+    });
+  });
+
+  describe('getProfileCompletenessLabel', () => {
+    it('100%は「完了」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(100)).toBe('完了');
+    });
+
+    it('80%は「ほぼ完了」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(80)).toBe('ほぼ完了');
+    });
+
+    it('50%は「半分入力済み」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(50)).toBe('半分入力済み');
+    });
+
+    it('30%は「入力が必要」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(30)).toBe('入力が必要');
+    });
+  });
+});

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -283,4 +283,53 @@ export class MemberEntity {
     }
     return 'ペット';
   }
+
+  /**
+   * プロフィールの完成度(0-100%)を算出する
+   */
+  static getProfileCompleteness(member: {
+    name: string;
+    memberType: string;
+    birthDate?: Date | null;
+    photoUrl?: string | null;
+    notes?: string | null;
+    petType?: string | null;
+  }): number {
+    const fields = [
+      !!member.name,
+      !!member.memberType,
+      !!member.birthDate,
+      !!member.photoUrl,
+      !!member.notes,
+    ];
+    const filled = fields.filter(Boolean).length;
+    return Math.round((filled / fields.length) * 100);
+  }
+
+  /**
+   * 未入力フィールドのリストを返す
+   */
+  static getMissingFields(member: {
+    name: string;
+    memberType: string;
+    birthDate?: Date | null;
+    photoUrl?: string | null;
+    notes?: string | null;
+  }): string[] {
+    const missing: string[] = [];
+    if (!member.birthDate) missing.push('生年月日');
+    if (!member.photoUrl) missing.push('写真');
+    if (!member.notes) missing.push('メモ');
+    return missing;
+  }
+
+  /**
+   * 完成度に応じたラベルを返す
+   */
+  static getProfileCompletenessLabel(percentage: number): string {
+    if (percentage >= 100) return '完了';
+    if (percentage >= 80) return 'ほぼ完了';
+    if (percentage >= 50) return '半分入力済み';
+    return '入力が必要';
+  }
 }


### PR DESCRIPTION
## Summary
- `getProfileCompleteness`: プロフィール各フィールドの入力率を算出(0-100%)
- `getMissingFields`: 未入力フィールドのリストを返す
- `getProfileCompletenessLabel`: 完成度に応じたラベル

## Test plan
- [x] getProfileCompleteness: 全入力/最小/一部/ペット(4テスト)
- [x] getMissingFields: 全入力/未入力(2テスト)
- [x] getProfileCompletenessLabel: 100/80/50/30%(4テスト)

closes #569