### PR TITLE
checkRateLimitのmaxRequestsをmaxAttemptsに修正

### DIFF
--- a/src/app/api/appointments/[appointmentId]/route.ts
+++ b/src/app/api/appointments/[appointmentId]/route.ts
@@ -11,7 +11,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ appo
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`appointments-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`appointments-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
     const { appointmentId } = await params;
@@ -43,7 +43,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ appo
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ appointmentId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`appointments-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`appointments-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { appointmentId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/health-logs/[logId]/route.ts
+++ b/src/app/api/health-logs/[logId]/route.ts
@@ -5,7 +5,7 @@ import { checkRateLimit } from '@/lib/security';
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ logId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`health-logs-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`health-logs-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { logId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/hospitals/[hospitalId]/route.ts
+++ b/src/app/api/hospitals/[hospitalId]/route.ts
@@ -11,7 +11,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ hosp
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`hospitals-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`hospitals-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
     const { hospitalId } = await params;
@@ -43,7 +43,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ hosp
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ hospitalId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`hospitals-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`hospitals-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { hospitalId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -8,7 +8,7 @@ const findMedication = (id: string) => prisma.medication.findUnique({ where: { i
 
 export async function GET(_request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`medications-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`medications-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({
@@ -26,7 +26,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`medications-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`medications-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({
@@ -63,7 +63,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ medicationId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`medications-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`medications-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/medications/[medicationId]/stock/route.ts
+++ b/src/app/api/medications/[medicationId]/stock/route.ts
@@ -13,7 +13,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`stock-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`stock-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { medicationId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/medications/alerts/route.ts
+++ b/src/app/api/medications/alerts/route.ts
@@ -6,7 +6,7 @@ import { StockAlertEntity } from '@/domain/entities/StockAlert';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const { allowed } = checkRateLimit(`medications-alerts-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  const { allowed } = checkRateLimit(`medications-alerts-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
 

--- a/src/app/api/medications/member/[memberId]/route.ts
+++ b/src/app/api/medications/member/[memberId]/route.ts
@@ -6,7 +6,7 @@ import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`medications-member-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`medications-member-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     const idError = validateParamId(memberId);

--- a/src/app/api/medications/search/route.ts
+++ b/src/app/api/medications/search/route.ts
@@ -7,7 +7,7 @@ import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(request: NextRequest) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`medications-search-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`medications-search-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const q = request.nextUrl.searchParams.get('q')?.trim() ?? '';
     if (!q) {

--- a/src/app/api/members/[memberId]/profile/route.ts
+++ b/src/app/api/members/[memberId]/profile/route.ts
@@ -6,7 +6,7 @@ import { DateRangeHelper } from '@/domain/entities/DateRange';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`member-profile-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`member-profile-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     const idError = validateParamId(memberId);

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -8,7 +8,7 @@ const findMember = (id: string) => prisma.member.findUnique({ where: { id } });
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`members-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`members-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     return withOwnershipCheck({
@@ -26,7 +26,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ memb
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`members-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`members-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     return withOwnershipCheck({
@@ -59,7 +59,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ memb
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`members-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`members-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/members/summary/route.ts
+++ b/src/app/api/members/summary/route.ts
@@ -5,7 +5,7 @@ import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const { allowed } = checkRateLimit(`members-summary-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  const { allowed } = checkRateLimit(`members-summary-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const [members, medications, appointments] = await Promise.all([
     prisma.member.findMany({

--- a/src/app/api/records/[recordId]/route.ts
+++ b/src/app/api/records/[recordId]/route.ts
@@ -7,7 +7,7 @@ const findRecord = (id: string) => prisma.medicationRecord.findUnique({ where: {
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ recordId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`records-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`records-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { recordId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/records/member/[memberId]/route.ts
+++ b/src/app/api/records/member/[memberId]/route.ts
@@ -6,7 +6,7 @@ import { QUERY_LIMITS } from '@/lib/constants';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`records-member-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`records-member-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { memberId } = await params;
     const idError = validateParamId(memberId);

--- a/src/app/api/records/stats/route.ts
+++ b/src/app/api/records/stats/route.ts
@@ -7,7 +7,7 @@ import { DateRangeHelper } from '@/domain/entities/DateRange';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const { allowed } = checkRateLimit(`records-stats-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  const { allowed } = checkRateLimit(`records-stats-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
   const sevenDaysAgo = DateRangeHelper.daysAgo(7, now);

--- a/src/app/api/records/trends/route.ts
+++ b/src/app/api/records/trends/route.ts
@@ -7,7 +7,7 @@ import { DateRangeHelper } from '@/domain/entities/DateRange';
 import { DAY_LABELS_JP, QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const { allowed } = checkRateLimit(`records-trends-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  const { allowed } = checkRateLimit(`records-trends-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
   const fourteenDaysAgo = DateRangeHelper.daysAgo(14, now);

--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -11,7 +11,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ sche
   if (sizeError) return sizeError;
 
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`schedules-put:${userId}`, { maxRequests: 20, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`schedules-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
     const { scheduleId } = await params;
@@ -37,7 +37,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ sche
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ scheduleId: string }> }) {
   return withAuth(async (userId) => {
-    const { allowed } = checkRateLimit(`schedules-delete:${userId}`, { maxRequests: 10, windowMs: 60000 });
+    const { allowed } = checkRateLimit(`schedules-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { scheduleId } = await params;
     return withOwnershipCheck({

--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -5,7 +5,7 @@ import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
-  const { allowed } = checkRateLimit(`schedules-today-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  const { allowed } = checkRateLimit(`schedules-today-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const now = new Date();
   const todayStart = new Date(now);

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -13,7 +13,7 @@ const USER_SELECT = {
 } as const;
 
 export const GET = withAuth(async (userId) => {
-  const { allowed } = checkRateLimit(`users-me-get:${userId}`, { maxRequests: 30, windowMs: 60000 });
+  const { allowed } = checkRateLimit(`users-me-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const user = await prisma.user.findUnique({
     where: { id: userId },


### PR DESCRIPTION
## Summary
- 18ファイル25箇所でcheckRateLimitに`maxRequests`が使われていたが、RateLimitConfigの正しいプロパティは`maxAttempts`
- `maxRequests`はRateLimitConfigに存在しないため、レート制限が実質無効だった
- 全25箇所を`maxAttempts`に一括修正

## Test plan
- [x] 全2831テストパス

closes #603