### PR TITLE
safeParseJsonにContent-Typeバリデーションを追加

### DIFF
--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -103,6 +103,10 @@ export function flattenRelations(
  * 不正なJSON時は400エラーレスポンスを返す
  */
 export async function safeParseJson(request: Request): Promise<{ data: unknown } | { error: Response }> {
+  const contentType = request.headers.get('content-type');
+  if (contentType && !contentType.includes('application/json')) {
+    return { error: errorResponse('Content-Typeはapplication/jsonを指定してください', 415) };
+  }
   try {
     const data = await request.json();
     return { data };


### PR DESCRIPTION
## Summary
- safeParseJsonでContent-Typeヘッダーを検証し、application/json以外を415エラーで拒否
- 不正なリクエストの早期検出によりセキュリティ向上

## Test plan
- [x] 全3344テストパス

closes #682