### PR TITLE
feat: 通知優先度スコアリング・症状相関分析・服薬時間差分析機能

### DIFF
--- a/src/__tests__/domain/entities/NotificationPriorityScoring.test.ts
+++ b/src/__tests__/domain/entities/NotificationPriorityScoring.test.ts
@@ -1,0 +1,69 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Notification Priority Scoring', () => {
+  describe('getNotificationPriority', () => {
+    it('期限超過で最高優先度10を返す', () => {
+      expect(ScheduleEntity.getNotificationPriority('overdue', 0)).toBe(10);
+    });
+
+    it('15分以内のpendingで優先度8を返す', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 10)).toBe(8);
+    });
+
+    it('30分以内のpendingで優先度6を返す', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 25)).toBe(6);
+    });
+
+    it('60分以内のpendingで優先度4を返す', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 45)).toBe(4);
+    });
+
+    it('60分超のpendingで優先度2を返す', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 120)).toBe(2);
+    });
+
+    it('completedで優先度0を返す', () => {
+      expect(ScheduleEntity.getNotificationPriority('completed', 0)).toBe(0);
+    });
+  });
+
+  describe('getNotificationPriorityLabel', () => {
+    it('優先度10で「緊急」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(10)).toBe('緊急');
+    });
+
+    it('優先度8で「高」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(8)).toBe('高');
+    });
+
+    it('優先度5で「中」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(5)).toBe('中');
+    });
+
+    it('優先度2で「低」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(2)).toBe('低');
+    });
+
+    it('優先度0で「なし」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(0)).toBe('なし');
+    });
+  });
+
+  describe('sortByNotificationPriority', () => {
+    it('優先度の高い順にソートする', () => {
+      const items = [
+        { status: 'completed' as const, minutesUntil: 0 },
+        { status: 'overdue' as const, minutesUntil: 0 },
+        { status: 'pending' as const, minutesUntil: 45 },
+      ];
+      const sorted = ScheduleEntity.sortByNotificationPriority(items);
+      expect(sorted[0].status).toBe('overdue');
+      expect(sorted[1].status).toBe('pending');
+      expect(sorted[2].status).toBe('completed');
+    });
+
+    it('空配列は空配列を返す', () => {
+      expect(ScheduleEntity.sortByNotificationPriority([])).toEqual([]);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/SymptomCorrelation.test.ts
+++ b/src/__tests__/domain/entities/SymptomCorrelation.test.ts
@@ -1,0 +1,71 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Symptom Correlation', () => {
+  describe('getSymptomCooccurrence', () => {
+    it('共起ペアを集計する', () => {
+      const logs = [
+        { symptoms: ['頭痛', '発熱'] },
+        { symptoms: ['頭痛', '発熱'] },
+        { symptoms: ['咳', '発熱'] },
+      ];
+      const result = HealthLogEntity.getSymptomCooccurrence(logs);
+      expect(result).toContainEqual({ pair: ['発熱', '頭痛'], count: 2 });
+      expect(result).toContainEqual({ pair: ['咳', '発熱'], count: 1 });
+    });
+
+    it('1症状のみのログは共起なし', () => {
+      const logs = [{ symptoms: ['頭痛'] }, { symptoms: ['発熱'] }];
+      const result = HealthLogEntity.getSymptomCooccurrence(logs);
+      expect(result).toEqual([]);
+    });
+
+    it('空配列は空を返す', () => {
+      expect(HealthLogEntity.getSymptomCooccurrence([])).toEqual([]);
+    });
+
+    it('症状なしのログは無視', () => {
+      const logs = [{ symptoms: [] }, { symptoms: ['頭痛', '発熱'] }];
+      const result = HealthLogEntity.getSymptomCooccurrence(logs);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('getMostCommonSymptomPair', () => {
+    it('最も多い共起ペアを返す', () => {
+      const logs = [
+        { symptoms: ['頭痛', '発熱'] },
+        { symptoms: ['頭痛', '発熱'] },
+        { symptoms: ['咳', '倦怠感'] },
+      ];
+      const result = HealthLogEntity.getMostCommonSymptomPair(logs);
+      expect(result).toEqual({ pair: ['発熱', '頭痛'], count: 2 });
+    });
+
+    it('共起がない場合nullを返す', () => {
+      const logs = [{ symptoms: ['頭痛'] }];
+      expect(HealthLogEntity.getMostCommonSymptomPair(logs)).toBeNull();
+    });
+
+    it('空配列はnullを返す', () => {
+      expect(HealthLogEntity.getMostCommonSymptomPair([])).toBeNull();
+    });
+  });
+
+  describe('getSymptomCorrelationLabel', () => {
+    it('5回以上で「強い相関」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(5)).toBe('強い相関');
+    });
+
+    it('3回で「中程度の相関」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(3)).toBe('中程度の相関');
+    });
+
+    it('1回で「弱い相関」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(1)).toBe('弱い相関');
+    });
+
+    it('0回で「相関なし」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(0)).toBe('相関なし');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/TimingGapAnalysis.test.ts
+++ b/src/__tests__/domain/entities/TimingGapAnalysis.test.ts
@@ -1,0 +1,67 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Timing Gap Analysis', () => {
+  describe('getTimingGaps', () => {
+    it('予定と実績の差を分単位で返す', () => {
+      const records = [
+        { scheduledTime: '08:00', takenAt: new Date('2026-03-05T08:15:00') },
+        { scheduledTime: '12:00', takenAt: new Date('2026-03-05T11:50:00') },
+      ];
+      const gaps = MedicationRecordEntity.getTimingGaps(records);
+      expect(gaps).toEqual([15, -10]);
+    });
+
+    it('空配列は空を返す', () => {
+      expect(MedicationRecordEntity.getTimingGaps([])).toEqual([]);
+    });
+
+    it('ちょうどの時刻で0を返す', () => {
+      const records = [
+        { scheduledTime: '08:00', takenAt: new Date('2026-03-05T08:00:00') },
+      ];
+      expect(MedicationRecordEntity.getTimingGaps(records)).toEqual([0]);
+    });
+  });
+
+  describe('getAverageTimingGap', () => {
+    it('平均ギャップを算出する', () => {
+      const gaps = [10, 20, 30];
+      expect(MedicationRecordEntity.getAverageTimingGap(gaps)).toBe(20);
+    });
+
+    it('正負が混在する場合絶対値の平均', () => {
+      const gaps = [15, -10, 5];
+      expect(MedicationRecordEntity.getAverageTimingGap(gaps)).toBe(10);
+    });
+
+    it('空配列は0を返す', () => {
+      expect(MedicationRecordEntity.getAverageTimingGap([])).toBe(0);
+    });
+
+    it('全て0なら0を返す', () => {
+      expect(MedicationRecordEntity.getAverageTimingGap([0, 0, 0])).toBe(0);
+    });
+  });
+
+  describe('getTimingAccuracyLabel', () => {
+    it('5分以内で「正確」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(3)).toBe('正確');
+    });
+
+    it('15分以内で「ほぼ正確」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(10)).toBe('ほぼ正確');
+    });
+
+    it('30分以内で「やや遅れ」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(25)).toBe('やや遅れ');
+    });
+
+    it('30分超で「大幅な遅れ」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(45)).toBe('大幅な遅れ');
+    });
+
+    it('0分で「正確」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(0)).toBe('正確');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -576,4 +576,42 @@ export class HealthLogEntity {
     if (diff <= -1) return '体調がやや低下しています';
     return '体調は安定しています';
   }
+
+  /**
+   * 症状の共起ペアを集計する
+   */
+  static getSymptomCooccurrence(logs: { symptoms: string[] }[]): Array<{ pair: string[]; count: number }> {
+    const pairCounts = new Map<string, number>();
+    for (const log of logs) {
+      const symptoms = log.symptoms;
+      for (let i = 0; i < symptoms.length; i++) {
+        for (let j = i + 1; j < symptoms.length; j++) {
+          const pair = [symptoms[i], symptoms[j]].sort();
+          const key = pair.join('|');
+          pairCounts.set(key, (pairCounts.get(key) ?? 0) + 1);
+        }
+      }
+    }
+    return Array.from(pairCounts.entries())
+      .map(([key, count]) => ({ pair: key.split('|'), count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  /**
+   * 最も多い症状共起ペアを返す
+   */
+  static getMostCommonSymptomPair(logs: { symptoms: string[] }[]): { pair: string[]; count: number } | null {
+    const cooccurrences = HealthLogEntity.getSymptomCooccurrence(logs);
+    return cooccurrences.length > 0 ? cooccurrences[0] : null;
+  }
+
+  /**
+   * 共起回数に応じた相関ラベルを返す
+   */
+  static getSymptomCorrelationLabel(count: number): string {
+    if (count >= 5) return '強い相関';
+    if (count >= 3) return '中程度の相関';
+    if (count >= 1) return '弱い相関';
+    return '相関なし';
+  }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -474,4 +474,35 @@ export class MedicationRecordEntity {
     };
     return labels[level];
   }
+
+  /**
+   * 予定時刻と実際の服薬時刻の差を分単位で算出する
+   */
+  static getTimingGaps(records: { scheduledTime: string; takenAt: Date }[]): number[] {
+    return records.map((r) => {
+      const [hours, minutes] = r.scheduledTime.split(':').map(Number);
+      const scheduled = hours * 60 + minutes;
+      const taken = r.takenAt.getHours() * 60 + r.takenAt.getMinutes();
+      return taken - scheduled;
+    });
+  }
+
+  /**
+   * 時間差の平均を算出する(絶対値の平均)
+   */
+  static getAverageTimingGap(gaps: number[]): number {
+    if (gaps.length === 0) return 0;
+    const totalAbs = gaps.reduce((sum, g) => sum + Math.abs(g), 0);
+    return Math.round(totalAbs / gaps.length);
+  }
+
+  /**
+   * 平均時間差に応じた正確性ラベルを返す
+   */
+  static getTimingAccuracyLabel(averageGapMinutes: number): string {
+    if (averageGapMinutes <= 5) return '正確';
+    if (averageGapMinutes <= 15) return 'ほぼ正確';
+    if (averageGapMinutes <= 30) return 'やや遅れ';
+    return '大幅な遅れ';
+  }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -617,4 +617,40 @@ export class ScheduleEntity {
     if (count < 20) return '多い';
     return '非常に多い';
   }
+
+  /**
+   * スケジュール状態と残り時間から通知優先度を算出する(0-10)
+   */
+  static getNotificationPriority(status: ScheduleStatus, minutesUntil: number): number {
+    if (status === 'completed') return 0;
+    if (status === 'overdue') return 10;
+    if (minutesUntil <= 15) return 8;
+    if (minutesUntil <= 30) return 6;
+    if (minutesUntil <= 60) return 4;
+    return 2;
+  }
+
+  /**
+   * 通知優先度に応じたラベルを返す
+   */
+  static getNotificationPriorityLabel(priority: number): string {
+    if (priority >= 10) return '緊急';
+    if (priority >= 7) return '高';
+    if (priority >= 4) return '中';
+    if (priority >= 1) return '低';
+    return 'なし';
+  }
+
+  /**
+   * 通知優先度の高い順にソートする
+   */
+  static sortByNotificationPriority<T extends { status: ScheduleStatus; minutesUntil: number }>(
+    items: T[],
+  ): T[] {
+    return [...items].sort((a, b) => {
+      const priorityA = ScheduleEntity.getNotificationPriority(a.status, a.minutesUntil);
+      const priorityB = ScheduleEntity.getNotificationPriority(b.status, b.minutesUntil);
+      return priorityB - priorityA;
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- ScheduleEntityに通知優先度スコアリング・ソート機能を追加
- HealthLogEntityに症状の共起パターン分析機能を追加
- MedicationRecordEntityに服薬時間の正確性分析機能を追加

closes #638
closes #639
closes #640

## Test plan
- [x] NotificationPriorityScoring: 優先度算出・ラベル・ソートテスト (13件)
- [x] SymptomCorrelation: 共起集計・最頻ペア・相関ラベルテスト (11件)
- [x] TimingGapAnalysis: 時間差算出・平均・正確性ラベルテスト (12件)
- [x] 全テスト3075件パス