### PR TITLE
服薬遵守率の期間比較メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AdherencePeriodComparison.test.ts
+++ b/src/__tests__/domain/entities/AdherencePeriodComparison.test.ts
@@ -1,0 +1,76 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Period Comparison', () => {
+  describe('comparePeriods', () => {
+    it('改善を正しく検出する', () => {
+      const result = AdherenceTrendEntity.comparePeriods(60, 80);
+      expect(result.change).toBe(20);
+      expect(result.direction).toBe('up');
+      expect(result.changePercentage).toBe(20);
+    });
+
+    it('悪化を正しく検出する', () => {
+      const result = AdherenceTrendEntity.comparePeriods(80, 60);
+      expect(result.change).toBe(-20);
+      expect(result.direction).toBe('down');
+    });
+
+    it('安定を正しく検出する', () => {
+      const result = AdherenceTrendEntity.comparePeriods(75, 78);
+      expect(result.direction).toBe('stable');
+    });
+
+    it('同値で安定を返す', () => {
+      const result = AdherenceTrendEntity.comparePeriods(80, 80);
+      expect(result.change).toBe(0);
+      expect(result.direction).toBe('stable');
+    });
+  });
+
+  describe('getImprovementMessage', () => {
+    it('大幅改善で励ましメッセージを返す', () => {
+      const msg = AdherenceTrendEntity.getImprovementMessage(20);
+      expect(msg).toBe('大幅に改善しています。素晴らしいです');
+    });
+
+    it('小幅改善でメッセージを返す', () => {
+      const msg = AdherenceTrendEntity.getImprovementMessage(8);
+      expect(msg).toBe('少しずつ改善しています');
+    });
+
+    it('変化なしでメッセージを返す', () => {
+      const msg = AdherenceTrendEntity.getImprovementMessage(0);
+      expect(msg).toBe('現状を維持できています');
+    });
+
+    it('悪化でメッセージを返す', () => {
+      const msg = AdherenceTrendEntity.getImprovementMessage(-10);
+      expect(msg).toBe('少し服薬率が下がっています。一緒に頑張りましょう');
+    });
+  });
+
+  describe('calculateConsistencyScore', () => {
+    it('全て同じ値で100を返す', () => {
+      expect(AdherenceTrendEntity.calculateConsistencyScore([80, 80, 80])).toBe(100);
+    });
+
+    it('ばらつきが大きい場合低いスコアを返す', () => {
+      const score = AdherenceTrendEntity.calculateConsistencyScore([20, 80, 40, 90]);
+      expect(score).toBeLessThan(50);
+    });
+
+    it('空配列で0を返す', () => {
+      expect(AdherenceTrendEntity.calculateConsistencyScore([])).toBe(0);
+    });
+
+    it('1要素で100を返す', () => {
+      expect(AdherenceTrendEntity.calculateConsistencyScore([75])).toBe(100);
+    });
+
+    it('スコアは0-100の範囲に収まる', () => {
+      const score = AdherenceTrendEntity.calculateConsistencyScore([0, 100, 0, 100]);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -86,4 +86,42 @@ export class AdherenceTrendEntity {
     };
     return messages[direction];
   }
+
+  /**
+   * 2期間の遵守率を比較し、変化量と方向を返す
+   */
+  static comparePeriods(previousRate: number, currentRate: number): {
+    change: number;
+    changePercentage: number;
+    direction: 'up' | 'down' | 'stable';
+  } {
+    const change = currentRate - previousRate;
+    return {
+      change,
+      changePercentage: Math.abs(change),
+      direction: AdherenceTrendEntity.calculateTrendDirection([previousRate, currentRate]),
+    };
+  }
+
+  /**
+   * 変化量に応じた改善メッセージを返す
+   */
+  static getImprovementMessage(change: number): string {
+    if (change >= 15) return '大幅に改善しています。素晴らしいです';
+    if (change > 0) return '少しずつ改善しています';
+    if (change === 0) return '現状を維持できています';
+    return '少し服薬率が下がっています。一緒に頑張りましょう';
+  }
+
+  /**
+   * 複数期間の遵守率から安定度スコア(0-100)を算出する
+   */
+  static calculateConsistencyScore(rates: number[]): number {
+    if (rates.length <= 1) return rates.length === 0 ? 0 : 100;
+    const avg = rates.reduce((a, b) => a + b, 0) / rates.length;
+    const variance = rates.reduce((sum, r) => sum + (r - avg) ** 2, 0) / rates.length;
+    const stdDev = Math.sqrt(variance);
+    const maxStdDev = 50;
+    return Math.round(Math.max(0, Math.min(100, 100 - (stdDev / maxStdDev) * 100)));
+  }
 }


### PR DESCRIPTION
## Summary
- `comparePeriods`: 2期間の遵守率比較（変化量・方向判定）
- `getImprovementMessage`: 変化量に応じた励まし/注意メッセージ生成
- `calculateConsistencyScore`: 複数期間の遵守率から安定度スコア(0-100)を算出
- テスト13件追加、全2720テストパス

## Test plan
- [x] AdherencePeriodComparison.test.ts 13件パス
- [x] 全2720テストパス

closes #583