### PR TITLE
Phase42エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionTrendPrediction.edge.test.ts
+++ b/src/__tests__/domain/entities/ConditionTrendPrediction.edge.test.ts
@@ -1,0 +1,51 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Prediction Edge Cases', () => {
+  describe('predictNextCondition', () => {
+    it('上限5を超えない', () => {
+      expect(HealthLogEntity.predictNextCondition([4, 5])).toBe(5);
+    });
+
+    it('下限1を下回らない', () => {
+      expect(HealthLogEntity.predictNextCondition([2, 1])).toBe(1);
+    });
+
+    it('急激な変動（1→5）', () => {
+      expect(HealthLogEntity.predictNextCondition([1, 5])).toBe(5);
+    });
+
+    it('急激な変動（5→1）', () => {
+      expect(HealthLogEntity.predictNextCondition([5, 1])).toBe(1);
+    });
+
+    it('2件のデータ', () => {
+      expect(HealthLogEntity.predictNextCondition([3, 4])).toBe(5);
+    });
+
+    it('長い配列は末尾2つのみ使用', () => {
+      expect(HealthLogEntity.predictNextCondition([1, 1, 1, 1, 3, 4])).toBe(5);
+    });
+
+    it('小数値は丸められる', () => {
+      const result = HealthLogEntity.predictNextCondition([3, 3.5]);
+      expect(Number.isInteger(result)).toBe(true);
+    });
+  });
+
+  describe('getConditionPredictionMessage', () => {
+    it('improving', () => {
+      const msg = HealthLogEntity.getConditionPredictionMessage('improving');
+      expect(msg.length).toBeGreaterThan(0);
+    });
+
+    it('declining', () => {
+      const msg = HealthLogEntity.getConditionPredictionMessage('declining');
+      expect(msg.length).toBeGreaterThan(0);
+    });
+
+    it('stable', () => {
+      const msg = HealthLogEntity.getConditionPredictionMessage('stable');
+      expect(msg.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/DailyComplianceScore.edge.test.ts
+++ b/src/__tests__/domain/entities/DailyComplianceScore.edge.test.ts
@@ -1,0 +1,43 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Compliance Score Edge Cases', () => {
+  describe('getDailyComplianceScore', () => {
+    it('大量の服用と予定', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(100, 100)).toBe(100);
+    });
+
+    it('1/3で33点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(1, 3)).toBe(33);
+    });
+
+    it('2/3で67点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(2, 3)).toBe(67);
+    });
+
+    it('負の服用数は0点', () => {
+      expect(MedicationRecordEntity.getDailyComplianceScore(-1, 5)).toBe(0);
+    });
+  });
+
+  describe('getComplianceScoreLabel', () => {
+    it('境界値99は優秀', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(99)).toBe('優秀');
+    });
+
+    it('境界値89は良好', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(89)).toBe('良好');
+    });
+
+    it('境界値69は要改善', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(69)).toBe('要改善');
+    });
+
+    it('境界値49は不十分', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(49)).toBe('不十分');
+    });
+
+    it('0は不十分', () => {
+      expect(MedicationRecordEntity.getComplianceScoreLabel(0)).toBe('不十分');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockWastageAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/StockWastageAnalysis.edge.test.ts
@@ -1,0 +1,56 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Wastage Analysis Edge Cases', () => {
+  describe('getWastageRate', () => {
+    it('消費量と購入量が同じで0%', () => {
+      expect(StockAlertEntity.getWastageRate(50, 50)).toBe(0);
+    });
+
+    it('1個消費/100個購入で99%', () => {
+      expect(StockAlertEntity.getWastageRate(1, 100)).toBe(99);
+    });
+
+    it('0個消費/1個購入で100%', () => {
+      expect(StockAlertEntity.getWastageRate(0, 1)).toBe(100);
+    });
+
+    it('負の購入量はnull', () => {
+      expect(StockAlertEntity.getWastageRate(10, -5)).toBeNull();
+    });
+
+    it('負の消費量は正の廃棄率', () => {
+      const result = StockAlertEntity.getWastageRate(-10, 100);
+      expect(result).toBeGreaterThan(100);
+    });
+  });
+
+  describe('getWastageLabel', () => {
+    it('境界値5で効率的', () => {
+      expect(StockAlertEntity.getWastageLabel(5)).toBe('効率的');
+    });
+
+    it('境界値6で許容範囲', () => {
+      expect(StockAlertEntity.getWastageLabel(6)).toBe('許容範囲');
+    });
+
+    it('境界値15で許容範囲', () => {
+      expect(StockAlertEntity.getWastageLabel(15)).toBe('許容範囲');
+    });
+
+    it('境界値16で要改善', () => {
+      expect(StockAlertEntity.getWastageLabel(16)).toBe('要改善');
+    });
+
+    it('境界値25で要改善', () => {
+      expect(StockAlertEntity.getWastageLabel(25)).toBe('要改善');
+    });
+
+    it('境界値26で非効率', () => {
+      expect(StockAlertEntity.getWastageLabel(26)).toBe('非効率');
+    });
+
+    it('0で効率的', () => {
+      expect(StockAlertEntity.getWastageLabel(0)).toBe('効率的');
+    });
+  });
+});

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -511,7 +511,7 @@ export class MedicationRecordEntity {
    */
   static getDailyComplianceScore(taken: number, scheduled: number): number {
     if (scheduled <= 0) return 100;
-    return Math.min(100, Math.round((taken / scheduled) * 100));
+    return Math.max(0, Math.min(100, Math.round((taken / scheduled) * 100)));
   }
 
   /**


### PR DESCRIPTION
## Summary
- 遵守スコアの境界値・負値テスト（9件）
- 体調予測の上下限制約・長配列テスト（10件）
- 廃棄率の境界値テスト（12件）
- getDailyComplianceScoreに0下限制約を追加

## Test plan
- [x] 31件のエッジケーステスト全パス
- [x] 全3344テストパス

closes #680