### PR TITLE
feat: 挨拶コンテキストビルダーとヘルススコア集計機能

### DIFF
--- a/src/__tests__/domain/entities/GreetingContextBuilder.test.ts
+++ b/src/__tests__/domain/entities/GreetingContextBuilder.test.ts
@@ -1,0 +1,93 @@
+import { CharacterEntity } from '@/domain/entities/Character';
+
+describe('CharacterEntity - Greeting Context Builder', () => {
+  describe('getTimeBasedGreeting', () => {
+    it('早朝(5時)で「おはようございます」を返す', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(5)).toBe('おはようございます');
+    });
+
+    it('午前(10時)で「おはようございます」を返す', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(10)).toBe('おはようございます');
+    });
+
+    it('昼(12時)で「こんにちは」を返す', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(12)).toBe('こんにちは');
+    });
+
+    it('夕方(17時)で「こんにちは」を返す', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(17)).toBe('こんにちは');
+    });
+
+    it('夜(18時)で「こんばんは」を返す', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(18)).toBe('こんばんは');
+    });
+
+    it('深夜(2時)で「こんばんは」を返す', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(2)).toBe('こんばんは');
+    });
+  });
+
+  describe('getGreetingContext', () => {
+    it('スケジュールありで服薬情報を含む', () => {
+      const context = CharacterEntity.getGreetingContext({
+        pendingMedications: 3,
+        upcomingAppointments: 1,
+        memberName: '太郎',
+      });
+      expect(context).toContain('太郎');
+      expect(context).toContain('3');
+    });
+
+    it('予定なしで予定なしメッセージを返す', () => {
+      const context = CharacterEntity.getGreetingContext({
+        pendingMedications: 0,
+        upcomingAppointments: 0,
+        memberName: '花子',
+      });
+      expect(context).toContain('予定はありません');
+    });
+
+    it('通院予定ありで通院情報を含む', () => {
+      const context = CharacterEntity.getGreetingContext({
+        pendingMedications: 0,
+        upcomingAppointments: 2,
+        memberName: '次郎',
+      });
+      expect(context).toContain('通院');
+      expect(context).toContain('2');
+    });
+  });
+
+  describe('buildGreetingMessage', () => {
+    it('挨拶とコンテキストを組み合わせる', () => {
+      const message = CharacterEntity.buildGreetingMessage(10, {
+        pendingMedications: 1,
+        upcomingAppointments: 0,
+        memberName: '太郎',
+      });
+      expect(message).toContain('おはようございます');
+      expect(message).toContain('太郎');
+    });
+
+    it('夜の挨拶とコンテキスト', () => {
+      const message = CharacterEntity.buildGreetingMessage(20, {
+        pendingMedications: 0,
+        upcomingAppointments: 0,
+        memberName: '花子',
+      });
+      expect(message).toContain('こんばんは');
+      expect(message).toContain('花子');
+    });
+
+    it('服薬と通院の両方がある場合', () => {
+      const message = CharacterEntity.buildGreetingMessage(14, {
+        pendingMedications: 2,
+        upcomingAppointments: 1,
+        memberName: '三郎',
+      });
+      expect(message).toContain('こんにちは');
+      expect(message).toContain('2');
+      expect(message).toContain('通院');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberHealthScore.test.ts
+++ b/src/__tests__/domain/entities/MemberHealthScore.test.ts
@@ -1,0 +1,97 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Health Score', () => {
+  describe('calculateHealthScore', () => {
+    it('全て満点で100を返す', () => {
+      expect(
+        MemberEntity.calculateHealthScore({
+          adherenceRate: 100,
+          averageCondition: 5,
+          appointmentComplianceRate: 100,
+        }),
+      ).toBe(100);
+    });
+
+    it('全て0で0を返す', () => {
+      expect(
+        MemberEntity.calculateHealthScore({
+          adherenceRate: 0,
+          averageCondition: 1,
+          appointmentComplianceRate: 0,
+        }),
+      ).toBe(0);
+    });
+
+    it('服薬遵守率の重みが50%', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 80,
+        averageCondition: 1,
+        appointmentComplianceRate: 0,
+      });
+      expect(score).toBe(40);
+    });
+
+    it('体調の重みが30%', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 0,
+        averageCondition: 5,
+        appointmentComplianceRate: 0,
+      });
+      expect(score).toBe(30);
+    });
+
+    it('通院遵守率の重みが20%', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 0,
+        averageCondition: 1,
+        appointmentComplianceRate: 100,
+      });
+      expect(score).toBe(20);
+    });
+
+    it('バランスの取れたスコア', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 70,
+        averageCondition: 3,
+        appointmentComplianceRate: 80,
+      });
+      expect(score).toBe(66);
+    });
+  });
+
+  describe('getHealthScoreLabel', () => {
+    it('90以上で「優良」を返す', () => {
+      expect(MemberEntity.getHealthScoreLabel(95)).toBe('優良');
+    });
+
+    it('70以上90未満で「良好」を返す', () => {
+      expect(MemberEntity.getHealthScoreLabel(75)).toBe('良好');
+    });
+
+    it('50以上70未満で「普通」を返す', () => {
+      expect(MemberEntity.getHealthScoreLabel(55)).toBe('普通');
+    });
+
+    it('50未満で「要改善」を返す', () => {
+      expect(MemberEntity.getHealthScoreLabel(30)).toBe('要改善');
+    });
+  });
+
+  describe('getHealthScoreColor', () => {
+    it('90以上で緑色', () => {
+      expect(MemberEntity.getHealthScoreColor(95)).toBe('text-green-600');
+    });
+
+    it('70以上90未満で青色', () => {
+      expect(MemberEntity.getHealthScoreColor(75)).toBe('text-blue-600');
+    });
+
+    it('50以上70未満でオレンジ色', () => {
+      expect(MemberEntity.getHealthScoreColor(55)).toBe('text-orange-600');
+    });
+
+    it('50未満で赤色', () => {
+      expect(MemberEntity.getHealthScoreColor(30)).toBe('text-red-600');
+    });
+  });
+});

--- a/src/domain/entities/Character.ts
+++ b/src/domain/entities/Character.ts
@@ -100,6 +100,48 @@ export class CharacterEntity {
     };
     return messages[mood];
   }
+
+  /**
+   * 時間帯に応じた挨拶テキストを返す
+   */
+  static getTimeBasedGreeting(hour: number): string {
+    if (hour >= 5 && hour < 12) return 'おはようございます';
+    if (hour >= 12 && hour < 18) return 'こんにちは';
+    return 'こんばんは';
+  }
+
+  /**
+   * 挨拶に含めるコンテキスト情報を構築する
+   */
+  static getGreetingContext(info: {
+    pendingMedications: number;
+    upcomingAppointments: number;
+    memberName: string;
+  }): string {
+    const parts: string[] = [];
+    if (info.pendingMedications > 0) {
+      parts.push(`${info.memberName}さんの服薬が${info.pendingMedications}件あります`);
+    }
+    if (info.upcomingAppointments > 0) {
+      parts.push(`通院予定が${info.upcomingAppointments}件あります`);
+    }
+    if (parts.length === 0) {
+      return `${info.memberName}さんの今日の予定はありません`;
+    }
+    return parts.join('。');
+  }
+
+  /**
+   * 挨拶テキストとコンテキストを組み合わせたメッセージを生成する
+   */
+  static buildGreetingMessage(
+    hour: number,
+    info: { pendingMedications: number; upcomingAppointments: number; memberName: string },
+  ): string {
+    const greeting = CharacterEntity.getTimeBasedGreeting(hour);
+    const context = CharacterEntity.getGreetingContext(info);
+    return `${greeting}、${info.memberName}さん。${context}`;
+  }
 }
 
 export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -372,4 +372,38 @@ export class MemberEntity {
     if (diffDays === 0) return '今日が誕生日です';
     return `誕生日まであと${diffDays}日`;
   }
+
+  /**
+   * 服薬遵守率・体調・通院状況からヘルススコアを算出する(0-100)
+   */
+  static calculateHealthScore(params: {
+    adherenceRate: number;
+    averageCondition: number;
+    appointmentComplianceRate: number;
+  }): number {
+    const adherenceScore = params.adherenceRate * 0.5;
+    const conditionScore = ((params.averageCondition - 1) / 4) * 100 * 0.3;
+    const appointmentScore = params.appointmentComplianceRate * 0.2;
+    return Math.round(adherenceScore + conditionScore + appointmentScore);
+  }
+
+  /**
+   * ヘルススコアに応じたラベルを返す
+   */
+  static getHealthScoreLabel(score: number): string {
+    if (score >= 90) return '優良';
+    if (score >= 70) return '良好';
+    if (score >= 50) return '普通';
+    return '要改善';
+  }
+
+  /**
+   * ヘルススコアに応じたカラークラスを返す
+   */
+  static getHealthScoreColor(score: number): string {
+    if (score >= 90) return 'text-green-600';
+    if (score >= 70) return 'text-blue-600';
+    if (score >= 50) return 'text-orange-600';
+    return 'text-red-600';
+  }
 }


### PR DESCRIPTION
## Summary
- CharacterEntityに時間帯別挨拶・コンテキスト構築・メッセージ生成機能を追加
- MemberEntityにヘルススコア算出・ラベル・カラー取得機能を追加

closes #619
closes #620

## Test plan
- [x] getTimeBasedGreeting: 朝昼夜の挨拶テスト (6件)
- [x] getGreetingContext: 服薬・通院・予定なしのテスト (3件)
- [x] buildGreetingMessage: 組み合わせテスト (3件)
- [x] calculateHealthScore: 重み付けスコア算出テスト (6件)
- [x] getHealthScoreLabel: ラベル閾値テスト (4件)
- [x] getHealthScoreColor: カラー閾値テスト (4件)
- [x] 全テスト2931件パス