### PR TITLE
個別リソースGETのレート制限追加

### DIFF
--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -8,6 +8,8 @@ const findMedication = (id: string) => prisma.medication.findUnique({ where: { i
 
 export async function GET(_request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medications-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({
       userId,

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -8,6 +8,8 @@ const findMember = (id: string) => prisma.member.findUnique({ where: { id } });
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`members-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     return withOwnershipCheck({
       userId,


### PR DESCRIPTION
## Summary
- `/api/members/[memberId]` GETに30req/minのレート制限を追加
- `/api/medications/[medicationId]` GETに30req/minのレート制限を追加
- これにより全GETエンドポイントにレート制限が適用済み

## Test plan
- [x] 全2696テストパス

closes #579