### PR TITLE
MathHelperにパーセンタイル・四分位数メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MathPercentile.test.ts
+++ b/src/__tests__/domain/entities/MathPercentile.test.ts
@@ -1,0 +1,71 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Percentile', () => {
+  describe('calculatePercentile', () => {
+    const data = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+    it('50パーセンタイルで中央値を返す', () => {
+      expect(MathHelper.calculatePercentile(data, 50)).toBe(55);
+    });
+
+    it('0パーセンタイルで最小値を返す', () => {
+      expect(MathHelper.calculatePercentile(data, 0)).toBe(10);
+    });
+
+    it('100パーセンタイルで最大値を返す', () => {
+      expect(MathHelper.calculatePercentile(data, 100)).toBe(100);
+    });
+
+    it('25パーセンタイル', () => {
+      expect(MathHelper.calculatePercentile(data, 25)).toBe(32.5);
+    });
+
+    it('空配列で0を返す', () => {
+      expect(MathHelper.calculatePercentile([], 50)).toBe(0);
+    });
+
+    it('1要素でその値を返す', () => {
+      expect(MathHelper.calculatePercentile([42], 50)).toBe(42);
+    });
+  });
+
+  describe('getQuartiles', () => {
+    it('四分位数を正しく返す', () => {
+      const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+      const q = MathHelper.getQuartiles(data);
+      expect(q.q1).toBe(3.25);
+      expect(q.q2).toBe(5.5);
+      expect(q.q3).toBe(7.75);
+    });
+
+    it('空配列で全て0を返す', () => {
+      const q = MathHelper.getQuartiles([]);
+      expect(q.q1).toBe(0);
+      expect(q.q2).toBe(0);
+      expect(q.q3).toBe(0);
+    });
+  });
+
+  describe('getOutlierBounds', () => {
+    it('IQRに基づく境界を返す', () => {
+      const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+      const bounds = MathHelper.getOutlierBounds(data);
+      const q = MathHelper.getQuartiles(data);
+      const iqr = q.q3 - q.q1;
+      expect(bounds.lower).toBe(q.q1 - 1.5 * iqr);
+      expect(bounds.upper).toBe(q.q3 + 1.5 * iqr);
+    });
+
+    it('空配列で0/0を返す', () => {
+      const bounds = MathHelper.getOutlierBounds([]);
+      expect(bounds.lower).toBe(0);
+      expect(bounds.upper).toBe(0);
+    });
+
+    it('外れ値を検出できる', () => {
+      const data = [10, 12, 11, 13, 12, 11, 100];
+      const bounds = MathHelper.getOutlierBounds(data);
+      expect(100).toBeGreaterThan(bounds.upper);
+    });
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -113,4 +113,43 @@ export class MathHelper {
     if (changeRate <= -10) return '下降';
     return '横ばい';
   }
+
+  /**
+   * パーセンタイルを算出する
+   */
+  static calculatePercentile(values: number[], percentile: number): number {
+    if (values.length === 0) return 0;
+    const sorted = [...values].sort((a, b) => a - b);
+    if (percentile <= 0) return sorted[0];
+    if (percentile >= 100) return sorted[sorted.length - 1];
+    const index = (percentile / 100) * (sorted.length - 1);
+    const lower = Math.floor(index);
+    const upper = Math.ceil(index);
+    if (lower === upper) return sorted[lower];
+    return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+  }
+
+  /**
+   * 四分位数（Q1/Q2/Q3）を算出する
+   */
+  static getQuartiles(values: number[]): { q1: number; q2: number; q3: number } {
+    return {
+      q1: MathHelper.calculatePercentile(values, 25),
+      q2: MathHelper.calculatePercentile(values, 50),
+      q3: MathHelper.calculatePercentile(values, 75),
+    };
+  }
+
+  /**
+   * IQRに基づく外れ値判定の境界を返す
+   */
+  static getOutlierBounds(values: number[]): { lower: number; upper: number } {
+    if (values.length === 0) return { lower: 0, upper: 0 };
+    const { q1, q3 } = MathHelper.getQuartiles(values);
+    const iqr = q3 - q1;
+    return {
+      lower: q1 - 1.5 * iqr,
+      upper: q3 + 1.5 * iqr,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- `calculatePercentile`: 任意のパーセンタイル算出（線形補間）
- `getQuartiles`: 四分位数（Q1/Q2/Q3）をまとめて算出
- `getOutlierBounds`: IQR(四分位範囲)に基づく外れ値判定の上下境界
- テスト11件追加、全2856テストパス

## Test plan
- [x] MathPercentile.test.ts 11件パス
- [x] 全2856テストパス

closes #607