### PR TITLE
Phase35エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentReminderScheduling.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentReminderScheduling.edge.test.ts
@@ -1,0 +1,46 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Reminder Scheduling Edge Cases', () => {
+  describe('shouldSendReminder', () => {
+    it('当日で0日リマインダーはtrue', () => {
+      const d = new Date('2026-03-05');
+      expect(AppointmentEntity.shouldSendReminder(d, d, 0)).toBe(true);
+    });
+
+    it('前日で0日リマインダーはfalse', () => {
+      const apt = new Date('2026-03-06');
+      const today = new Date('2026-03-05');
+      expect(AppointmentEntity.shouldSendReminder(apt, today, 0)).toBe(false);
+    });
+
+    it('30日前リマインダー', () => {
+      const apt = new Date('2026-04-04');
+      const today = new Date('2026-03-05');
+      expect(AppointmentEntity.shouldSendReminder(apt, today, 30)).toBe(true);
+    });
+  });
+
+  describe('getReminderPriority', () => {
+    it('境界値2でmedium', () => {
+      expect(AppointmentEntity.getReminderPriority(2)).toBe('medium');
+    });
+
+    it('境界値4でlow', () => {
+      expect(AppointmentEntity.getReminderPriority(4)).toBe('low');
+    });
+
+    it('負の値でhigh', () => {
+      expect(AppointmentEntity.getReminderPriority(-1)).toBe('high');
+    });
+  });
+
+  describe('formatReminderSchedule', () => {
+    it('21日で3週間前', () => {
+      expect(AppointmentEntity.formatReminderSchedule(21)).toBe('3週間前にお知らせ');
+    });
+
+    it('10日で10日前', () => {
+      expect(AppointmentEntity.formatReminderSchedule(10)).toBe('10日前にお知らせ');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MathPercentile.edge.test.ts
+++ b/src/__tests__/domain/entities/MathPercentile.edge.test.ts
@@ -1,0 +1,49 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Percentile Edge Cases', () => {
+  describe('calculatePercentile', () => {
+    it('2要素で50パーセンタイルは中間値', () => {
+      expect(MathHelper.calculatePercentile([10, 20], 50)).toBe(15);
+    });
+
+    it('負のパーセンタイルで最小値を返す', () => {
+      expect(MathHelper.calculatePercentile([1, 2, 3], -10)).toBe(1);
+    });
+
+    it('100超のパーセンタイルで最大値を返す', () => {
+      expect(MathHelper.calculatePercentile([1, 2, 3], 150)).toBe(3);
+    });
+
+    it('全て同じ値の配列', () => {
+      expect(MathHelper.calculatePercentile([5, 5, 5, 5], 75)).toBe(5);
+    });
+  });
+
+  describe('getQuartiles', () => {
+    it('1要素で全て同じ値', () => {
+      const q = MathHelper.getQuartiles([42]);
+      expect(q.q1).toBe(42);
+      expect(q.q2).toBe(42);
+      expect(q.q3).toBe(42);
+    });
+
+    it('2要素の四分位数', () => {
+      const q = MathHelper.getQuartiles([0, 100]);
+      expect(q.q2).toBe(50);
+    });
+  });
+
+  describe('getOutlierBounds', () => {
+    it('全て同じ値でIQR=0', () => {
+      const bounds = MathHelper.getOutlierBounds([5, 5, 5]);
+      expect(bounds.lower).toBe(5);
+      expect(bounds.upper).toBe(5);
+    });
+
+    it('1要素でIQR=0', () => {
+      const bounds = MathHelper.getOutlierBounds([10]);
+      expect(bounds.lower).toBe(10);
+      expect(bounds.upper).toBe(10);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleFrequencyAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleFrequencyAnalysis.edge.test.ts
@@ -1,0 +1,50 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Frequency Analysis Edge Cases', () => {
+  describe('getWeeklyScheduleCount', () => {
+    it('全曜日指定で7を返す', () => {
+      const schedules = [{ daysOfWeek: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] }];
+      expect(ScheduleEntity.getWeeklyScheduleCount(schedules)).toBe(7);
+    });
+
+    it('複数スケジュールが全て毎日', () => {
+      const schedules = [{ daysOfWeek: [] }, { daysOfWeek: [] }];
+      expect(ScheduleEntity.getWeeklyScheduleCount(schedules)).toBe(14);
+    });
+
+    it('1曜日のみ', () => {
+      const schedules = [{ daysOfWeek: ['mon'] }];
+      expect(ScheduleEntity.getWeeklyScheduleCount(schedules)).toBe(1);
+    });
+  });
+
+  describe('getScheduleLoadLabel', () => {
+    it('境界値5で「軽い」', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(5)).toBe('軽い');
+    });
+
+    it('境界値6で「普通」', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(6)).toBe('普通');
+    });
+
+    it('境界値10で「普通」', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(10)).toBe('普通');
+    });
+
+    it('境界値11で「多い」', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(11)).toBe('多い');
+    });
+
+    it('境界値19で「多い」', () => {
+      expect(ScheduleEntity.getScheduleLoadLabel(19)).toBe('多い');
+    });
+  });
+
+  describe('getMedicationScheduleSummary', () => {
+    it('1薬品のみ', () => {
+      const schedules = [{ medicationId: 'a', medicationName: '薬X' }];
+      const result = ScheduleEntity.getMedicationScheduleSummary(schedules);
+      expect(result).toEqual([{ medicationId: 'a', name: '薬X', count: 1 }]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- AppointmentReminderScheduling: 当日/前日、30日前、負値優先度 (8テスト)
- MathPercentile: 極端パーセンタイル値、同値配列、1-2要素 (8テスト)
- ScheduleFrequencyAnalysis: 全曜日指定、境界負荷ラベル(5/6/10/11/19) (9テスト)
- 全2893テストパス

## Test plan
- [x] エッジケーステスト25件パス
- [x] 全2893テストパス

closes #613