### PR TITLE
Phase40エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/CompletionRateTrend.edge.test.ts
+++ b/src/__tests__/domain/entities/CompletionRateTrend.edge.test.ts
@@ -1,0 +1,74 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Completion Rate Trend Edge Cases', () => {
+  describe('getWeeklyCompletionRates', () => {
+    it('10日分を2週に分割（7+3）', () => {
+      const dailyRates = [100, 100, 100, 100, 100, 100, 100, 0, 0, 0];
+      const result = AdherenceTrendEntity.getWeeklyCompletionRates(dailyRates);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(100);
+      expect(result[1]).toBe(0);
+    });
+
+    it('全て0%の場合', () => {
+      const dailyRates = new Array(7).fill(0);
+      const result = AdherenceTrendEntity.getWeeklyCompletionRates(dailyRates);
+      expect(result[0]).toBe(0);
+    });
+
+    it('全て100%の場合', () => {
+      const dailyRates = new Array(14).fill(100);
+      const result = AdherenceTrendEntity.getWeeklyCompletionRates(dailyRates);
+      expect(result).toEqual([100, 100]);
+    });
+
+    it('1日分のデータ', () => {
+      const result = AdherenceTrendEntity.getWeeklyCompletionRates([50]);
+      expect(result).toEqual([50]);
+    });
+  });
+
+  describe('getCompletionTrend', () => {
+    it('差がちょうど5はstable', () => {
+      expect(AdherenceTrendEntity.getCompletionTrend([50, 55])).toBe('stable');
+    });
+
+    it('差が5.1でimproving', () => {
+      expect(AdherenceTrendEntity.getCompletionTrend([50, 55.1])).toBe('improving');
+    });
+
+    it('差が-5.1でdeclining', () => {
+      expect(AdherenceTrendEntity.getCompletionTrend([55.1, 50])).toBe('declining');
+    });
+
+    it('中間値は無視して最初と最後だけ比較', () => {
+      expect(AdherenceTrendEntity.getCompletionTrend([50, 90, 60])).toBe('improving');
+    });
+  });
+
+  describe('getCompletionRateLabel', () => {
+    it('境界値100で完璧', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(100)).toBe('完璧');
+    });
+
+    it('境界値99で優秀', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(99)).toBe('優秀');
+    });
+
+    it('境界値89で良好', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(89)).toBe('良好');
+    });
+
+    it('境界値69で要改善', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(69)).toBe('要改善');
+    });
+
+    it('境界値49で不十分', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(49)).toBe('不十分');
+    });
+
+    it('0%で不十分', () => {
+      expect(AdherenceTrendEntity.getCompletionRateLabel(0)).toBe('不十分');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberActivitySummary.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberActivitySummary.edge.test.ts
@@ -1,0 +1,51 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Activity Summary Edge Cases', () => {
+  describe('getActivityLevel', () => {
+    it('境界値0.8でhigh', () => {
+      expect(MemberEntity.getActivityLevel(80, 100)).toBe('high');
+    });
+
+    it('境界値0.79でmedium', () => {
+      expect(MemberEntity.getActivityLevel(79, 100)).toBe('medium');
+    });
+
+    it('境界値0.5でmedium', () => {
+      expect(MemberEntity.getActivityLevel(50, 100)).toBe('medium');
+    });
+
+    it('境界値0.49でlow', () => {
+      expect(MemberEntity.getActivityLevel(49, 100)).toBe('low');
+    });
+
+    it('recordDaysがtotalDaysを超える場合はhigh', () => {
+      expect(MemberEntity.getActivityLevel(35, 30)).toBe('high');
+    });
+
+    it('負のrecordDaysはinactive', () => {
+      expect(MemberEntity.getActivityLevel(-1, 30)).toBe('inactive');
+    });
+
+    it('1日中1日記録はhigh', () => {
+      expect(MemberEntity.getActivityLevel(1, 1)).toBe('high');
+    });
+  });
+
+  describe('getMemberSummaryMessage', () => {
+    it('low活動メンバーのサマリー', () => {
+      const result = MemberEntity.getMemberSummaryMessage('タロウ', 'low', 30);
+      expect(result).toContain('タロウ');
+      expect(result).toContain('30');
+    });
+
+    it('名前に特殊文字を含む場合', () => {
+      const result = MemberEntity.getMemberSummaryMessage('ポチ（犬）', 'high', 100);
+      expect(result).toContain('ポチ（犬）');
+    });
+
+    it('服薬率0%の場合', () => {
+      const result = MemberEntity.getMemberSummaryMessage('花子', 'inactive', 0);
+      expect(result).toContain('花子');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockCostAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/StockCostAnalysis.edge.test.ts
@@ -1,0 +1,72 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Cost Analysis Edge Cases', () => {
+  describe('getCostCategory', () => {
+    it('境界値999はlow', () => {
+      expect(StockAlertEntity.getCostCategory(999)).toBe('low');
+    });
+
+    it('境界値1000はstandard', () => {
+      expect(StockAlertEntity.getCostCategory(1000)).toBe('standard');
+    });
+
+    it('境界値4999はstandard', () => {
+      expect(StockAlertEntity.getCostCategory(4999)).toBe('standard');
+    });
+
+    it('境界値5000はmoderate', () => {
+      expect(StockAlertEntity.getCostCategory(5000)).toBe('moderate');
+    });
+
+    it('境界値9999はmoderate', () => {
+      expect(StockAlertEntity.getCostCategory(9999)).toBe('moderate');
+    });
+
+    it('境界値10000はhigh', () => {
+      expect(StockAlertEntity.getCostCategory(10000)).toBe('high');
+    });
+
+    it('0はlow', () => {
+      expect(StockAlertEntity.getCostCategory(0)).toBe('low');
+    });
+
+    it('負の値はlow', () => {
+      expect(StockAlertEntity.getCostCategory(-100)).toBe('low');
+    });
+  });
+
+  describe('getStockValueSummary', () => {
+    it('大量アイテムの合計', () => {
+      const items = Array.from({ length: 100 }, () => ({ stockQuantity: 10, unitPrice: 50 }));
+      const result = StockAlertEntity.getStockValueSummary(items);
+      expect(result.totalValue).toBe(50000);
+      expect(result.itemCount).toBe(100);
+    });
+
+    it('小数単価の場合', () => {
+      const items = [{ stockQuantity: 3, unitPrice: 33.33 }];
+      const result = StockAlertEntity.getStockValueSummary(items);
+      expect(result.totalValue).toBeCloseTo(99.99, 2);
+    });
+
+    it('単価0のアイテム', () => {
+      const items = [{ stockQuantity: 100, unitPrice: 0 }];
+      const result = StockAlertEntity.getStockValueSummary(items);
+      expect(result.totalValue).toBe(0);
+    });
+  });
+
+  describe('getMonthlyConsumptionCost', () => {
+    it('小数の消費量', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(0.5, 100)).toBe(1500);
+    });
+
+    it('負の消費量は0', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(-1, 100)).toBe(0);
+    });
+
+    it('負の単価は0', () => {
+      expect(StockAlertEntity.getMonthlyConsumptionCost(2, -50)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 完了率トレンドの境界値テスト（14件）
- メンバー活動サマリーの境界値テスト（10件）
- 在庫コスト分析の境界値テスト（14件）

## Test plan
- [x] 38件のエッジケーステスト全パス
- [x] 全3224テストパス

closes #664