### PR TITLE
服薬量トラッキング・カレンダーヒートマップ・メンバー比較サマリーの機能追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarHeatMap.test.ts
+++ b/src/__tests__/domain/entities/CalendarHeatMap.test.ts
@@ -1,0 +1,47 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Heat Map', () => {
+  describe('getHeatMapIntensity', () => {
+    it('0は0', () => {
+      expect(CalendarEntity.getHeatMapIntensity(0, 10)).toBe(0);
+    });
+
+    it('最大値と同じは4', () => {
+      expect(CalendarEntity.getHeatMapIntensity(10, 10)).toBe(4);
+    });
+
+    it('半分は2', () => {
+      expect(CalendarEntity.getHeatMapIntensity(5, 10)).toBe(2);
+    });
+
+    it('最大値0の場合は0', () => {
+      expect(CalendarEntity.getHeatMapIntensity(5, 0)).toBe(0);
+    });
+
+    it('25%は1', () => {
+      expect(CalendarEntity.getHeatMapIntensity(1, 4)).toBe(1);
+    });
+  });
+
+  describe('getHeatMapColor', () => {
+    it('0はbg-gray-100', () => {
+      expect(CalendarEntity.getHeatMapColor(0)).toBe('bg-gray-100');
+    });
+
+    it('1はbg-green-100', () => {
+      expect(CalendarEntity.getHeatMapColor(1)).toBe('bg-green-100');
+    });
+
+    it('2はbg-green-200', () => {
+      expect(CalendarEntity.getHeatMapColor(2)).toBe('bg-green-200');
+    });
+
+    it('3はbg-green-300', () => {
+      expect(CalendarEntity.getHeatMapColor(3)).toBe('bg-green-300');
+    });
+
+    it('4はbg-green-400', () => {
+      expect(CalendarEntity.getHeatMapColor(4)).toBe('bg-green-400');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationDosageTracking.test.ts
+++ b/src/__tests__/domain/entities/MedicationDosageTracking.test.ts
@@ -1,0 +1,48 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Dosage Tracking', () => {
+  describe('getDailyDosageCount', () => {
+    it('同じ薬の日別服薬回数を集計', () => {
+      const records = [
+        { medicationName: '薬A', date: '2026-03-06' },
+        { medicationName: '薬A', date: '2026-03-06' },
+        { medicationName: '薬B', date: '2026-03-06' },
+        { medicationName: '薬A', date: '2026-03-05' },
+      ];
+      const result = MedicationRecordEntity.getDailyDosageCount(records, '2026-03-06');
+      expect(result).toEqual({ '薬A': 2, '薬B': 1 });
+    });
+
+    it('該当日の記録がない場合は空オブジェクト', () => {
+      const records = [{ medicationName: '薬A', date: '2026-03-05' }];
+      const result = MedicationRecordEntity.getDailyDosageCount(records, '2026-03-06');
+      expect(result).toEqual({});
+    });
+
+    it('空配列は空オブジェクト', () => {
+      expect(MedicationRecordEntity.getDailyDosageCount([], '2026-03-06')).toEqual({});
+    });
+  });
+
+  describe('getDosageCategoryLabel', () => {
+    it('1回は少なめ', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(1)).toBe('少なめ');
+    });
+
+    it('3回は標準', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(3)).toBe('標準');
+    });
+
+    it('5回は多め', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(5)).toBe('多め');
+    });
+
+    it('8回は非常に多い', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(8)).toBe('非常に多い');
+    });
+
+    it('0回はなし', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(0)).toBe('なし');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberComparisonSummary.test.ts
+++ b/src/__tests__/domain/entities/MemberComparisonSummary.test.ts
@@ -1,0 +1,43 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Comparison Summary', () => {
+  describe('getMemberComparisonSummary', () => {
+    it('複数メンバーの比較サマリーを生成', () => {
+      const members = [
+        { name: '太郎', adherenceRate: 90 },
+        { name: '花子', adherenceRate: 70 },
+        { name: '次郎', adherenceRate: 80 },
+      ];
+      const result = MemberEntity.getMemberComparisonSummary(members);
+      expect(result.bestMember).toBe('太郎');
+      expect(result.worstMember).toBe('花子');
+      expect(result.averageRate).toBe(80);
+    });
+
+    it('1人の場合はその人がベスト・ワースト', () => {
+      const members = [{ name: '太郎', adherenceRate: 85 }];
+      const result = MemberEntity.getMemberComparisonSummary(members);
+      expect(result.bestMember).toBe('太郎');
+      expect(result.worstMember).toBe('太郎');
+      expect(result.averageRate).toBe(85);
+    });
+
+    it('空配列はnull', () => {
+      expect(MemberEntity.getMemberComparisonSummary([])).toBeNull();
+    });
+  });
+
+  describe('getComparisonMessage', () => {
+    it('差が大きい場合', () => {
+      expect(MemberEntity.getComparisonMessage(90, 50)).toBe('メンバー間で差があります');
+    });
+
+    it('差が小さい場合', () => {
+      expect(MemberEntity.getComparisonMessage(85, 80)).toBe('メンバー全体で安定しています');
+    });
+
+    it('同じ場合', () => {
+      expect(MemberEntity.getComparisonMessage(80, 80)).toBe('メンバー全体で安定しています');
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -408,4 +408,31 @@ export class CalendarEntity {
     if (days % 7 === 0) return `${days / 7}週間連続`;
     return `${days}日連続`;
   }
+
+  /**
+   * 記録数からヒートマップ強度(0-4)を算出する
+   */
+  static getHeatMapIntensity(count: number, maxCount: number): number {
+    if (maxCount <= 0 || count <= 0) return 0;
+    const ratio = count / maxCount;
+    if (ratio >= 1) return 4;
+    if (ratio >= 0.75) return 3;
+    if (ratio >= 0.5) return 2;
+    return 1;
+  }
+
+  private static readonly HEAT_MAP_COLORS = [
+    'bg-gray-100',
+    'bg-green-100',
+    'bg-green-200',
+    'bg-green-300',
+    'bg-green-400',
+  ];
+
+  /**
+   * ヒートマップ強度に応じた背景色クラスを返す
+   */
+  static getHeatMapColor(intensity: number): string {
+    return CalendarEntity.HEAT_MAP_COLORS[intensity] ?? CalendarEntity.HEAT_MAP_COLORS[0];
+  }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -573,4 +573,31 @@ export class MedicationRecordEntity {
     if (pattern.evening / total > MedicationRecordEntity.PATTERN_DOMINANCE_THRESHOLD) return '夕方型';
     return '均等';
   }
+
+  /**
+   * 指定日の薬別服薬回数を集計する
+   */
+  static getDailyDosageCount(
+    records: { medicationName: string; date: string }[],
+    dateKey: string,
+  ): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const r of records) {
+      if (r.date === dateKey) {
+        counts[r.medicationName] = (counts[r.medicationName] || 0) + 1;
+      }
+    }
+    return counts;
+  }
+
+  /**
+   * 服薬回数に応じたカテゴリラベルを返す
+   */
+  static getDosageCategoryLabel(count: number): string {
+    if (count === 0) return 'なし';
+    if (count <= 2) return '少なめ';
+    if (count <= 4) return '標準';
+    if (count <= 6) return '多め';
+    return '非常に多い';
+  }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -464,4 +464,29 @@ export class MemberEntity {
     if (rank <= 0) return 'ランク外';
     return `${rank}位`;
   }
+
+  /**
+   * 複数メンバーの服薬率比較サマリーを生成する
+   */
+  static getMemberComparisonSummary(
+    members: { name: string; adherenceRate: number }[],
+  ): { bestMember: string; worstMember: string; averageRate: number } | null {
+    if (members.length === 0) return null;
+    const sorted = [...members].sort((a, b) => b.adherenceRate - a.adherenceRate);
+    const sum = members.reduce((acc, m) => acc + m.adherenceRate, 0);
+    return {
+      bestMember: sorted[0].name,
+      worstMember: sorted[sorted.length - 1].name,
+      averageRate: Math.round(sum / members.length),
+    };
+  }
+
+  /**
+   * メンバー間の服薬率差に応じたメッセージを返す
+   */
+  static getComparisonMessage(bestRate: number, worstRate: number): string {
+    const diff = bestRate - worstRate;
+    if (diff >= 20) return 'メンバー間で差があります';
+    return 'メンバー全体で安定しています';
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityに日別服薬量集計・カテゴリ判定機能を追加（getDailyDosageCount, getDosageCategoryLabel）
- CalendarEntityにヒートマップ強度レベル・背景色算出機能を追加（getHeatMapIntensity, getHeatMapColor）
- MemberEntityに複数メンバーの服薬率比較サマリー機能を追加（getMemberComparisonSummary, getComparisonMessage）

## Test plan
- [x] 服薬量トラッキングテスト: 8件パス
- [x] カレンダーヒートマップテスト: 10件パス
- [x] メンバー比較サマリーテスト: 6件パス
- [x] 全テスト: 3487件パス