### PR TITLE
fix: 不正JSONリクエスト時のエラーハンドリングを追加

### DIFF
--- a/src/app/api/appointments/[appointmentId]/route.ts
+++ b/src/app/api/appointments/[appointmentId]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateAppointmentSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const findAppointment = (id: string) => prisma.appointment.findUnique({ where: { id } });
@@ -21,7 +21,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ appo
       finder: findAppointment,
       resourceName: '予約',
       handler: async () => {
-        const body = await request.json();
+        const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
         const parsed = updateAppointmentSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createAppointmentSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations , safeParseJson } from '@/lib/api-helpers';
 import { QUERY_LIMITS } from '@/lib/constants';
 import { checkRateLimit } from '@/lib/security';
 
@@ -31,7 +31,9 @@ export async function POST(request: Request) {
     const { allowed } = checkRateLimit(`appointments-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = createAppointmentSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createHealthLogSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
@@ -32,7 +32,9 @@ export async function POST(request: Request) {
       return errorResponse('記録回数の上限に達しました。しばらくしてから再試行してください。', 429);
     }
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = createHealthLogSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/hospitals/[hospitalId]/route.ts
+++ b/src/app/api/hospitals/[hospitalId]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateHospitalSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const findHospital = (id: string) => prisma.hospital.findUnique({ where: { id } });
@@ -21,7 +21,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ hosp
       finder: findHospital,
       resourceName: '病院',
       handler: async () => {
-        const body = await request.json();
+        const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
         const parsed = updateHospitalSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createHospitalSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { QUERY_LIMITS } from '@/lib/constants';
 import { checkRateLimit } from '@/lib/security';
 
@@ -20,7 +20,9 @@ export async function POST(request: Request) {
     const { allowed } = checkRateLimit(`hospitals-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = createHospitalSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateMedicationSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const findMedication = (id: string) => prisma.medication.findUnique({ where: { id } });
@@ -35,7 +35,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
       finder: findMedication,
       resourceName: 'お薬',
       handler: async () => {
-        const body = await request.json();
+        const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
         const parsed = updateMedicationSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/medications/[medicationId]/stock/route.ts
+++ b/src/app/api/medications/[medicationId]/stock/route.ts
@@ -2,7 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { updateStockSchema } from '@/lib/schemas';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const findMedicationWithMember = (id: string) =>
@@ -22,7 +22,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
       finder: findMedicationWithMember,
       resourceName: 'お薬',
       handler: async (medication) => {
-        const body = await request.json();
+        const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
         const parsed = updateStockSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createMedicationSchema } from '@/lib/schemas';
 import { created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 export async function POST(request: Request) {
@@ -14,7 +14,9 @@ export async function POST(request: Request) {
       return errorResponse('作成回数の上限に達しました。しばらくしてから再試行してください。', 429);
     }
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = createMedicationSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
     if (!parsed.data.memberId) return errorResponse('メンバーIDは必須です');

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateMemberSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const findMember = (id: string) => prisma.member.findUnique({ where: { id } });
@@ -35,7 +35,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ memb
       finder: findMember,
       resourceName: 'メンバー',
       handler: async () => {
-        const body = await request.json();
+        const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
         const parsed = updateMemberSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createMemberSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
@@ -22,7 +22,9 @@ export async function POST(request: Request) {
       return errorResponse('作成回数の上限に達しました。しばらくしてから再試行してください。', 429);
     }
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = createMemberSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const sendNotificationSchema = z.object({
@@ -23,7 +23,9 @@ export async function POST(request: NextRequest) {
       return errorResponse('通知の送信回数が上限に達しました。しばらくしてから再試行してください。', 429);
     }
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = sendNotificationSchema.safeParse(body);
     if (!parsed.success) {
       return errorResponse('Invalid request body');

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createRecordSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
@@ -33,7 +33,9 @@ export async function POST(request: Request) {
       return errorResponse('記録回数の上限に達しました。しばらくしてから再試行してください。', 429);
     }
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = createRecordSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateScheduleSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const findSchedule = (id: string) => prisma.schedule.findUnique({ where: { id } });
@@ -21,7 +21,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ sche
       finder: findSchedule,
       resourceName: 'スケジュール',
       handler: async () => {
-        const body = await request.json();
+        const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
         const parsed = updateScheduleSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createScheduleSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { ScheduleEntity, Schedule } from '@/domain/entities/Schedule';
 import { QUERY_LIMITS } from '@/lib/constants';
 import { checkRateLimit } from '@/lib/security';
@@ -21,7 +21,9 @@ export async function POST(request: Request) {
     const { allowed } = checkRateLimit(`schedules-post:${userId}`, { maxAttempts: 15, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = createScheduleSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateUserProfileSchema } from '@/lib/schemas';
 import { success, errorResponse, notFound } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize } from '@/lib/api-helpers';
+import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const USER_SELECT = {
@@ -34,7 +34,9 @@ export async function PUT(request: Request) {
       return errorResponse('更新回数の上限に達しました。しばらくしてから再試行してください。', 429);
     }
 
-    const body = await request.json();
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
     const parsed = updateUserProfileSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -98,6 +98,19 @@ export function flattenRelations(
   return result;
 }
 
+/**
+ * リクエストボディを安全にJSONパースする
+ * 不正なJSON時は400エラーレスポンスを返す
+ */
+export async function safeParseJson(request: Request): Promise<{ data: unknown } | { error: Response }> {
+  try {
+    const data = await request.json();
+    return { data };
+  } catch {
+    return { error: errorResponse('リクエストの形式が不正です', 400) };
+  }
+}
+
 const MAX_BODY_SIZE = 100 * 1024; // 100KB
 
 export function validateBodySize(request: Request): Response | null {


### PR DESCRIPTION
## Summary
- api-helpersにsafeParseJson関数を追加し、不正JSON時に400エラーを返す
- 15のAPIルートでrequest.json()をsafeParseJsonに置き換え
- 認証ルートは既にtry-catch済みのため対象外

closes #646

## Test plan
- [x] 全テスト3108件パス
- [x] 既存のAPI動作に影響なし