### PR TITLE
feat: メンバーの年齢マイルストーン・誕生日カウントダウン機能

### DIFF
--- a/src/__tests__/domain/entities/MemberAgeMilestone.test.ts
+++ b/src/__tests__/domain/entities/MemberAgeMilestone.test.ts
@@ -1,0 +1,70 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Age Milestone', () => {
+  describe('getAgeMilestone', () => {
+    it('0歳で「誕生」を返す', () => {
+      expect(MemberEntity.getAgeMilestone(0)).toBe('誕生');
+    });
+
+    it('1歳で「1歳」を返す', () => {
+      expect(MemberEntity.getAgeMilestone(1)).toBe('1歳');
+    });
+
+    it('20歳で「成人」を返す', () => {
+      expect(MemberEntity.getAgeMilestone(20)).toBe('成人');
+    });
+
+    it('65歳で「高齢者」を返す', () => {
+      expect(MemberEntity.getAgeMilestone(65)).toBe('高齢者');
+    });
+
+    it('75歳で「後期高齢者」を返す', () => {
+      expect(MemberEntity.getAgeMilestone(75)).toBe('後期高齢者');
+    });
+
+    it('マイルストーンに該当しない年齢でnullを返す', () => {
+      expect(MemberEntity.getAgeMilestone(25)).toBeNull();
+    });
+  });
+
+  describe('isUpcomingBirthday', () => {
+    it('7日以内の誕生日でtrueを返す', () => {
+      const birthDate = new Date('1990-03-10');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.isUpcomingBirthday(birthDate, today, 7)).toBe(true);
+    });
+
+    it('8日後の誕生日で7日以内ならfalseを返す', () => {
+      const birthDate = new Date('1990-03-13');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.isUpcomingBirthday(birthDate, today, 7)).toBe(false);
+    });
+
+    it('当日の誕生日でtrueを返す', () => {
+      const birthDate = new Date('1990-03-05');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.isUpcomingBirthday(birthDate, today, 7)).toBe(true);
+    });
+  });
+
+  describe('getBirthdayCountdown', () => {
+    it('当日で「今日が誕生日です」を返す', () => {
+      const birthDate = new Date('1990-03-05');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.getBirthdayCountdown(birthDate, today)).toBe('今日が誕生日です');
+    });
+
+    it('3日後で「誕生日まであと3日」を返す', () => {
+      const birthDate = new Date('1990-03-08');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.getBirthdayCountdown(birthDate, today)).toBe('誕生日まであと3日');
+    });
+
+    it('翌年の場合でも正しく計算する', () => {
+      const birthDate = new Date('1990-01-10');
+      const today = new Date('2026-12-25');
+      const result = MemberEntity.getBirthdayCountdown(birthDate, today);
+      expect(result).toBe('誕生日まであと16日');
+    });
+  });
+});

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -332,4 +332,44 @@ export class MemberEntity {
     if (percentage >= 50) return '半分入力済み';
     return '入力が必要';
   }
+
+  private static readonly ageMilestones: Record<number, string> = {
+    0: '誕生',
+    1: '1歳',
+    20: '成人',
+    65: '高齢者',
+    75: '後期高齢者',
+  };
+
+  /**
+   * 年齢に応じたマイルストーンを返す
+   */
+  static getAgeMilestone(age: number): string | null {
+    return MemberEntity.ageMilestones[age] ?? null;
+  }
+
+  /**
+   * 誕生日が指定日数以内かどうかを判定する
+   */
+  static isUpcomingBirthday(birthDate: Date, today: Date, withinDays: number): boolean {
+    const thisYearBirthday = new Date(today.getFullYear(), birthDate.getMonth(), birthDate.getDate());
+    const diffTime = thisYearBirthday.getTime() - today.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return diffDays >= 0 && diffDays <= withinDays;
+  }
+
+  /**
+   * 誕生日までのカウントダウンテキストを返す
+   */
+  static getBirthdayCountdown(birthDate: Date, today: Date): string {
+    const todayNorm = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    let nextBirthday = new Date(today.getFullYear(), birthDate.getMonth(), birthDate.getDate());
+    if (nextBirthday.getTime() < todayNorm.getTime()) {
+      nextBirthday = new Date(today.getFullYear() + 1, birthDate.getMonth(), birthDate.getDate());
+    }
+    const diffTime = nextBirthday.getTime() - today.getTime();
+    const diffDays = Math.round(diffTime / (1000 * 60 * 60 * 24));
+    if (diffDays === 0) return '今日が誕生日です';
+    return `誕生日まであと${diffDays}日`;
+  }
 }


### PR DESCRIPTION
## Summary
- `getAgeMilestone`: 年齢に応じたマイルストーンラベル（誕生、成人、高齢者等）を返す
- `isUpcomingBirthday`: 誕生日が指定日数以内かを判定する
- `getBirthdayCountdown`: 誕生日までのカウントダウンテキストを返す

closes #617

## Test plan
- [x] getAgeMilestone: 各マイルストーン年齢と該当しない年齢のテスト (6件)
- [x] isUpcomingBirthday: 期間内・期間外・当日のテスト (3件)
- [x] getBirthdayCountdown: 当日・数日後・翌年のテスト (3件)
- [x] 全テスト2905件パス