### PR TITLE
feat: 症状に「生理痛」を追加

### DIFF
--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -19,6 +19,7 @@ export const SYMPTOM_OPTIONS = [
   'runny_nose',
   'joint_pain',
   'insomnia',
+  'menstrual_pain',
 ] as const;
 export type SymptomType = (typeof SYMPTOM_OPTIONS)[number];
 
@@ -33,6 +34,7 @@ export const SYMPTOM_LABELS: Record<SymptomType, string> = {
   runny_nose: '鼻水',
   joint_pain: '関節痛',
   insomnia: '不眠',
+  menstrual_pain: '生理痛',
 };
 
 export interface HealthLog {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -141,7 +141,7 @@ export const updateAppointmentSchema = z.object({
 export const createHealthLogSchema = z.object({
   memberId: idField,
   conditionLevel: z.number().int().min(1, '体調レベルは1以上を指定してください').max(5, '体調レベルは5以下を指定してください'),
-  symptoms: z.array(z.enum(['headache', 'fever', 'fatigue', 'nausea', 'stomachache', 'dizziness', 'cough', 'runny_nose', 'joint_pain', 'insomnia'])).max(10).optional(),
+  symptoms: z.array(z.enum(['headache', 'fever', 'fatigue', 'nausea', 'stomachache', 'dizziness', 'cough', 'runny_nose', 'joint_pain', 'insomnia', 'menstrual_pain'])).max(10).optional(),
   notes: z.string().trim().max(500).optional(),
 });
 


### PR DESCRIPTION
## Summary
- 体調記録の症状選択肢に「生理痛」(menstrual_pain)を追加
- SYMPTOM_OPTIONS, SYMPTOM_LABELS, Zodスキーマの3箇所を更新

closes #648

## Test plan
- [x] 全テスト3108件パス