### PR TITLE
体調変動性・パフォーマンスグレードの定数抽出

### DIFF
--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -22,6 +22,10 @@ export interface AdherenceTrend {
 const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
 
 export class AdherenceTrendEntity {
+  private static readonly GRADE_A_THRESHOLD = 80;
+  private static readonly GRADE_B_THRESHOLD = 60;
+  private static readonly GRADE_C_THRESHOLD = 40;
+
   constructor(private readonly trend: AdherenceTrend) {}
 
   get data(): AdherenceTrend {
@@ -229,9 +233,9 @@ export class AdherenceTrendEntity {
    */
   static getPerformanceGrade(rate: number, consistency: number): string {
     const combined = (rate + consistency) / 2;
-    if (combined >= 80) return 'A';
-    if (combined >= 60) return 'B';
-    if (combined >= 40) return 'C';
+    if (combined >= AdherenceTrendEntity.GRADE_A_THRESHOLD) return 'A';
+    if (combined >= AdherenceTrendEntity.GRADE_B_THRESHOLD) return 'B';
+    if (combined >= AdherenceTrendEntity.GRADE_C_THRESHOLD) return 'C';
     return 'D';
   }
 

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -57,6 +57,9 @@ export interface DailyHealthLogGroup {
  * 体調記録のビジネスロジック
  */
 export class HealthLogEntity {
+  private static readonly VOLATILITY_MAX_DIFF = 4;
+  private static readonly VOLATILITY_STABLE_THRESHOLD = 30;
+  private static readonly VOLATILITY_MODERATE_THRESHOLD = 60;
   private static readonly TEMP_HYPOTHERMIA = 35.0;
   private static readonly TEMP_LOW_FEVER = 37.5;
   private static readonly TEMP_FEVER = 38.0;
@@ -736,16 +739,15 @@ export class HealthLogEntity {
       totalDiff += Math.abs(conditions[i] - conditions[i - 1]);
     }
     const avgDiff = totalDiff / (conditions.length - 1);
-    const maxPossibleDiff = 4;
-    return Math.min(100, Math.round((avgDiff / maxPossibleDiff) * 100));
+    return Math.min(100, Math.round((avgDiff / HealthLogEntity.VOLATILITY_MAX_DIFF) * 100));
   }
 
   /**
    * 変動性スコアに応じたラベルを返す
    */
   static getVolatilityLabel(score: number): string {
-    if (score <= 30) return '安定';
-    if (score <= 60) return 'やや変動';
+    if (score <= HealthLogEntity.VOLATILITY_STABLE_THRESHOLD) return '安定';
+    if (score <= HealthLogEntity.VOLATILITY_MODERATE_THRESHOLD) return 'やや変動';
     return '不安定';
   }
 }


### PR DESCRIPTION
## Summary
- HealthLogEntityの変動性スコア算出で使用するマジックナンバーをstatic readonly定数として抽出
- AdherenceTrendEntityのグレード判定閾値をstatic readonly定数として抽出

## Test plan
- [x] 全3595件のテストがパス

closes #718