### PR TITLE
目標達成率・在庫消費予測・スケジュール間隔スコアのエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/AdherenceGoalTracking.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceGoalTracking.edge.test.ts
@@ -1,0 +1,51 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Goal Tracking Edge Cases', () => {
+  describe('getGoalProgress', () => {
+    it('負の現在値は0', () => {
+      expect(AdherenceTrendEntity.getGoalProgress(-10, 100)).toBe(0);
+    });
+
+    it('負の目標は100', () => {
+      expect(AdherenceTrendEntity.getGoalProgress(50, -10)).toBe(100);
+    });
+
+    it('ちょうど目標達成は100', () => {
+      expect(AdherenceTrendEntity.getGoalProgress(100, 100)).toBe(100);
+    });
+
+    it('小さな目標値', () => {
+      expect(AdherenceTrendEntity.getGoalProgress(1, 2)).toBe(50);
+    });
+
+    it('大きな超過', () => {
+      expect(AdherenceTrendEntity.getGoalProgress(200, 100)).toBe(100);
+    });
+  });
+
+  describe('getGoalProgressLabel', () => {
+    it('99はあと少し', () => {
+      expect(AdherenceTrendEntity.getGoalProgressLabel(99)).toBe('あと少し');
+    });
+
+    it('70はあと少し', () => {
+      expect(AdherenceTrendEntity.getGoalProgressLabel(70)).toBe('あと少し');
+    });
+
+    it('69は半分', () => {
+      expect(AdherenceTrendEntity.getGoalProgressLabel(69)).toBe('半分');
+    });
+
+    it('40は半分', () => {
+      expect(AdherenceTrendEntity.getGoalProgressLabel(40)).toBe('半分');
+    });
+
+    it('39は頑張りましょう', () => {
+      expect(AdherenceTrendEntity.getGoalProgressLabel(39)).toBe('頑張りましょう');
+    });
+
+    it('0は頑張りましょう', () => {
+      expect(AdherenceTrendEntity.getGoalProgressLabel(0)).toBe('頑張りましょう');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleSpacingScore.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleSpacingScore.edge.test.ts
@@ -1,0 +1,50 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Spacing Score Edge Cases', () => {
+  describe('getScheduleSpacingScore', () => {
+    it('2件で均等は100', () => {
+      expect(ScheduleEntity.getScheduleSpacingScore(['08:00', '20:00'])).toBe(100);
+    });
+
+    it('同じ時刻は100', () => {
+      expect(ScheduleEntity.getScheduleSpacingScore(['08:00', '08:00'])).toBe(100);
+    });
+
+    it('4件で均等', () => {
+      const times = ['06:00', '10:00', '14:00', '18:00'];
+      const score = ScheduleEntity.getScheduleSpacingScore(times);
+      expect(score).toBe(100);
+    });
+
+    it('2件のみ', () => {
+      const score = ScheduleEntity.getScheduleSpacingScore(['08:00', '20:00']);
+      expect(score).toBe(100);
+    });
+  });
+
+  describe('getSpacingLabel', () => {
+    it('80は均等', () => {
+      expect(ScheduleEntity.getSpacingLabel(80)).toBe('均等');
+    });
+
+    it('79はやや偏り', () => {
+      expect(ScheduleEntity.getSpacingLabel(79)).toBe('やや偏り');
+    });
+
+    it('50はやや偏り', () => {
+      expect(ScheduleEntity.getSpacingLabel(50)).toBe('やや偏り');
+    });
+
+    it('49は偏りあり', () => {
+      expect(ScheduleEntity.getSpacingLabel(49)).toBe('偏りあり');
+    });
+
+    it('0は偏りあり', () => {
+      expect(ScheduleEntity.getSpacingLabel(0)).toBe('偏りあり');
+    });
+
+    it('100は均等', () => {
+      expect(ScheduleEntity.getSpacingLabel(100)).toBe('均等');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockDepletionForecast.edge.test.ts
+++ b/src/__tests__/domain/entities/StockDepletionForecast.edge.test.ts
@@ -1,0 +1,51 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Depletion Forecast Edge Cases', () => {
+  describe('getDepletionDays', () => {
+    it('負の在庫', () => {
+      expect(StockAlertEntity.getDepletionDays(-5, 2)).toBe(-3);
+    });
+
+    it('消費率が負はnull', () => {
+      expect(StockAlertEntity.getDepletionDays(30, -1)).toBeNull();
+    });
+
+    it('大量在庫', () => {
+      expect(StockAlertEntity.getDepletionDays(1000, 10)).toBe(100);
+    });
+
+    it('小数の消費率', () => {
+      expect(StockAlertEntity.getDepletionDays(10, 3)).toBe(3);
+    });
+  });
+
+  describe('getDepletionUrgencyLabel', () => {
+    it('0日は緊急', () => {
+      expect(StockAlertEntity.getDepletionUrgencyLabel(0)).toBe('緊急');
+    });
+
+    it('3日は緊急', () => {
+      expect(StockAlertEntity.getDepletionUrgencyLabel(3)).toBe('緊急');
+    });
+
+    it('4日は注意', () => {
+      expect(StockAlertEntity.getDepletionUrgencyLabel(4)).toBe('注意');
+    });
+
+    it('7日は注意', () => {
+      expect(StockAlertEntity.getDepletionUrgencyLabel(7)).toBe('注意');
+    });
+
+    it('8日はやや余裕', () => {
+      expect(StockAlertEntity.getDepletionUrgencyLabel(8)).toBe('やや余裕');
+    });
+
+    it('14日はやや余裕', () => {
+      expect(StockAlertEntity.getDepletionUrgencyLabel(14)).toBe('やや余裕');
+    });
+
+    it('15日は余裕あり', () => {
+      expect(StockAlertEntity.getDepletionUrgencyLabel(15)).toBe('余裕あり');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -211,7 +211,7 @@ export class AdherenceTrendEntity {
    */
   static getGoalProgress(current: number, goal: number): number {
     if (goal <= 0) return 100;
-    return Math.min(100, Math.round((current / goal) * 100));
+    return Math.max(0, Math.min(100, Math.round((current / goal) * 100)));
   }
 
   /**


### PR DESCRIPTION
## Summary
- getGoalProgressの負値入力で0を返すようMath.max(0,...)を追加
- getDepletionDaysの境界値テスト11件追加
- getScheduleSpacingScoreの均等間隔テスト10件追加
- getGoalProgressの境界値テスト11件追加

## Test plan
- [x] 32件のエッジケーステストが全てパス
- [x] 全3565件のテストがパス

closes #712