### PR TITLE
加重平均・症状多様性の閾値定数抽出

### DIFF
--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -60,6 +60,8 @@ export class HealthLogEntity {
   private static readonly VOLATILITY_MAX_DIFF = 4;
   private static readonly VOLATILITY_STABLE_THRESHOLD = 30;
   private static readonly VOLATILITY_MODERATE_THRESHOLD = 60;
+  private static readonly DIVERSITY_HIGH_THRESHOLD = 70;
+  private static readonly DIVERSITY_MEDIUM_THRESHOLD = 30;
   private static readonly TEMP_HYPOTHERMIA = 35.0;
   private static readonly TEMP_LOW_FEVER = 37.5;
   private static readonly TEMP_FEVER = 38.0;
@@ -764,8 +766,8 @@ export class HealthLogEntity {
    * 症状多様性スコアに応じたラベルを返す
    */
   static getSymptomDiversityLabel(score: number): string {
-    if (score >= 70) return '多様';
-    if (score >= 30) return '中程度';
+    if (score >= HealthLogEntity.DIVERSITY_HIGH_THRESHOLD) return '多様';
+    if (score >= HealthLogEntity.DIVERSITY_MEDIUM_THRESHOLD) return '中程度';
     return '限定的';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -2,6 +2,10 @@
  * 数値計算ヘルパー
  */
 export class MathHelper {
+  private static readonly WEIGHTED_AVG_VERY_HIGH_THRESHOLD = 90;
+  private static readonly WEIGHTED_AVG_HIGH_THRESHOLD = 70;
+  private static readonly WEIGHTED_AVG_NORMAL_THRESHOLD = 40;
+
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -173,9 +177,9 @@ export class MathHelper {
    * 加重平均値に応じたラベルを返す
    */
   static getWeightedAverageLabel(value: number): string {
-    if (value >= 90) return '非常に高い';
-    if (value >= 70) return '高い';
-    if (value >= 40) return '普通';
+    if (value >= MathHelper.WEIGHTED_AVG_VERY_HIGH_THRESHOLD) return '非常に高い';
+    if (value >= MathHelper.WEIGHTED_AVG_HIGH_THRESHOLD) return '高い';
+    if (value >= MathHelper.WEIGHTED_AVG_NORMAL_THRESHOLD) return '普通';
     return '低い';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelperの加重平均ラベル閾値(90/70/40)をstatic readonly定数に抽出
- HealthLogEntityの症状多様性ラベル閾値(70/30)をstatic readonly定数に抽出

## Test plan
- [x] 全3699件のテストがパス

closes #734