### PR TITLE
加重平均・予約間隔分析・症状多様性スコア機能追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentGapAnalysis.test.ts
+++ b/src/__tests__/domain/entities/AppointmentGapAnalysis.test.ts
@@ -1,0 +1,48 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Gap Analysis', () => {
+  describe('getAppointmentGapAnalysis', () => {
+    it('均等な間隔', () => {
+      const intervals = [30, 30, 30];
+      const result = AppointmentEntity.getAppointmentGapAnalysis(intervals);
+      expect(result.maxGap).toBe(30);
+      expect(result.minGap).toBe(30);
+      expect(result.averageGap).toBe(30);
+    });
+
+    it('不均等な間隔', () => {
+      const intervals = [10, 50, 20];
+      const result = AppointmentEntity.getAppointmentGapAnalysis(intervals);
+      expect(result.maxGap).toBe(50);
+      expect(result.minGap).toBe(10);
+    });
+
+    it('空配列', () => {
+      const result = AppointmentEntity.getAppointmentGapAnalysis([]);
+      expect(result.maxGap).toBe(0);
+      expect(result.minGap).toBe(0);
+      expect(result.averageGap).toBe(0);
+    });
+
+    it('1件のみ', () => {
+      const result = AppointmentEntity.getAppointmentGapAnalysis([14]);
+      expect(result.maxGap).toBe(14);
+      expect(result.minGap).toBe(14);
+      expect(result.averageGap).toBe(14);
+    });
+  });
+
+  describe('getGapAnalysisLabel', () => {
+    it('最大と最小の差が小さいと規則的', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(30, 28)).toBe('規則的');
+    });
+
+    it('差が中程度はやや不規則', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(40, 20)).toBe('やや不規則');
+    });
+
+    it('差が大きいと不規則', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(60, 10)).toBe('不規則');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/SymptomDiversity.test.ts
+++ b/src/__tests__/domain/entities/SymptomDiversity.test.ts
@@ -1,0 +1,46 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Symptom Diversity', () => {
+  describe('getSymptomDiversity', () => {
+    it('多種類の症状は高スコア', () => {
+      const symptoms = ['headache', 'fever', 'cough', 'fatigue', 'nausea'];
+      const score = HealthLogEntity.getSymptomDiversity(symptoms, 10);
+      expect(score).toBeGreaterThan(30);
+    });
+
+    it('同じ症状のみは低スコア', () => {
+      const symptoms = ['headache', 'headache', 'headache'];
+      const score = HealthLogEntity.getSymptomDiversity(symptoms, 10);
+      expect(score).toBeLessThanOrEqual(10);
+    });
+
+    it('空配列は0', () => {
+      expect(HealthLogEntity.getSymptomDiversity([], 10)).toBe(0);
+    });
+
+    it('スコアは0-100の範囲', () => {
+      const symptoms = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+      const score = HealthLogEntity.getSymptomDiversity(symptoms, 10);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('getSymptomDiversityLabel', () => {
+    it('70以上は多様', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(70)).toBe('多様');
+    });
+
+    it('30以上は中程度', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(30)).toBe('中程度');
+    });
+
+    it('30未満は限定的', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(29)).toBe('限定的');
+    });
+
+    it('0は限定的', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(0)).toBe('限定的');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/WeightedAverage.test.ts
+++ b/src/__tests__/domain/entities/WeightedAverage.test.ts
@@ -1,0 +1,51 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Weighted Average', () => {
+  describe('getWeightedAverage', () => {
+    it('均等な重みは通常の平均と同じ', () => {
+      const values = [10, 20, 30];
+      const weights = [1, 1, 1];
+      expect(MathHelper.getWeightedAverage(values, weights)).toBe(20);
+    });
+
+    it('重みが異なる場合', () => {
+      const values = [10, 20];
+      const weights = [3, 1];
+      expect(MathHelper.getWeightedAverage(values, weights)).toBe(12.5);
+    });
+
+    it('空配列は0', () => {
+      expect(MathHelper.getWeightedAverage([], [])).toBe(0);
+    });
+
+    it('重みが全て0は0', () => {
+      expect(MathHelper.getWeightedAverage([10, 20], [0, 0])).toBe(0);
+    });
+
+    it('1件のみ', () => {
+      expect(MathHelper.getWeightedAverage([50], [1])).toBe(50);
+    });
+
+    it('配列長が異なる場合は短い方に合わせる', () => {
+      expect(MathHelper.getWeightedAverage([10, 20, 30], [1, 1])).toBe(15);
+    });
+  });
+
+  describe('getWeightedAverageLabel', () => {
+    it('90以上は非常に高い', () => {
+      expect(MathHelper.getWeightedAverageLabel(90)).toBe('非常に高い');
+    });
+
+    it('70以上は高い', () => {
+      expect(MathHelper.getWeightedAverageLabel(70)).toBe('高い');
+    });
+
+    it('40以上は普通', () => {
+      expect(MathHelper.getWeightedAverageLabel(40)).toBe('普通');
+    });
+
+    it('40未満は低い', () => {
+      expect(MathHelper.getWeightedAverageLabel(39)).toBe('低い');
+    });
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -457,4 +457,32 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.REGULARITY_MEDIUM_THRESHOLD) return 'やや不規則';
     return '不規則';
   }
+
+  /**
+   * 予約間隔の最大/最小/平均を算出する
+   */
+  static getAppointmentGapAnalysis(intervals: number[]): {
+    maxGap: number;
+    minGap: number;
+    averageGap: number;
+  } {
+    if (intervals.length === 0) return { maxGap: 0, minGap: 0, averageGap: 0 };
+    const maxGap = Math.max(...intervals);
+    const minGap = Math.min(...intervals);
+    const averageGap = Math.round(intervals.reduce((a, b) => a + b, 0) / intervals.length);
+    return { maxGap, minGap, averageGap };
+  }
+
+  private static readonly GAP_REGULAR_THRESHOLD = 7;
+  private static readonly GAP_IRREGULAR_THRESHOLD = 30;
+
+  /**
+   * 最大/最小間隔の差からラベルを返す
+   */
+  static getGapAnalysisLabel(maxGap: number, minGap: number): string {
+    const diff = maxGap - minGap;
+    if (diff <= AppointmentEntity.GAP_REGULAR_THRESHOLD) return '規則的';
+    if (diff <= AppointmentEntity.GAP_IRREGULAR_THRESHOLD) return 'やや不規則';
+    return '不規則';
+  }
 }

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -750,4 +750,22 @@ export class HealthLogEntity {
     if (score <= HealthLogEntity.VOLATILITY_MODERATE_THRESHOLD) return 'やや変動';
     return '不安定';
   }
+
+  /**
+   * 症状リストからユニーク症状数に基づく多様性スコア(0-100)を算出する
+   */
+  static getSymptomDiversity(symptoms: string[], totalKnownSymptoms: number): number {
+    if (symptoms.length === 0 || totalKnownSymptoms <= 0) return 0;
+    const unique = new Set(symptoms).size;
+    return Math.min(100, Math.round((unique / totalKnownSymptoms) * 100));
+  }
+
+  /**
+   * 症状多様性スコアに応じたラベルを返す
+   */
+  static getSymptomDiversityLabel(score: number): string {
+    if (score >= 70) return '多様';
+    if (score >= 30) return '中程度';
+    return '限定的';
+  }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -152,4 +152,30 @@ export class MathHelper {
       upper: q3 + 1.5 * iqr,
     };
   }
+
+  /**
+   * 加重平均を算出する
+   */
+  static getWeightedAverage(values: number[], weights: number[]): number {
+    const len = Math.min(values.length, weights.length);
+    if (len === 0) return 0;
+    let weightedSum = 0;
+    let totalWeight = 0;
+    for (let i = 0; i < len; i++) {
+      weightedSum += values[i] * weights[i];
+      totalWeight += weights[i];
+    }
+    if (totalWeight === 0) return 0;
+    return weightedSum / totalWeight;
+  }
+
+  /**
+   * 加重平均値に応じたラベルを返す
+   */
+  static getWeightedAverageLabel(value: number): string {
+    if (value >= 90) return '非常に高い';
+    if (value >= 70) return '高い';
+    if (value >= 40) return '普通';
+    return '低い';
+  }
 }


### PR DESCRIPTION
## Summary
- MathHelperに加重平均算出とラベル生成メソッドを追加
- AppointmentEntityに予約間隔の最大/最小/平均分析メソッドを追加
- HealthLogEntityにユニーク症状数ベースの多様性スコアメソッドを追加

## Test plan
- [x] 25件の新規テストが全てパス
- [x] 全3699件のテストがパス

closes #732