### PR TITLE
test: Cycle 38 Phase 1機能のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/NotificationPriorityScoring.edge.test.ts
+++ b/src/__tests__/domain/entities/NotificationPriorityScoring.edge.test.ts
@@ -1,0 +1,55 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Notification Priority Edge Cases', () => {
+  describe('getNotificationPriority', () => {
+    it('境界値15分でpendingは優先度8', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 15)).toBe(8);
+    });
+
+    it('境界値16分でpendingは優先度6', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 16)).toBe(6);
+    });
+
+    it('境界値30分でpendingは優先度6', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 30)).toBe(6);
+    });
+
+    it('境界値31分でpendingは優先度4', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 31)).toBe(4);
+    });
+
+    it('境界値60分でpendingは優先度4', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 60)).toBe(4);
+    });
+
+    it('境界値61分でpendingは優先度2', () => {
+      expect(ScheduleEntity.getNotificationPriority('pending', 61)).toBe(2);
+    });
+
+    it('overdueは残り時間に関係なく10', () => {
+      expect(ScheduleEntity.getNotificationPriority('overdue', 999)).toBe(10);
+    });
+  });
+
+  describe('getNotificationPriorityLabel', () => {
+    it('境界値7で「高」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(7)).toBe('高');
+    });
+
+    it('境界値6で「中」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(6)).toBe('中');
+    });
+
+    it('境界値4で「中」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(4)).toBe('中');
+    });
+
+    it('境界値3で「低」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(3)).toBe('低');
+    });
+
+    it('境界値1で「低」', () => {
+      expect(ScheduleEntity.getNotificationPriorityLabel(1)).toBe('低');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/SymptomCorrelation.edge.test.ts
+++ b/src/__tests__/domain/entities/SymptomCorrelation.edge.test.ts
@@ -1,0 +1,65 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Symptom Correlation Edge Cases', () => {
+  describe('getSymptomCooccurrence', () => {
+    it('3症状で3ペアを生成', () => {
+      const logs = [{ symptoms: ['頭痛', '発熱', '咳'] }];
+      const result = HealthLogEntity.getSymptomCooccurrence(logs);
+      expect(result).toHaveLength(3);
+    });
+
+    it('同じ症状ペアが複数ログに出現', () => {
+      const logs = [
+        { symptoms: ['A', 'B', 'C'] },
+        { symptoms: ['A', 'B'] },
+        { symptoms: ['A', 'C'] },
+      ];
+      const result = HealthLogEntity.getSymptomCooccurrence(logs);
+      const abPair = result.find((r) => r.pair.includes('A') && r.pair.includes('B'));
+      expect(abPair?.count).toBe(2);
+    });
+
+    it('ソートされた順序で返される', () => {
+      const logs = [
+        { symptoms: ['X', 'Y'] },
+        { symptoms: ['A', 'B'] },
+        { symptoms: ['A', 'B'] },
+      ];
+      const result = HealthLogEntity.getSymptomCooccurrence(logs);
+      expect(result[0].count).toBeGreaterThanOrEqual(result[result.length - 1].count);
+    });
+  });
+
+  describe('getMostCommonSymptomPair', () => {
+    it('全て同頻度なら最初のペアを返す', () => {
+      const logs = [
+        { symptoms: ['A', 'B'] },
+        { symptoms: ['C', 'D'] },
+      ];
+      const result = HealthLogEntity.getMostCommonSymptomPair(logs);
+      expect(result?.count).toBe(1);
+    });
+  });
+
+  describe('getSymptomCorrelationLabel', () => {
+    it('境界値5で「強い相関」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(5)).toBe('強い相関');
+    });
+
+    it('境界値4で「中程度の相関」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(4)).toBe('中程度の相関');
+    });
+
+    it('境界値3で「中程度の相関」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(3)).toBe('中程度の相関');
+    });
+
+    it('境界値2で「弱い相関」', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(2)).toBe('弱い相関');
+    });
+
+    it('大量の共起', () => {
+      expect(HealthLogEntity.getSymptomCorrelationLabel(100)).toBe('強い相関');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/TimingGapAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/TimingGapAnalysis.edge.test.ts
@@ -1,0 +1,68 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Timing Gap Edge Cases', () => {
+  describe('getTimingGaps', () => {
+    it('深夜の服薬(23:30予定、23:45実績)', () => {
+      const records = [
+        { scheduledTime: '23:30', takenAt: new Date('2026-03-05T23:45:00') },
+      ];
+      expect(MedicationRecordEntity.getTimingGaps(records)).toEqual([15]);
+    });
+
+    it('早朝の服薬(06:00予定、05:50実績)で負値', () => {
+      const records = [
+        { scheduledTime: '06:00', takenAt: new Date('2026-03-05T05:50:00') },
+      ];
+      expect(MedicationRecordEntity.getTimingGaps(records)).toEqual([-10]);
+    });
+
+    it('複数レコードの場合', () => {
+      const records = [
+        { scheduledTime: '08:00', takenAt: new Date('2026-03-05T08:00:00') },
+        { scheduledTime: '12:00', takenAt: new Date('2026-03-05T12:30:00') },
+        { scheduledTime: '20:00', takenAt: new Date('2026-03-05T19:45:00') },
+      ];
+      expect(MedicationRecordEntity.getTimingGaps(records)).toEqual([0, 30, -15]);
+    });
+  });
+
+  describe('getAverageTimingGap', () => {
+    it('大きなギャップ', () => {
+      expect(MedicationRecordEntity.getAverageTimingGap([120, -60])).toBe(90);
+    });
+
+    it('1要素', () => {
+      expect(MedicationRecordEntity.getAverageTimingGap([7])).toBe(7);
+    });
+
+    it('全て負値', () => {
+      expect(MedicationRecordEntity.getAverageTimingGap([-5, -10, -15])).toBe(10);
+    });
+  });
+
+  describe('getTimingAccuracyLabel', () => {
+    it('境界値5で「正確」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(5)).toBe('正確');
+    });
+
+    it('境界値6で「ほぼ正確」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(6)).toBe('ほぼ正確');
+    });
+
+    it('境界値15で「ほぼ正確」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(15)).toBe('ほぼ正確');
+    });
+
+    it('境界値16で「やや遅れ」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(16)).toBe('やや遅れ');
+    });
+
+    it('境界値30で「やや遅れ」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(30)).toBe('やや遅れ');
+    });
+
+    it('境界値31で「大幅な遅れ」', () => {
+      expect(MedicationRecordEntity.getTimingAccuracyLabel(31)).toBe('大幅な遅れ');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- NotificationPriorityScoring: 時間境界値(15/30/60分)・ラベル境界値テスト (12件)
- SymptomCorrelation: 3症状ペア生成・頻度ソート・境界値テスト (9件)
- TimingGapAnalysis: 深夜/早朝パターン・正確性境界値テスト (12件)

closes #644

## Test plan
- [x] 33件のエッジケーステスト全てパス
- [x] 全テスト3108件パス