### PR TITLE
feat: 遵守率分布分析・体調回復速度・スケジュールカバー率を追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionRecoveryRate.test.ts
+++ b/src/__tests__/domain/entities/ConditionRecoveryRate.test.ts
@@ -1,0 +1,51 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Recovery Rate', () => {
+  describe('getConditionRecoveryRate', () => {
+    it('空配列は0', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([])).toBe(0);
+    });
+
+    it('1件のみは0', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([3])).toBe(0);
+    });
+
+    it('常に上昇は100', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([1, 2, 3, 4, 5])).toBe(100);
+    });
+
+    it('常に下降は0', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([5, 4, 3, 2, 1])).toBe(0);
+    });
+
+    it('横ばいは50', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([3, 3, 3, 3])).toBe(50);
+    });
+
+    it('部分的に回復', () => {
+      const result = HealthLogEntity.getConditionRecoveryRate([1, 3, 2, 4]);
+      expect(result).toBeGreaterThan(50);
+      expect(result).toBeLessThanOrEqual(100);
+    });
+
+    it('部分的に悪化', () => {
+      const result = HealthLogEntity.getConditionRecoveryRate([5, 3, 4, 2]);
+      expect(result).toBeLessThan(50);
+      expect(result).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('getRecoveryRateLabel', () => {
+    it('高い回復率', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(80)).toBe('良好な回復');
+    });
+
+    it('中程度の回復率', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(50)).toBe('緩やかな回復');
+    });
+
+    it('低い回復率', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(20)).toBe('回復が遅い');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RateDistribution.test.ts
+++ b/src/__tests__/domain/entities/RateDistribution.test.ts
@@ -1,0 +1,64 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Rate Distribution', () => {
+  describe('getRateDistribution', () => {
+    it('空配列は全て0', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([]);
+      expect(result).toEqual({ high: 0, medium: 0, low: 0 });
+    });
+
+    it('全て高い率', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([90, 95, 100]);
+      expect(result.high).toBe(100);
+      expect(result.medium).toBe(0);
+      expect(result.low).toBe(0);
+    });
+
+    it('全て低い率', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([10, 20, 30]);
+      expect(result.low).toBe(100);
+      expect(result.high).toBe(0);
+    });
+
+    it('混在', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([90, 60, 30, 10]);
+      expect(result.high).toBe(25);
+      expect(result.medium).toBe(25);
+      expect(result.low).toBe(50);
+    });
+
+    it('境界値70は中', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([70]);
+      expect(result.medium).toBe(100);
+    });
+
+    it('境界値80は高', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([80]);
+      expect(result.high).toBe(100);
+    });
+
+    it('境界値50は中', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([50]);
+      expect(result.medium).toBe(100);
+    });
+
+    it('境界値49は低', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([49]);
+      expect(result.low).toBe(100);
+    });
+  });
+
+  describe('getRateDistributionLabel', () => {
+    it('高い率が多い場合', () => {
+      expect(AdherenceTrendEntity.getRateDistributionLabel({ high: 60, medium: 20, low: 20 })).toBe('安定して高い');
+    });
+
+    it('低い率が多い場合', () => {
+      expect(AdherenceTrendEntity.getRateDistributionLabel({ high: 10, medium: 20, low: 70 })).toBe('改善が必要');
+    });
+
+    it('均等な場合', () => {
+      expect(AdherenceTrendEntity.getRateDistributionLabel({ high: 33, medium: 34, low: 33 })).toBe('ばらつきあり');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleCoverage.test.ts
+++ b/src/__tests__/domain/entities/ScheduleCoverage.test.ts
@@ -1,0 +1,57 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Schedule Coverage', () => {
+  describe('getScheduleCoverage', () => {
+    it('空配列は0', () => {
+      expect(ScheduleEntity.getScheduleCoverage([])).toBe(0);
+    });
+
+    it('空の曜日配列(毎日)は100', () => {
+      expect(ScheduleEntity.getScheduleCoverage([{ daysOfWeek: [] }])).toBe(100);
+    });
+
+    it('全曜日指定は100', () => {
+      expect(ScheduleEntity.getScheduleCoverage([{ daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] }])).toBe(100);
+    });
+
+    it('平日のみは71', () => {
+      const result = ScheduleEntity.getScheduleCoverage([{ daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri'] }]);
+      expect(result).toBe(71);
+    });
+
+    it('1日のみは14', () => {
+      const result = ScheduleEntity.getScheduleCoverage([{ daysOfWeek: ['mon'] }]);
+      expect(result).toBe(14);
+    });
+
+    it('複数スケジュールで曜日が重複', () => {
+      const result = ScheduleEntity.getScheduleCoverage([
+        { daysOfWeek: ['mon', 'wed'] },
+        { daysOfWeek: ['mon', 'fri'] },
+      ]);
+      expect(result).toBe(43);
+    });
+
+    it('複数スケジュールで全曜日カバー', () => {
+      const result = ScheduleEntity.getScheduleCoverage([
+        { daysOfWeek: ['mon', 'tue', 'wed', 'thu'] },
+        { daysOfWeek: ['fri', 'sat', 'sun'] },
+      ]);
+      expect(result).toBe(100);
+    });
+  });
+
+  describe('getScheduleCoverageLabel', () => {
+    it('高いカバー率', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(100)).toBe('完全');
+    });
+
+    it('中程度のカバー率', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(60)).toBe('普通');
+    });
+
+    it('低いカバー率', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(20)).toBe('不足');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -242,6 +242,37 @@ export class AdherenceTrendEntity {
   /**
    * パフォーマンスグレードに応じたラベルを返す
    */
+  /**
+   * 遵守率配列の分布（高/中/低の割合%）を算出する
+   * 高: 80以上, 中: 50-79, 低: 50未満
+   */
+  static getRateDistribution(rates: number[]): { high: number; medium: number; low: number } {
+    if (rates.length === 0) return { high: 0, medium: 0, low: 0 };
+    let high = 0;
+    let medium = 0;
+    let low = 0;
+    for (const rate of rates) {
+      if (rate >= 80) high++;
+      else if (rate >= 50) medium++;
+      else low++;
+    }
+    const total = rates.length;
+    return {
+      high: Math.round((high / total) * 100),
+      medium: Math.round((medium / total) * 100),
+      low: Math.round((low / total) * 100),
+    };
+  }
+
+  /**
+   * 遵守率分布に応じたラベルを返す
+   */
+  static getRateDistributionLabel(dist: { high: number; medium: number; low: number }): string {
+    if (dist.high >= 50) return '安定して高い';
+    if (dist.low >= 50) return '改善が必要';
+    return 'ばらつきあり';
+  }
+
   static getPerformanceGradeLabel(grade: string): string {
     const labels: Record<string, string> = {
       A: '優秀',

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -765,6 +765,34 @@ export class HealthLogEntity {
   /**
    * 症状多様性スコアに応じたラベルを返す
    */
+  /**
+   * 体調レベル配列から回復速度スコア(0-100)を算出する
+   * 上昇ステップの割合をスコア化（横ばいは中立=50基準）
+   */
+  static getConditionRecoveryRate(conditions: number[]): number {
+    if (conditions.length <= 1) return 0;
+    let upSteps = 0;
+    let downSteps = 0;
+    for (let i = 1; i < conditions.length; i++) {
+      const diff = conditions[i] - conditions[i - 1];
+      if (diff > 0) upSteps++;
+      else if (diff < 0) downSteps++;
+    }
+    const totalSteps = conditions.length - 1;
+    const neutralSteps = totalSteps - upSteps - downSteps;
+    const score = ((upSteps + neutralSteps * 0.5) / totalSteps) * 100;
+    return Math.min(100, Math.max(0, Math.round(score)));
+  }
+
+  /**
+   * 回復速度スコアに応じたラベルを返す
+   */
+  static getRecoveryRateLabel(score: number): string {
+    if (score >= 70) return '良好な回復';
+    if (score >= 40) return '緩やかな回復';
+    return '回復が遅い';
+  }
+
   static getSymptomDiversityLabel(score: number): string {
     if (score >= HealthLogEntity.DIVERSITY_HIGH_THRESHOLD) return '多様';
     if (score >= HealthLogEntity.DIVERSITY_MEDIUM_THRESHOLD) return '中程度';

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -796,6 +796,33 @@ export class ScheduleEntity {
   /**
    * スケジュール効率に応じたラベルを返す
    */
+  /**
+   * スケジュール群の曜日カバー率(0-100%)を算出する
+   * 空の曜日配列は毎日(7日)としてカウント
+   */
+  static getScheduleCoverage(schedules: { daysOfWeek: string[] }[]): number {
+    if (schedules.length === 0) return 0;
+    const coveredDays = new Set<string>();
+    const allDays = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+    for (const s of schedules) {
+      if (s.daysOfWeek.length === 0) {
+        for (const d of allDays) coveredDays.add(d);
+      } else {
+        for (const d of s.daysOfWeek) coveredDays.add(d);
+      }
+    }
+    return Math.round((coveredDays.size / 7) * 100);
+  }
+
+  /**
+   * 曜日カバー率に応じたラベルを返す
+   */
+  static getScheduleCoverageLabel(coverage: number): string {
+    if (coverage >= 80) return '完全';
+    if (coverage >= 50) return '普通';
+    return '不足';
+  }
+
   static getScheduleEfficiencyLabel(score: number): string {
     if (score >= ScheduleEntity.EFFICIENCY_EXCELLENT_THRESHOLD) return '優秀';
     if (score >= ScheduleEntity.EFFICIENCY_GOOD_THRESHOLD) return '良好';


### PR DESCRIPTION
## Summary
- AdherenceTrend: getRateDistribution / getRateDistributionLabel を追加（遵守率の高/中/低分布を分析）
- HealthLog: getConditionRecoveryRate / getRecoveryRateLabel を追加（体調回復速度スコアを算出）
- Schedule: getScheduleCoverage / getScheduleCoverageLabel を追加（曜日カバー率を算出）

## Test plan
- [x] getRateDistribution / getRateDistributionLabel のユニットテスト（11件）
- [x] getConditionRecoveryRate / getRecoveryRateLabel のユニットテスト（10件）
- [x] getScheduleCoverage / getScheduleCoverageLabel のユニットテスト（10件）
- [x] 全3862テスト通過確認