### PR TITLE
スケジュール規則性・体調ストリーク・通院規則性のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentIntervalRegularity.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentIntervalRegularity.edge.test.ts
@@ -1,0 +1,49 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Interval Regularity Edge Cases', () => {
+  describe('getIntervalRegularity', () => {
+    it('全て同じ間隔は100', () => {
+      expect(AppointmentEntity.getIntervalRegularity([14, 14, 14, 14])).toBe(100);
+    });
+
+    it('全て0は100', () => {
+      expect(AppointmentEntity.getIntervalRegularity([0, 0, 0])).toBe(100);
+    });
+
+    it('大きなばらつき', () => {
+      const score = AppointmentEntity.getIntervalRegularity([1, 100]);
+      expect(score).toBeLessThan(50);
+    });
+
+    it('2件の同じ値は100', () => {
+      expect(AppointmentEntity.getIntervalRegularity([30, 30])).toBe(100);
+    });
+
+    it('わずかなばらつき', () => {
+      const score = AppointmentEntity.getIntervalRegularity([29, 30, 31]);
+      expect(score).toBeGreaterThan(90);
+    });
+  });
+
+  describe('getIntervalRegularityLabel', () => {
+    it('80は規則的', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(80)).toBe('規則的');
+    });
+
+    it('79はやや不規則', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(79)).toBe('やや不規則');
+    });
+
+    it('50はやや不規則', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(50)).toBe('やや不規則');
+    });
+
+    it('49は不規則', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(49)).toBe('不規則');
+    });
+
+    it('100は規則的', () => {
+      expect(AppointmentEntity.getIntervalRegularityLabel(100)).toBe('規則的');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/HealthLogStreak.edge.test.ts
+++ b/src/__tests__/domain/entities/HealthLogStreak.edge.test.ts
@@ -1,0 +1,53 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Log Streak Edge Cases', () => {
+  describe('getLogStreak', () => {
+    it('重複日付がある場合も正しく算出', () => {
+      const dateKeys = ['2026-03-05', '2026-03-05', '2026-03-06'];
+      expect(HealthLogEntity.getLogStreak(dateKeys, '2026-03-06')).toBe(2);
+    });
+
+    it('昨日の記録のみで今日がない場合は0', () => {
+      expect(HealthLogEntity.getLogStreak(['2026-03-05'], '2026-03-06')).toBe(0);
+    });
+
+    it('長い連続記録', () => {
+      const dateKeys: string[] = [];
+      for (let i = 0; i < 30; i++) {
+        const d = new Date(2026, 2, 6 - i);
+        const year = d.getFullYear();
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        dateKeys.push(`${year}-${month}-${day}`);
+      }
+      expect(HealthLogEntity.getLogStreak(dateKeys, '2026-03-06')).toBe(30);
+    });
+
+    it('ソートされていない入力でも正しく動作', () => {
+      const dateKeys = ['2026-03-06', '2026-03-04', '2026-03-05'];
+      expect(HealthLogEntity.getLogStreak(dateKeys, '2026-03-06')).toBe(3);
+    });
+  });
+
+  describe('getLogStreakLabel', () => {
+    it('2日は2日連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(2)).toBe('2日連続');
+    });
+
+    it('14日は2週間連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(14)).toBe('2週間連続');
+    });
+
+    it('60日は2ヶ月連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(60)).toBe('2ヶ月連続');
+    });
+
+    it('10日は10日連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(10)).toBe('10日連続');
+    });
+
+    it('21日は3週間連続', () => {
+      expect(HealthLogEntity.getLogStreakLabel(21)).toBe('3週間連続');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleRegularity.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleRegularity.edge.test.ts
@@ -1,0 +1,55 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Regularity Edge Cases', () => {
+  describe('getScheduleRegularityScore', () => {
+    it('長い履歴で1件のみ未完了', () => {
+      const history = Array(100).fill(true);
+      history[50] = false;
+      expect(ScheduleEntity.getScheduleRegularityScore(history)).toBe(99);
+    });
+
+    it('長い履歴で1件のみ完了', () => {
+      const history = Array(100).fill(false);
+      history[0] = true;
+      expect(ScheduleEntity.getScheduleRegularityScore(history)).toBe(1);
+    });
+
+    it('2件で1件完了は50', () => {
+      expect(ScheduleEntity.getScheduleRegularityScore([true, false])).toBe(50);
+    });
+
+    it('3件で2件完了は67', () => {
+      expect(ScheduleEntity.getScheduleRegularityScore([true, true, false])).toBe(67);
+    });
+  });
+
+  describe('getRegularityLabel', () => {
+    it('80は優秀', () => {
+      expect(ScheduleEntity.getRegularityLabel(80)).toBe('優秀');
+    });
+
+    it('79は良好', () => {
+      expect(ScheduleEntity.getRegularityLabel(79)).toBe('良好');
+    });
+
+    it('60は良好', () => {
+      expect(ScheduleEntity.getRegularityLabel(60)).toBe('良好');
+    });
+
+    it('59は要改善', () => {
+      expect(ScheduleEntity.getRegularityLabel(59)).toBe('要改善');
+    });
+
+    it('40は要改善', () => {
+      expect(ScheduleEntity.getRegularityLabel(40)).toBe('要改善');
+    });
+
+    it('39は不十分', () => {
+      expect(ScheduleEntity.getRegularityLabel(39)).toBe('不十分');
+    });
+
+    it('0は不十分', () => {
+      expect(ScheduleEntity.getRegularityLabel(0)).toBe('不十分');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getScheduleRegularityScore/getRegularityLabelの境界値テスト（11件）
- getLogStreak/getLogStreakLabelのエッジケーステスト（9件）
- getIntervalRegularity/getIntervalRegularityLabelのエッジケーステスト（10件）

## Test plan
- [x] エッジケーステスト: 30件パス
- [x] 全テスト: 3463件パス