### PR TITLE
キャラクタームード判定メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/CharacterMood.test.ts
+++ b/src/__tests__/domain/entities/CharacterMood.test.ts
@@ -1,0 +1,65 @@
+import { CharacterEntity } from '@/domain/entities/Character';
+import type { CharacterMood } from '@/domain/entities/Character';
+
+describe('CharacterEntity - Mood', () => {
+  describe('getMoodByAdherence', () => {
+    it('遵守率90以上でhappyを返す', () => {
+      expect(CharacterEntity.getMoodByAdherence(95)).toBe('happy');
+    });
+
+    it('遵守率70-89でnormalを返す', () => {
+      expect(CharacterEntity.getMoodByAdherence(75)).toBe('normal');
+    });
+
+    it('遵守率50-69でremindingを返す', () => {
+      expect(CharacterEntity.getMoodByAdherence(55)).toBe('reminding');
+    });
+
+    it('遵守率30-49でworriedを返す', () => {
+      expect(CharacterEntity.getMoodByAdherence(35)).toBe('worried');
+    });
+
+    it('遵守率30未満でsadを返す', () => {
+      expect(CharacterEntity.getMoodByAdherence(20)).toBe('sad');
+    });
+
+    it('遵守率100でhappyを返す', () => {
+      expect(CharacterEntity.getMoodByAdherence(100)).toBe('happy');
+    });
+
+    it('遵守率0でsadを返す', () => {
+      expect(CharacterEntity.getMoodByAdherence(0)).toBe('sad');
+    });
+  });
+
+  describe('getMoodLabel', () => {
+    it.each<[CharacterMood, string]>([
+      ['happy', '喜び'],
+      ['excited', '興奮'],
+      ['normal', '通常'],
+      ['reminding', 'お知らせ'],
+      ['worried', '心配'],
+      ['sad', '悲しみ'],
+      ['cheering', '応援'],
+    ])('%sのラベルを返す', (mood, expected) => {
+      expect(CharacterEntity.getMoodLabel(mood)).toBe(expected);
+    });
+  });
+
+  describe('getMoodMessage', () => {
+    it('happyで励ましメッセージを返す', () => {
+      const msg = CharacterEntity.getMoodMessage('happy');
+      expect(msg).toBe('とても良い調子です');
+    });
+
+    it('sadで応援メッセージを返す', () => {
+      const msg = CharacterEntity.getMoodMessage('sad');
+      expect(msg).toBe('一緒に頑張りましょう');
+    });
+
+    it('normalで通常メッセージを返す', () => {
+      const msg = CharacterEntity.getMoodMessage('normal');
+      expect(msg).toBe('いつも通りです');
+    });
+  });
+});

--- a/src/domain/entities/Character.ts
+++ b/src/domain/entities/Character.ts
@@ -57,6 +57,49 @@ export class CharacterEntity {
   static getAllCharacterTypes(): CharacterType[] {
     return [...VALID_TYPES];
   }
+
+  /**
+   * 服薬遵守率に応じたムードを判定する
+   */
+  static getMoodByAdherence(rate: number): CharacterMood {
+    if (rate >= 90) return 'happy';
+    if (rate >= 70) return 'normal';
+    if (rate >= 50) return 'reminding';
+    if (rate >= 30) return 'worried';
+    return 'sad';
+  }
+
+  /**
+   * ムードの日本語ラベルを返す
+   */
+  static getMoodLabel(mood: CharacterMood): string {
+    const labels: Record<CharacterMood, string> = {
+      happy: '喜び',
+      excited: '興奮',
+      normal: '通常',
+      reminding: 'お知らせ',
+      worried: '心配',
+      sad: '悲しみ',
+      cheering: '応援',
+    };
+    return labels[mood];
+  }
+
+  /**
+   * ムードに応じたメッセージを返す
+   */
+  static getMoodMessage(mood: CharacterMood): string {
+    const messages: Record<CharacterMood, string> = {
+      happy: 'とても良い調子です',
+      excited: '素晴らしい成果です',
+      normal: 'いつも通りです',
+      reminding: 'お薬を忘れずに',
+      worried: '少し心配しています',
+      sad: '一緒に頑張りましょう',
+      cheering: '応援しています',
+    };
+    return messages[mood];
+  }
 }
 
 export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {


### PR DESCRIPTION
## Summary
- `getMoodByAdherence`: 服薬遵守率からムード判定（happy/normal/reminding/worried/sad）
- `getMoodLabel`: 全7ムードの日本語ラベル
- `getMoodMessage`: ムードに応じたメッセージ生成
- テスト17件追加、全2737テストパス

## Test plan
- [x] CharacterMood.test.ts 17件パス
- [x] 全2737テストパス

closes #585