### PR TITLE
Phase32エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/HealthLogSymptomSummary.edge.test.ts
+++ b/src/__tests__/domain/entities/HealthLogSymptomSummary.edge.test.ts
@@ -1,0 +1,37 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Symptom Summary Edge Cases', () => {
+  describe('getSymptomFrequency 境界値', () => {
+    it('全て同じ症状の場合1エントリ', () => {
+      const symptoms = ['頭痛', '頭痛', '頭痛', '頭痛', '頭痛'];
+      const result = HealthLogEntity.getSymptomFrequency(symptoms);
+      expect(result).toHaveLength(1);
+      expect(result[0].count).toBe(5);
+    });
+
+    it('大量の種類がある場合', () => {
+      const symptoms = Array.from({ length: 50 }, (_, i) => `症状${i}`);
+      const result = HealthLogEntity.getSymptomFrequency(symptoms);
+      expect(result).toHaveLength(50);
+      expect(result.every(r => r.count === 1)).toBe(true);
+    });
+  });
+
+  describe('getSymptomCountLabel 境界値', () => {
+    it('非常に大きい数は「重度」', () => {
+      expect(HealthLogEntity.getSymptomCountLabel(100)).toBe('重度');
+    });
+  });
+
+  describe('getMostCommonSymptom 境界値', () => {
+    it('1件のみの場合その症状を返す', () => {
+      expect(HealthLogEntity.getMostCommonSymptom(['発熱'])).toBe('発熱');
+    });
+
+    it('大量のデータでも正しく動作', () => {
+      const symptoms = Array.from({ length: 1000 }, () => '頭痛');
+      symptoms.push('発熱');
+      expect(HealthLogEntity.getMostCommonSymptom(symptoms)).toBe('頭痛');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberProfileCompleteness.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberProfileCompleteness.edge.test.ts
@@ -1,0 +1,56 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Profile Completeness Edge Cases', () => {
+  describe('getProfileCompleteness 境界値', () => {
+    it('全フィールドnullの場合は最低限(名前+タイプで40%)', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+        birthDate: null,
+        photoUrl: null,
+        notes: null,
+      };
+      expect(MemberEntity.getProfileCompleteness(member)).toBe(40);
+    });
+
+    it('空文字のnotesは未入力扱い', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+        notes: '',
+      };
+      expect(MemberEntity.getProfileCompleteness(member)).toBe(40);
+    });
+  });
+
+  describe('getMissingFields 境界値', () => {
+    it('全てnullの場合3フィールド', () => {
+      const member = {
+        name: '太郎',
+        memberType: 'human' as const,
+        birthDate: null,
+        photoUrl: null,
+        notes: null,
+      };
+      expect(MemberEntity.getMissingFields(member)).toHaveLength(3);
+    });
+  });
+
+  describe('getProfileCompletenessLabel 境界値', () => {
+    it('0%は「入力が必要」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(0)).toBe('入力が必要');
+    });
+
+    it('49%は「入力が必要」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(49)).toBe('入力が必要');
+    });
+
+    it('50%は「半分入力済み」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(50)).toBe('半分入力済み');
+    });
+
+    it('79%は「半分入力済み」', () => {
+      expect(MemberEntity.getProfileCompletenessLabel(79)).toBe('半分入力済み');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleTimeSlot.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimeSlot.edge.test.ts
@@ -1,0 +1,37 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Time Slot Edge Cases', () => {
+  describe('hasTimeOverlap 境界値', () => {
+    it('0分閾値の場合同一時刻のみ重複', () => {
+      expect(ScheduleEntity.hasTimeOverlap('08:00', '08:00', 0)).toBe(true);
+      expect(ScheduleEntity.hasTimeOverlap('08:00', '08:01', 0)).toBe(false);
+    });
+
+    it('深夜の時刻', () => {
+      expect(ScheduleEntity.hasTimeOverlap('00:00', '00:30', 30)).toBe(true);
+    });
+
+    it('23:59の時刻', () => {
+      expect(ScheduleEntity.hasTimeOverlap('23:30', '23:59', 30)).toBe(true);
+    });
+  });
+
+  describe('getScheduleDensity 境界値', () => {
+    it('非常に多い件数', () => {
+      expect(ScheduleEntity.getScheduleDensity(100)).toBe('high');
+    });
+  });
+
+  describe('getOptimalTimeSuggestion 境界値', () => {
+    it('全候補時刻に既存がある場合', () => {
+      const times = ['08:00', '12:00', '14:00', '16:00', '18:00', '20:00'];
+      const result = ScheduleEntity.getOptimalTimeSuggestion(times);
+      expect(result).toBeTruthy();
+    });
+
+    it('近い時刻が複数ある場合', () => {
+      const result = ScheduleEntity.getOptimalTimeSuggestion(['12:00', '13:00']);
+      expect(result).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MemberProfileCompleteness: null/undefinedフィールド、空文字列、境界値テスト (7件)
- ScheduleTimeSlot: 0分閾値、深夜時間帯、高密度判定、全候補使用済みケース (6件)
- HealthLogSymptomSummary: 単一症状種、大量ユニーク症状、大規模データセット (5件)
- 全2696テストパス

## Test plan
- [x] エッジケーステスト18件パス
- [x] 既存テスト含む全2696テストパス

closes #577