### PR TITLE
認証ルートにsafeParseJsonを適用

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates, generateVerificationCode } from '@/lib/email';
 import { forgotPasswordSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { validateBodySize } from '@/lib/api-helpers';
+import { validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 export async function POST(request: NextRequest) {
@@ -11,8 +11,9 @@ export async function POST(request: NextRequest) {
   if (sizeError) return sizeError;
 
   try {
-    const body = await request.json();
-    const parsed = forgotPasswordSchema.safeParse(body);
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const parsed = forgotPasswordSchema.safeParse(jsonResult.data);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
     const email = parsed.data.email;

--- a/src/app/api/auth/resend-code/route.ts
+++ b/src/app/api/auth/resend-code/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates, generateVerificationCode } from '@/lib/email';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { validateBodySize } from '@/lib/api-helpers';
+import { validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const resendSchema = z.object({
@@ -15,8 +15,9 @@ export async function POST(request: NextRequest) {
   if (sizeError) return sizeError;
 
   try {
-    const body = await request.json();
-    const parsed = resendSchema.safeParse(body);
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const parsed = resendSchema.safeParse(jsonResult.data);
     if (!parsed.success) {
       return errorResponse('有効なメールアドレスを入力してください');
     }

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { validateBodySize } from '@/lib/api-helpers';
+import { validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { timingSafeEqual, checkRateLimit } from '@/lib/security';
 
 const resetPasswordSchema = z.object({
@@ -21,8 +21,9 @@ export async function POST(request: NextRequest) {
   if (sizeError) return sizeError;
 
   try {
-    const body = await request.json();
-    const parsed = resetPasswordSchema.safeParse(body);
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const parsed = resetPasswordSchema.safeParse(jsonResult.data);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
     const { email, code, newPassword } = parsed.data;

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { signUpSchema } from '@/lib/schemas';
 import { sendEmail, emailTemplates, generateVerificationCode } from '@/lib/email';
 import { created, errorResponse } from '@/lib/auth-helpers';
-import { validateBodySize } from '@/lib/api-helpers';
+import { validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 export async function POST(request: NextRequest) {
@@ -18,8 +18,9 @@ export async function POST(request: NextRequest) {
       return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     }
 
-    const body = await request.json();
-    const parsed = signUpSchema.safeParse(body);
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const parsed = signUpSchema.safeParse(jsonResult.data);
     if (!parsed.success) {
       return errorResponse(parsed.error.errors[0].message);
     }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { validateBodySize } from '@/lib/api-helpers';
+import { validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { timingSafeEqual, checkRateLimit } from '@/lib/security';
 
 const verifySchema = z.object({
@@ -17,8 +17,9 @@ export async function POST(request: NextRequest) {
   if (sizeError) return sizeError;
 
   try {
-    const body = await request.json();
-    const parsed = verifySchema.safeParse(body);
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const parsed = verifySchema.safeParse(jsonResult.data);
     if (!parsed.success) {
       return errorResponse('確認コードは6桁の数字です');
     }


### PR DESCRIPTION
## Summary
- signup, forgot-password, verify, resend-code, reset-passwordの5ルートでraw request.json()をsafeParseJsonに置換
- 不正なJSONリクエスト時に500エラーではなく400エラーを返すように改善

## Test plan
- [x] 全3224テストパス

closes #666