### PR TITLE
createScheduleSchemaのscheduledTimeにtrim追加

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -72,7 +72,7 @@ const dayOfWeekEnum = z.enum(['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']);
 export const createScheduleSchema = z.object({
   medicationId: idField,
   memberId: idField,
-  scheduledTime: z.string().min(1, '予定時刻は必須です').max(10),
+  scheduledTime: z.string().trim().min(1, '予定時刻は必須です').max(10),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),


### PR DESCRIPTION
## Summary
- createScheduleSchemaのscheduledTimeに.trim()を追加
- updateScheduleSchemaとの整合性を確保

## Test plan
- [x] 全3674件のテストがパス

closes #730