### PR TITLE
Zodスキーマのバリデーション強化と英語console.error修正

### DIFF
--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -8,9 +8,9 @@ import { checkRateLimit } from '@/lib/security';
 
 const sendNotificationSchema = z.object({
   type: z.enum(['medication_reminder', 'missed_medication', 'appointment_reminder', 'low_stock']),
-  memberId: z.string(),
-  medicationId: z.string().optional(),
-  appointmentId: z.string().optional(),
+  memberId: z.string().min(1).max(50),
+  medicationId: z.string().min(1).max(50).optional(),
+  appointmentId: z.string().min(1).max(50).optional(),
 });
 
 export async function POST(request: NextRequest) {

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -20,7 +20,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    console.error('ErrorBoundary caught:', error, errorInfo);
+    console.error('エラーバウンダリーが例外をキャッチしました:', error, errorInfo);
   }
 
   handleReload = (): void => {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -127,8 +127,8 @@ export const createAppointmentSchema = z.object({
 });
 
 export const updateAppointmentSchema = z.object({
-  appointmentDate: z.string().max(20).optional(),
-  appointmentTime: z.string().max(10).optional(),
+  appointmentDate: dateString.optional(),
+  appointmentTime: z.string().trim().max(10).optional(),
   type: z.string().trim().max(100).optional(),
   notes: z.string().trim().max(1000).optional(),
   reminderEnabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- updateAppointmentSchemaのappointmentDateにdateStringバリデーションを適用（不正な日付形式を拒否）
- updateAppointmentSchemaのappointmentTimeに.trim()を追加
- sendNotificationSchemaのIDフィールドにmin(1).max(50)制約を追加
- ErrorBoundaryのconsole.errorメッセージを日本語化

## Test plan
- [x] 全テスト: 3509件パス