### PR TITLE
DateRange曜日パターン分析メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/DateRangeWeekdayPattern.test.ts
+++ b/src/__tests__/domain/entities/DateRangeWeekdayPattern.test.ts
@@ -1,0 +1,80 @@
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper - Weekday Pattern', () => {
+  describe('getWeekdayDistribution', () => {
+    it('7日間で各曜日1回ずつを返す', () => {
+      const from = new Date('2026-03-02'); // 月曜日
+      const to = new Date('2026-03-08');   // 日曜日
+      const result = DateRangeHelper.getWeekdayDistribution(from, to);
+      expect(result).toEqual([1, 1, 1, 1, 1, 1, 1]);
+    });
+
+    it('14日間で各曜日2回ずつを返す', () => {
+      const from = new Date('2026-03-02');
+      const to = new Date('2026-03-15');
+      const result = DateRangeHelper.getWeekdayDistribution(from, to);
+      expect(result).toEqual([2, 2, 2, 2, 2, 2, 2]);
+    });
+
+    it('1日間で該当曜日のみ1を返す', () => {
+      const date = new Date('2026-03-05'); // 木曜日
+      const result = DateRangeHelper.getWeekdayDistribution(date, date);
+      expect(result[4]).toBe(1); // 木曜
+      expect(result.reduce((a, b) => a + b, 0)).toBe(1);
+    });
+
+    it('同一日で合計1を返す', () => {
+      const date = new Date('2026-03-01'); // 日曜日
+      const result = DateRangeHelper.getWeekdayDistribution(date, date);
+      expect(result[0]).toBe(1);
+    });
+  });
+
+  describe('isSameWeek', () => {
+    it('同じ週の月曜と金曜でtrueを返す', () => {
+      const mon = new Date('2026-03-02');
+      const fri = new Date('2026-03-06');
+      expect(DateRangeHelper.isSameWeek(mon, fri)).toBe(true);
+    });
+
+    it('異なる週でfalseを返す', () => {
+      const fri = new Date('2026-03-06');
+      const nextMon = new Date('2026-03-09');
+      expect(DateRangeHelper.isSameWeek(fri, nextMon)).toBe(false);
+    });
+
+    it('同一日でtrueを返す', () => {
+      const date = new Date('2026-03-05');
+      expect(DateRangeHelper.isSameWeek(date, date)).toBe(true);
+    });
+
+    it('日曜と土曜（同じ週）でtrueを返す', () => {
+      const sun = new Date('2026-03-01'); // 日曜
+      const sat = new Date('2026-03-07'); // 土曜
+      expect(DateRangeHelper.isSameWeek(sun, sat)).toBe(true);
+    });
+  });
+
+  describe('getWeekRange', () => {
+    it('水曜日の週の開始（日曜）と終了（土曜）を返す', () => {
+      const wed = new Date('2026-03-04');
+      const { start, end } = DateRangeHelper.getWeekRange(wed);
+      expect(start.getDay()).toBe(0); // 日曜
+      expect(end.getDay()).toBe(6);   // 土曜
+      expect(start.getDate()).toBe(1);
+      expect(end.getDate()).toBe(7);
+    });
+
+    it('日曜日はその日が開始日', () => {
+      const sun = new Date('2026-03-01');
+      const { start } = DateRangeHelper.getWeekRange(sun);
+      expect(start.getDate()).toBe(1);
+    });
+
+    it('土曜日はその日が終了日', () => {
+      const sat = new Date('2026-03-07');
+      const { end } = DateRangeHelper.getWeekRange(sat);
+      expect(end.getDate()).toBe(7);
+    });
+  });
+});

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -218,4 +218,43 @@ export class DateRangeHelper {
     if (days % 7 === 0 && days <= 28) return `${days / 7}週間`;
     return `${days}日間`;
   }
+
+  /**
+   * 期間内の曜日別日数分布を返す（[日,月,火,水,木,金,土]）
+   */
+  static getWeekdayDistribution(from: Date, to: Date): number[] {
+    const dist = new Array(7).fill(0);
+    const current = DateRangeHelper.toStartOfDay(from);
+    const end = DateRangeHelper.toStartOfDay(to);
+    while (current <= end) {
+      dist[current.getDay()]++;
+      current.setDate(current.getDate() + 1);
+    }
+    return dist;
+  }
+
+  /**
+   * 2つの日付が同じ週（日曜始まり）に属するか判定する
+   */
+  static isSameWeek(date1: Date, date2: Date): boolean {
+    const d1 = DateRangeHelper.toStartOfDay(date1);
+    const d2 = DateRangeHelper.toStartOfDay(date2);
+    const startOfWeek1 = new Date(d1);
+    startOfWeek1.setDate(d1.getDate() - d1.getDay());
+    const startOfWeek2 = new Date(d2);
+    startOfWeek2.setDate(d2.getDate() - d2.getDay());
+    return startOfWeek1.getTime() === startOfWeek2.getTime();
+  }
+
+  /**
+   * 指定日の週の開始日（日曜）と終了日（土曜）を返す
+   */
+  static getWeekRange(date: Date): { start: Date; end: Date } {
+    const d = DateRangeHelper.toStartOfDay(date);
+    const start = new Date(d);
+    start.setDate(d.getDate() - d.getDay());
+    const end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    return { start, end };
+  }
 }


### PR DESCRIPTION
## Summary
- `getWeekdayDistribution`: 期間内の曜日別日数分布（[日,月,火,水,木,金,土]）
- `isSameWeek`: 2つの日付が同じ週（日曜始まり）に属するか判定
- `getWeekRange`: 指定日の週の開始日（日曜）と終了日（土曜）を返す
- テスト11件追加、全2778テストパス

## Test plan
- [x] DateRangeWeekdayPattern.test.ts 11件パス
- [x] 全2778テストパス

closes #593