### PR TITLE
Phase41エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentFrequencyAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentFrequencyAnalysis.edge.test.ts
@@ -1,0 +1,59 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Frequency Analysis Edge Cases', () => {
+  describe('getAppointmentFrequency', () => {
+    it('年をまたぐ予約', () => {
+      const dates = [new Date(2024, 11, 31), new Date(2025, 0, 1)];
+      const result = AppointmentEntity.getAppointmentFrequency(dates);
+      expect(result['2024-12']).toBe(1);
+      expect(result['2025-01']).toBe(1);
+    });
+
+    it('同日の複数予約', () => {
+      const dates = [new Date(2025, 5, 15), new Date(2025, 5, 15)];
+      const result = AppointmentEntity.getAppointmentFrequency(dates);
+      expect(result['2025-06']).toBe(2);
+    });
+
+    it('月のゼロパディング', () => {
+      const dates = [new Date(2025, 0, 1)];
+      const result = AppointmentEntity.getAppointmentFrequency(dates);
+      expect(result['2025-01']).toBe(1);
+    });
+  });
+
+  describe('getFrequencyTrend', () => {
+    it('同数は安定', () => {
+      const monthly = { '2025-01': 2, '2025-02': 2 };
+      expect(AppointmentEntity.getFrequencyTrend(monthly)).toBe('stable');
+    });
+
+    it('1→2は増加', () => {
+      const monthly = { '2025-01': 1, '2025-02': 2 };
+      expect(AppointmentEntity.getFrequencyTrend(monthly)).toBe('increasing');
+    });
+
+    it('月が非連続でもソートして比較', () => {
+      const monthly = { '2025-03': 3, '2025-01': 1 };
+      expect(AppointmentEntity.getFrequencyTrend(monthly)).toBe('increasing');
+    });
+  });
+
+  describe('getAppointmentDensityLabel', () => {
+    it('境界値3は定期的', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(3)).toBe('定期的');
+    });
+
+    it('境界値4は頻繁', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(4)).toBe('頻繁');
+    });
+
+    it('負の値はなし', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(-1)).toBe('なし');
+    });
+
+    it('大きな値は頻繁', () => {
+      expect(AppointmentEntity.getAppointmentDensityLabel(100)).toBe('頻繁');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HealthLogWeeklySummary.edge.test.ts
+++ b/src/__tests__/domain/entities/HealthLogWeeklySummary.edge.test.ts
@@ -1,0 +1,60 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Weekly Summary Edge Cases', () => {
+  describe('getConditionWeeklySummary', () => {
+    it('全て同じ体調レベル', () => {
+      const logs = Array.from({ length: 7 }, () => ({ condition: 3, symptoms: [] }));
+      const result = HealthLogEntity.getConditionWeeklySummary(logs);
+      expect(result.averageCondition).toBe(3);
+      expect(result.mostCommonSymptom).toBeNull();
+    });
+
+    it('1件のログ', () => {
+      const logs = [{ condition: 5, symptoms: ['headache'] }];
+      const result = HealthLogEntity.getConditionWeeklySummary(logs);
+      expect(result.logCount).toBe(1);
+      expect(result.averageCondition).toBe(5);
+      expect(result.mostCommonSymptom).toBe('headache');
+    });
+
+    it('全症状が同頻度の場合は最初に見つかったものを返す', () => {
+      const logs = [
+        { condition: 3, symptoms: ['A'] },
+        { condition: 3, symptoms: ['B'] },
+      ];
+      const result = HealthLogEntity.getConditionWeeklySummary(logs);
+      expect(result.mostCommonSymptom).toBe('A');
+    });
+
+    it('体調レベル1と5の平均', () => {
+      const logs = [
+        { condition: 1, symptoms: [] },
+        { condition: 5, symptoms: [] },
+      ];
+      const result = HealthLogEntity.getConditionWeeklySummary(logs);
+      expect(result.averageCondition).toBe(3);
+    });
+  });
+
+  describe('getConditionWeeklySummaryLabel', () => {
+    it('境界値: condition=4, symptom=1で体調良好', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(4, 1)).toBe('体調良好');
+    });
+
+    it('境界値: condition=4, symptom=2でやや不調', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(4, 2)).toBe('やや不調');
+    });
+
+    it('境界値: condition=3, symptom=0でやや不調', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(3, 0)).toBe('やや不調');
+    });
+
+    it('境界値: condition=2.99で注意が必要', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(2.99, 0)).toBe('注意が必要');
+    });
+
+    it('condition=5, symptom=0で体調良好', () => {
+      expect(HealthLogEntity.getConditionWeeklySummaryLabel(5, 0)).toBe('体調良好');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleTimePeriodDistribution.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleTimePeriodDistribution.edge.test.ts
@@ -1,0 +1,58 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Time Period Distribution Edge Cases', () => {
+  describe('getTimePeriodDistribution', () => {
+    it('境界値4:59は夜', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['04:59']);
+      expect(result.night).toBe(1);
+    });
+
+    it('境界値11:59は朝', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['11:59']);
+      expect(result.morning).toBe(1);
+    });
+
+    it('境界値16:59は午後', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['16:59']);
+      expect(result.afternoon).toBe(1);
+    });
+
+    it('境界値20:59は夕方', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['20:59']);
+      expect(result.evening).toBe(1);
+    });
+
+    it('0時は夜', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['00:00']);
+      expect(result.night).toBe(1);
+    });
+
+    it('23:59は夜', () => {
+      const result = ScheduleEntity.getTimePeriodDistribution(['23:59']);
+      expect(result.night).toBe(1);
+    });
+
+    it('大量のスケジュール', () => {
+      const times = Array.from({ length: 100 }, () => '08:00');
+      const result = ScheduleEntity.getTimePeriodDistribution(times);
+      expect(result.morning).toBe(100);
+    });
+  });
+
+  describe('getTimePeriodDistributionLabel', () => {
+    it('ちょうど60%は均等', () => {
+      const dist = { morning: 6, afternoon: 2, evening: 1, night: 1 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('均等');
+    });
+
+    it('61%で集中判定', () => {
+      const dist = { morning: 61, afternoon: 20, evening: 10, night: 9 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('朝に集中');
+    });
+
+    it('2つの時間帯が同率で最大の場合', () => {
+      const dist = { morning: 5, afternoon: 5, evening: 0, night: 0 };
+      expect(ScheduleEntity.getTimePeriodDistributionLabel(dist)).toBe('均等');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- スケジュール時間帯分布の境界値テスト（10件）
- 体調週間サマリーの境界値テスト（9件）
- 予約頻度分析の境界値テスト（10件）

## Test plan
- [x] 29件のエッジケーステスト全パス
- [x] 全3284テストパス

closes #672