### PR TITLE
曜日別遵守パターン・体調変動性・パフォーマンスグレード機能追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionVolatility.test.ts
+++ b/src/__tests__/domain/entities/ConditionVolatility.test.ts
@@ -1,0 +1,65 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Volatility', () => {
+  describe('getConditionVolatility', () => {
+    it('安定した体調は低いスコア', () => {
+      const conditions = [3, 3, 3, 3, 3];
+      const score = HealthLogEntity.getConditionVolatility(conditions);
+      expect(score).toBe(0);
+    });
+
+    it('変動が大きいと高いスコア', () => {
+      const conditions = [1, 5, 1, 5, 1];
+      const score = HealthLogEntity.getConditionVolatility(conditions);
+      expect(score).toBeGreaterThan(50);
+    });
+
+    it('1件のみは0', () => {
+      expect(HealthLogEntity.getConditionVolatility([3])).toBe(0);
+    });
+
+    it('空配列は0', () => {
+      expect(HealthLogEntity.getConditionVolatility([])).toBe(0);
+    });
+
+    it('徐々に変化する場合は中程度', () => {
+      const conditions = [1, 2, 3, 4, 5];
+      const score = HealthLogEntity.getConditionVolatility(conditions);
+      expect(score).toBeGreaterThan(0);
+      expect(score).toBeLessThan(80);
+    });
+
+    it('スコアは0-100の範囲', () => {
+      const conditions = [1, 5, 1, 5, 1, 5];
+      const score = HealthLogEntity.getConditionVolatility(conditions);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('getVolatilityLabel', () => {
+    it('0は安定', () => {
+      expect(HealthLogEntity.getVolatilityLabel(0)).toBe('安定');
+    });
+
+    it('30は安定', () => {
+      expect(HealthLogEntity.getVolatilityLabel(30)).toBe('安定');
+    });
+
+    it('31はやや変動', () => {
+      expect(HealthLogEntity.getVolatilityLabel(31)).toBe('やや変動');
+    });
+
+    it('60はやや変動', () => {
+      expect(HealthLogEntity.getVolatilityLabel(60)).toBe('やや変動');
+    });
+
+    it('61は不安定', () => {
+      expect(HealthLogEntity.getVolatilityLabel(61)).toBe('不安定');
+    });
+
+    it('100は不安定', () => {
+      expect(HealthLogEntity.getVolatilityLabel(100)).toBe('不安定');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/PerformanceGrade.test.ts
+++ b/src/__tests__/domain/entities/PerformanceGrade.test.ts
@@ -1,0 +1,47 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Performance Grade', () => {
+  describe('getPerformanceGrade', () => {
+    it('高い遵守率と高い一貫性でAグレード', () => {
+      expect(AdherenceTrendEntity.getPerformanceGrade(95, 90)).toBe('A');
+    });
+
+    it('高い遵守率と中程度の一貫性でBグレード', () => {
+      expect(AdherenceTrendEntity.getPerformanceGrade(85, 70)).toBe('B');
+    });
+
+    it('中程度の遵守率でCグレード', () => {
+      expect(AdherenceTrendEntity.getPerformanceGrade(50, 50)).toBe('C');
+    });
+
+    it('低い遵守率でDグレード', () => {
+      expect(AdherenceTrendEntity.getPerformanceGrade(20, 20)).toBe('D');
+    });
+
+    it('100/100はA', () => {
+      expect(AdherenceTrendEntity.getPerformanceGrade(100, 100)).toBe('A');
+    });
+
+    it('0/0はD', () => {
+      expect(AdherenceTrendEntity.getPerformanceGrade(0, 0)).toBe('D');
+    });
+  });
+
+  describe('getPerformanceGradeLabel', () => {
+    it('Aは優秀', () => {
+      expect(AdherenceTrendEntity.getPerformanceGradeLabel('A')).toBe('優秀');
+    });
+
+    it('Bは良好', () => {
+      expect(AdherenceTrendEntity.getPerformanceGradeLabel('B')).toBe('良好');
+    });
+
+    it('Cは要改善', () => {
+      expect(AdherenceTrendEntity.getPerformanceGradeLabel('C')).toBe('要改善');
+    });
+
+    it('Dは要注意', () => {
+      expect(AdherenceTrendEntity.getPerformanceGradeLabel('D')).toBe('要注意');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/WeekdayAdherencePattern.test.ts
+++ b/src/__tests__/domain/entities/WeekdayAdherencePattern.test.ts
@@ -1,0 +1,100 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Weekday Adherence Pattern', () => {
+  describe('getWeekdayAdherencePattern', () => {
+    it('曜日別の遵守率を算出する', () => {
+      // 月水金に服薬記録あり（7日間）
+      const records = [
+        { dayOfWeek: 1 }, // 月
+        { dayOfWeek: 3 }, // 水
+        { dayOfWeek: 5 }, // 金
+      ];
+      const result = MedicationRecordEntity.getWeekdayAdherencePattern(records, 7);
+      expect(result).toHaveLength(7);
+      expect(result[1].count).toBe(1); // 月曜
+      expect(result[0].count).toBe(0); // 日曜
+    });
+
+    it('空の記録は全て0', () => {
+      const result = MedicationRecordEntity.getWeekdayAdherencePattern([], 7);
+      expect(result).toHaveLength(7);
+      result.forEach((day) => {
+        expect(day.count).toBe(0);
+      });
+    });
+
+    it('同じ曜日に複数記録', () => {
+      const records = [
+        { dayOfWeek: 1 },
+        { dayOfWeek: 1 },
+        { dayOfWeek: 1 },
+      ];
+      const result = MedicationRecordEntity.getWeekdayAdherencePattern(records, 7);
+      expect(result[1].count).toBe(3);
+    });
+
+    it('全曜日に記録あり', () => {
+      const records = [
+        { dayOfWeek: 0 },
+        { dayOfWeek: 1 },
+        { dayOfWeek: 2 },
+        { dayOfWeek: 3 },
+        { dayOfWeek: 4 },
+        { dayOfWeek: 5 },
+        { dayOfWeek: 6 },
+      ];
+      const result = MedicationRecordEntity.getWeekdayAdherencePattern(records, 7);
+      result.forEach((day) => {
+        expect(day.count).toBe(1);
+      });
+    });
+
+    it('曜日ラベルが正しい', () => {
+      const result = MedicationRecordEntity.getWeekdayAdherencePattern([], 7);
+      expect(result[0].label).toBe('日');
+      expect(result[1].label).toBe('月');
+      expect(result[6].label).toBe('土');
+    });
+  });
+
+  describe('getWeekdayPatternLabel', () => {
+    it('平日優位はラベルを返す', () => {
+      const pattern = [
+        { label: '日', count: 0 },
+        { label: '月', count: 3 },
+        { label: '火', count: 3 },
+        { label: '水', count: 3 },
+        { label: '木', count: 3 },
+        { label: '金', count: 3 },
+        { label: '土', count: 0 },
+      ];
+      expect(MedicationRecordEntity.getWeekdayPatternLabel(pattern)).toBe('平日中心');
+    });
+
+    it('休日優位はラベルを返す', () => {
+      const pattern = [
+        { label: '日', count: 5 },
+        { label: '月', count: 0 },
+        { label: '火', count: 0 },
+        { label: '水', count: 0 },
+        { label: '木', count: 0 },
+        { label: '金', count: 0 },
+        { label: '土', count: 5 },
+      ];
+      expect(MedicationRecordEntity.getWeekdayPatternLabel(pattern)).toBe('休日中心');
+    });
+
+    it('均等はラベルを返す', () => {
+      const pattern = [
+        { label: '日', count: 2 },
+        { label: '月', count: 2 },
+        { label: '火', count: 2 },
+        { label: '水', count: 2 },
+        { label: '木', count: 2 },
+        { label: '金', count: 2 },
+        { label: '土', count: 2 },
+      ];
+      expect(MedicationRecordEntity.getWeekdayPatternLabel(pattern)).toBe('均等');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -223,4 +223,28 @@ export class AdherenceTrendEntity {
     if (progress >= 40) return '半分';
     return '頑張りましょう';
   }
+
+  /**
+   * 遵守率と一貫性スコアからパフォーマンスグレード(A-D)を判定する
+   */
+  static getPerformanceGrade(rate: number, consistency: number): string {
+    const combined = (rate + consistency) / 2;
+    if (combined >= 80) return 'A';
+    if (combined >= 60) return 'B';
+    if (combined >= 40) return 'C';
+    return 'D';
+  }
+
+  /**
+   * パフォーマンスグレードに応じたラベルを返す
+   */
+  static getPerformanceGradeLabel(grade: string): string {
+    const labels: Record<string, string> = {
+      A: '優秀',
+      B: '良好',
+      C: '要改善',
+      D: '要注意',
+    };
+    return labels[grade] ?? '要注意';
+  }
 }

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -724,4 +724,28 @@ export class HealthLogEntity {
     };
     return messages[trend];
   }
+
+  /**
+   * 体調レベル配列から変動性スコア(0-100)を算出する
+   * 隣接日の差分の平均を使用
+   */
+  static getConditionVolatility(conditions: number[]): number {
+    if (conditions.length <= 1) return 0;
+    let totalDiff = 0;
+    for (let i = 1; i < conditions.length; i++) {
+      totalDiff += Math.abs(conditions[i] - conditions[i - 1]);
+    }
+    const avgDiff = totalDiff / (conditions.length - 1);
+    const maxPossibleDiff = 4;
+    return Math.min(100, Math.round((avgDiff / maxPossibleDiff) * 100));
+  }
+
+  /**
+   * 変動性スコアに応じたラベルを返す
+   */
+  static getVolatilityLabel(score: number): string {
+    if (score <= 30) return '安定';
+    if (score <= 60) return 'やや変動';
+    return '不安定';
+  }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -600,4 +600,40 @@ export class MedicationRecordEntity {
     if (count <= 6) return '多め';
     return '非常に多い';
   }
+
+  private static readonly WEEKDAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+  /**
+   * 曜日別の服薬記録パターンを算出する
+   */
+  static getWeekdayAdherencePattern(
+    records: { dayOfWeek: number }[],
+    _totalDays: number,
+  ): { label: string; count: number }[] {
+    const counts = new Array(7).fill(0);
+    for (const record of records) {
+      if (record.dayOfWeek >= 0 && record.dayOfWeek <= 6) {
+        counts[record.dayOfWeek]++;
+      }
+    }
+    return counts.map((count, i) => ({
+      label: MedicationRecordEntity.WEEKDAY_LABELS[i],
+      count,
+    }));
+  }
+
+  /**
+   * 曜日別パターンから平日/休日/均等のラベルを返す
+   */
+  static getWeekdayPatternLabel(pattern: { label: string; count: number }[]): string {
+    if (pattern.length < 7) return '均等';
+    const weekdayTotal = pattern[1].count + pattern[2].count + pattern[3].count + pattern[4].count + pattern[5].count;
+    const weekendTotal = pattern[0].count + pattern[6].count;
+    const total = weekdayTotal + weekendTotal;
+    if (total === 0) return '均等';
+    const weekdayRatio = weekdayTotal / total;
+    if (weekdayRatio > 0.8) return '平日中心';
+    if (weekdayRatio < 0.3) return '休日中心';
+    return '均等';
+  }
 }


### PR DESCRIPTION
## Summary
- MedicationRecordEntityにgetWeekdayAdherencePattern/getWeekdayPatternLabelを追加
- HealthLogEntityにgetConditionVolatility/getVolatilityLabelを追加
- AdherenceTrendEntityにgetPerformanceGrade/getPerformanceGradeLabelを追加

## Test plan
- [x] 30件の新規テストが全てパス
- [x] 全3595件のテストがパス

closes #716