### PR TITLE
リセットコード・IDフィールド・日付文字列のtrim追加

### DIFF
--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -8,7 +8,7 @@ import { timingSafeEqual, checkRateLimit } from '@/lib/security';
 
 const resetPasswordSchema = z.object({
   email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),
-  code: z.string().length(6, 'リセットコードは6桁で入力してください'),
+  code: z.string().trim().length(6, 'リセットコードは6桁で入力してください'),
   newPassword: z.string()
     .min(8, 'パスワードは8文字以上で入力してください')
     .max(128, 'パスワードは128文字以内で入力してください')

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
-const dateString = z.string().max(50, '日付形式が長すぎます').refine(
+const dateString = z.string().trim().max(50, '日付形式が長すぎます').refine(
   (val) => !isNaN(Date.parse(val)),
   { message: '有効な日付形式で入力してください' },
 );
 
-const idField = z.string().min(1).max(50);
-const optionalIdField = z.string().max(50).optional();
+const idField = z.string().trim().min(1).max(50);
+const optionalIdField = z.string().trim().max(50).optional();
 
 // ===== Users =====
 export const createUserProfileSchema = z.object({


### PR DESCRIPTION
## Summary
- reset-passwordのcodeフィールドに.trim()を追加し空白混入を防止
- idField/optionalIdFieldの基底定義に.trim()を追加
- dateStringに.trim()を追加

## Test plan
- [x] 全3725件のテストがパス

closes #738