### PR TITLE
feat: Schedule タイムスロット管理メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleTimeSlot.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimeSlot.test.ts
@@ -1,0 +1,67 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Time Slot', () => {
+  describe('getScheduleDensity', () => {
+    it('0件は「なし」を返す', () => {
+      expect(ScheduleEntity.getScheduleDensity(0)).toBe('none');
+    });
+
+    it('1件は「低」を返す', () => {
+      expect(ScheduleEntity.getScheduleDensity(1)).toBe('low');
+    });
+
+    it('3件は「低」を返す', () => {
+      expect(ScheduleEntity.getScheduleDensity(3)).toBe('low');
+    });
+
+    it('4件は「中」を返す', () => {
+      expect(ScheduleEntity.getScheduleDensity(4)).toBe('medium');
+    });
+
+    it('6件は「中」を返す', () => {
+      expect(ScheduleEntity.getScheduleDensity(6)).toBe('medium');
+    });
+
+    it('7件は「高」を返す', () => {
+      expect(ScheduleEntity.getScheduleDensity(7)).toBe('high');
+    });
+  });
+
+  describe('hasTimeOverlap', () => {
+    it('同じ時刻は重複', () => {
+      expect(ScheduleEntity.hasTimeOverlap('08:00', '08:00', 30)).toBe(true);
+    });
+
+    it('30分以内は重複', () => {
+      expect(ScheduleEntity.hasTimeOverlap('08:00', '08:20', 30)).toBe(true);
+    });
+
+    it('30分ちょうどは重複', () => {
+      expect(ScheduleEntity.hasTimeOverlap('08:00', '08:30', 30)).toBe(true);
+    });
+
+    it('31分は非重複', () => {
+      expect(ScheduleEntity.hasTimeOverlap('08:00', '08:31', 30)).toBe(false);
+    });
+
+    it('大きく離れた時刻は非重複', () => {
+      expect(ScheduleEntity.hasTimeOverlap('08:00', '20:00', 30)).toBe(false);
+    });
+  });
+
+  describe('getOptimalTimeSuggestion', () => {
+    it('既存スケジュールなしの場合08:00を返す', () => {
+      expect(ScheduleEntity.getOptimalTimeSuggestion([])).toBe('08:00');
+    });
+
+    it('朝のみの場合は夜を提案', () => {
+      const result = ScheduleEntity.getOptimalTimeSuggestion(['08:00']);
+      expect(result).toBe('20:00');
+    });
+
+    it('朝と夜の場合は昼を提案', () => {
+      const result = ScheduleEntity.getOptimalTimeSuggestion(['08:00', '20:00']);
+      expect(result).toBe('14:00');
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -519,4 +519,56 @@ export class ScheduleEntity {
 
     return sorted.map((d) => ScheduleEntity.DAY_LABELS[d]).join(', ');
   }
+
+  /**
+   * 1日のスケジュール数から密度レベルを返す
+   */
+  static getScheduleDensity(count: number): 'none' | 'low' | 'medium' | 'high' {
+    if (count === 0) return 'none';
+    if (count <= 3) return 'low';
+    if (count <= 6) return 'medium';
+    return 'high';
+  }
+
+  /**
+   * 2つの時刻が指定分数以内に近いか判定する
+   */
+  static hasTimeOverlap(time1: string, time2: string, thresholdMinutes: number): boolean {
+    const toMinutes = (t: string) => {
+      const [h, m] = t.split(':').map(Number);
+      return h * 60 + m;
+    };
+    const diff = Math.abs(toMinutes(time1) - toMinutes(time2));
+    return diff <= thresholdMinutes;
+  }
+
+  /**
+   * 既存時刻から最も離れた時刻帯を提案する(08:00-20:00の範囲)
+   */
+  static getOptimalTimeSuggestion(existingTimes: string[]): string {
+    if (existingTimes.length === 0) return '08:00';
+
+    const toMinutes = (t: string) => {
+      const [h, m] = t.split(':').map(Number);
+      return h * 60 + m;
+    };
+
+    const existing = existingTimes.map(toMinutes).sort((a, b) => a - b);
+    const candidates = [480, 720, 840, 960, 1080, 1200]; // 08,12,14,16,18,20
+
+    let bestTime = candidates[0];
+    let maxMinDist = -1;
+
+    for (const candidate of candidates) {
+      const minDist = Math.min(...existing.map((e) => Math.abs(candidate - e)));
+      if (minDist > maxMinDist) {
+        maxMinDist = minDist;
+        bestTime = candidate;
+      }
+    }
+
+    const h = Math.floor(bestTime / 60).toString().padStart(2, '0');
+    const m = (bestTime % 60).toString().padStart(2, '0');
+    return `${h}:${m}`;
+  }
 }


### PR DESCRIPTION
## Summary
- `getScheduleDensity`: 1日のスケジュール数から密度レベル(none/low/medium/high)
- `hasTimeOverlap`: 2つの時刻が指定分数以内に近いか判定
- `getOptimalTimeSuggestion`: 既存時刻から最も離れた時刻帯を提案

## Test plan
- [x] getScheduleDensity: 0/1/3/4/6/7件(6テスト)
- [x] hasTimeOverlap: 同一/近い/境界/離れた(5テスト)
- [x] getOptimalTimeSuggestion: 空/朝のみ/朝夜(3テスト)

closes #571