### PR TITLE
完了率トレンド・メンバー活動サマリー・在庫コスト分析を追加

### DIFF
--- a/src/__tests__/domain/entities/CompletionRateTrend.test.ts
+++ b/src/__tests__/domain/entities/CompletionRateTrend.test.ts
@@ -1,0 +1,75 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Completion Rate Trend', () => {
+  describe('getWeeklyCompletionRates', () => {
+    it('7日分のデータを1週に集約', () => {
+      const dailyRates = [100, 80, 90, 70, 60, 50, 100];
+      const result = AdherenceTrendEntity.getWeeklyCompletionRates(dailyRates);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeCloseTo(78.6, 0);
+    });
+
+    it('14日分のデータを2週に集約', () => {
+      const dailyRates = [100, 100, 100, 100, 100, 100, 100, 0, 0, 0, 0, 0, 0, 0];
+      const result = AdherenceTrendEntity.getWeeklyCompletionRates(dailyRates);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(100);
+      expect(result[1]).toBe(0);
+    });
+
+    it('空配列は空配列を返す', () => {
+      expect(AdherenceTrendEntity.getWeeklyCompletionRates([])).toEqual([]);
+    });
+
+    it('7日未満のデータも1週として集約', () => {
+      const dailyRates = [80, 60, 40];
+      const result = AdherenceTrendEntity.getWeeklyCompletionRates(dailyRates);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(60);
+    });
+  });
+
+  describe('getCompletionTrend', () => {
+    it('上昇傾向を検出', () => {
+      const weeklyRates = [50, 60, 70, 80];
+      expect(AdherenceTrendEntity.getCompletionTrend(weeklyRates)).toBe('improving');
+    });
+
+    it('下降傾向を検出', () => {
+      const weeklyRates = [80, 70, 60, 50];
+      expect(AdherenceTrendEntity.getCompletionTrend(weeklyRates)).toBe('declining');
+    });
+
+    it('安定を検出', () => {
+      const weeklyRates = [70, 72, 68, 71];
+      expect(AdherenceTrendEntity.getCompletionTrend(weeklyRates)).toBe('stable');
+    });
+
+    it('データ不足はstable', () => {
+      expect(AdherenceTrendEntity.getCompletionTrend([])).toBe('stable');
+      expect(AdherenceTrendEntity.getCompletionTrend([80])).toBe('stable');
+    });
+  });
+
+  describe('getCompletionRateLabel', () => {
+    it('100%は完璧', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(100)).toBe('完璧');
+    });
+
+    it('90%は優秀', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(90)).toBe('優秀');
+    });
+
+    it('70%は良好', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(70)).toBe('良好');
+    });
+
+    it('50%は要改善', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(50)).toBe('要改善');
+    });
+
+    it('30%は不十分', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(30)).toBe('不十分');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberActivitySummary.test.ts
+++ b/src/__tests__/domain/entities/MemberActivitySummary.test.ts
@@ -1,0 +1,62 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Activity Summary', () => {
+  describe('getActivityLevel', () => {
+    it('毎日記録があれば高活動', () => {
+      expect(MemberEntity.getActivityLevel(30, 30)).toBe('high');
+    });
+
+    it('半分以上記録があれば中活動', () => {
+      expect(MemberEntity.getActivityLevel(15, 30)).toBe('medium');
+    });
+
+    it('少しだけ記録があれば低活動', () => {
+      expect(MemberEntity.getActivityLevel(5, 30)).toBe('low');
+    });
+
+    it('記録なしはinactive', () => {
+      expect(MemberEntity.getActivityLevel(0, 30)).toBe('inactive');
+    });
+
+    it('期間0日はinactive', () => {
+      expect(MemberEntity.getActivityLevel(5, 0)).toBe('inactive');
+    });
+  });
+
+  describe('getActivityLevelLabel', () => {
+    it('high は 活発', () => {
+      expect(MemberEntity.getActivityLevelLabel('high')).toBe('活発');
+    });
+
+    it('medium は 普通', () => {
+      expect(MemberEntity.getActivityLevelLabel('medium')).toBe('普通');
+    });
+
+    it('low は 少なめ', () => {
+      expect(MemberEntity.getActivityLevelLabel('low')).toBe('少なめ');
+    });
+
+    it('inactive は 記録なし', () => {
+      expect(MemberEntity.getActivityLevelLabel('inactive')).toBe('記録なし');
+    });
+  });
+
+  describe('getMemberSummaryMessage', () => {
+    it('高活動メンバーのサマリー', () => {
+      const result = MemberEntity.getMemberSummaryMessage('太郎', 'high', 95);
+      expect(result).toContain('太郎');
+      expect(result).toContain('95');
+    });
+
+    it('記録なしメンバーのサマリー', () => {
+      const result = MemberEntity.getMemberSummaryMessage('花子', 'inactive', 0);
+      expect(result).toContain('花子');
+      expect(result).toContain('記録');
+    });
+
+    it('中活動メンバーのサマリー', () => {
+      const result = MemberEntity.getMemberSummaryMessage('ポチ', 'medium', 60);
+      expect(result).toContain('ポチ');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockCostAnalysis.test.ts
+++ b/src/__tests__/domain/entities/StockCostAnalysis.test.ts
@@ -1,0 +1,59 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Cost Analysis', () => {
+  describe('getMonthlyConsumptionCost', () => {
+    it('日消費2個x単価100円=月6000円', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(2, 100)).toBe(6000);
+    });
+
+    it('消費量0は0円', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(0, 100)).toBe(0);
+    });
+
+    it('単価0は0円', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(2, 0)).toBe(0);
+    });
+  });
+
+  describe('getCostCategory', () => {
+    it('1000円未満は低コスト', () => {
+      expect(StockAlertEntity.getCostCategory(500)).toBe('low');
+    });
+
+    it('1000-4999円は標準', () => {
+      expect(StockAlertEntity.getCostCategory(3000)).toBe('standard');
+    });
+
+    it('5000-9999円はやや高額', () => {
+      expect(StockAlertEntity.getCostCategory(7000)).toBe('moderate');
+    });
+
+    it('10000円以上は高額', () => {
+      expect(StockAlertEntity.getCostCategory(15000)).toBe('high');
+    });
+  });
+
+  describe('getStockValueSummary', () => {
+    it('複数薬の在庫総額を算出', () => {
+      const items = [
+        { stockQuantity: 30, unitPrice: 100 },
+        { stockQuantity: 10, unitPrice: 500 },
+      ];
+      const result = StockAlertEntity.getStockValueSummary(items);
+      expect(result.totalValue).toBe(8000);
+      expect(result.itemCount).toBe(2);
+    });
+
+    it('空配列は0', () => {
+      const result = StockAlertEntity.getStockValueSummary([]);
+      expect(result.totalValue).toBe(0);
+      expect(result.itemCount).toBe(0);
+    });
+
+    it('在庫0の薬は値が0', () => {
+      const items = [{ stockQuantity: 0, unitPrice: 100 }];
+      const result = StockAlertEntity.getStockValueSummary(items);
+      expect(result.totalValue).toBe(0);
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -167,4 +167,42 @@ export class AdherenceTrendEntity {
     if (days === 7) return '1週間連続';
     return `${days}日連続`;
   }
+
+  /**
+   * 日別完了率から週別平均完了率を算出する
+   */
+  static getWeeklyCompletionRates(dailyRates: number[]): number[] {
+    if (dailyRates.length === 0) return [];
+    const weeks: number[] = [];
+    for (let i = 0; i < dailyRates.length; i += 7) {
+      const chunk = dailyRates.slice(i, i + 7);
+      const avg = chunk.reduce((sum, r) => sum + r, 0) / chunk.length;
+      weeks.push(Math.round(avg * 10) / 10);
+    }
+    return weeks;
+  }
+
+  /**
+   * 週別完了率から推移傾向を判定する
+   */
+  static getCompletionTrend(weeklyRates: number[]): 'improving' | 'declining' | 'stable' {
+    if (weeklyRates.length < 2) return 'stable';
+    const first = weeklyRates[0];
+    const last = weeklyRates[weeklyRates.length - 1];
+    const diff = last - first;
+    if (diff > 5) return 'improving';
+    if (diff < -5) return 'declining';
+    return 'stable';
+  }
+
+  /**
+   * 完了率に応じたラベルを返す
+   */
+  static getCompletionRateLabel(rate: number): string {
+    if (rate >= 100) return '完璧';
+    if (rate >= 90) return '優秀';
+    if (rate >= 70) return '良好';
+    if (rate >= 50) return '要改善';
+    return '不十分';
+  }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -406,4 +406,42 @@ export class MemberEntity {
     if (score >= 50) return 'text-orange-600';
     return 'text-red-600';
   }
+
+  /**
+   * 記録日数と期間から活動レベルを判定する
+   */
+  static getActivityLevel(recordDays: number, totalDays: number): 'high' | 'medium' | 'low' | 'inactive' {
+    if (totalDays <= 0 || recordDays <= 0) return 'inactive';
+    const rate = recordDays / totalDays;
+    if (rate >= 0.8) return 'high';
+    if (rate >= 0.5) return 'medium';
+    return 'low';
+  }
+
+  private static readonly activityLevelLabels: Record<string, string> = {
+    high: '活発',
+    medium: '普通',
+    low: '少なめ',
+    inactive: '記録なし',
+  };
+
+  /**
+   * 活動レベルの日本語ラベルを返す
+   */
+  static getActivityLevelLabel(level: 'high' | 'medium' | 'low' | 'inactive'): string {
+    return MemberEntity.activityLevelLabels[level];
+  }
+
+  /**
+   * メンバーの状態サマリーメッセージを返す
+   */
+  static getMemberSummaryMessage(
+    name: string,
+    activityLevel: 'high' | 'medium' | 'low' | 'inactive',
+    adherenceRate: number,
+  ): string {
+    if (activityLevel === 'inactive') return `${name}さんの記録がありません`;
+    if (activityLevel === 'high') return `${name}さんは活発に記録中（服薬率${adherenceRate}%）`;
+    return `${name}さんの服薬率は${adherenceRate}%です`;
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -321,4 +321,24 @@ export class StockAlertEntity {
   static getRefillCostEstimate(quantity: number, unitPrice: number): number {
     return Math.round(quantity * unitPrice);
   }
+
+  /**
+   * 月間コストに応じたカテゴリを返す
+   */
+  static getCostCategory(monthlyCost: number): 'low' | 'standard' | 'moderate' | 'high' {
+    if (monthlyCost < 1000) return 'low';
+    if (monthlyCost < 5000) return 'standard';
+    if (monthlyCost < 10000) return 'moderate';
+    return 'high';
+  }
+
+  /**
+   * 在庫金額サマリーを算出する
+   */
+  static getStockValueSummary(
+    items: { stockQuantity: number; unitPrice: number }[],
+  ): { totalValue: number; itemCount: number } {
+    const totalValue = items.reduce((sum, item) => sum + item.stockQuantity * item.unitPrice, 0);
+    return { totalValue, itemCount: items.length };
+  }
 }


### PR DESCRIPTION
## Summary
- AdherenceTrendEntityに週別完了率集計・推移傾向判定・完了率ラベルを追加
- MemberEntityに活動レベル判定・ラベル・サマリーメッセージを追加
- StockAlertEntityにコストカテゴリ判定・在庫金額サマリーを追加

## Test plan
- [x] 35件の新規テスト全パス
- [x] 全3186テストパス

closes #660