### PR TITLE
加重平均・予約間隔分析・症状多様性のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/AppointmentGapAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentGapAnalysis.edge.test.ts
@@ -1,0 +1,46 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Gap Analysis Edge Cases', () => {
+  describe('getAppointmentGapAnalysis', () => {
+    it('全て同じ間隔', () => {
+      const result = AppointmentEntity.getAppointmentGapAnalysis([14, 14, 14]);
+      expect(result.maxGap).toBe(14);
+      expect(result.minGap).toBe(14);
+      expect(result.averageGap).toBe(14);
+    });
+
+    it('極端な差がある間隔', () => {
+      const result = AppointmentEntity.getAppointmentGapAnalysis([1, 365]);
+      expect(result.maxGap).toBe(365);
+      expect(result.minGap).toBe(1);
+      expect(result.averageGap).toBe(183);
+    });
+
+    it('0日間隔を含む', () => {
+      const result = AppointmentEntity.getAppointmentGapAnalysis([0, 30]);
+      expect(result.minGap).toBe(0);
+    });
+  });
+
+  describe('getGapAnalysisLabel', () => {
+    it('差が7は規則的', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(37, 30)).toBe('規則的');
+    });
+
+    it('差が8はやや不規則', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(38, 30)).toBe('やや不規則');
+    });
+
+    it('差が30はやや不規則', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(60, 30)).toBe('やや不規則');
+    });
+
+    it('差が31は不規則', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(61, 30)).toBe('不規則');
+    });
+
+    it('差が0は規則的', () => {
+      expect(AppointmentEntity.getGapAnalysisLabel(30, 30)).toBe('規則的');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/SymptomDiversity.edge.test.ts
+++ b/src/__tests__/domain/entities/SymptomDiversity.edge.test.ts
@@ -1,0 +1,45 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Symptom Diversity Edge Cases', () => {
+  describe('getSymptomDiversity', () => {
+    it('totalKnownSymptomsが0は0', () => {
+      expect(HealthLogEntity.getSymptomDiversity(['a'], 0)).toBe(0);
+    });
+
+    it('ユニーク数がtotalを超える場合は100以下', () => {
+      const symptoms = ['a', 'b', 'c', 'd', 'e'];
+      expect(HealthLogEntity.getSymptomDiversity(symptoms, 3)).toBe(100);
+    });
+
+    it('1種類のみ', () => {
+      expect(HealthLogEntity.getSymptomDiversity(['a'], 10)).toBe(10);
+    });
+
+    it('全種類ある場合は100', () => {
+      const symptoms = Array.from({ length: 10 }, (_, i) => `s${i}`);
+      expect(HealthLogEntity.getSymptomDiversity(symptoms, 10)).toBe(100);
+    });
+  });
+
+  describe('getSymptomDiversityLabel', () => {
+    it('境界値70は多様', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(70)).toBe('多様');
+    });
+
+    it('境界値69は中程度', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(69)).toBe('中程度');
+    });
+
+    it('境界値30は中程度', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(30)).toBe('中程度');
+    });
+
+    it('境界値29は限定的', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(29)).toBe('限定的');
+    });
+
+    it('100は多様', () => {
+      expect(HealthLogEntity.getSymptomDiversityLabel(100)).toBe('多様');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/WeightedAverage.edge.test.ts
+++ b/src/__tests__/domain/entities/WeightedAverage.edge.test.ts
@@ -1,0 +1,43 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Weighted Average Edge Cases', () => {
+  describe('getWeightedAverage', () => {
+    it('負の値を含む', () => {
+      expect(MathHelper.getWeightedAverage([-10, 20], [1, 1])).toBe(5);
+    });
+
+    it('非常に大きな重み', () => {
+      expect(MathHelper.getWeightedAverage([100, 0], [1000, 1])).toBeCloseTo(99.9, 0);
+    });
+
+    it('小数の重み', () => {
+      expect(MathHelper.getWeightedAverage([10, 20], [0.5, 0.5])).toBe(15);
+    });
+  });
+
+  describe('getWeightedAverageLabel', () => {
+    it('境界値90は非常に高い', () => {
+      expect(MathHelper.getWeightedAverageLabel(90)).toBe('非常に高い');
+    });
+
+    it('境界値89は高い', () => {
+      expect(MathHelper.getWeightedAverageLabel(89)).toBe('高い');
+    });
+
+    it('境界値70は高い', () => {
+      expect(MathHelper.getWeightedAverageLabel(70)).toBe('高い');
+    });
+
+    it('境界値69は普通', () => {
+      expect(MathHelper.getWeightedAverageLabel(69)).toBe('普通');
+    });
+
+    it('境界値40は普通', () => {
+      expect(MathHelper.getWeightedAverageLabel(40)).toBe('普通');
+    });
+
+    it('境界値39は低い', () => {
+      expect(MathHelper.getWeightedAverageLabel(39)).toBe('低い');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getWeightedAverageの負値・大重み・小数テスト追加
- getAppointmentGapAnalysisの同一間隔・極端差テスト追加
- getSymptomDiversityの超過・境界値テスト追加

## Test plan
- [x] 26件のエッジケーステストが全てパス
- [x] 全3725件のテストがパス

closes #736