### PR TITLE
test: 遵守率分布・回復速度・カバー率のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionRecoveryRate.edge.test.ts
+++ b/src/__tests__/domain/entities/ConditionRecoveryRate.edge.test.ts
@@ -1,0 +1,67 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Recovery Rate Edge Cases', () => {
+  describe('getConditionRecoveryRate', () => {
+    it('2件で上昇は100', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([1, 5])).toBe(100);
+    });
+
+    it('2件で下降は0', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([5, 1])).toBe(0);
+    });
+
+    it('2件で横ばいは50', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([3, 3])).toBe(50);
+    });
+
+    it('大きな配列で全て同じ値', () => {
+      const conditions = Array(100).fill(3);
+      expect(HealthLogEntity.getConditionRecoveryRate(conditions)).toBe(50);
+    });
+
+    it('交互に上下', () => {
+      const result = HealthLogEntity.getConditionRecoveryRate([1, 5, 1, 5, 1]);
+      expect(result).toBe(50);
+    });
+
+    it('最小値から最大値への段階的回復', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([1, 2, 3, 4, 5])).toBe(100);
+    });
+
+    it('最大値から最小値への段階的悪化', () => {
+      expect(HealthLogEntity.getConditionRecoveryRate([5, 4, 3, 2, 1])).toBe(0);
+    });
+
+    it('結果が0-100の範囲内', () => {
+      const result = HealthLogEntity.getConditionRecoveryRate([1, 5, 1, 5, 1, 5]);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('getRecoveryRateLabel', () => {
+    it('境界値70は良好な回復', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(70)).toBe('良好な回復');
+    });
+
+    it('境界値69は緩やかな回復', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(69)).toBe('緩やかな回復');
+    });
+
+    it('境界値40は緩やかな回復', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(40)).toBe('緩やかな回復');
+    });
+
+    it('境界値39は回復が遅い', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(39)).toBe('回復が遅い');
+    });
+
+    it('0は回復が遅い', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(0)).toBe('回復が遅い');
+    });
+
+    it('100は良好な回復', () => {
+      expect(HealthLogEntity.getRecoveryRateLabel(100)).toBe('良好な回復');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RateDistribution.edge.test.ts
+++ b/src/__tests__/domain/entities/RateDistribution.edge.test.ts
@@ -1,0 +1,56 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Rate Distribution Edge Cases', () => {
+  describe('getRateDistribution', () => {
+    it('1件のみ(高)', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([100]);
+      expect(result.high).toBe(100);
+    });
+
+    it('境界値79は中', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([79]);
+      expect(result.medium).toBe(100);
+    });
+
+    it('0は低', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([0]);
+      expect(result.low).toBe(100);
+    });
+
+    it('100は高', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([100]);
+      expect(result.high).toBe(100);
+    });
+
+    it('同じ値が多数', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([80, 80, 80, 80, 80]);
+      expect(result.high).toBe(100);
+      expect(result.medium).toBe(0);
+      expect(result.low).toBe(0);
+    });
+
+    it('丸め誤差で合計が100にならないケース', () => {
+      const result = AdherenceTrendEntity.getRateDistribution([90, 60, 10]);
+      expect(result.high + result.medium + result.low).toBeGreaterThanOrEqual(99);
+      expect(result.high + result.medium + result.low).toBeLessThanOrEqual(101);
+    });
+  });
+
+  describe('getRateDistributionLabel', () => {
+    it('高が丁度50は安定して高い', () => {
+      expect(AdherenceTrendEntity.getRateDistributionLabel({ high: 50, medium: 25, low: 25 })).toBe('安定して高い');
+    });
+
+    it('低が丁度50は改善が必要', () => {
+      expect(AdherenceTrendEntity.getRateDistributionLabel({ high: 25, medium: 25, low: 50 })).toBe('改善が必要');
+    });
+
+    it('全て0', () => {
+      expect(AdherenceTrendEntity.getRateDistributionLabel({ high: 0, medium: 0, low: 0 })).toBe('ばらつきあり');
+    });
+
+    it('高49/低49はばらつきあり', () => {
+      expect(AdherenceTrendEntity.getRateDistributionLabel({ high: 49, medium: 2, low: 49 })).toBe('ばらつきあり');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleCoverage.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleCoverage.edge.test.ts
@@ -1,0 +1,76 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Schedule Coverage Edge Cases', () => {
+  describe('getScheduleCoverage', () => {
+    it('複数の空曜日配列(毎日)でも100', () => {
+      expect(ScheduleEntity.getScheduleCoverage([
+        { daysOfWeek: [] },
+        { daysOfWeek: [] },
+      ])).toBe(100);
+    });
+
+    it('週末のみは29', () => {
+      const result = ScheduleEntity.getScheduleCoverage([{ daysOfWeek: ['sat', 'sun'] }]);
+      expect(result).toBe(29);
+    });
+
+    it('3スケジュールで全曜日カバー', () => {
+      const result = ScheduleEntity.getScheduleCoverage([
+        { daysOfWeek: ['mon', 'tue'] },
+        { daysOfWeek: ['wed', 'thu'] },
+        { daysOfWeek: ['fri', 'sat', 'sun'] },
+      ]);
+      expect(result).toBe(100);
+    });
+
+    it('全て同じ曜日のスケジュール', () => {
+      const result = ScheduleEntity.getScheduleCoverage([
+        { daysOfWeek: ['mon'] },
+        { daysOfWeek: ['mon'] },
+        { daysOfWeek: ['mon'] },
+      ]);
+      expect(result).toBe(14);
+    });
+
+    it('空配列と曜日指定の混在', () => {
+      const result = ScheduleEntity.getScheduleCoverage([
+        { daysOfWeek: ['mon'] },
+        { daysOfWeek: [] },
+      ]);
+      expect(result).toBe(100);
+    });
+
+    it('6曜日カバーは86', () => {
+      const result = ScheduleEntity.getScheduleCoverage([
+        { daysOfWeek: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat'] },
+      ]);
+      expect(result).toBe(86);
+    });
+  });
+
+  describe('getScheduleCoverageLabel', () => {
+    it('境界値80は完全', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(80)).toBe('完全');
+    });
+
+    it('境界値79は普通', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(79)).toBe('普通');
+    });
+
+    it('境界値50は普通', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(50)).toBe('普通');
+    });
+
+    it('境界値49は不足', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(49)).toBe('不足');
+    });
+
+    it('0は不足', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(0)).toBe('不足');
+    });
+
+    it('100は完全', () => {
+      expect(ScheduleEntity.getScheduleCoverageLabel(100)).toBe('完全');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getRateDistribution / getRateDistributionLabel のエッジケーステスト（10件）
- getConditionRecoveryRate / getRecoveryRateLabel のエッジケーステスト（14件）
- getScheduleCoverage / getScheduleCoverageLabel のエッジケーステスト（12件）

## Test plan
- [x] エッジケーステスト36件全て通過
- [x] 全3898テスト通過確認