### PR TITLE
予約リマインダータイミング計算メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentReminderScheduling.test.ts
+++ b/src/__tests__/domain/entities/AppointmentReminderScheduling.test.ts
@@ -1,0 +1,72 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Reminder Scheduling', () => {
+  describe('shouldSendReminder', () => {
+    it('予約3日前で3日リマインダーならtrueを返す', () => {
+      const appointmentDate = new Date('2026-03-08');
+      const today = new Date('2026-03-05');
+      expect(AppointmentEntity.shouldSendReminder(appointmentDate, today, 3)).toBe(true);
+    });
+
+    it('予約2日前で3日リマインダーならfalseを返す', () => {
+      const appointmentDate = new Date('2026-03-08');
+      const today = new Date('2026-03-06');
+      expect(AppointmentEntity.shouldSendReminder(appointmentDate, today, 3)).toBe(false);
+    });
+
+    it('予約当日でtrueを返す', () => {
+      const date = new Date('2026-03-05');
+      expect(AppointmentEntity.shouldSendReminder(date, date, 0)).toBe(true);
+    });
+
+    it('予約が過去ならfalseを返す', () => {
+      const appointmentDate = new Date('2026-03-01');
+      const today = new Date('2026-03-05');
+      expect(AppointmentEntity.shouldSendReminder(appointmentDate, today, 3)).toBe(false);
+    });
+  });
+
+  describe('getReminderPriority', () => {
+    it('当日でhighを返す', () => {
+      expect(AppointmentEntity.getReminderPriority(0)).toBe('high');
+    });
+
+    it('1日前でhighを返す', () => {
+      expect(AppointmentEntity.getReminderPriority(1)).toBe('high');
+    });
+
+    it('3日前でmediumを返す', () => {
+      expect(AppointmentEntity.getReminderPriority(3)).toBe('medium');
+    });
+
+    it('7日前でlowを返す', () => {
+      expect(AppointmentEntity.getReminderPriority(7)).toBe('low');
+    });
+
+    it('14日前でlowを返す', () => {
+      expect(AppointmentEntity.getReminderPriority(14)).toBe('low');
+    });
+  });
+
+  describe('formatReminderSchedule', () => {
+    it('1日前リマインダーのテキスト', () => {
+      expect(AppointmentEntity.formatReminderSchedule(1)).toBe('1日前にお知らせ');
+    });
+
+    it('当日リマインダーのテキスト', () => {
+      expect(AppointmentEntity.formatReminderSchedule(0)).toBe('当日にお知らせ');
+    });
+
+    it('7日前リマインダーのテキスト', () => {
+      expect(AppointmentEntity.formatReminderSchedule(7)).toBe('1週間前にお知らせ');
+    });
+
+    it('14日前リマインダーのテキスト', () => {
+      expect(AppointmentEntity.formatReminderSchedule(14)).toBe('2週間前にお知らせ');
+    });
+
+    it('3日前リマインダーのテキスト', () => {
+      expect(AppointmentEntity.formatReminderSchedule(3)).toBe('3日前にお知らせ');
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -365,4 +365,30 @@ export class AppointmentEntity {
     if (conflictCount === 0) return null;
     return `同日に${conflictCount}件の予約があります`;
   }
+
+  /**
+   * 指定日数前にリマインダーを送るべきか判定する
+   */
+  static shouldSendReminder(appointmentDate: Date, today: Date, daysBefore: number): boolean {
+    const diff = DateRangeHelper.diffDays(today, appointmentDate);
+    return diff === daysBefore;
+  }
+
+  /**
+   * 残り日数に応じたリマインダー優先度を返す
+   */
+  static getReminderPriority(daysUntil: number): 'high' | 'medium' | 'low' {
+    if (daysUntil <= 1) return 'high';
+    if (daysUntil <= 3) return 'medium';
+    return 'low';
+  }
+
+  /**
+   * リマインダースケジュールのテキストを生成する
+   */
+  static formatReminderSchedule(daysBefore: number): string {
+    if (daysBefore === 0) return '当日にお知らせ';
+    if (daysBefore % 7 === 0) return `${daysBefore / 7}週間前にお知らせ`;
+    return `${daysBefore}日前にお知らせ`;
+  }
 }


### PR DESCRIPTION
## Summary
- `shouldSendReminder`: 予約日と現在日の差分から送信タイミング判定
- `getReminderPriority`: 残り日数に応じたhigh/medium/low優先度
- `formatReminderSchedule`: 「X日前にお知らせ」「当日にお知らせ」テキスト生成
- テスト14件追加、全2845テストパス

## Test plan
- [x] AppointmentReminderScheduling.test.ts 14件パス
- [x] 全2845テストパス

closes #605