### PR TITLE
test: Cycle 37 Phase 1機能のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceStreakAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStreakAnalysis.edge.test.ts
@@ -1,0 +1,59 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Streak Analysis Edge Cases', () => {
+  describe('getLongestStreak', () => {
+    it('交互パターンで最長1', () => {
+      expect(AdherenceTrendEntity.getLongestStreak([true, false, true, false, true])).toBe(1);
+    });
+
+    it('末尾に最長ストリーク', () => {
+      expect(AdherenceTrendEntity.getLongestStreak([false, true, true, true, true])).toBe(4);
+    });
+
+    it('先頭に最長ストリーク', () => {
+      expect(AdherenceTrendEntity.getLongestStreak([true, true, true, false, true])).toBe(3);
+    });
+
+    it('100要素の全true', () => {
+      const data = new Array(100).fill(true);
+      expect(AdherenceTrendEntity.getLongestStreak(data)).toBe(100);
+    });
+  });
+
+  describe('getCurrentStreak', () => {
+    it('1要素falseで0', () => {
+      expect(AdherenceTrendEntity.getCurrentStreak([false])).toBe(0);
+    });
+
+    it('1要素trueで1', () => {
+      expect(AdherenceTrendEntity.getCurrentStreak([true])).toBe(1);
+    });
+
+    it('長い配列の末尾ストリーク', () => {
+      const data = [false, false, true, true, true, true, true];
+      expect(AdherenceTrendEntity.getCurrentStreak(data)).toBe(5);
+    });
+  });
+
+  describe('getStreakLabel', () => {
+    it('1日で「1日連続」', () => {
+      expect(AdherenceTrendEntity.getStreakLabel(1)).toBe('1日連続');
+    });
+
+    it('21日で「3週間連続」', () => {
+      expect(AdherenceTrendEntity.getStreakLabel(21)).toBe('3週間連続');
+    });
+
+    it('28日で「4週間連続」', () => {
+      expect(AdherenceTrendEntity.getStreakLabel(28)).toBe('4週間連続');
+    });
+
+    it('31日で「1ヶ月連続」', () => {
+      expect(AdherenceTrendEntity.getStreakLabel(31)).toBe('1ヶ月連続');
+    });
+
+    it('8日で「8日連続」(7の倍数でない)', () => {
+      expect(AdherenceTrendEntity.getStreakLabel(8)).toBe('8日連続');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/CalendarEventDensity.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarEventDensity.edge.test.ts
@@ -1,0 +1,55 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Event Density Edge Cases', () => {
+  describe('getEventDensity', () => {
+    it('1日1イベントで1.0', () => {
+      expect(CalendarEntity.getEventDensity(1, 1)).toBe(1);
+    });
+
+    it('小数点2桁に丸める', () => {
+      expect(CalendarEntity.getEventDensity(1, 3)).toBe(0.33);
+    });
+
+    it('大量イベント', () => {
+      expect(CalendarEntity.getEventDensity(100, 1)).toBe(100);
+    });
+  });
+
+  describe('getBusiestWeekday', () => {
+    it('7要素未満の配列', () => {
+      const counts = [5, 3];
+      expect(CalendarEntity.getBusiestWeekday(counts)).toBe('日曜日');
+    });
+
+    it('7要素超の配列でも7曜日内で判定', () => {
+      const counts = [0, 0, 0, 0, 0, 0, 0, 100];
+      expect(CalendarEntity.getBusiestWeekday(counts)).toBe('日曜日');
+    });
+
+    it('最後の要素が最大', () => {
+      const counts = [0, 0, 0, 0, 0, 0, 10];
+      expect(CalendarEntity.getBusiestWeekday(counts)).toBe('土曜日');
+    });
+  });
+
+  describe('getEventDistributionLabel', () => {
+    it('1要素のみの配列', () => {
+      expect(CalendarEntity.getEventDistributionLabel([10])).toBe('均等');
+    });
+
+    it('2要素で差が大きい場合', () => {
+      const counts = [100, 0];
+      expect(CalendarEntity.getEventDistributionLabel(counts)).toBe('偏りあり');
+    });
+
+    it('微小な差は均等', () => {
+      const counts = [10, 10, 10, 10, 10, 10, 11];
+      expect(CalendarEntity.getEventDistributionLabel(counts)).toBe('均等');
+    });
+
+    it('中程度の偏り', () => {
+      const counts = [15, 5, 5, 5, 5, 5, 5];
+      expect(CalendarEntity.getEventDistributionLabel(counts)).toBe('やや偏り');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockRefillOptimization.edge.test.ts
+++ b/src/__tests__/domain/entities/StockRefillOptimization.edge.test.ts
@@ -1,0 +1,48 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Refill Optimization Edge Cases', () => {
+  describe('getOptimalRefillDate', () => {
+    it('バッファが残日数を超える場合今日を返す', () => {
+      const today = new Date('2026-03-05');
+      const result = StockAlertEntity.getOptimalRefillDate(5, 1, today, 10);
+      expect(result).toEqual(new Date('2026-03-05'));
+    });
+
+    it('残り1錠で1日1錠ならバッファ0で翌日が切れる日', () => {
+      const today = new Date('2026-03-05');
+      const result = StockAlertEntity.getOptimalRefillDate(1, 1, today, 0);
+      expect(result).toEqual(new Date('2026-03-06'));
+    });
+
+    it('大量在庫の場合遠い日付を返す', () => {
+      const today = new Date('2026-03-05');
+      const result = StockAlertEntity.getOptimalRefillDate(365, 1, today, 0);
+      expect(result).toEqual(new Date('2027-03-05'));
+    });
+
+    it('負の消費率でnullを返す', () => {
+      const today = new Date('2026-03-05');
+      expect(StockAlertEntity.getOptimalRefillDate(10, -1, today, 3)).toBeNull();
+    });
+  });
+
+  describe('getRefillQuantitySuggestion', () => {
+    it('0日分なら0を返す', () => {
+      expect(StockAlertEntity.getRefillQuantitySuggestion(3, 0)).toBe(0);
+    });
+
+    it('大量消費の場合', () => {
+      expect(StockAlertEntity.getRefillQuantitySuggestion(10, 90)).toBe(900);
+    });
+  });
+
+  describe('getRefillCostEstimate', () => {
+    it('大量購入のコスト', () => {
+      expect(StockAlertEntity.getRefillCostEstimate(1000, 50)).toBe(50000);
+    });
+
+    it('小数の結果は四捨五入', () => {
+      expect(StockAlertEntity.getRefillCostEstimate(7, 33.33)).toBe(233);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- StockRefillOptimization: バッファ超過・大量在庫・負値テスト (8件)
- CalendarEventDensity: 不正配列長・微小差・偏り判定テスト (10件)
- AdherenceStreakAnalysis: 交互パターン・大量データ・週ラベルテスト (12件)

closes #634

## Test plan
- [x] 30件のエッジケーステスト全てパス
- [x] 全テスト3039件パス