### PR TITLE
スケジュール完了連続日数・一括在庫ステータス・相対日付ラベル機能追加

### DIFF
--- a/src/__tests__/domain/entities/BulkStockStatus.test.ts
+++ b/src/__tests__/domain/entities/BulkStockStatus.test.ts
@@ -1,0 +1,51 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Bulk Stock Status', () => {
+  describe('getBulkStockStatus', () => {
+    it('全て余裕ありは安心', () => {
+      const items = [
+        { remainingDays: 30 },
+        { remainingDays: 20 },
+      ];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('安心');
+    });
+
+    it('1つでも緊急がある場合は緊急', () => {
+      const items = [
+        { remainingDays: 30 },
+        { remainingDays: 2 },
+      ];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('緊急');
+    });
+
+    it('注意レベルがある場合は注意', () => {
+      const items = [
+        { remainingDays: 30 },
+        { remainingDays: 5 },
+      ];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('注意');
+    });
+
+    it('空配列はデータなし', () => {
+      expect(StockAlertEntity.getBulkStockStatus([])).toBe('データなし');
+    });
+  });
+
+  describe('getBulkStockLabel', () => {
+    it('緊急は早急に補充が必要です', () => {
+      expect(StockAlertEntity.getBulkStockLabel('緊急')).toBe('早急に補充が必要です');
+    });
+
+    it('注意はそろそろ補充を検討してください', () => {
+      expect(StockAlertEntity.getBulkStockLabel('注意')).toBe('そろそろ補充を検討してください');
+    });
+
+    it('安心は在庫に余裕があります', () => {
+      expect(StockAlertEntity.getBulkStockLabel('安心')).toBe('在庫に余裕があります');
+    });
+
+    it('データなし', () => {
+      expect(StockAlertEntity.getBulkStockLabel('データなし')).toBe('在庫データがありません');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RelativeDateLabel.test.ts
+++ b/src/__tests__/domain/entities/RelativeDateLabel.test.ts
@@ -1,0 +1,60 @@
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper - Relative Date Label', () => {
+  describe('getRelativeDateLabel', () => {
+    it('今日は今日', () => {
+      const today = new Date(2026, 2, 6);
+      expect(DateRangeHelper.getRelativeDateLabel(today, today)).toBe('今日');
+    });
+
+    it('1日前は昨日', () => {
+      const today = new Date(2026, 2, 6);
+      const yesterday = new Date(2026, 2, 5);
+      expect(DateRangeHelper.getRelativeDateLabel(yesterday, today)).toBe('昨日');
+    });
+
+    it('1日後は明日', () => {
+      const today = new Date(2026, 2, 6);
+      const tomorrow = new Date(2026, 2, 7);
+      expect(DateRangeHelper.getRelativeDateLabel(tomorrow, today)).toBe('明日');
+    });
+
+    it('2日前はN日前', () => {
+      const today = new Date(2026, 2, 6);
+      const twoDaysAgo = new Date(2026, 2, 4);
+      expect(DateRangeHelper.getRelativeDateLabel(twoDaysAgo, today)).toBe('2日前');
+    });
+
+    it('3日後はN日後', () => {
+      const today = new Date(2026, 2, 6);
+      const threeDaysLater = new Date(2026, 2, 9);
+      expect(DateRangeHelper.getRelativeDateLabel(threeDaysLater, today)).toBe('3日後');
+    });
+
+    it('7日前は1週間前', () => {
+      const today = new Date(2026, 2, 6);
+      const weekAgo = new Date(2026, 1, 27);
+      expect(DateRangeHelper.getRelativeDateLabel(weekAgo, today)).toBe('1週間前');
+    });
+  });
+
+  describe('isConsecutiveDates', () => {
+    it('連続する日付はtrue', () => {
+      const dates = ['2026-03-04', '2026-03-05', '2026-03-06'];
+      expect(DateRangeHelper.isConsecutiveDates(dates)).toBe(true);
+    });
+
+    it('飛びがある場合はfalse', () => {
+      const dates = ['2026-03-04', '2026-03-06'];
+      expect(DateRangeHelper.isConsecutiveDates(dates)).toBe(false);
+    });
+
+    it('空配列はtrue', () => {
+      expect(DateRangeHelper.isConsecutiveDates([])).toBe(true);
+    });
+
+    it('1件はtrue', () => {
+      expect(DateRangeHelper.isConsecutiveDates(['2026-03-06'])).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleCompletionStreak.test.ts
+++ b/src/__tests__/domain/entities/ScheduleCompletionStreak.test.ts
@@ -1,0 +1,51 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Completion Streak', () => {
+  describe('getScheduleCompletionStreak', () => {
+    it('全て完了なら全日数', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([true, true, true])).toBe(3);
+    });
+
+    it('最後が未完了なら0', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([true, true, false])).toBe(0);
+    });
+
+    it('途中から連続完了', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([false, true, true])).toBe(2);
+    });
+
+    it('空配列は0', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([])).toBe(0);
+    });
+
+    it('1件のみ完了', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([true])).toBe(1);
+    });
+
+    it('1件のみ未完了', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([false])).toBe(0);
+    });
+
+    it('交互パターン', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([true, false, true])).toBe(1);
+    });
+  });
+
+  describe('getCompletionStreakLabel', () => {
+    it('0日は記録なし', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(0)).toBe('記録なし');
+    });
+
+    it('7日は1週間連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(7)).toBe('1週間連続');
+    });
+
+    it('30日は1ヶ月連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(30)).toBe('1ヶ月連続');
+    });
+
+    it('5日はN日連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(5)).toBe('5日連続');
+    });
+  });
+});

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -264,4 +264,33 @@ export class DateRangeHelper {
   static getBusinessDayLabel(date: Date): string {
     return DateRangeHelper.isWeekend(date) ? '休日' : '営業日';
   }
+
+  /**
+   * 相対日付ラベルを返す（今日、昨日、明日、N日前、N日後、N週間前）
+   */
+  static getRelativeDateLabel(date: Date, today: Date): string {
+    const diff = DateRangeHelper.diffDays(today, date);
+    if (diff === 0) return '今日';
+    if (diff === 1) return '明日';
+    if (diff === -1) return '昨日';
+    if (diff < 0 && diff % 7 === 0) return `${Math.abs(diff) / 7}週間前`;
+    if (diff < 0) return `${Math.abs(diff)}日前`;
+    if (diff > 0 && diff % 7 === 0) return `${diff / 7}週間後`;
+    return `${diff}日後`;
+  }
+
+  /**
+   * 日付文字列配列が全て連続しているかチェックする
+   */
+  static isConsecutiveDates(dateKeys: string[]): boolean {
+    if (dateKeys.length <= 1) return true;
+    for (let i = 1; i < dateKeys.length; i++) {
+      const prev = new Date(dateKeys[i - 1]);
+      const curr = new Date(dateKeys[i]);
+      const diffMs = curr.getTime() - prev.getTime();
+      const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+      if (diffDays !== 1) return false;
+    }
+    return true;
+  }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -747,4 +747,29 @@ export class ScheduleEntity {
     if (score >= 50) return 'やや偏り';
     return '偏りあり';
   }
+
+  /**
+   * 完了履歴から末尾の連続完了日数を算出する
+   */
+  static getScheduleCompletionStreak(completionHistory: boolean[]): number {
+    let streak = 0;
+    for (let i = completionHistory.length - 1; i >= 0; i--) {
+      if (completionHistory[i]) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  /**
+   * 連続完了日数に応じたラベルを返す
+   */
+  static getCompletionStreakLabel(days: number): string {
+    if (days === 0) return '記録なし';
+    if (days >= 30) return '1ヶ月連続';
+    if (days >= 7 && days % 7 === 0) return `${days / 7}週間連続`;
+    return `${days}日連続`;
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -385,4 +385,29 @@ export class StockAlertEntity {
     if (days <= StockAlertEntity.DEPLETION_COMFORT_THRESHOLD) return 'やや余裕';
     return '余裕あり';
   }
+
+  /**
+   * 複数薬の残日数から一括在庫ステータスを判定する
+   */
+  static getBulkStockStatus(items: { remainingDays: number }[]): string {
+    if (items.length === 0) return 'データなし';
+    const hasUrgent = items.some((i) => i.remainingDays <= StockAlertEntity.CRITICAL_DAYS_THRESHOLD);
+    if (hasUrgent) return '緊急';
+    const hasWarning = items.some((i) => i.remainingDays <= StockAlertEntity.WARNING_DAYS_THRESHOLD);
+    if (hasWarning) return '注意';
+    return '安心';
+  }
+
+  /**
+   * 一括在庫ステータスに応じたメッセージを返す
+   */
+  static getBulkStockLabel(status: string): string {
+    const labels: Record<string, string> = {
+      '緊急': '早急に補充が必要です',
+      '注意': 'そろそろ補充を検討してください',
+      '安心': '在庫に余裕があります',
+      'データなし': '在庫データがありません',
+    };
+    return labels[status] ?? '在庫データがありません';
+  }
 }


### PR DESCRIPTION
## Summary
- ScheduleEntityに完了連続日数の算出とラベル生成メソッドを追加
- StockAlertEntityに複数薬の一括在庫ステータス判定メソッドを追加
- DateRangeHelperに相対日付ラベルと連続日チェックメソッドを追加

## Test plan
- [x] 29件の新規テストが全てパス
- [x] 全3649件のテストがパス

closes #724