### PR TITLE
dateStringスキーマにmax長制約を追加

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const dateString = z.string().refine(
+const dateString = z.string().max(50, '日付形式が長すぎます').refine(
   (val) => !isNaN(Date.parse(val)),
   { message: '有効な日付形式で入力してください' },
 );


### PR DESCRIPTION
## Summary
- dateStringスキーマにmax(50)を追加して極端に長い日付文字列によるDoS攻撃を防止
- birthDate, stockAlertDate, appointmentDate全てに適用

## Test plan
- [x] 全テスト: 3463件パス