### PR TITLE
スケジュール時間帯分布・体調週間サマリー・予約頻度分析を追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentFrequencyAnalysis.test.ts
+++ b/src/__tests__/domain/entities/AppointmentFrequencyAnalysis.test.ts
@@ -1,0 +1,72 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Frequency Analysis', () => {
+  describe('getAppointmentFrequency', () => {
+    it('月別に予約件数を集計', () => {
+      const dates = [
+        new Date(2025, 0, 10),
+        new Date(2025, 0, 20),
+        new Date(2025, 1, 15),
+        new Date(2025, 2, 5),
+      ];
+      const result = AppointmentEntity.getAppointmentFrequency(dates);
+      expect(result['2025-01']).toBe(2);
+      expect(result['2025-02']).toBe(1);
+      expect(result['2025-03']).toBe(1);
+    });
+
+    it('空配列は空オブジェクト', () => {
+      expect(AppointmentEntity.getAppointmentFrequency([])).toEqual({});
+    });
+
+    it('同月の複数予約', () => {
+      const dates = [
+        new Date(2025, 5, 1),
+        new Date(2025, 5, 15),
+        new Date(2025, 5, 30),
+      ];
+      const result = AppointmentEntity.getAppointmentFrequency(dates);
+      expect(result['2025-06']).toBe(3);
+    });
+  });
+
+  describe('getFrequencyTrend', () => {
+    it('増加傾向を検出', () => {
+      const monthly = { '2025-01': 1, '2025-02': 2, '2025-03': 3 };
+      expect(AppointmentEntity.getFrequencyTrend(monthly)).toBe('increasing');
+    });
+
+    it('減少傾向を検出', () => {
+      const monthly = { '2025-01': 3, '2025-02': 2, '2025-03': 1 };
+      expect(AppointmentEntity.getFrequencyTrend(monthly)).toBe('decreasing');
+    });
+
+    it('安定を検出', () => {
+      const monthly = { '2025-01': 2, '2025-02': 2, '2025-03': 2 };
+      expect(AppointmentEntity.getFrequencyTrend(monthly)).toBe('stable');
+    });
+
+    it('データ不足はstable', () => {
+      expect(AppointmentEntity.getFrequencyTrend({})).toBe('stable');
+      expect(AppointmentEntity.getFrequencyTrend({ '2025-01': 1 })).toBe('stable');
+    });
+  });
+
+  describe('getAppointmentDensityLabel', () => {
+    it('月4回以上は頻繁', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(4)).toBe('頻繁');
+    });
+
+    it('月2回は定期的', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(2)).toBe('定期的');
+    });
+
+    it('月1回は少なめ', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(1)).toBe('少なめ');
+    });
+
+    it('月0回はなし', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(0)).toBe('なし');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HealthLogWeeklySummary.test.ts
+++ b/src/__tests__/domain/entities/HealthLogWeeklySummary.test.ts
@@ -1,0 +1,59 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Weekly Summary', () => {
+  describe('getWeeklySummary', () => {
+    it('7日分のログを集計', () => {
+      const logs = [
+        { condition: 4, symptoms: ['headache'] },
+        { condition: 3, symptoms: ['fatigue'] },
+        { condition: 5, symptoms: [] },
+        { condition: 4, symptoms: ['headache', 'fatigue'] },
+        { condition: 2, symptoms: ['nausea'] },
+        { condition: 4, symptoms: [] },
+        { condition: 3, symptoms: ['headache'] },
+      ];
+      const result = HealthLogEntity.getConditionWeeklySummary(logs);
+      expect(result.logCount).toBe(7);
+      expect(result.averageCondition).toBeCloseTo(3.57, 1);
+      expect(result.symptomCount).toBe(6);
+      expect(result.mostCommonSymptom).toBe('headache');
+    });
+
+    it('空配列', () => {
+      const result = HealthLogEntity.getConditionWeeklySummary([]);
+      expect(result.logCount).toBe(0);
+      expect(result.averageCondition).toBeNull();
+      expect(result.symptomCount).toBe(0);
+      expect(result.mostCommonSymptom).toBeNull();
+    });
+
+    it('症状なしのログのみ', () => {
+      const logs = [
+        { condition: 5, symptoms: [] },
+        { condition: 4, symptoms: [] },
+      ];
+      const result = HealthLogEntity.getConditionWeeklySummary(logs);
+      expect(result.logCount).toBe(2);
+      expect(result.symptomCount).toBe(0);
+      expect(result.mostCommonSymptom).toBeNull();
+    });
+  });
+
+  describe('getConditionWeeklySummaryLabel', () => {
+    it('体調良好', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(4.5, 0)).toBe('体調良好');
+    });
+
+    it('やや不調', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(3.0, 3)).toBe('やや不調');
+    });
+
+    it('注意が必要', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(2.0, 5)).toBe('注意が必要');
+    });
+
+    it('体調nullでログあり', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(null, 2)).toBe('データ不足');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleTimePeriodDistribution.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimePeriodDistribution.test.ts
@@ -1,0 +1,81 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Time Period Distribution', () => {
+  describe('getTimePeriodDistribution', () => {
+    it('時間帯別にスケジュール数を集計', () => {
+      const times = ['06:00', '08:00', '13:00', '18:00', '22:00'];
+      const result = ScheduleEntity.getTimePeriodDistribution(times);
+      expect(result.morning).toBe(2);
+      expect(result.afternoon).toBe(1);
+      expect(result.evening).toBe(1);
+      expect(result.night).toBe(1);
+    });
+
+    it('空配列は全て0', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution([]);
+      expect(result.morning).toBe(0);
+      expect(result.afternoon).toBe(0);
+      expect(result.evening).toBe(0);
+      expect(result.night).toBe(0);
+    });
+
+    it('全て朝の場合', () => {
+      const times = ['05:00', '07:00', '09:00', '11:00'];
+      const result = ScheduleEntity.getTimePeriodDistribution(times);
+      expect(result.morning).toBe(4);
+      expect(result.afternoon).toBe(0);
+    });
+
+    it('境界値テスト: 5時は朝', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['05:00']);
+      expect(result.morning).toBe(1);
+    });
+
+    it('境界値テスト: 12時は午後', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['12:00']);
+      expect(result.afternoon).toBe(1);
+    });
+
+    it('境界値テスト: 17時は夕方', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['17:00']);
+      expect(result.evening).toBe(1);
+    });
+
+    it('境界値テスト: 21時は夜', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['21:00']);
+      expect(result.night).toBe(1);
+    });
+  });
+
+  describe('getTimePeriodDistributionLabel', () => {
+    it('均等分布', () => {
+      const dist = { morning: 2, afternoon: 2, evening: 2, night: 2 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('均等');
+    });
+
+    it('朝に集中', () => {
+      const dist = { morning: 8, afternoon: 1, evening: 1, night: 0 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('朝に集中');
+    });
+
+    it('午後に集中', () => {
+      const dist = { morning: 0, afternoon: 8, evening: 1, night: 1 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('午後に集中');
+    });
+
+    it('夕方に集中', () => {
+      const dist = { morning: 1, afternoon: 0, evening: 8, night: 1 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('夕方に集中');
+    });
+
+    it('夜に集中', () => {
+      const dist = { morning: 1, afternoon: 1, evening: 0, night: 8 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('夜に集中');
+    });
+
+    it('全て0は均等', () => {
+      const dist = { morning: 0, afternoon: 0, evening: 0, night: 0 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('均等');
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -395,4 +395,40 @@ export class AppointmentEntity {
     if (daysBefore % 7 === 0) return `${daysBefore / 7}週間前にお知らせ`;
     return `${daysBefore}日前にお知らせ`;
   }
+
+  /**
+   * 予約日リストから月別件数を集計する
+   */
+  static getAppointmentFrequency(dates: Date[]): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const date of dates) {
+      const d = new Date(date);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      counts[key] = (counts[key] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  /**
+   * 月別件数から頻度の推移傾向を判定する
+   */
+  static getFrequencyTrend(monthly: Record<string, number>): 'increasing' | 'decreasing' | 'stable' {
+    const keys = Object.keys(monthly).sort();
+    if (keys.length < 2) return 'stable';
+    const first = monthly[keys[0]];
+    const last = monthly[keys[keys.length - 1]];
+    if (last > first) return 'increasing';
+    if (last < first) return 'decreasing';
+    return 'stable';
+  }
+
+  /**
+   * 月間予約件数に応じた密度ラベルを返す
+   */
+  static getAppointmentDensityLabel(countPerMonth: number): string {
+    if (countPerMonth >= 4) return '頻繁';
+    if (countPerMonth >= 2) return '定期的';
+    if (countPerMonth >= 1) return '少なめ';
+    return 'なし';
+  }
 }

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -616,4 +616,50 @@ export class HealthLogEntity {
     if (count >= 1) return '弱い相関';
     return '相関なし';
   }
+
+  /**
+   * 週間の体調・症状サマリーを算出する（簡易版）
+   */
+  static getConditionWeeklySummary(
+    logs: { condition: number; symptoms: string[] }[],
+  ): {
+    logCount: number;
+    averageCondition: number | null;
+    symptomCount: number;
+    mostCommonSymptom: string | null;
+  } {
+    if (logs.length === 0) {
+      return { logCount: 0, averageCondition: null, symptomCount: 0, mostCommonSymptom: null };
+    }
+    const avgCondition = logs.reduce((sum, l) => sum + l.condition, 0) / logs.length;
+    const allSymptoms = logs.flatMap((l) => l.symptoms);
+    const symptomCounts = new Map<string, number>();
+    for (const s of allSymptoms) {
+      symptomCounts.set(s, (symptomCounts.get(s) ?? 0) + 1);
+    }
+    let mostCommon: string | null = null;
+    let maxCount = 0;
+    for (const [symptom, count] of symptomCounts) {
+      if (count > maxCount) {
+        maxCount = count;
+        mostCommon = symptom;
+      }
+    }
+    return {
+      logCount: logs.length,
+      averageCondition: Math.round(avgCondition * 100) / 100,
+      symptomCount: allSymptoms.length,
+      mostCommonSymptom: mostCommon,
+    };
+  }
+
+  /**
+   * 週間サマリーの状態ラベルを返す
+   */
+  static getConditionWeeklySummaryLabel(averageCondition: number | null, symptomCount: number): string {
+    if (averageCondition === null) return 'データ不足';
+    if (averageCondition >= 4 && symptomCount <= 1) return '体調良好';
+    if (averageCondition >= 3) return 'やや不調';
+    return '注意が必要';
+  }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -653,4 +653,47 @@ export class ScheduleEntity {
       return priorityB - priorityA;
     });
   }
+
+  /**
+   * 時間帯別のスケジュール分布を集計する
+   */
+  static getTimePeriodDistribution(times: string[]): Record<TimePeriod, number> {
+    const dist: Record<TimePeriod, number> = { morning: 0, afternoon: 0, evening: 0, night: 0 };
+    for (const time of times) {
+      const hour = parseInt(time.split(':')[0], 10);
+      const period = ScheduleEntity.getTimePeriodForHour(hour);
+      dist[period]++;
+    }
+    return dist;
+  }
+
+  private static getTimePeriodForHour(hour: number): TimePeriod {
+    if (hour >= ScheduleEntity.TIME_PERIOD_NIGHT_START) return 'night';
+    if (hour >= ScheduleEntity.TIME_PERIOD_EVENING_START) return 'evening';
+    if (hour >= ScheduleEntity.TIME_PERIOD_AFTERNOON_START) return 'afternoon';
+    if (hour >= ScheduleEntity.TIME_PERIOD_MORNING_START) return 'morning';
+    return 'night';
+  }
+
+  private static readonly TIME_PERIOD_LABELS: Record<TimePeriod, string> = {
+    morning: '朝',
+    afternoon: '午後',
+    evening: '夕方',
+    night: '夜',
+  };
+
+  /**
+   * 時間帯分布の偏りラベルを返す
+   */
+  static getTimePeriodDistributionLabel(dist: Record<TimePeriod, number>): string {
+    const total = dist.morning + dist.afternoon + dist.evening + dist.night;
+    if (total === 0) return '均等';
+    const periods: TimePeriod[] = ['morning', 'afternoon', 'evening', 'night'];
+    const max = Math.max(...periods.map((p) => dist[p]));
+    if (max > total * 0.6) {
+      const dominant = periods.find((p) => dist[p] === max);
+      return `${ScheduleEntity.TIME_PERIOD_LABELS[dominant!]}に集中`;
+    }
+    return '均等';
+  }
 }


### PR DESCRIPTION
## Summary
- ScheduleEntityに時間帯別分布集計と偏りラベル判定を追加
- HealthLogEntityに体調週間サマリー(getConditionWeeklySummary)とラベルを追加
- AppointmentEntityに月別予約頻度集計・推移傾向判定・密度ラベルを追加

## Test plan
- [x] 31件の新規テスト全パス
- [x] 全3255テストパス

closes #668