### PR TITLE
病院訪問パターン分析メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/HospitalVisitPattern.test.ts
+++ b/src/__tests__/domain/entities/HospitalVisitPattern.test.ts
@@ -1,0 +1,74 @@
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity - Visit Pattern', () => {
+  describe('getVisitFrequencyLabel', () => {
+    it('訪問間隔7日で「週1回程度」を返す', () => {
+      expect(HospitalEntity.getVisitFrequencyLabel(7)).toBe('週1回程度');
+    });
+
+    it('訪問間隔14日で「2週に1回程度」を返す', () => {
+      expect(HospitalEntity.getVisitFrequencyLabel(14)).toBe('2週に1回程度');
+    });
+
+    it('訪問間隔30日で「月1回程度」を返す', () => {
+      expect(HospitalEntity.getVisitFrequencyLabel(30)).toBe('月1回程度');
+    });
+
+    it('訪問間隔90日で「3ヶ月に1回程度」を返す', () => {
+      expect(HospitalEntity.getVisitFrequencyLabel(90)).toBe('3ヶ月に1回程度');
+    });
+
+    it('訪問間隔365日で「年1回程度」を返す', () => {
+      expect(HospitalEntity.getVisitFrequencyLabel(365)).toBe('年1回程度');
+    });
+
+    it('訪問間隔0日で「毎日」を返す', () => {
+      expect(HospitalEntity.getVisitFrequencyLabel(0)).toBe('毎日');
+    });
+  });
+
+  describe('groupByType', () => {
+    const hospitals = [
+      { name: 'A病院', hospitalType: 'general' },
+      { name: 'Bクリニック', hospitalType: 'clinic' },
+      { name: 'C病院', hospitalType: 'general' },
+      { name: 'D歯科', hospitalType: 'dental' },
+    ];
+
+    it('タイプ別にグループ化する', () => {
+      const result = HospitalEntity.groupByType(hospitals);
+      expect(result['general']).toHaveLength(2);
+      expect(result['clinic']).toHaveLength(1);
+      expect(result['dental']).toHaveLength(1);
+    });
+
+    it('空配列で空オブジェクトを返す', () => {
+      expect(HospitalEntity.groupByType([])).toEqual({});
+    });
+  });
+
+  describe('getTypeDistribution', () => {
+    const hospitals = [
+      { name: 'A', hospitalType: 'general' },
+      { name: 'B', hospitalType: 'general' },
+      { name: 'C', hospitalType: 'clinic' },
+      { name: 'D', hospitalType: 'dental' },
+    ];
+
+    it('タイプ別の件数と割合を返す', () => {
+      const result = HospitalEntity.getTypeDistribution(hospitals);
+      expect(result).toContainEqual({ type: 'general', label: '総合病院', count: 2, percentage: 50 });
+      expect(result).toContainEqual({ type: 'clinic', label: 'クリニック', count: 1, percentage: 25 });
+      expect(result).toContainEqual({ type: 'dental', label: '歯科', count: 1, percentage: 25 });
+    });
+
+    it('空配列で空配列を返す', () => {
+      expect(HospitalEntity.getTypeDistribution([])).toEqual([]);
+    });
+
+    it('件数降順でソートされる', () => {
+      const result = HospitalEntity.getTypeDistribution(hospitals);
+      expect(result[0].count).toBeGreaterThanOrEqual(result[1].count);
+    });
+  });
+});

--- a/src/domain/entities/Hospital.ts
+++ b/src/domain/entities/Hospital.ts
@@ -100,4 +100,46 @@ export class HospitalEntity {
     if (daysSinceLastVisit <= 90) return 'warning';
     return 'alert';
   }
+
+  /**
+   * 訪問間隔（日数）から頻度ラベルを返す
+   */
+  static getVisitFrequencyLabel(intervalDays: number): string {
+    if (intervalDays <= 0) return '毎日';
+    if (intervalDays <= 7) return '週1回程度';
+    if (intervalDays <= 14) return '2週に1回程度';
+    if (intervalDays <= 31) return '月1回程度';
+    if (intervalDays <= 180) return `${Math.round(intervalDays / 30)}ヶ月に1回程度`;
+    return '年1回程度';
+  }
+
+  /**
+   * 病院をタイプ別にグループ化する
+   */
+  static groupByType<T extends { hospitalType?: string }>(hospitals: T[]): Record<string, T[]> {
+    const result: Record<string, T[]> = {};
+    for (const h of hospitals) {
+      const type = h.hospitalType ?? 'unknown';
+      if (!result[type]) result[type] = [];
+      result[type].push(h);
+    }
+    return result;
+  }
+
+  /**
+   * タイプ別の分布を件数降順で返す
+   */
+  static getTypeDistribution(hospitals: { hospitalType?: string }[]): Array<{ type: string; label: string; count: number; percentage: number }> {
+    if (hospitals.length === 0) return [];
+    const groups = HospitalEntity.groupByType(hospitals);
+    const total = hospitals.length;
+    return Object.entries(groups)
+      .map(([type, items]) => ({
+        type,
+        label: HospitalEntity.getHospitalTypeLabel(type),
+        count: items.length,
+        percentage: Math.round((items.length / total) * 100),
+      }))
+      .sort((a, b) => b.count - a.count);
+  }
 }


### PR DESCRIPTION
## Summary
- `getVisitFrequencyLabel`: 訪問間隔（日数）から頻度ラベルを返す
- `groupByType`: 病院をタイプ別にグループ化
- `getTypeDistribution`: タイプ別分布を件数降順で集計
- テスト11件追加、全2707テストパス

## Test plan
- [x] HospitalVisitPattern.test.ts 11件パス
- [x] 全2707テストパス

closes #581