### PR TITLE
スケジュール頻度分析メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/ScheduleFrequencyAnalysis.test.ts
+++ b/src/__tests__/domain/entities/ScheduleFrequencyAnalysis.test.ts
@@ -1,0 +1,79 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Frequency Analysis', () => {
+  describe('getWeeklyScheduleCount', () => {
+    it('毎日のスケジュールで7を返す', () => {
+      const schedules = [{ daysOfWeek: [] }]; // 空は毎日
+      expect(ScheduleEntity.getWeeklyScheduleCount(schedules)).toBe(7);
+    });
+
+    it('特定曜日のスケジュールで正しい数を返す', () => {
+      const schedules = [
+        { daysOfWeek: ['mon', 'wed', 'fri'] },
+        { daysOfWeek: ['tue', 'thu'] },
+      ];
+      expect(ScheduleEntity.getWeeklyScheduleCount(schedules)).toBe(5);
+    });
+
+    it('空配列で0を返す', () => {
+      expect(ScheduleEntity.getWeeklyScheduleCount([])).toBe(0);
+    });
+
+    it('重複曜日を含む場合は合計を返す', () => {
+      const schedules = [
+        { daysOfWeek: ['mon'] },
+        { daysOfWeek: ['mon'] },
+      ];
+      expect(ScheduleEntity.getWeeklyScheduleCount(schedules)).toBe(2);
+    });
+  });
+
+  describe('getMedicationScheduleSummary', () => {
+    it('薬別の件数を返す', () => {
+      const schedules = [
+        { medicationId: 'med1', medicationName: '薬A' },
+        { medicationId: 'med1', medicationName: '薬A' },
+        { medicationId: 'med2', medicationName: '薬B' },
+      ];
+      const result = ScheduleEntity.getMedicationScheduleSummary(schedules);
+      expect(result).toContainEqual({ medicationId: 'med1', name: '薬A', count: 2 });
+      expect(result).toContainEqual({ medicationId: 'med2', name: '薬B', count: 1 });
+    });
+
+    it('空配列で空配列を返す', () => {
+      expect(ScheduleEntity.getMedicationScheduleSummary([])).toEqual([]);
+    });
+
+    it('件数降順でソートされる', () => {
+      const schedules = [
+        { medicationId: 'med1', medicationName: '薬A' },
+        { medicationId: 'med2', medicationName: '薬B' },
+        { medicationId: 'med2', medicationName: '薬B' },
+      ];
+      const result = ScheduleEntity.getMedicationScheduleSummary(schedules);
+      expect(result[0].count).toBeGreaterThanOrEqual(result[1].count);
+    });
+  });
+
+  describe('getScheduleLoadLabel', () => {
+    it('0件で「なし」を返す', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(0)).toBe('なし');
+    });
+
+    it('3件で「軽い」を返す', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(3)).toBe('軽い');
+    });
+
+    it('7件で「普通」を返す', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(7)).toBe('普通');
+    });
+
+    it('15件で「多い」を返す', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(15)).toBe('多い');
+    });
+
+    it('20件以上で「非常に多い」を返す', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(20)).toBe('非常に多い');
+    });
+  });
+});

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -570,4 +570,46 @@ export class ScheduleEntity {
     const m = (bestTime % 60).toString().padStart(2, '0');
     return `${h}:${m}`;
   }
+
+  /**
+   * 週あたりのスケジュール回数を算出する
+   */
+  static getWeeklyScheduleCount(schedules: { daysOfWeek: string[] }[]): number {
+    let count = 0;
+    for (const s of schedules) {
+      count += s.daysOfWeek.length === 0 ? 7 : s.daysOfWeek.length;
+    }
+    return count;
+  }
+
+  /**
+   * 薬別のスケジュール件数サマリーを件数降順で返す
+   */
+  static getMedicationScheduleSummary(
+    schedules: { medicationId: string; medicationName: string }[],
+  ): Array<{ medicationId: string; name: string; count: number }> {
+    const map = new Map<string, { name: string; count: number }>();
+    for (const s of schedules) {
+      const existing = map.get(s.medicationId);
+      if (existing) {
+        existing.count++;
+      } else {
+        map.set(s.medicationId, { name: s.medicationName, count: 1 });
+      }
+    }
+    return Array.from(map.entries())
+      .map(([medicationId, v]) => ({ medicationId, name: v.name, count: v.count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  /**
+   * スケジュール件数に応じた負荷ラベルを返す
+   */
+  static getScheduleLoadLabel(count: number): string {
+    if (count === 0) return 'なし';
+    if (count <= 5) return '軽い';
+    if (count <= 10) return '普通';
+    if (count < 20) return '多い';
+    return '非常に多い';
+  }
 }


### PR DESCRIPTION
## Summary
- `getWeeklyScheduleCount`: 週あたりのスケジュール回数算出（空曜日=毎日=7）
- `getMedicationScheduleSummary`: 薬別スケジュール件数を件数降順で集計
- `getScheduleLoadLabel`: スケジュール件数に応じた負荷ラベル（なし/軽い/普通/多い/非常に多い）
- テスト12件追加、全2868テストパス

## Test plan
- [x] ScheduleFrequencyAnalysis.test.ts 12件パス
- [x] 全2868テストパス

closes #609