### PR TITLE
一覧取得GETルートのレート制限追加

### DIFF
--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -6,6 +6,8 @@ import { QUERY_LIMITS } from '@/lib/constants';
 import { checkRateLimit } from '@/lib/security';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`appointments-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const appointments = await prisma.appointment.findMany({
     where: { userId },
     orderBy: { appointmentDate: 'asc' },

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -6,6 +6,8 @@ import { QUERY_LIMITS } from '@/lib/constants';
 import { checkRateLimit } from '@/lib/security';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`hospitals-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const hospitals = await prisma.hospital.findMany({ where: { userId }, take: QUERY_LIMITS.DEFAULT });
   return success(hospitals);
 });

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -7,6 +7,8 @@ import { QUERY_LIMITS } from '@/lib/constants';
 import { checkRateLimit } from '@/lib/security';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`schedules-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const schedules = await prisma.schedule.findMany({ where: { userId }, take: QUERY_LIMITS.SCHEDULES });
   return success(schedules);
 });


### PR DESCRIPTION
## Summary
- `/api/appointments` GETに30req/minのレート制限を追加
- `/api/hospitals` GETに30req/minのレート制限を追加
- `/api/schedules` GETに30req/minのレート制限を追加
- これにより全一覧取得GETエンドポイントにレート制限が適用済み

## Test plan
- [x] 全2893テストパス

closes #615