### PR TITLE
HealthLogの体調マップを静的定数に抽出

### DIFF
--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -55,46 +55,49 @@ export interface DailyHealthLogGroup {
  * 体調記録のビジネスロジック
  */
 export class HealthLogEntity {
+  private static readonly CONDITION_LABELS: Record<ConditionLevel, string> = {
+    1: 'とても悪い',
+    2: '悪い',
+    3: '普通',
+    4: '良い',
+    5: 'とても良い',
+  };
+
+  private static readonly CONDITION_COLORS: Record<ConditionLevel, string> = {
+    1: 'text-red-600',
+    2: 'text-orange-500',
+    3: 'text-yellow-500',
+    4: 'text-green-500',
+    5: 'text-green-600',
+  };
+
+  private static readonly CONDITION_ICONS: Record<ConditionLevel, string> = {
+    1: 'Frown',
+    2: 'Meh',
+    3: 'MinusCircle',
+    4: 'Smile',
+    5: 'Laugh',
+  };
+
   /**
    * 体調レベルのラベルを取得
    */
   static getConditionLabel(level: ConditionLevel): string {
-    const labels: Record<ConditionLevel, string> = {
-      1: 'とても悪い',
-      2: '悪い',
-      3: '普通',
-      4: '良い',
-      5: 'とても良い',
-    };
-    return labels[level];
+    return HealthLogEntity.CONDITION_LABELS[level];
   }
 
   /**
    * 体調レベルのカラークラスを取得
    */
   static getConditionColor(level: ConditionLevel): string {
-    const colors: Record<ConditionLevel, string> = {
-      1: 'text-red-600',
-      2: 'text-orange-500',
-      3: 'text-yellow-500',
-      4: 'text-green-500',
-      5: 'text-green-600',
-    };
-    return colors[level];
+    return HealthLogEntity.CONDITION_COLORS[level];
   }
 
   /**
    * 体調レベルに応じたlucide-reactアイコン名を取得
    */
   static getConditionIcon(level: ConditionLevel): string {
-    const icons: Record<ConditionLevel, string> = {
-      1: 'Frown',
-      2: 'Meh',
-      3: 'MinusCircle',
-      4: 'Smile',
-      5: 'Laugh',
-    };
-    return icons[level];
+    return HealthLogEntity.CONDITION_ICONS[level];
   }
 
   /**


### PR DESCRIPTION
## Summary
- `CONDITION_LABELS`、`CONDITION_COLORS`、`CONDITION_ICONS`を静的定数として定義
- `getConditionLabel`/`getConditionColor`/`getConditionIcon`で毎回のオブジェクト生成を排除
- パフォーマンス改善と既存パターン（Appointment.typeLabels、Medication.categoryLabels等）との一貫性向上

## Test plan
- [x] 全2804テストパス（既存テスト全件通過で動作影響なし確認）

closes #599