### PR TITLE
feat: HealthLog 症状サマリーメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/HealthLogSymptomSummary.test.ts
+++ b/src/__tests__/domain/entities/HealthLogSymptomSummary.test.ts
@@ -1,0 +1,67 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Symptom Summary', () => {
+  describe('getSymptomFrequency', () => {
+    it('症状別の出現頻度を降順で返す', () => {
+      const symptoms = ['頭痛', '発熱', '頭痛', '咳', '頭痛', '発熱'];
+      const result = HealthLogEntity.getSymptomFrequency(symptoms);
+      expect(result).toEqual([
+        { symptom: '頭痛', count: 3 },
+        { symptom: '発熱', count: 2 },
+        { symptom: '咳', count: 1 },
+      ]);
+    });
+
+    it('空配列は空配列を返す', () => {
+      expect(HealthLogEntity.getSymptomFrequency([])).toEqual([]);
+    });
+
+    it('1種類のみの場合', () => {
+      const result = HealthLogEntity.getSymptomFrequency(['頭痛', '頭痛']);
+      expect(result).toEqual([{ symptom: '頭痛', count: 2 }]);
+    });
+  });
+
+  describe('getSymptomCountLabel', () => {
+    it('0は「症状なし」', () => {
+      expect(HealthLogEntity.getSymptomCountLabel(0)).toBe('症状なし');
+    });
+
+    it('1は「軽度」', () => {
+      expect(HealthLogEntity.getSymptomCountLabel(1)).toBe('軽度');
+    });
+
+    it('2は「軽度」', () => {
+      expect(HealthLogEntity.getSymptomCountLabel(2)).toBe('軽度');
+    });
+
+    it('3は「中度」', () => {
+      expect(HealthLogEntity.getSymptomCountLabel(3)).toBe('中度');
+    });
+
+    it('4は「中度」', () => {
+      expect(HealthLogEntity.getSymptomCountLabel(4)).toBe('中度');
+    });
+
+    it('5は「重度」', () => {
+      expect(HealthLogEntity.getSymptomCountLabel(5)).toBe('重度');
+    });
+  });
+
+  describe('getMostCommonSymptom', () => {
+    it('最も頻度が高い症状を返す', () => {
+      const symptoms = ['頭痛', '発熱', '頭痛'];
+      expect(HealthLogEntity.getMostCommonSymptom(symptoms)).toBe('頭痛');
+    });
+
+    it('空配列はnullを返す', () => {
+      expect(HealthLogEntity.getMostCommonSymptom([])).toBeNull();
+    });
+
+    it('全て同数の場合は最初に出現した症状を返す', () => {
+      const symptoms = ['頭痛', '発熱', '咳'];
+      const result = HealthLogEntity.getMostCommonSymptom(symptoms);
+      expect(result).toBe('頭痛');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -510,4 +510,36 @@ export class HealthLogEntity {
     if (recordDays >= totalDays / 2) return '順調に記録できています';
     return 'もう少し記録をつけてみましょう';
   }
+
+  /**
+   * 症状別の出現頻度を降順で返す
+   */
+  static getSymptomFrequency(symptoms: string[]): Array<{ symptom: string; count: number }> {
+    const counts: Record<string, number> = {};
+    for (const s of symptoms) {
+      counts[s] = (counts[s] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .map(([symptom, count]) => ({ symptom, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  /**
+   * 症状数に応じたラベルを返す
+   */
+  static getSymptomCountLabel(count: number): string {
+    if (count === 0) return '症状なし';
+    if (count <= 2) return '軽度';
+    if (count <= 4) return '中度';
+    return '重度';
+  }
+
+  /**
+   * 最も頻度が高い症状を返す
+   */
+  static getMostCommonSymptom(symptoms: string[]): string | null {
+    if (symptoms.length === 0) return null;
+    const freq = HealthLogEntity.getSymptomFrequency(symptoms);
+    return freq[0].symptom;
+  }
 }


### PR DESCRIPTION
## Summary
- `getSymptomFrequency`: 症状別の出現頻度を降順で返す
- `getSymptomCountLabel`: 症状数に応じたラベル(なし/軽度/中度/重度)
- `getMostCommonSymptom`: 最も頻度が高い症状を返す

## Test plan
- [x] getSymptomFrequency: 複数種/空/1種(3テスト)
- [x] getSymptomCountLabel: 0/1/2/3/4/5(6テスト)
- [x] getMostCommonSymptom: 正常系/空/同数(3テスト)

closes #573