### PR TITLE
test: Cycle 36 Phase 1機能のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/GreetingContextBuilder.edge.test.ts
+++ b/src/__tests__/domain/entities/GreetingContextBuilder.edge.test.ts
@@ -1,0 +1,72 @@
+import { CharacterEntity } from '@/domain/entities/Character';
+
+describe('CharacterEntity - Greeting Context Builder Edge Cases', () => {
+  describe('getTimeBasedGreeting', () => {
+    it('境界値4時で「こんばんは」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(4)).toBe('こんばんは');
+    });
+
+    it('境界値5時で「おはようございます」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(5)).toBe('おはようございます');
+    });
+
+    it('境界値11時で「おはようございます」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(11)).toBe('おはようございます');
+    });
+
+    it('境界値12時で「こんにちは」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(12)).toBe('こんにちは');
+    });
+
+    it('境界値17時で「こんにちは」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(17)).toBe('こんにちは');
+    });
+
+    it('境界値18時で「こんばんは」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(18)).toBe('こんばんは');
+    });
+
+    it('23時で「こんばんは」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(23)).toBe('こんばんは');
+    });
+
+    it('0時で「こんばんは」', () => {
+      expect(CharacterEntity.getTimeBasedGreeting(0)).toBe('こんばんは');
+    });
+  });
+
+  describe('getGreetingContext', () => {
+    it('服薬と通院の両方がある場合', () => {
+      const context = CharacterEntity.getGreetingContext({
+        pendingMedications: 5,
+        upcomingAppointments: 3,
+        memberName: '太郎',
+      });
+      expect(context).toContain('5');
+      expect(context).toContain('3');
+      expect(context).toContain('通院');
+    });
+
+    it('大量の服薬予定', () => {
+      const context = CharacterEntity.getGreetingContext({
+        pendingMedications: 100,
+        upcomingAppointments: 0,
+        memberName: 'テスト',
+      });
+      expect(context).toContain('100');
+    });
+  });
+
+  describe('buildGreetingMessage', () => {
+    it('深夜0時のメッセージ', () => {
+      const message = CharacterEntity.buildGreetingMessage(0, {
+        pendingMedications: 0,
+        upcomingAppointments: 0,
+        memberName: 'ユーザー',
+      });
+      expect(message).toContain('こんばんは');
+      expect(message).toContain('ユーザー');
+      expect(message).toContain('予定はありません');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberAgeMilestone.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberAgeMilestone.edge.test.ts
@@ -1,0 +1,60 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Age Milestone Edge Cases', () => {
+  describe('getAgeMilestone', () => {
+    it('マイルストーン直前の年齢(19歳)でnull', () => {
+      expect(MemberEntity.getAgeMilestone(19)).toBeNull();
+    });
+
+    it('マイルストーン直後の年齢(21歳)でnull', () => {
+      expect(MemberEntity.getAgeMilestone(21)).toBeNull();
+    });
+
+    it('64歳でnull', () => {
+      expect(MemberEntity.getAgeMilestone(64)).toBeNull();
+    });
+
+    it('66歳でnull', () => {
+      expect(MemberEntity.getAgeMilestone(66)).toBeNull();
+    });
+
+    it('100歳でnull', () => {
+      expect(MemberEntity.getAgeMilestone(100)).toBeNull();
+    });
+  });
+
+  describe('isUpcomingBirthday', () => {
+    it('withinDays=0で当日のみtrue', () => {
+      const birth = new Date('1990-03-05');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.isUpcomingBirthday(birth, today, 0)).toBe(true);
+    });
+
+    it('withinDays=0で翌日はfalse', () => {
+      const birth = new Date('1990-03-06');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.isUpcomingBirthday(birth, today, 0)).toBe(false);
+    });
+
+    it('年末で翌年1月の誕生日は範囲外', () => {
+      const birth = new Date('1990-01-05');
+      const today = new Date('2026-12-30');
+      expect(MemberEntity.isUpcomingBirthday(birth, today, 7)).toBe(false);
+    });
+  });
+
+  describe('getBirthdayCountdown', () => {
+    it('1日前で「誕生日まであと1日」', () => {
+      const birth = new Date('1990-03-06');
+      const today = new Date('2026-03-05');
+      expect(MemberEntity.getBirthdayCountdown(birth, today)).toBe('誕生日まであと1日');
+    });
+
+    it('誕生日翌日で翌年までカウント', () => {
+      const birth = new Date('1990-03-04');
+      const today = new Date('2026-03-05');
+      const result = MemberEntity.getBirthdayCountdown(birth, today);
+      expect(result).toBe('誕生日まであと364日');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberHealthScore.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberHealthScore.edge.test.ts
@@ -1,0 +1,97 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Health Score Edge Cases', () => {
+  describe('calculateHealthScore', () => {
+    it('全て中間値でバランスの取れたスコア', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 50,
+        averageCondition: 3,
+        appointmentComplianceRate: 50,
+      });
+      expect(score).toBe(50);
+    });
+
+    it('体調が最低(1)で他が満点', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 100,
+        averageCondition: 1,
+        appointmentComplianceRate: 100,
+      });
+      expect(score).toBe(70);
+    });
+
+    it('体調が2の場合', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 0,
+        averageCondition: 2,
+        appointmentComplianceRate: 0,
+      });
+      expect(score).toBe(8);
+    });
+
+    it('体調が4の場合', () => {
+      const score = MemberEntity.calculateHealthScore({
+        adherenceRate: 0,
+        averageCondition: 4,
+        appointmentComplianceRate: 0,
+      });
+      expect(score).toBe(23);
+    });
+  });
+
+  describe('getHealthScoreLabel', () => {
+    it('境界値90で「優良」', () => {
+      expect(MemberEntity.getHealthScoreLabel(90)).toBe('優良');
+    });
+
+    it('境界値89で「良好」', () => {
+      expect(MemberEntity.getHealthScoreLabel(89)).toBe('良好');
+    });
+
+    it('境界値70で「良好」', () => {
+      expect(MemberEntity.getHealthScoreLabel(70)).toBe('良好');
+    });
+
+    it('境界値69で「普通」', () => {
+      expect(MemberEntity.getHealthScoreLabel(69)).toBe('普通');
+    });
+
+    it('境界値50で「普通」', () => {
+      expect(MemberEntity.getHealthScoreLabel(50)).toBe('普通');
+    });
+
+    it('境界値49で「要改善」', () => {
+      expect(MemberEntity.getHealthScoreLabel(49)).toBe('要改善');
+    });
+
+    it('0で「要改善」', () => {
+      expect(MemberEntity.getHealthScoreLabel(0)).toBe('要改善');
+    });
+
+    it('100で「優良」', () => {
+      expect(MemberEntity.getHealthScoreLabel(100)).toBe('優良');
+    });
+  });
+
+  describe('getHealthScoreColor', () => {
+    it('境界値90で緑色', () => {
+      expect(MemberEntity.getHealthScoreColor(90)).toBe('text-green-600');
+    });
+
+    it('境界値89で青色', () => {
+      expect(MemberEntity.getHealthScoreColor(89)).toBe('text-blue-600');
+    });
+
+    it('境界値70で青色', () => {
+      expect(MemberEntity.getHealthScoreColor(70)).toBe('text-blue-600');
+    });
+
+    it('境界値50でオレンジ色', () => {
+      expect(MemberEntity.getHealthScoreColor(50)).toBe('text-orange-600');
+    });
+
+    it('境界値49で赤色', () => {
+      expect(MemberEntity.getHealthScoreColor(49)).toBe('text-red-600');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- MemberAgeMilestone: マイルストーン境界値・年跨ぎ誕生日テスト (10件)
- GreetingContextBuilder: 時間帯境界値(0-23時)・大量データテスト (11件)
- MemberHealthScore: スコア境界値(49/50/69/70/89/90)・重み検証テスト (17件)

closes #624

## Test plan
- [x] 38件のエッジケーステスト全てパス
- [x] 全テスト2969件パス