### PR TITLE
月間完了率・メンバー別遵守率・補充優先度推奨機能追加

### DIFF
--- a/src/__tests__/domain/entities/MemberAdherence.test.ts
+++ b/src/__tests__/domain/entities/MemberAdherence.test.ts
@@ -1,0 +1,49 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Member Adherence', () => {
+  describe('getMedicationAdherenceByMember', () => {
+    it('メンバー別の遵守率を算出する', () => {
+      const records = [
+        { memberId: 'a', completed: true },
+        { memberId: 'a', completed: true },
+        { memberId: 'a', completed: false },
+        { memberId: 'b', completed: true },
+        { memberId: 'b', completed: false },
+      ];
+      const result = MedicationRecordEntity.getMedicationAdherenceByMember(records);
+      expect(result['a']).toBeCloseTo(67, 0);
+      expect(result['b']).toBe(50);
+    });
+
+    it('空配列は空オブジェクト', () => {
+      expect(MedicationRecordEntity.getMedicationAdherenceByMember([])).toEqual({});
+    });
+
+    it('1メンバーのみ', () => {
+      const records = [
+        { memberId: 'a', completed: true },
+        { memberId: 'a', completed: true },
+      ];
+      const result = MedicationRecordEntity.getMedicationAdherenceByMember(records);
+      expect(result['a']).toBe(100);
+    });
+  });
+
+  describe('getMemberAdherenceLabel', () => {
+    it('90以上は優秀', () => {
+      expect(MedicationRecordEntity.getMemberAdherenceLabel(90)).toBe('優秀');
+    });
+
+    it('70以上は良好', () => {
+      expect(MedicationRecordEntity.getMemberAdherenceLabel(70)).toBe('良好');
+    });
+
+    it('50以上は要注意', () => {
+      expect(MedicationRecordEntity.getMemberAdherenceLabel(50)).toBe('要注意');
+    });
+
+    it('50未満は要改善', () => {
+      expect(MedicationRecordEntity.getMemberAdherenceLabel(49)).toBe('要改善');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/MonthlyCompletionRate.test.ts
+++ b/src/__tests__/domain/entities/MonthlyCompletionRate.test.ts
@@ -1,0 +1,46 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Monthly Completion Rate', () => {
+  describe('getMonthlyCompletionRate', () => {
+    it('全日完了は100', () => {
+      const dailyCompleted = [true, true, true, true, true];
+      expect(CalendarEntity.getMonthlyCompletionRate(dailyCompleted)).toBe(100);
+    });
+
+    it('半分完了は50', () => {
+      const dailyCompleted = [true, false, true, false];
+      expect(CalendarEntity.getMonthlyCompletionRate(dailyCompleted)).toBe(50);
+    });
+
+    it('全日未完了は0', () => {
+      const dailyCompleted = [false, false, false];
+      expect(CalendarEntity.getMonthlyCompletionRate(dailyCompleted)).toBe(0);
+    });
+
+    it('空配列は0', () => {
+      expect(CalendarEntity.getMonthlyCompletionRate([])).toBe(0);
+    });
+
+    it('1件完了は100', () => {
+      expect(CalendarEntity.getMonthlyCompletionRate([true])).toBe(100);
+    });
+  });
+
+  describe('getMonthlyCompletionLabel', () => {
+    it('90以上は完璧', () => {
+      expect(CalendarEntity.getMonthlyCompletionLabel(90)).toBe('完璧');
+    });
+
+    it('70以上は良好', () => {
+      expect(CalendarEntity.getMonthlyCompletionLabel(70)).toBe('良好');
+    });
+
+    it('50以上はまずまず', () => {
+      expect(CalendarEntity.getMonthlyCompletionLabel(50)).toBe('まずまず');
+    });
+
+    it('50未満は要改善', () => {
+      expect(CalendarEntity.getMonthlyCompletionLabel(49)).toBe('要改善');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RefillRecommendation.test.ts
+++ b/src/__tests__/domain/entities/RefillRecommendation.test.ts
@@ -1,0 +1,48 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Refill Recommendation', () => {
+  describe('getRefillRecommendation', () => {
+    it('残り少ない順にソートされる', () => {
+      const items = [
+        { name: '薬A', remainingDays: 30 },
+        { name: '薬B', remainingDays: 3 },
+        { name: '薬C', remainingDays: 10 },
+      ];
+      const result = StockAlertEntity.getRefillRecommendation(items);
+      expect(result[0].name).toBe('薬B');
+      expect(result[1].name).toBe('薬C');
+      expect(result[2].name).toBe('薬A');
+    });
+
+    it('空配列は空配列', () => {
+      expect(StockAlertEntity.getRefillRecommendation([])).toEqual([]);
+    });
+
+    it('同じ残日数は順序維持', () => {
+      const items = [
+        { name: '薬A', remainingDays: 5 },
+        { name: '薬B', remainingDays: 5 },
+      ];
+      const result = StockAlertEntity.getRefillRecommendation(items);
+      expect(result[0].name).toBe('薬A');
+    });
+  });
+
+  describe('getRefillPriorityLabel', () => {
+    it('1位は最優先', () => {
+      expect(StockAlertEntity.getRefillPriorityLabel(1)).toBe('最優先');
+    });
+
+    it('2位は優先', () => {
+      expect(StockAlertEntity.getRefillPriorityLabel(2)).toBe('優先');
+    });
+
+    it('3位は通常', () => {
+      expect(StockAlertEntity.getRefillPriorityLabel(3)).toBe('通常');
+    });
+
+    it('4位以降は低優先', () => {
+      expect(StockAlertEntity.getRefillPriorityLabel(4)).toBe('低優先');
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -439,4 +439,23 @@ export class CalendarEntity {
   static getHeatMapColor(intensity: number): string {
     return CalendarEntity.HEAT_MAP_COLORS[intensity] ?? CalendarEntity.HEAT_MAP_COLORS[0];
   }
+
+  /**
+   * 日別完了フラグから月間完了率(0-100)を算出する
+   */
+  static getMonthlyCompletionRate(dailyCompleted: boolean[]): number {
+    if (dailyCompleted.length === 0) return 0;
+    const completed = dailyCompleted.filter(Boolean).length;
+    return Math.round((completed / dailyCompleted.length) * 100);
+  }
+
+  /**
+   * 月間完了率に応じたラベルを返す
+   */
+  static getMonthlyCompletionLabel(rate: number): string {
+    if (rate >= 90) return '完璧';
+    if (rate >= 70) return '良好';
+    if (rate >= 50) return 'まずまず';
+    return '要改善';
+  }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -636,4 +636,36 @@ export class MedicationRecordEntity {
     if (weekdayRatio < 0.3) return '休日中心';
     return '均等';
   }
+
+  /**
+   * メンバー別の遵守率(0-100)を算出する
+   */
+  static getMedicationAdherenceByMember(
+    records: { memberId: string; completed: boolean }[],
+  ): Record<string, number> {
+    if (records.length === 0) return {};
+    const memberData: Record<string, { total: number; completed: number }> = {};
+    for (const record of records) {
+      if (!memberData[record.memberId]) {
+        memberData[record.memberId] = { total: 0, completed: 0 };
+      }
+      memberData[record.memberId].total++;
+      if (record.completed) memberData[record.memberId].completed++;
+    }
+    const result: Record<string, number> = {};
+    for (const [memberId, data] of Object.entries(memberData)) {
+      result[memberId] = Math.round((data.completed / data.total) * 100);
+    }
+    return result;
+  }
+
+  /**
+   * メンバー別遵守率に応じたラベルを返す
+   */
+  static getMemberAdherenceLabel(rate: number): string {
+    if (rate >= 90) return '優秀';
+    if (rate >= 70) return '良好';
+    if (rate >= 50) return '要注意';
+    return '要改善';
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -410,4 +410,23 @@ export class StockAlertEntity {
     };
     return labels[status] ?? '在庫データがありません';
   }
+
+  /**
+   * 残日数の少ない順にソートした補充推奨リストを返す
+   */
+  static getRefillRecommendation(
+    items: { name: string; remainingDays: number }[],
+  ): { name: string; remainingDays: number }[] {
+    return [...items].sort((a, b) => a.remainingDays - b.remainingDays);
+  }
+
+  /**
+   * 補充優先度の順位に応じたラベルを返す
+   */
+  static getRefillPriorityLabel(rank: number): string {
+    if (rank === 1) return '最優先';
+    if (rank === 2) return '優先';
+    if (rank === 3) return '通常';
+    return '低優先';
+  }
 }


### PR DESCRIPTION
## Summary
- CalendarEntityに日別完了フラグから月間完了率を算出するメソッドを追加
- MedicationRecordEntityにメンバー別の遵守率算出メソッドを追加
- StockAlertEntityに残日数ベースの補充推奨リストメソッドを追加

## Test plan
- [x] 23件の新規テストが全てパス
- [x] 全3748件のテストがパス

closes #740