### PR TITLE
checkRateLimitの呼び出し形式を修正

### DIFF
--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -26,8 +26,8 @@ export async function POST(request: Request) {
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const rateLimitError = checkRateLimit(userId, 'appointments-post', 10);
-    if (rateLimitError) return rateLimitError;
+    const { allowed } = checkRateLimit(`appointments-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
     const body = await request.json();
     const parsed = createAppointmentSchema.safeParse(body);

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -15,8 +15,8 @@ export async function POST(request: Request) {
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const rateLimitError = checkRateLimit(userId, 'hospitals-post', 10);
-    if (rateLimitError) return rateLimitError;
+    const { allowed } = checkRateLimit(`hospitals-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
     const body = await request.json();
     const parsed = createHospitalSchema.safeParse(body);

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -16,8 +16,8 @@ export async function POST(request: Request) {
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const rateLimitError = checkRateLimit(userId, 'schedules-post', 15);
-    if (rateLimitError) return rateLimitError;
+    const { allowed } = checkRateLimit(`schedules-post:${userId}`, { maxAttempts: 15, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
     const body = await request.json();
     const parsed = createScheduleSchema.safeParse(body);


### PR DESCRIPTION
## Summary
- 3つのAPIルートでcheckRateLimitが古い3引数形式で呼ばれており、レート制限が正しく機能していなかった
- `/api/schedules` POST: 15req/min
- `/api/appointments` POST: 10req/min
- `/api/hospitals` POST: 10req/min
- 正しい2引数形式（キー文字列 + RateLimitConfig）に修正

## Test plan
- [x] 全2767テストパス

closes #591