### PR TITLE
認証APIとstock APIのconsole.errorメッセージを日本語化

### DIFF
--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: NextRequest) {
 
     return success({ message: 'リセットコードを送信しました' });
   } catch (error) {
-    console.error('Forgot password error:', error);
+    console.error('パスワード再設定エラー:', error);
     return errorResponse('送信に失敗しました', 500);
   }
 }

--- a/src/app/api/auth/resend-code/route.ts
+++ b/src/app/api/auth/resend-code/route.ts
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
 
     return success({ message: '確認コードを再送信しました' });
   } catch (error) {
-    console.error('Resend code error:', error);
+    console.error('認証コード再送エラー:', error);
     return errorResponse('再送信に失敗しました', 500);
   }
 }

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
 
     return success({ message: 'パスワードを再設定しました' });
   } catch (error) {
-    console.error('Reset password error:', error);
+    console.error('パスワードリセットエラー:', error);
     return errorResponse('再設定に失敗しました', 500);
   }
 }

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
 
     return created({ email, requiresVerification: true });
   } catch (error) {
-    console.error('Signup error:', error);
+    console.error('サインアップエラー:', error);
     return errorResponse('登録に失敗しました', 500);
   }
 }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
 
     return success({ message: 'メールアドレスが確認されました' });
   } catch (error) {
-    console.error('Verify error:', error);
+    console.error('認証コード確認エラー:', error);
     return errorResponse('認証に失敗しました', 500);
   }
 }

--- a/src/app/api/medications/[medicationId]/stock/route.ts
+++ b/src/app/api/medications/[medicationId]/stock/route.ts
@@ -53,7 +53,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
                 daysUntilAlert,
               });
               sendEmail({ to: user.email, ...template }).catch((err) => {
-                console.error('Low stock email failed:', err);
+                console.error('在庫不足メール送信エラー:', err);
               });
             }
           }


### PR DESCRIPTION
## Summary
- auth系5ルートのconsole.errorメッセージを英語から日本語に変更
- medications/stock APIのconsole.errorメッセージを日本語化

## Test plan
- [x] 全テスト: 3405件パス