### PR TITLE
updateScheduleSchemaのscheduledTimeバリデーション強化

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -79,7 +79,7 @@ export const createScheduleSchema = z.object({
 });
 
 export const updateScheduleSchema = z.object({
-  scheduledTime: z.string().max(10).optional(),
+  scheduledTime: z.string().trim().min(1, '予定時刻は必須です').max(10).optional(),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),


### PR DESCRIPTION
## Summary
- updateScheduleSchemaのscheduledTimeに.trim().min(1)を追加
- createScheduleSchemaと同様のバリデーションを適用
- 空文字列の保存を防止

## Test plan
- [x] 全3565件のテストがパス

closes #714