### PR TITLE
活動スコア・効率・正規化の閾値定数抽出

### DIFF
--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -5,6 +5,9 @@ export class MathHelper {
   private static readonly WEIGHTED_AVG_VERY_HIGH_THRESHOLD = 90;
   private static readonly WEIGHTED_AVG_HIGH_THRESHOLD = 70;
   private static readonly WEIGHTED_AVG_NORMAL_THRESHOLD = 40;
+  private static readonly NORMALIZED_HIGH_THRESHOLD = 80;
+  private static readonly NORMALIZED_MEDIUM_THRESHOLD = 50;
+  private static readonly NORMALIZED_LOW_THRESHOLD = 20;
 
   /**
    * パーセントを算出(0-100%)
@@ -196,9 +199,9 @@ export class MathHelper {
    * 正規化された値に応じたラベルを返す
    */
   static getNormalizedRangeLabel(value: number): string {
-    if (value >= 80) return '高い';
-    if (value >= 50) return '中程度';
-    if (value >= 20) return '低い';
+    if (value >= MathHelper.NORMALIZED_HIGH_THRESHOLD) return '高い';
+    if (value >= MathHelper.NORMALIZED_MEDIUM_THRESHOLD) return '中程度';
+    if (value >= MathHelper.NORMALIZED_LOW_THRESHOLD) return '低い';
     return '非常に低い';
   }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -150,6 +150,10 @@ export class MemberEntity {
     return age;
   }
 
+  private static readonly ACTIVITY_HIGH_THRESHOLD = 80;
+  private static readonly ACTIVITY_NORMAL_THRESHOLD = 50;
+  private static readonly ACTIVITY_LOW_THRESHOLD = 20;
+
   private static readonly memberTypeLabels: Record<MemberType, string> = {
     human: '家族',
     pet: 'ペット',
@@ -504,9 +508,9 @@ export class MemberEntity {
    * 活動スコアに応じたラベルを返す
    */
   static getActivityScoreLabel(score: number): string {
-    if (score >= 80) return '活発';
-    if (score >= 50) return '普通';
-    if (score >= 20) return '低調';
+    if (score >= MemberEntity.ACTIVITY_HIGH_THRESHOLD) return '活発';
+    if (score >= MemberEntity.ACTIVITY_NORMAL_THRESHOLD) return '普通';
+    if (score >= MemberEntity.ACTIVITY_LOW_THRESHOLD) return '低調';
     return '非活動';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -776,6 +776,9 @@ export class ScheduleEntity {
   }
 
   private static readonly EFFICIENCY_MAX_DELAY = 120;
+  private static readonly EFFICIENCY_EXCELLENT_THRESHOLD = 90;
+  private static readonly EFFICIENCY_GOOD_THRESHOLD = 70;
+  private static readonly EFFICIENCY_NORMAL_THRESHOLD = 50;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -794,9 +797,9 @@ export class ScheduleEntity {
    * スケジュール効率に応じたラベルを返す
    */
   static getScheduleEfficiencyLabel(score: number): string {
-    if (score >= 90) return '優秀';
-    if (score >= 70) return '良好';
-    if (score >= 50) return '普通';
+    if (score >= ScheduleEntity.EFFICIENCY_EXCELLENT_THRESHOLD) return '優秀';
+    if (score >= ScheduleEntity.EFFICIENCY_GOOD_THRESHOLD) return '良好';
+    if (score >= ScheduleEntity.EFFICIENCY_NORMAL_THRESHOLD) return '普通';
     return '要改善';
   }
 }


### PR DESCRIPTION
## Summary
- MemberEntityの活動スコアラベル閾値をstatic readonly定数に抽出
- ScheduleEntityの効率ラベル閾値をstatic readonly定数に抽出
- MathHelperの正規化ラベル閾値をstatic readonly定数に抽出

## Test plan
- [x] 全3802件のテストがパス

closes #750