### PR TITLE
体調ログの期間別スコアサマリー追加

### DIFF
--- a/src/__tests__/domain/entities/HealthLogPeriodScore.test.ts
+++ b/src/__tests__/domain/entities/HealthLogPeriodScore.test.ts
@@ -1,0 +1,73 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Period Score', () => {
+  describe('getPeriodAverageCondition', () => {
+    it('条件値の平均を返す', () => {
+      const logs = [
+        { condition: 3 },
+        { condition: 4 },
+        { condition: 5 },
+      ];
+      expect(HealthLogEntity.getPeriodAverageCondition(logs)).toBe(4);
+    });
+
+    it('小数点第1位まで返す', () => {
+      const logs = [
+        { condition: 3 },
+        { condition: 4 },
+      ];
+      expect(HealthLogEntity.getPeriodAverageCondition(logs)).toBe(3.5);
+    });
+
+    it('空配列で0を返す', () => {
+      expect(HealthLogEntity.getPeriodAverageCondition([])).toBe(0);
+    });
+
+    it('1件でその値を返す', () => {
+      expect(HealthLogEntity.getPeriodAverageCondition([{ condition: 5 }])).toBe(5);
+    });
+  });
+
+  describe('getConditionStabilityScore', () => {
+    it('全て同じ値で100を返す', () => {
+      expect(HealthLogEntity.getConditionStabilityScore([3, 3, 3])).toBe(100);
+    });
+
+    it('ばらつきが大きいと低スコアを返す', () => {
+      const score = HealthLogEntity.getConditionStabilityScore([1, 5, 1, 5]);
+      expect(score).toBeLessThan(50);
+    });
+
+    it('空配列で0を返す', () => {
+      expect(HealthLogEntity.getConditionStabilityScore([])).toBe(0);
+    });
+
+    it('1要素で100を返す', () => {
+      expect(HealthLogEntity.getConditionStabilityScore([4])).toBe(100);
+    });
+
+    it('スコアは0-100の範囲', () => {
+      const score = HealthLogEntity.getConditionStabilityScore([1, 5, 1, 5, 1, 5]);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('getConditionComparisonLabel', () => {
+    it('改善でラベルを返す', () => {
+      expect(HealthLogEntity.getConditionComparisonLabel(3, 4.5)).toBe('体調が改善しています');
+    });
+
+    it('悪化でラベルを返す', () => {
+      expect(HealthLogEntity.getConditionComparisonLabel(4, 2.5)).toBe('体調がやや低下しています');
+    });
+
+    it('変化なしでラベルを返す', () => {
+      expect(HealthLogEntity.getConditionComparisonLabel(3.5, 3.8)).toBe('体調は安定しています');
+    });
+
+    it('同値で安定ラベルを返す', () => {
+      expect(HealthLogEntity.getConditionComparisonLabel(4, 4)).toBe('体調は安定しています');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -542,4 +542,35 @@ export class HealthLogEntity {
     const freq = HealthLogEntity.getSymptomFrequency(symptoms);
     return freq[0].symptom;
   }
+
+  /**
+   * 期間別平均体調スコアを返す（小数点第1位）
+   */
+  static getPeriodAverageCondition(logs: { condition: number }[]): number {
+    if (logs.length === 0) return 0;
+    const sum = logs.reduce((a, b) => a + b.condition, 0);
+    return Math.round((sum / logs.length) * 10) / 10;
+  }
+
+  /**
+   * 体調値の安定度スコア(0-100)を返す
+   */
+  static getConditionStabilityScore(conditions: number[]): number {
+    if (conditions.length <= 1) return conditions.length === 0 ? 0 : 100;
+    const avg = conditions.reduce((a, b) => a + b, 0) / conditions.length;
+    const variance = conditions.reduce((sum, c) => sum + (c - avg) ** 2, 0) / conditions.length;
+    const stdDev = Math.sqrt(variance);
+    const maxStdDev = 2;
+    return Math.round(Math.max(0, Math.min(100, 100 - (stdDev / maxStdDev) * 100)));
+  }
+
+  /**
+   * 2期間の平均体調を比較しラベルを返す
+   */
+  static getConditionComparisonLabel(previousAvg: number, currentAvg: number): string {
+    const diff = currentAvg - previousAvg;
+    if (diff >= 1) return '体調が改善しています';
+    if (diff <= -1) return '体調がやや低下しています';
+    return '体調は安定しています';
+  }
 }


### PR DESCRIPTION
## Summary
- `getPeriodAverageCondition`: 期間別平均体調スコア（小数点第1位）
- `getConditionStabilityScore`: 体調値の安定度スコア(0-100)
- `getConditionComparisonLabel`: 2期間の平均体調を比較しラベル生成
- テスト13件追加、全2804テストパス

## Test plan
- [x] HealthLogPeriodScore.test.ts 13件パス
- [x] 全2804テストパス

closes #597