### PR TITLE
服薬遵守スコア・体調トレンド予測・在庫廃棄率分析を追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionTrendPrediction.test.ts
+++ b/src/__tests__/domain/entities/ConditionTrendPrediction.test.ts
@@ -1,0 +1,52 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Trend Prediction', () => {
+  describe('predictNextCondition', () => {
+    it('上昇傾向なら次の値も上がる', () => {
+      const conditions = [2, 3, 4];
+      const result = HealthLogEntity.predictNextCondition(conditions);
+      expect(result).toBe(5);
+    });
+
+    it('下降傾向なら次の値も下がる', () => {
+      const conditions = [5, 4, 3];
+      const result = HealthLogEntity.predictNextCondition(conditions);
+      expect(result).toBe(2);
+    });
+
+    it('安定傾向なら同じ値', () => {
+      const conditions = [3, 3, 3];
+      const result = HealthLogEntity.predictNextCondition(conditions);
+      expect(result).toBe(3);
+    });
+
+    it('結果は1-5の範囲に制約される', () => {
+      const conditions = [4, 5, 5];
+      const result = HealthLogEntity.predictNextCondition(conditions);
+      expect(result).toBeGreaterThanOrEqual(1);
+      expect(result).toBeLessThanOrEqual(5);
+    });
+
+    it('空配列はnull', () => {
+      expect(HealthLogEntity.predictNextCondition([])).toBeNull();
+    });
+
+    it('1件のみは同じ値', () => {
+      expect(HealthLogEntity.predictNextCondition([4])).toBe(4);
+    });
+  });
+
+  describe('getConditionPredictionMessage', () => {
+    it('改善傾向のメッセージ', () => {
+      expect(HealthLogEntity.getConditionPredictionMessage('improving')).toContain('改善');
+    });
+
+    it('悪化傾向のメッセージ', () => {
+      expect(HealthLogEntity.getConditionPredictionMessage('declining')).toContain('注意');
+    });
+
+    it('安定傾向のメッセージ', () => {
+      expect(HealthLogEntity.getConditionPredictionMessage('stable')).toContain('安定');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/DailyComplianceScore.test.ts
+++ b/src/__tests__/domain/entities/DailyComplianceScore.test.ts
@@ -1,0 +1,47 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Daily Compliance Score', () => {
+  describe('getDailyComplianceScore', () => {
+    it('全て服用で100点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(5, 5)).toBe(100);
+    });
+
+    it('半分服用で50点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(2, 4)).toBe(50);
+    });
+
+    it('予定0件は100点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(0, 0)).toBe(100);
+    });
+
+    it('1件も服用していなければ0点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(0, 3)).toBe(0);
+    });
+
+    it('服用数が予定を超えても100点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(6, 5)).toBe(100);
+    });
+  });
+
+  describe('getComplianceScoreLabel', () => {
+    it('100点は完璧', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(100)).toBe('完璧');
+    });
+
+    it('90点は優秀', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(90)).toBe('優秀');
+    });
+
+    it('70点は良好', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(70)).toBe('良好');
+    });
+
+    it('50点は要改善', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(50)).toBe('要改善');
+    });
+
+    it('30点は不十分', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(30)).toBe('不十分');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockWastageAnalysis.test.ts
+++ b/src/__tests__/domain/entities/StockWastageAnalysis.test.ts
@@ -1,0 +1,47 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Wastage Analysis', () => {
+  describe('getWastageRate', () => {
+    it('全量消費で廃棄率0%', () => {
+      expect(StockAlertEntity.getWastageRate(100, 100)).toBe(0);
+    });
+
+    it('半分廃棄で50%', () => {
+      expect(StockAlertEntity.getWastageRate(50, 100)).toBe(50);
+    });
+
+    it('全廃棄で100%', () => {
+      expect(StockAlertEntity.getWastageRate(0, 100)).toBe(100);
+    });
+
+    it('購入量0はnull', () => {
+      expect(StockAlertEntity.getWastageRate(50, 0)).toBeNull();
+    });
+
+    it('消費量が購入量を超えた場合は0%', () => {
+      expect(StockAlertEntity.getWastageRate(120, 100)).toBe(0);
+    });
+  });
+
+  describe('getWastageLabel', () => {
+    it('5%以下は効率的', () => {
+      expect(StockAlertEntity.getWastageLabel(5)).toBe('効率的');
+    });
+
+    it('10%は許容範囲', () => {
+      expect(StockAlertEntity.getWastageLabel(10)).toBe('許容範囲');
+    });
+
+    it('20%は要改善', () => {
+      expect(StockAlertEntity.getWastageLabel(20)).toBe('要改善');
+    });
+
+    it('30%は非効率', () => {
+      expect(StockAlertEntity.getWastageLabel(30)).toBe('非効率');
+    });
+
+    it('nullはデータなし', () => {
+      expect(StockAlertEntity.getWastageLabel(null)).toBe('データなし');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -662,4 +662,29 @@ export class HealthLogEntity {
     if (averageCondition >= 3) return 'やや不調';
     return '注意が必要';
   }
+
+  /**
+   * 直近の体調データから次の体調を予測する(1-5)
+   */
+  static predictNextCondition(conditions: number[]): number | null {
+    if (conditions.length === 0) return null;
+    if (conditions.length === 1) return conditions[0];
+    const last = conditions[conditions.length - 1];
+    const prev = conditions[conditions.length - 2];
+    const trend = last - prev;
+    const predicted = last + trend;
+    return Math.max(1, Math.min(5, Math.round(predicted)));
+  }
+
+  /**
+   * 体調予測トレンドに応じたメッセージを返す
+   */
+  static getConditionPredictionMessage(trend: 'improving' | 'declining' | 'stable'): string {
+    const messages: Record<string, string> = {
+      improving: '体調が改善傾向にあります',
+      declining: '体調の変化に注意してください',
+      stable: '体調は安定しています',
+    };
+    return messages[trend];
+  }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -505,4 +505,23 @@ export class MedicationRecordEntity {
     if (averageGapMinutes <= 30) return 'やや遅れ';
     return '大幅な遅れ';
   }
+
+  /**
+   * 日別の服薬遵守スコアを算出する(0-100)
+   */
+  static getDailyComplianceScore(taken: number, scheduled: number): number {
+    if (scheduled <= 0) return 100;
+    return Math.min(100, Math.round((taken / scheduled) * 100));
+  }
+
+  /**
+   * 遵守スコアに応じたラベルを返す
+   */
+  static getComplianceScoreLabel(score: number): string {
+    if (score >= 100) return '完璧';
+    if (score >= 90) return '優秀';
+    if (score >= 70) return '良好';
+    if (score >= 50) return '要改善';
+    return '不十分';
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -345,4 +345,24 @@ export class StockAlertEntity {
     const totalValue = items.reduce((sum, item) => sum + item.stockQuantity * item.unitPrice, 0);
     return { totalValue, itemCount: items.length };
   }
+
+  /**
+   * 消費量と購入量から廃棄率を算出する(0-100)
+   */
+  static getWastageRate(consumed: number, purchased: number): number | null {
+    if (purchased <= 0) return null;
+    if (consumed >= purchased) return 0;
+    return Math.round(((purchased - consumed) / purchased) * 100);
+  }
+
+  /**
+   * 廃棄率に応じたラベルを返す
+   */
+  static getWastageLabel(rate: number | null): string {
+    if (rate === null) return 'データなし';
+    if (rate <= 5) return '効率的';
+    if (rate <= 15) return '許容範囲';
+    if (rate <= 25) return '要改善';
+    return '非効率';
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityに日別遵守スコアとラベルを追加
- HealthLogEntityに体調予測(predictNextCondition)とトレンドメッセージを追加
- StockAlertEntityに廃棄率算出とラベルを追加

## Test plan
- [x] 29件の新規テスト全パス
- [x] 全3313テストパス

closes #676