### PR TITLE
活動スコア・効率・正規化のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/MemberActivityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberActivityScore.edge.test.ts
@@ -1,0 +1,48 @@
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity - Activity Score Edge Cases', () => {
+  describe('getMemberActivityScore', () => {
+    it('大量データ30日分', () => {
+      const data = Array.from({ length: 30 }, (_, i) => (i < 24 ? 1 : 0));
+      expect(MemberEntity.getMemberActivityScore(data)).toBe(80);
+    });
+
+    it('全て1件ずつは100', () => {
+      expect(MemberEntity.getMemberActivityScore([1, 1, 1, 1, 1])).toBe(100);
+    });
+  });
+
+  describe('getActivityScoreLabel', () => {
+    it('境界値80は活発', () => {
+      expect(MemberEntity.getActivityScoreLabel(80)).toBe('活発');
+    });
+
+    it('境界値79は普通', () => {
+      expect(MemberEntity.getActivityScoreLabel(79)).toBe('普通');
+    });
+
+    it('境界値50は普通', () => {
+      expect(MemberEntity.getActivityScoreLabel(50)).toBe('普通');
+    });
+
+    it('境界値49は低調', () => {
+      expect(MemberEntity.getActivityScoreLabel(49)).toBe('低調');
+    });
+
+    it('境界値20は低調', () => {
+      expect(MemberEntity.getActivityScoreLabel(20)).toBe('低調');
+    });
+
+    it('境界値19は非活動', () => {
+      expect(MemberEntity.getActivityScoreLabel(19)).toBe('非活動');
+    });
+
+    it('0は非活動', () => {
+      expect(MemberEntity.getActivityScoreLabel(0)).toBe('非活動');
+    });
+
+    it('100は活発', () => {
+      expect(MemberEntity.getActivityScoreLabel(100)).toBe('活発');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/NormalizeRange.edge.test.ts
+++ b/src/__tests__/domain/entities/NormalizeRange.edge.test.ts
@@ -1,0 +1,47 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Normalize Range Edge Cases', () => {
+  describe('normalizeToRange', () => {
+    it('min > maxは100', () => {
+      expect(MathHelper.normalizeToRange(50, 100, 0)).toBe(100);
+    });
+
+    it('負の範囲', () => {
+      expect(MathHelper.normalizeToRange(0, -100, 100)).toBe(50);
+    });
+
+    it('小数値', () => {
+      expect(MathHelper.normalizeToRange(0.5, 0, 1)).toBe(50);
+    });
+
+    it('非常に大きな範囲', () => {
+      expect(MathHelper.normalizeToRange(500000, 0, 1000000)).toBe(50);
+    });
+  });
+
+  describe('getNormalizedRangeLabel', () => {
+    it('境界値80は高い', () => {
+      expect(MathHelper.getNormalizedRangeLabel(80)).toBe('高い');
+    });
+
+    it('境界値79は中程度', () => {
+      expect(MathHelper.getNormalizedRangeLabel(79)).toBe('中程度');
+    });
+
+    it('境界値50は中程度', () => {
+      expect(MathHelper.getNormalizedRangeLabel(50)).toBe('中程度');
+    });
+
+    it('境界値49は低い', () => {
+      expect(MathHelper.getNormalizedRangeLabel(49)).toBe('低い');
+    });
+
+    it('境界値20は低い', () => {
+      expect(MathHelper.getNormalizedRangeLabel(20)).toBe('低い');
+    });
+
+    it('境界値19は非常に低い', () => {
+      expect(MathHelper.getNormalizedRangeLabel(19)).toBe('非常に低い');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleEfficiency.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleEfficiency.edge.test.ts
@@ -1,0 +1,43 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Efficiency Edge Cases', () => {
+  describe('getScheduleEfficiency', () => {
+    it('全て120分以上遅延は0', () => {
+      expect(ScheduleEntity.getScheduleEfficiency([120, 150, 200])).toBe(0);
+    });
+
+    it('全て60分遅延は50', () => {
+      expect(ScheduleEntity.getScheduleEfficiency([60, 60, 60])).toBe(50);
+    });
+
+    it('1件のみ30分遅延', () => {
+      expect(ScheduleEntity.getScheduleEfficiency([30])).toBe(75);
+    });
+  });
+
+  describe('getScheduleEfficiencyLabel', () => {
+    it('境界値90は優秀', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(90)).toBe('優秀');
+    });
+
+    it('境界値89は良好', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(89)).toBe('良好');
+    });
+
+    it('境界値70は良好', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(70)).toBe('良好');
+    });
+
+    it('境界値69は普通', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(69)).toBe('普通');
+    });
+
+    it('境界値50は普通', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(50)).toBe('普通');
+    });
+
+    it('境界値49は要改善', () => {
+      expect(ScheduleEntity.getScheduleEfficiencyLabel(49)).toBe('要改善');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getMemberActivityScoreの大量データ・境界値テスト追加
- getScheduleEfficiencyの全遅延・部分遅延テスト追加
- normalizeToRangeの負範囲・min>max・小数テスト追加

## Test plan
- [x] 29件のエッジケーステストが全てパス
- [x] 全3831件のテストがパス

closes #752