### PR TITLE
服薬パターン分析・メンバースコア比較・連続記録日数の機能追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarConsecutiveRecord.test.ts
+++ b/src/__tests__/domain/entities/CalendarConsecutiveRecord.test.ts
@@ -1,0 +1,51 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Consecutive Record', () => {
+  describe('getConsecutiveRecordDays', () => {
+    it('連続記録日数を算出', () => {
+      const recordCounts = [1, 2, 3, 0, 1, 1];
+      expect(CalendarEntity.getConsecutiveRecordDays(recordCounts)).toBe(3);
+    });
+
+    it('全て記録あり', () => {
+      const recordCounts = [1, 1, 1, 1, 1];
+      expect(CalendarEntity.getConsecutiveRecordDays(recordCounts)).toBe(5);
+    });
+
+    it('全て記録なし', () => {
+      const recordCounts = [0, 0, 0];
+      expect(CalendarEntity.getConsecutiveRecordDays(recordCounts)).toBe(0);
+    });
+
+    it('空配列', () => {
+      expect(CalendarEntity.getConsecutiveRecordDays([])).toBe(0);
+    });
+
+    it('最後に最長連続がある場合', () => {
+      const recordCounts = [1, 0, 1, 1, 1, 1];
+      expect(CalendarEntity.getConsecutiveRecordDays(recordCounts)).toBe(4);
+    });
+  });
+
+  describe('getConsecutiveRecordLabel', () => {
+    it('0日は記録なし', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(0)).toBe('記録なし');
+    });
+
+    it('7日は1週間連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(7)).toBe('1週間連続');
+    });
+
+    it('30日は1ヶ月連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(30)).toBe('1ヶ月連続');
+    });
+
+    it('3日は3日連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(3)).toBe('3日連続');
+    });
+
+    it('14日は2週間連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(14)).toBe('2週間連続');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationPatternAnalysis.test.ts
+++ b/src/__tests__/domain/entities/MedicationPatternAnalysis.test.ts
@@ -1,0 +1,50 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Pattern Analysis', () => {
+  describe('getMedicationPatternByTimeOfDay', () => {
+    it('時間帯別の服薬回数を集計', () => {
+      const times = ['07:00', '08:00', '12:30', '18:00', '22:00'];
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(times);
+      expect(result.morning).toBe(2);
+      expect(result.afternoon).toBe(1);
+      expect(result.evening).toBe(1);
+      expect(result.night).toBe(1);
+    });
+
+    it('空配列は全て0', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay([]);
+      expect(result.morning).toBe(0);
+      expect(result.afternoon).toBe(0);
+      expect(result.evening).toBe(0);
+      expect(result.night).toBe(0);
+    });
+
+    it('全て同じ時間帯', () => {
+      const times = ['08:00', '09:00', '10:00'];
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(times);
+      expect(result.morning).toBe(3);
+    });
+  });
+
+  describe('getMedicationPatternLabel', () => {
+    it('朝型パターン', () => {
+      const pattern = { morning: 5, afternoon: 1, evening: 0, night: 0 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('朝型');
+    });
+
+    it('均等パターン', () => {
+      const pattern = { morning: 2, afternoon: 2, evening: 2, night: 2 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('均等');
+    });
+
+    it('夜型パターン', () => {
+      const pattern = { morning: 0, afternoon: 1, evening: 1, night: 5 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('夜型');
+    });
+
+    it('全て0は均等', () => {
+      const pattern = { morning: 0, afternoon: 0, evening: 0, night: 0 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('均等');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberScoreComparison.test.ts
+++ b/src/__tests__/domain/entities/MemberScoreComparison.test.ts
@@ -1,0 +1,41 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Score Comparison', () => {
+  describe('compareMemberScores', () => {
+    it('スコアの差を算出', () => {
+      const result = MemberEntity.compareMemberScores(90, 70);
+      expect(result.difference).toBe(20);
+      expect(result.higherLabel).toBe('高い');
+    });
+
+    it('同じスコア', () => {
+      const result = MemberEntity.compareMemberScores(80, 80);
+      expect(result.difference).toBe(0);
+      expect(result.higherLabel).toBe('同じ');
+    });
+
+    it('低いスコアの場合', () => {
+      const result = MemberEntity.compareMemberScores(50, 80);
+      expect(result.difference).toBe(-30);
+      expect(result.higherLabel).toBe('低い');
+    });
+  });
+
+  describe('getMemberRankingLabel', () => {
+    it('1位', () => {
+      expect(MemberEntity.getMemberRankingLabel(1)).toBe('1位');
+    });
+
+    it('2位', () => {
+      expect(MemberEntity.getMemberRankingLabel(2)).toBe('2位');
+    });
+
+    it('10位', () => {
+      expect(MemberEntity.getMemberRankingLabel(10)).toBe('10位');
+    });
+
+    it('0以下はランク外', () => {
+      expect(MemberEntity.getMemberRankingLabel(0)).toBe('ランク外');
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -381,4 +381,31 @@ export class CalendarEntity {
     if (cv >= 0.5) return 'やや偏り';
     return '均等';
   }
+
+  /**
+   * 記録件数配列から最長連続記録日数を算出する
+   */
+  static getConsecutiveRecordDays(recordCounts: number[]): number {
+    let maxStreak = 0;
+    let current = 0;
+    for (const count of recordCounts) {
+      if (count > 0) {
+        current++;
+        maxStreak = Math.max(maxStreak, current);
+      } else {
+        current = 0;
+      }
+    }
+    return maxStreak;
+  }
+
+  /**
+   * 連続記録日数のラベルを返す
+   */
+  static getConsecutiveRecordLabel(days: number): string {
+    if (days === 0) return '記録なし';
+    if (days % 30 === 0) return `${days / 30}ヶ月連続`;
+    if (days % 7 === 0) return `${days / 7}週間連続`;
+    return `${days}日連続`;
+  }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -524,4 +524,47 @@ export class MedicationRecordEntity {
     if (score >= 50) return '要改善';
     return '不十分';
   }
+
+  /**
+   * 時間帯別の服薬回数を集計する
+   */
+  static getMedicationPatternByTimeOfDay(times: string[]): {
+    morning: number;
+    afternoon: number;
+    evening: number;
+    night: number;
+  } {
+    const result = { morning: 0, afternoon: 0, evening: 0, night: 0 };
+    for (const time of times) {
+      const hour = parseInt(time.split(':')[0], 10);
+      if (hour >= 5 && hour < 12) {
+        result.morning++;
+      } else if (hour >= 12 && hour < 17) {
+        result.afternoon++;
+      } else if (hour >= 17 && hour < 21) {
+        result.evening++;
+      } else {
+        result.night++;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * 服薬パターンのラベルを返す
+   */
+  static getMedicationPatternLabel(pattern: {
+    morning: number;
+    afternoon: number;
+    evening: number;
+    night: number;
+  }): string {
+    const total = pattern.morning + pattern.afternoon + pattern.evening + pattern.night;
+    if (total === 0) return '均等';
+    if (pattern.morning / total > 0.5) return '朝型';
+    if (pattern.night / total > 0.5) return '夜型';
+    if (pattern.afternoon / total > 0.5) return '午後型';
+    if (pattern.evening / total > 0.5) return '夕方型';
+    return '均等';
+  }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -444,4 +444,24 @@ export class MemberEntity {
     if (activityLevel === 'high') return `${name}さんは活発に記録中（服薬率${adherenceRate}%）`;
     return `${name}さんの服薬率は${adherenceRate}%です`;
   }
+
+  /**
+   * 2つのスコアを比較する
+   */
+  static compareMemberScores(
+    score1: number,
+    score2: number,
+  ): { difference: number; higherLabel: string } {
+    const difference = score1 - score2;
+    const higherLabel = difference > 0 ? '高い' : difference < 0 ? '低い' : '同じ';
+    return { difference, higherLabel };
+  }
+
+  /**
+   * 順位のラベルを返す
+   */
+  static getMemberRankingLabel(rank: number): string {
+    if (rank <= 0) return 'ランク外';
+    return `${rank}位`;
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityに時間帯別服薬パターン分析機能を追加（getMedicationPatternByTimeOfDay, getMedicationPatternLabel）
- MemberEntityにスコア比較・ランキングラベル機能を追加（compareMemberScores, getMemberRankingLabel）
- CalendarEntityに連続記録日数算出・ラベル機能を追加（getConsecutiveRecordDays, getConsecutiveRecordLabel）

## Test plan
- [x] 服薬パターン分析テスト: 7件パス
- [x] メンバースコア比較テスト: 7件パス
- [x] 連続記録日数テスト: 10件パス
- [x] 全テスト: 3368件パス