### PR TITLE
スケジュール規則性・体調記録ストリーク・通院間隔規則性の機能追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentIntervalRegularity.test.ts
+++ b/src/__tests__/domain/entities/AppointmentIntervalRegularity.test.ts
@@ -1,0 +1,44 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Interval Regularity', () => {
+  describe('getIntervalRegularity', () => {
+    it('均等な間隔は高スコア', () => {
+      const intervals = [30, 30, 30];
+      const score = AppointmentEntity.getIntervalRegularity(intervals);
+      expect(score).toBe(100);
+    });
+
+    it('ばらつきがある場合はスコアが下がる', () => {
+      const intervals = [10, 30, 50];
+      const score = AppointmentEntity.getIntervalRegularity(intervals);
+      expect(score).toBeLessThan(100);
+      expect(score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('空配列は0', () => {
+      expect(AppointmentEntity.getIntervalRegularity([])).toBe(0);
+    });
+
+    it('1件は100', () => {
+      expect(AppointmentEntity.getIntervalRegularity([30])).toBe(100);
+    });
+  });
+
+  describe('getIntervalRegularityLabel', () => {
+    it('高スコアは規則的', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(90)).toBe('規則的');
+    });
+
+    it('中スコアはやや不規則', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(60)).toBe('やや不規則');
+    });
+
+    it('低スコアは不規則', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(40)).toBe('不規則');
+    });
+
+    it('0は不規則', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(0)).toBe('不規則');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HealthLogStreak.test.ts
+++ b/src/__tests__/domain/entities/HealthLogStreak.test.ts
@@ -1,0 +1,50 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Log Streak', () => {
+  describe('getLogStreak', () => {
+    it('連続記録日数を算出', () => {
+      const dateKeys = ['2026-03-04', '2026-03-05', '2026-03-06'];
+      expect(HealthLogEntity.getLogStreak(dateKeys, '2026-03-06')).toBe(3);
+    });
+
+    it('途切れた場合は直近の連続のみ', () => {
+      const dateKeys = ['2026-03-02', '2026-03-04', '2026-03-05', '2026-03-06'];
+      expect(HealthLogEntity.getLogStreak(dateKeys, '2026-03-06')).toBe(3);
+    });
+
+    it('今日の記録がない場合は0', () => {
+      const dateKeys = ['2026-03-04', '2026-03-05'];
+      expect(HealthLogEntity.getLogStreak(dateKeys, '2026-03-06')).toBe(0);
+    });
+
+    it('空配列は0', () => {
+      expect(HealthLogEntity.getLogStreak([], '2026-03-06')).toBe(0);
+    });
+
+    it('今日のみの記録は1', () => {
+      expect(HealthLogEntity.getLogStreak(['2026-03-06'], '2026-03-06')).toBe(1);
+    });
+  });
+
+  describe('getLogStreakLabel', () => {
+    it('0日は記録なし', () => {
+      expect(HealthLogEntity.getLogStreakLabel(0)).toBe('記録なし');
+    });
+
+    it('1日は記録開始', () => {
+      expect(HealthLogEntity.getLogStreakLabel(1)).toBe('記録開始');
+    });
+
+    it('3日は3日連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(3)).toBe('3日連続');
+    });
+
+    it('7日は1週間連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(7)).toBe('1週間連続');
+    });
+
+    it('30日は1ヶ月連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(30)).toBe('1ヶ月連続');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleRegularity.test.ts
+++ b/src/__tests__/domain/entities/ScheduleRegularity.test.ts
@@ -1,0 +1,47 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Schedule Regularity', () => {
+  describe('getScheduleRegularityScore', () => {
+    it('全て完了の場合は100', () => {
+      expect(ScheduleEntity.getScheduleRegularityScore([true, true, true, true, true])).toBe(100);
+    });
+
+    it('全て未完了の場合は0', () => {
+      expect(ScheduleEntity.getScheduleRegularityScore([false, false, false])).toBe(0);
+    });
+
+    it('半分完了の場合は50', () => {
+      expect(ScheduleEntity.getScheduleRegularityScore([true, false, true, false])).toBe(50);
+    });
+
+    it('空配列は0', () => {
+      expect(ScheduleEntity.getScheduleRegularityScore([])).toBe(0);
+    });
+
+    it('1件完了は100', () => {
+      expect(ScheduleEntity.getScheduleRegularityScore([true])).toBe(100);
+    });
+  });
+
+  describe('getRegularityLabel', () => {
+    it('100は完璧', () => {
+      expect(ScheduleEntity.getRegularityLabel(100)).toBe('完璧');
+    });
+
+    it('90は優秀', () => {
+      expect(ScheduleEntity.getRegularityLabel(90)).toBe('優秀');
+    });
+
+    it('70は良好', () => {
+      expect(ScheduleEntity.getRegularityLabel(70)).toBe('良好');
+    });
+
+    it('50は要改善', () => {
+      expect(ScheduleEntity.getRegularityLabel(50)).toBe('要改善');
+    });
+
+    it('30は不十分', () => {
+      expect(ScheduleEntity.getRegularityLabel(30)).toBe('不十分');
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -431,4 +431,26 @@ export class AppointmentEntity {
     if (countPerMonth >= 1) return '少なめ';
     return 'なし';
   }
+
+  /**
+   * 通院間隔の規則性スコア(0-100)を算出する
+   */
+  static getIntervalRegularity(intervals: number[]): number {
+    if (intervals.length === 0) return 0;
+    if (intervals.length === 1) return 100;
+    const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+    if (avg === 0) return 100;
+    const variance = intervals.reduce((sum, v) => sum + (v - avg) ** 2, 0) / intervals.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.max(0, Math.round(100 - cv * 100));
+  }
+
+  /**
+   * 規則性スコアに応じたラベルを返す
+   */
+  static getIntervalRegularityLabel(score: number): string {
+    if (score >= 80) return '規則的';
+    if (score >= 50) return 'やや不規則';
+    return '不規則';
+  }
 }

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -684,6 +684,38 @@ export class HealthLogEntity {
   /**
    * 体調予測トレンドに応じたメッセージを返す
    */
+  /**
+   * 今日から遡って連続記録日数を算出する
+   */
+  static getLogStreak(dateKeys: string[], todayKey: string): number {
+    if (dateKeys.length === 0) return 0;
+    const sorted = [...new Set(dateKeys)].sort((a, b) => b.localeCompare(a));
+    if (sorted[0] !== todayKey) return 0;
+    let streak = 1;
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = new Date(sorted[i - 1] + 'T00:00:00');
+      const curr = new Date(sorted[i] + 'T00:00:00');
+      const diffMs = prev.getTime() - curr.getTime();
+      if (Math.round(diffMs / (1000 * 60 * 60 * 24)) === 1) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  /**
+   * 連続記録日数のラベルを返す
+   */
+  static getLogStreakLabel(days: number): string {
+    if (days === 0) return '記録なし';
+    if (days === 1) return '記録開始';
+    if (days % 30 === 0) return `${days / 30}ヶ月連続`;
+    if (days % 7 === 0) return `${days / 7}週間連続`;
+    return `${days}日連続`;
+  }
+
   static getConditionPredictionMessage(trend: 'improving' | 'declining' | 'stable'): string {
     const messages: Record<string, string> = {
       improving: '体調が改善傾向にあります',

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -688,6 +688,26 @@ export class ScheduleEntity {
   /**
    * 時間帯分布の偏りラベルを返す
    */
+  /**
+   * 完了履歴から規則性スコア(0-100)を算出する
+   */
+  static getScheduleRegularityScore(completionHistory: boolean[]): number {
+    if (completionHistory.length === 0) return 0;
+    const completed = completionHistory.filter(Boolean).length;
+    return Math.round((completed / completionHistory.length) * 100);
+  }
+
+  /**
+   * 規則性スコアに応じたラベルを返す
+   */
+  static getRegularityLabel(score: number): string {
+    if (score >= 100) return '完璧';
+    if (score >= 80) return '優秀';
+    if (score >= 60) return '良好';
+    if (score >= 40) return '要改善';
+    return '不十分';
+  }
+
   static getTimePeriodDistributionLabel(dist: Record<TimePeriod, number>): string {
     const total = dist.morning + dist.afternoon + dist.evening + dist.night;
     if (total === 0) return '均等';


### PR DESCRIPTION
## Summary
- ScheduleEntityにスケジュール完了履歴の規則性スコア算出機能を追加（getScheduleRegularityScore, getRegularityLabel）
- HealthLogEntityに体調記録の連続日数ストリーク機能を追加（getLogStreak, getLogStreakLabel）
- AppointmentEntityに通院間隔の規則性スコア算出機能を追加（getIntervalRegularity, getIntervalRegularityLabel）

## Test plan
- [x] スケジュール規則性テスト: 10件パス
- [x] 体調記録ストリークテスト: 10件パス
- [x] 通院間隔規則性テスト: 8件パス
- [x] 全テスト: 3433件パス