### PR TITLE
メンバー活動スコア・スケジュール効率・範囲正規化機能追加

### DIFF
--- a/src/__tests__/domain/entities/MemberActivityScore.test.ts
+++ b/src/__tests__/domain/entities/MemberActivityScore.test.ts
@@ -1,0 +1,46 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Activity Score', () => {
+  describe('getMemberActivityScore', () => {
+    it('毎日記録ありは100', () => {
+      const dailyRecordCounts = [3, 2, 1, 4, 2, 3, 1];
+      expect(MemberEntity.getMemberActivityScore(dailyRecordCounts)).toBe(100);
+    });
+
+    it('半分記録ありは約50', () => {
+      const dailyRecordCounts = [3, 0, 1, 0, 2, 0, 1];
+      const score = MemberEntity.getMemberActivityScore(dailyRecordCounts);
+      expect(score).toBeCloseTo(57, 0);
+    });
+
+    it('全て0は0', () => {
+      expect(MemberEntity.getMemberActivityScore([0, 0, 0])).toBe(0);
+    });
+
+    it('空配列は0', () => {
+      expect(MemberEntity.getMemberActivityScore([])).toBe(0);
+    });
+
+    it('1日のみ記録あり', () => {
+      expect(MemberEntity.getMemberActivityScore([5])).toBe(100);
+    });
+  });
+
+  describe('getActivityScoreLabel', () => {
+    it('80以上は活発', () => {
+      expect(MemberEntity.getActivityScoreLabel(80)).toBe('活発');
+    });
+
+    it('50以上は普通', () => {
+      expect(MemberEntity.getActivityScoreLabel(50)).toBe('普通');
+    });
+
+    it('20以上は低調', () => {
+      expect(MemberEntity.getActivityScoreLabel(20)).toBe('低調');
+    });
+
+    it('20未満は非活動', () => {
+      expect(MemberEntity.getActivityScoreLabel(19)).toBe('非活動');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/NormalizeRange.test.ts
+++ b/src/__tests__/domain/entities/NormalizeRange.test.ts
@@ -1,0 +1,51 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Normalize Range', () => {
+  describe('normalizeToRange', () => {
+    it('中間値は50', () => {
+      expect(MathHelper.normalizeToRange(50, 0, 100)).toBe(50);
+    });
+
+    it('最小値は0', () => {
+      expect(MathHelper.normalizeToRange(0, 0, 100)).toBe(0);
+    });
+
+    it('最大値は100', () => {
+      expect(MathHelper.normalizeToRange(100, 0, 100)).toBe(100);
+    });
+
+    it('範囲外の値はクランプされる(下限)', () => {
+      expect(MathHelper.normalizeToRange(-10, 0, 100)).toBe(0);
+    });
+
+    it('範囲外の値はクランプされる(上限)', () => {
+      expect(MathHelper.normalizeToRange(150, 0, 100)).toBe(100);
+    });
+
+    it('カスタム範囲', () => {
+      expect(MathHelper.normalizeToRange(75, 50, 100)).toBe(50);
+    });
+
+    it('同じmin/maxは100', () => {
+      expect(MathHelper.normalizeToRange(5, 5, 5)).toBe(100);
+    });
+  });
+
+  describe('getNormalizedRangeLabel', () => {
+    it('80以上は高い', () => {
+      expect(MathHelper.getNormalizedRangeLabel(80)).toBe('高い');
+    });
+
+    it('50以上は中程度', () => {
+      expect(MathHelper.getNormalizedRangeLabel(50)).toBe('中程度');
+    });
+
+    it('20以上は低い', () => {
+      expect(MathHelper.getNormalizedRangeLabel(20)).toBe('低い');
+    });
+
+    it('20未満は非常に低い', () => {
+      expect(MathHelper.getNormalizedRangeLabel(19)).toBe('非常に低い');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleEfficiency.test.ts
+++ b/src/__tests__/domain/entities/ScheduleEfficiency.test.ts
@@ -1,0 +1,48 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Efficiency', () => {
+  describe('getScheduleEfficiency', () => {
+    it('全て時間内は100', () => {
+      const delayMinutes = [0, 0, 0, 0];
+      expect(ScheduleEntity.getScheduleEfficiency(delayMinutes)).toBe(100);
+    });
+
+    it('遅延があると低下', () => {
+      const delayMinutes = [0, 30, 0, 60];
+      const score = ScheduleEntity.getScheduleEfficiency(delayMinutes);
+      expect(score).toBeLessThan(100);
+      expect(score).toBeGreaterThan(0);
+    });
+
+    it('全て大幅遅延は0', () => {
+      const delayMinutes = [120, 120, 120];
+      expect(ScheduleEntity.getScheduleEfficiency(delayMinutes)).toBe(0);
+    });
+
+    it('空配列は100', () => {
+      expect(ScheduleEntity.getScheduleEfficiency([])).toBe(100);
+    });
+
+    it('1件のみ0分遅延は100', () => {
+      expect(ScheduleEntity.getScheduleEfficiency([0])).toBe(100);
+    });
+  });
+
+  describe('getScheduleEfficiencyLabel', () => {
+    it('90以上は優秀', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(90)).toBe('優秀');
+    });
+
+    it('70以上は良好', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(70)).toBe('良好');
+    });
+
+    it('50以上は普通', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(50)).toBe('普通');
+    });
+
+    it('50未満は要改善', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(49)).toBe('要改善');
+    });
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -182,4 +182,23 @@ export class MathHelper {
     if (value >= MathHelper.WEIGHTED_AVG_NORMAL_THRESHOLD) return '普通';
     return '低い';
   }
+
+  /**
+   * 任意の値を0-100の範囲に正規化する
+   */
+  static normalizeToRange(value: number, min: number, max: number): number {
+    if (min >= max) return 100;
+    const clamped = Math.max(min, Math.min(max, value));
+    return Math.round(((clamped - min) / (max - min)) * 100);
+  }
+
+  /**
+   * 正規化された値に応じたラベルを返す
+   */
+  static getNormalizedRangeLabel(value: number): string {
+    if (value >= 80) return '高い';
+    if (value >= 50) return '中程度';
+    if (value >= 20) return '低い';
+    return '非常に低い';
+  }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -489,4 +489,24 @@ export class MemberEntity {
     if (diff >= 20) return 'メンバー間で差があります';
     return 'メンバー全体で安定しています';
   }
+
+  /**
+   * 日別記録件数から活動スコア(0-100)を算出する
+   * 記録がある日の割合をスコアとする
+   */
+  static getMemberActivityScore(dailyRecordCounts: number[]): number {
+    if (dailyRecordCounts.length === 0) return 0;
+    const activeDays = dailyRecordCounts.filter((c) => c > 0).length;
+    return Math.round((activeDays / dailyRecordCounts.length) * 100);
+  }
+
+  /**
+   * 活動スコアに応じたラベルを返す
+   */
+  static getActivityScoreLabel(score: number): string {
+    if (score >= 80) return '活発';
+    if (score >= 50) return '普通';
+    if (score >= 20) return '低調';
+    return '非活動';
+  }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -774,4 +774,29 @@ export class ScheduleEntity {
     if (days >= ScheduleEntity.STREAK_WEEK_THRESHOLD && days % ScheduleEntity.STREAK_WEEK_THRESHOLD === 0) return `${days / ScheduleEntity.STREAK_WEEK_THRESHOLD}週間連続`;
     return `${days}日連続`;
   }
+
+  private static readonly EFFICIENCY_MAX_DELAY = 120;
+
+  /**
+   * 遅延分数配列からスケジュール効率(0-100)を算出する
+   */
+  static getScheduleEfficiency(delayMinutes: number[]): number {
+    if (delayMinutes.length === 0) return 100;
+    const totalPenalty = delayMinutes.reduce((sum, delay) => {
+      const penalty = Math.min(delay, ScheduleEntity.EFFICIENCY_MAX_DELAY) / ScheduleEntity.EFFICIENCY_MAX_DELAY;
+      return sum + penalty;
+    }, 0);
+    const avgPenalty = totalPenalty / delayMinutes.length;
+    return Math.max(0, Math.round((1 - avgPenalty) * 100));
+  }
+
+  /**
+   * スケジュール効率に応じたラベルを返す
+   */
+  static getScheduleEfficiencyLabel(score: number): string {
+    if (score >= 90) return '優秀';
+    if (score >= 70) return '良好';
+    if (score >= 50) return '普通';
+    return '要改善';
+  }
 }


### PR DESCRIPTION
## Summary
- MemberEntityに日別記録件数から活動スコアを算出するメソッドを追加
- ScheduleEntityに遅延分数から効率スコアを算出するメソッドを追加
- MathHelperに任意範囲を0-100に正規化するメソッドを追加

## Test plan
- [x] 29件の新規テストが全てパス
- [x] 全3802件のテストがパス

closes #748