### PR TITLE
連続日数ラベルと相対日付の定数抽出リファクタリング

### DIFF
--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -95,6 +95,8 @@ export class DateRangeHelper {
    * 曜日の日本語ラベルを返す
    */
   private static readonly DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+  private static readonly DAYS_IN_WEEK = 7;
+  private static readonly MS_PER_DAY = 1000 * 60 * 60 * 24;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -273,9 +275,9 @@ export class DateRangeHelper {
     if (diff === 0) return '今日';
     if (diff === 1) return '明日';
     if (diff === -1) return '昨日';
-    if (diff < 0 && diff % 7 === 0) return `${Math.abs(diff) / 7}週間前`;
+    if (diff < 0 && diff % DateRangeHelper.DAYS_IN_WEEK === 0) return `${Math.abs(diff) / DateRangeHelper.DAYS_IN_WEEK}週間前`;
     if (diff < 0) return `${Math.abs(diff)}日前`;
-    if (diff > 0 && diff % 7 === 0) return `${diff / 7}週間後`;
+    if (diff > 0 && diff % DateRangeHelper.DAYS_IN_WEEK === 0) return `${diff / DateRangeHelper.DAYS_IN_WEEK}週間後`;
     return `${diff}日後`;
   }
 
@@ -288,7 +290,7 @@ export class DateRangeHelper {
       const prev = new Date(dateKeys[i - 1]);
       const curr = new Date(dateKeys[i]);
       const diffMs = curr.getTime() - prev.getTime();
-      const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+      const diffDays = Math.round(diffMs / DateRangeHelper.MS_PER_DAY);
       if (diffDays !== 1) return false;
     }
     return true;

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -39,6 +39,8 @@ export class ScheduleEntity {
   private static readonly PROXIMITY_IMMINENT_MINUTES = 15;
   private static readonly PROXIMITY_SOON_MINUTES = 30;
   private static readonly PROXIMITY_NEAR_MINUTES = 60;
+  private static readonly STREAK_MONTH_THRESHOLD = 30;
+  private static readonly STREAK_WEEK_THRESHOLD = 7;
 
   constructor(private readonly schedule: Schedule) {}
 
@@ -768,8 +770,8 @@ export class ScheduleEntity {
    */
   static getCompletionStreakLabel(days: number): string {
     if (days === 0) return '記録なし';
-    if (days >= 30) return '1ヶ月連続';
-    if (days >= 7 && days % 7 === 0) return `${days / 7}週間連続`;
+    if (days >= ScheduleEntity.STREAK_MONTH_THRESHOLD) return '1ヶ月連続';
+    if (days >= ScheduleEntity.STREAK_WEEK_THRESHOLD && days % ScheduleEntity.STREAK_WEEK_THRESHOLD === 0) return `${days / ScheduleEntity.STREAK_WEEK_THRESHOLD}週間連続`;
     return `${days}日連続`;
   }
 }


### PR DESCRIPTION
## Summary
- ScheduleEntityの連続日数ラベル閾値(30日/7日)をstatic readonly定数に抽出
- DateRangeHelperの週日数(7)とミリ秒定数をstatic readonly定数に抽出

## Test plan
- [x] 全3649件のテストがパス

closes #726