### PR TITLE
月間完了率・メンバー遵守率の閾値定数抽出

### DIFF
--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -29,6 +29,9 @@ export class CalendarEntity {
   private static readonly HEAT_MAP_MEDIUM_HIGH_RATIO = 0.75;
   private static readonly HEAT_MAP_MEDIUM_RATIO = 0.5;
   private static readonly COMPARISON_TOLERANCE = 5;
+  private static readonly COMPLETION_PERFECT_THRESHOLD = 90;
+  private static readonly COMPLETION_GOOD_THRESHOLD = 70;
+  private static readonly COMPLETION_FAIR_THRESHOLD = 50;
 
   /**
    * 指定月のカレンダーデータを生成
@@ -453,9 +456,9 @@ export class CalendarEntity {
    * 月間完了率に応じたラベルを返す
    */
   static getMonthlyCompletionLabel(rate: number): string {
-    if (rate >= 90) return '完璧';
-    if (rate >= 70) return '良好';
-    if (rate >= 50) return 'まずまず';
+    if (rate >= CalendarEntity.COMPLETION_PERFECT_THRESHOLD) return '完璧';
+    if (rate >= CalendarEntity.COMPLETION_GOOD_THRESHOLD) return '良好';
+    if (rate >= CalendarEntity.COMPLETION_FAIR_THRESHOLD) return 'まずまず';
     return '要改善';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -33,6 +33,9 @@ export class MedicationRecordEntity {
   private static readonly EVENING_START_HOUR = 17;
   private static readonly NIGHT_START_HOUR = 21;
   private static readonly PATTERN_DOMINANCE_THRESHOLD = 0.5;
+  private static readonly ADHERENCE_EXCELLENT_THRESHOLD = 90;
+  private static readonly ADHERENCE_GOOD_THRESHOLD = 70;
+  private static readonly ADHERENCE_WARNING_THRESHOLD = 50;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -663,9 +666,9 @@ export class MedicationRecordEntity {
    * メンバー別遵守率に応じたラベルを返す
    */
   static getMemberAdherenceLabel(rate: number): string {
-    if (rate >= 90) return '優秀';
-    if (rate >= 70) return '良好';
-    if (rate >= 50) return '要注意';
+    if (rate >= MedicationRecordEntity.ADHERENCE_EXCELLENT_THRESHOLD) return '優秀';
+    if (rate >= MedicationRecordEntity.ADHERENCE_GOOD_THRESHOLD) return '良好';
+    if (rate >= MedicationRecordEntity.ADHERENCE_WARNING_THRESHOLD) return '要注意';
     return '要改善';
   }
 }


### PR DESCRIPTION
## Summary
- CalendarEntityの月間完了率ラベル閾値をstatic readonly定数に抽出
- MedicationRecordEntityのメンバー遵守率ラベル閾値をstatic readonly定数に抽出

## Test plan
- [x] 全3748件のテストがパス

closes #742