### PR TITLE
認証コード確認のcodeフィールドにtrim追加

### DIFF
--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -7,7 +7,7 @@ import { timingSafeEqual, checkRateLimit } from '@/lib/security';
 
 const verifySchema = z.object({
   email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email(),
-  code: z.string().length(6),
+  code: z.string().trim().length(6),
 });
 
 const MAX_ATTEMPTS = 5;


### PR DESCRIPTION
## Summary
- verifyルートのcodeフィールドに.trim()を追加
- reset-passwordルートと整合性を確保

## Test plan
- [x] 全3773件のテストがパス

closes #746