### PR TITLE
完了連続日数・一括在庫ステータス・相対日付ラベルのエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/BulkStockStatus.edge.test.ts
+++ b/src/__tests__/domain/entities/BulkStockStatus.edge.test.ts
@@ -1,0 +1,45 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Bulk Stock Status Edge Cases', () => {
+  describe('getBulkStockStatus', () => {
+    it('残り3日ちょうどは緊急', () => {
+      const items = [{ remainingDays: 3 }];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('緊急');
+    });
+
+    it('残り4日は注意', () => {
+      const items = [{ remainingDays: 4 }];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('注意');
+    });
+
+    it('残り7日ちょうどは注意', () => {
+      const items = [{ remainingDays: 7 }];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('注意');
+    });
+
+    it('残り8日は安心', () => {
+      const items = [{ remainingDays: 8 }];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('安心');
+    });
+
+    it('複数薬で最小が緊急', () => {
+      const items = [
+        { remainingDays: 100 },
+        { remainingDays: 50 },
+        { remainingDays: 1 },
+      ];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('緊急');
+    });
+
+    it('残り0日は緊急', () => {
+      const items = [{ remainingDays: 0 }];
+      expect(StockAlertEntity.getBulkStockStatus(items)).toBe('緊急');
+    });
+  });
+
+  describe('getBulkStockLabel', () => {
+    it('不明なステータスはデータなし扱い', () => {
+      expect(StockAlertEntity.getBulkStockLabel('不明')).toBe('在庫データがありません');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RelativeDateLabel.edge.test.ts
+++ b/src/__tests__/domain/entities/RelativeDateLabel.edge.test.ts
@@ -1,0 +1,62 @@
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper - Relative Date Label Edge Cases', () => {
+  describe('getRelativeDateLabel', () => {
+    it('14日前は2週間前', () => {
+      const today = new Date(2026, 2, 6);
+      const twoWeeksAgo = new Date(2026, 1, 20);
+      expect(DateRangeHelper.getRelativeDateLabel(twoWeeksAgo, today)).toBe('2週間前');
+    });
+
+    it('14日後は2週間後', () => {
+      const today = new Date(2026, 2, 6);
+      const twoWeeksLater = new Date(2026, 2, 20);
+      expect(DateRangeHelper.getRelativeDateLabel(twoWeeksLater, today)).toBe('2週間後');
+    });
+
+    it('6日前は6日前', () => {
+      const today = new Date(2026, 2, 6);
+      const sixDaysAgo = new Date(2026, 1, 28);
+      expect(DateRangeHelper.getRelativeDateLabel(sixDaysAgo, today)).toBe('6日前');
+    });
+
+    it('8日後は8日後', () => {
+      const today = new Date(2026, 2, 6);
+      const eightDaysLater = new Date(2026, 2, 14);
+      expect(DateRangeHelper.getRelativeDateLabel(eightDaysLater, today)).toBe('8日後');
+    });
+  });
+
+  describe('isConsecutiveDates', () => {
+    it('逆順は連続でない', () => {
+      const dates = ['2026-03-06', '2026-03-05'];
+      expect(DateRangeHelper.isConsecutiveDates(dates)).toBe(false);
+    });
+
+    it('同じ日付は連続でない', () => {
+      const dates = ['2026-03-06', '2026-03-06'];
+      expect(DateRangeHelper.isConsecutiveDates(dates)).toBe(false);
+    });
+
+    it('2日飛びは連続でない', () => {
+      const dates = ['2026-03-04', '2026-03-06'];
+      expect(DateRangeHelper.isConsecutiveDates(dates)).toBe(false);
+    });
+
+    it('月をまたぐ連続日付', () => {
+      const dates = ['2026-02-28', '2026-03-01'];
+      expect(DateRangeHelper.isConsecutiveDates(dates)).toBe(true);
+    });
+
+    it('長い連続日付', () => {
+      const dates = Array.from({ length: 10 }, (_, i) => {
+        const d = new Date(2026, 2, 1 + i);
+        const y = d.getFullYear();
+        const m = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${y}-${m}-${day}`;
+      });
+      expect(DateRangeHelper.isConsecutiveDates(dates)).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleCompletionStreak.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleCompletionStreak.edge.test.ts
@@ -1,0 +1,44 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Completion Streak Edge Cases', () => {
+  describe('getScheduleCompletionStreak', () => {
+    it('全てfalseは0', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([false, false, false])).toBe(0);
+    });
+
+    it('大量データ100件連続true', () => {
+      const data = Array.from({ length: 100 }, () => true);
+      expect(ScheduleEntity.getScheduleCompletionStreak(data)).toBe(100);
+    });
+
+    it('最後の1件のみtrue', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([false, false, true])).toBe(1);
+    });
+
+    it('最初の1件のみtrue', () => {
+      expect(ScheduleEntity.getScheduleCompletionStreak([true, false, false])).toBe(0);
+    });
+  });
+
+  describe('getCompletionStreakLabel', () => {
+    it('14日は2週間連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(14)).toBe('2週間連続');
+    });
+
+    it('21日は3週間連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(21)).toBe('3週間連続');
+    });
+
+    it('29日は29日連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(29)).toBe('29日連続');
+    });
+
+    it('31日は1ヶ月連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(31)).toBe('1ヶ月連続');
+    });
+
+    it('1日は1日連続', () => {
+      expect(ScheduleEntity.getCompletionStreakLabel(1)).toBe('1日連続');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getScheduleCompletionStreakの全false・大量データテスト追加
- getBulkStockStatusの境界値(3/4/7/8日)テスト追加
- isConsecutiveDatesの月またぎ・逆順テスト追加

## Test plan
- [x] 25件のエッジケーステストが全てパス
- [x] 全3674件のテストがパス

closes #728