### PR TITLE
服薬量・ヒートマップ・メンバー比較のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarHeatMap.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarHeatMap.edge.test.ts
@@ -1,0 +1,39 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Heat Map Edge Cases', () => {
+  describe('getHeatMapIntensity', () => {
+    it('countが負の場合は0', () => {
+      expect(CalendarEntity.getHeatMapIntensity(-1, 10)).toBe(0);
+    });
+
+    it('maxCountが負の場合は0', () => {
+      expect(CalendarEntity.getHeatMapIntensity(5, -1)).toBe(0);
+    });
+
+    it('countがmaxCountを超える場合は4', () => {
+      expect(CalendarEntity.getHeatMapIntensity(15, 10)).toBe(4);
+    });
+
+    it('75%ちょうどは3', () => {
+      expect(CalendarEntity.getHeatMapIntensity(75, 100)).toBe(3);
+    });
+
+    it('50%ちょうどは2', () => {
+      expect(CalendarEntity.getHeatMapIntensity(50, 100)).toBe(2);
+    });
+
+    it('1%は1', () => {
+      expect(CalendarEntity.getHeatMapIntensity(1, 100)).toBe(1);
+    });
+  });
+
+  describe('getHeatMapColor', () => {
+    it('範囲外の強度はbg-gray-100', () => {
+      expect(CalendarEntity.getHeatMapColor(5)).toBe('bg-gray-100');
+    });
+
+    it('負の強度はbg-gray-100', () => {
+      expect(CalendarEntity.getHeatMapColor(-1)).toBe('bg-gray-100');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MedicationDosageTracking.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationDosageTracking.edge.test.ts
@@ -1,0 +1,52 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Dosage Tracking Edge Cases', () => {
+  describe('getDailyDosageCount', () => {
+    it('同じ薬が大量にある場合', () => {
+      const records = Array(50).fill({ medicationName: '薬A', date: '2026-03-06' });
+      const result = MedicationRecordEntity.getDailyDosageCount(records, '2026-03-06');
+      expect(result['薬A']).toBe(50);
+    });
+
+    it('複数の薬が混在', () => {
+      const records = [
+        { medicationName: '薬A', date: '2026-03-06' },
+        { medicationName: '薬B', date: '2026-03-06' },
+        { medicationName: '薬C', date: '2026-03-06' },
+      ];
+      const result = MedicationRecordEntity.getDailyDosageCount(records, '2026-03-06');
+      expect(Object.keys(result)).toHaveLength(3);
+    });
+
+    it('異なる日付の記録は含まれない', () => {
+      const records = [
+        { medicationName: '薬A', date: '2026-03-05' },
+        { medicationName: '薬A', date: '2026-03-07' },
+      ];
+      const result = MedicationRecordEntity.getDailyDosageCount(records, '2026-03-06');
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('getDosageCategoryLabel', () => {
+    it('2回は少なめ', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(2)).toBe('少なめ');
+    });
+
+    it('4回は標準', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(4)).toBe('標準');
+    });
+
+    it('6回は多め', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(6)).toBe('多め');
+    });
+
+    it('7回は非常に多い', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(7)).toBe('非常に多い');
+    });
+
+    it('100回は非常に多い', () => {
+      expect(MedicationRecordEntity.getDosageCategoryLabel(100)).toBe('非常に多い');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MemberComparisonSummary.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberComparisonSummary.edge.test.ts
@@ -1,0 +1,53 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Comparison Summary Edge Cases', () => {
+  describe('getMemberComparisonSummary', () => {
+    it('全員同じ率', () => {
+      const members = [
+        { name: '太郎', adherenceRate: 80 },
+        { name: '花子', adherenceRate: 80 },
+      ];
+      const result = MemberEntity.getMemberComparisonSummary(members);
+      expect(result!.averageRate).toBe(80);
+    });
+
+    it('0%のメンバーがいる場合', () => {
+      const members = [
+        { name: '太郎', adherenceRate: 100 },
+        { name: '花子', adherenceRate: 0 },
+      ];
+      const result = MemberEntity.getMemberComparisonSummary(members);
+      expect(result!.bestMember).toBe('太郎');
+      expect(result!.worstMember).toBe('花子');
+      expect(result!.averageRate).toBe(50);
+    });
+
+    it('多数メンバー', () => {
+      const members = [
+        { name: 'A', adherenceRate: 90 },
+        { name: 'B', adherenceRate: 70 },
+        { name: 'C', adherenceRate: 80 },
+        { name: 'D', adherenceRate: 60 },
+        { name: 'E', adherenceRate: 100 },
+      ];
+      const result = MemberEntity.getMemberComparisonSummary(members);
+      expect(result!.bestMember).toBe('E');
+      expect(result!.worstMember).toBe('D');
+      expect(result!.averageRate).toBe(80);
+    });
+  });
+
+  describe('getComparisonMessage', () => {
+    it('差が20の境界', () => {
+      expect(MemberEntity.getComparisonMessage(90, 70)).toBe('メンバー間で差があります');
+    });
+
+    it('差が19の境界', () => {
+      expect(MemberEntity.getComparisonMessage(90, 71)).toBe('メンバー全体で安定しています');
+    });
+
+    it('差が0', () => {
+      expect(MemberEntity.getComparisonMessage(100, 100)).toBe('メンバー全体で安定しています');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getDailyDosageCount/getDosageCategoryLabelの境界値テスト（8件）
- getHeatMapIntensity/getHeatMapColorのエッジケーステスト（8件）
- getMemberComparisonSummary/getComparisonMessageのエッジケーステスト（6件）

## Test plan
- [x] エッジケーステスト: 22件パス
- [x] 全テスト: 3509件パス