### PR TITLE
予約時刻のtrim追加とメール認証スキーマのmax長制約追加

### DIFF
--- a/src/app/api/auth/resend-code/route.ts
+++ b/src/app/api/auth/resend-code/route.ts
@@ -7,7 +7,7 @@ import { validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 
 const resendSchema = z.object({
-  email: z.string().trim().toLowerCase().email(),
+  email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email(),
 });
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -6,7 +6,7 @@ import { validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { timingSafeEqual, checkRateLimit } from '@/lib/security';
 
 const verifySchema = z.object({
-  email: z.string().trim().toLowerCase().email(),
+  email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email(),
   code: z.string().length(6),
 });
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -119,7 +119,7 @@ export const createAppointmentSchema = z.object({
   memberId: idField,
   hospitalId: optionalIdField,
   appointmentDate: dateString,
-  appointmentTime: z.string().max(10).optional(),
+  appointmentTime: z.string().trim().max(10).optional(),
   type: z.string().trim().max(100).optional(),
   notes: z.string().trim().max(1000).optional(),
   reminderEnabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- createAppointmentSchemaのappointmentTimeに.trim()を追加しupdateと統一
- resend-codeとverifyルートのemailに.max(254)を追加しDoS対策

## Test plan
- [x] 全3620件のテストがパス

closes #722