### PR TITLE
fix: records GETエンドポイントにレート制限追加

### DIFF
--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -6,6 +6,8 @@ import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`records-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const records = await prisma.medicationRecord.findMany({
     where: { userId },
     orderBy: { takenAt: 'desc' },


### PR DESCRIPTION
## Summary
- /api/records GETにcheckRateLimit(30req/min)を追加
- 全GETエンドポイントのレート制限が統一された

closes #636

## Test plan
- [x] 全テスト3039件パス