### PR TITLE
服薬パターン分析・スコア比較・連続記録のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarConsecutiveRecord.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarConsecutiveRecord.edge.test.ts
@@ -1,0 +1,60 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Consecutive Record Edge Cases', () => {
+  describe('getConsecutiveRecordDays', () => {
+    it('1要素で記録あり', () => {
+      expect(CalendarEntity.getConsecutiveRecordDays([1])).toBe(1);
+    });
+
+    it('1要素で記録なし', () => {
+      expect(CalendarEntity.getConsecutiveRecordDays([0])).toBe(0);
+    });
+
+    it('先頭と末尾に0がある場合', () => {
+      expect(CalendarEntity.getConsecutiveRecordDays([0, 1, 1, 1, 0])).toBe(3);
+    });
+
+    it('複数の同じ長さの連続がある場合', () => {
+      expect(CalendarEntity.getConsecutiveRecordDays([1, 1, 0, 1, 1])).toBe(2);
+    });
+
+    it('大きな値も記録ありとして扱う', () => {
+      expect(CalendarEntity.getConsecutiveRecordDays([10, 20, 30])).toBe(3);
+    });
+
+    it('交互の記録', () => {
+      expect(CalendarEntity.getConsecutiveRecordDays([1, 0, 1, 0, 1])).toBe(1);
+    });
+
+    it('長い配列の最長連続', () => {
+      const arr = [0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0];
+      expect(CalendarEntity.getConsecutiveRecordDays(arr)).toBe(5);
+    });
+  });
+
+  describe('getConsecutiveRecordLabel', () => {
+    it('1日連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(1)).toBe('1日連続');
+    });
+
+    it('21日は3週間連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(21)).toBe('3週間連続');
+    });
+
+    it('60日は2ヶ月連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(60)).toBe('2ヶ月連続');
+    });
+
+    it('28日は4週間連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(28)).toBe('4週間連続');
+    });
+
+    it('35日は5週間連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(35)).toBe('5週間連続');
+    });
+
+    it('90日は3ヶ月連続', () => {
+      expect(CalendarEntity.getConsecutiveRecordLabel(90)).toBe('3ヶ月連続');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationPatternAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationPatternAnalysis.edge.test.ts
@@ -1,0 +1,84 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Pattern Analysis Edge Cases', () => {
+  describe('getMedicationPatternByTimeOfDay', () => {
+    it('深夜0時はnight', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['00:00']);
+      expect(result.night).toBe(1);
+      expect(result.morning).toBe(0);
+    });
+
+    it('早朝4時はnight', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['04:59']);
+      expect(result.night).toBe(1);
+    });
+
+    it('朝5時はmorning', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['05:00']);
+      expect(result.morning).toBe(1);
+    });
+
+    it('11:59はmorning', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['11:59']);
+      expect(result.morning).toBe(1);
+    });
+
+    it('12:00はafternoon', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['12:00']);
+      expect(result.afternoon).toBe(1);
+    });
+
+    it('16:59はafternoon', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['16:59']);
+      expect(result.afternoon).toBe(1);
+    });
+
+    it('17:00はevening', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['17:00']);
+      expect(result.evening).toBe(1);
+    });
+
+    it('20:59はevening', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['20:59']);
+      expect(result.evening).toBe(1);
+    });
+
+    it('21:00はnight', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['21:00']);
+      expect(result.night).toBe(1);
+    });
+
+    it('23:59はnight', () => {
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(['23:59']);
+      expect(result.night).toBe(1);
+    });
+
+    it('大量の時刻を正しく集計', () => {
+      const times = Array(100).fill('08:00');
+      const result = MedicationRecordEntity.getMedicationPatternByTimeOfDay(times);
+      expect(result.morning).toBe(100);
+    });
+  });
+
+  describe('getMedicationPatternLabel', () => {
+    it('午後型パターン', () => {
+      const pattern = { morning: 0, afternoon: 5, evening: 1, night: 0 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('午後型');
+    });
+
+    it('夕方型パターン', () => {
+      const pattern = { morning: 0, afternoon: 0, evening: 5, night: 1 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('夕方型');
+    });
+
+    it('ちょうど50%は均等', () => {
+      const pattern = { morning: 5, afternoon: 5, evening: 0, night: 0 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('均等');
+    });
+
+    it('51%超で朝型', () => {
+      const pattern = { morning: 6, afternoon: 3, evening: 1, night: 1 };
+      expect(MedicationRecordEntity.getMedicationPatternLabel(pattern)).toBe('朝型');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberScoreComparison.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberScoreComparison.edge.test.ts
@@ -1,0 +1,53 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Score Comparison Edge Cases', () => {
+  describe('compareMemberScores', () => {
+    it('非常に大きいスコア差', () => {
+      const result = MemberEntity.compareMemberScores(100, 0);
+      expect(result.difference).toBe(100);
+      expect(result.higherLabel).toBe('高い');
+    });
+
+    it('負のスコア', () => {
+      const result = MemberEntity.compareMemberScores(-10, -20);
+      expect(result.difference).toBe(10);
+      expect(result.higherLabel).toBe('高い');
+    });
+
+    it('小数点スコア', () => {
+      const result = MemberEntity.compareMemberScores(85.5, 85.3);
+      expect(result.difference).toBeCloseTo(0.2);
+      expect(result.higherLabel).toBe('高い');
+    });
+
+    it('0と0の比較', () => {
+      const result = MemberEntity.compareMemberScores(0, 0);
+      expect(result.difference).toBe(0);
+      expect(result.higherLabel).toBe('同じ');
+    });
+
+    it('逆順でも正しい符号', () => {
+      const result = MemberEntity.compareMemberScores(30, 70);
+      expect(result.difference).toBe(-40);
+      expect(result.higherLabel).toBe('低い');
+    });
+  });
+
+  describe('getMemberRankingLabel', () => {
+    it('負の数はランク外', () => {
+      expect(MemberEntity.getMemberRankingLabel(-1)).toBe('ランク外');
+    });
+
+    it('大きな順位', () => {
+      expect(MemberEntity.getMemberRankingLabel(100)).toBe('100位');
+    });
+
+    it('1位の境界', () => {
+      expect(MemberEntity.getMemberRankingLabel(1)).toBe('1位');
+    });
+
+    it('0の境界', () => {
+      expect(MemberEntity.getMemberRankingLabel(0)).toBe('ランク外');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getMedicationPatternByTimeOfDayの全時間帯境界値テスト（15件）
- compareMemberScores/getMemberRankingLabelのエッジケーステスト（9件）
- getConsecutiveRecordDays/getConsecutiveRecordLabelのエッジケーステスト（13件）

## Test plan
- [x] エッジケーステスト: 37件パス
- [x] 全テスト: 3405件パス