### PR TITLE
fix: members・health-logs GETエンドポイントにレート制限追加

### DIFF
--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -6,6 +6,8 @@ import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`health-logs-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const logs = await prisma.healthLog.findMany({
     where: { userId },
     orderBy: { recordedAt: 'desc' },

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -6,6 +6,8 @@ import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`members-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const members = await prisma.member.findMany({ where: { userId }, take: QUERY_LIMITS.MEMBERS });
   return success(members);
 });


### PR DESCRIPTION
## Summary
- /api/members GETにcheckRateLimit(30req/min)を追加
- /api/health-logs GETにcheckRateLimit(30req/min)を追加
- 他のGETエンドポイントと一貫したレート制限を適用

closes #626

## Test plan
- [x] 全テスト2969件パス
- [x] 既存のAPI動作に影響なし