### PR TITLE
feat: 相関係数・曜日記録バランス・在庫トレンドを追加

### DIFF
--- a/src/__tests__/domain/entities/CorrelationCoefficient.test.ts
+++ b/src/__tests__/domain/entities/CorrelationCoefficient.test.ts
@@ -1,0 +1,57 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Correlation Coefficient', () => {
+  describe('getCorrelationCoefficient', () => {
+    it('空配列は0', () => {
+      expect(MathHelper.getCorrelationCoefficient([], [])).toBe(0);
+    });
+
+    it('1件のみは0', () => {
+      expect(MathHelper.getCorrelationCoefficient([1], [2])).toBe(0);
+    });
+
+    it('完全正相関は1', () => {
+      expect(MathHelper.getCorrelationCoefficient([1, 2, 3, 4, 5], [2, 4, 6, 8, 10])).toBe(1);
+    });
+
+    it('完全負相関は-1', () => {
+      expect(MathHelper.getCorrelationCoefficient([1, 2, 3, 4, 5], [10, 8, 6, 4, 2])).toBe(-1);
+    });
+
+    it('無相関は0付近', () => {
+      const result = MathHelper.getCorrelationCoefficient([1, 2, 3, 4, 5], [3, 1, 4, 1, 5]);
+      expect(Math.abs(result)).toBeLessThan(0.5);
+    });
+
+    it('長さが異なる場合は短い方に合わせる', () => {
+      const result = MathHelper.getCorrelationCoefficient([1, 2, 3], [2, 4, 6, 8]);
+      expect(result).toBe(1);
+    });
+
+    it('全て同じ値は0', () => {
+      expect(MathHelper.getCorrelationCoefficient([5, 5, 5], [3, 3, 3])).toBe(0);
+    });
+  });
+
+  describe('getCorrelationLabel', () => {
+    it('強い正相関', () => {
+      expect(MathHelper.getCorrelationLabel(0.8)).toBe('強い正相関');
+    });
+
+    it('弱い正相関', () => {
+      expect(MathHelper.getCorrelationLabel(0.4)).toBe('弱い正相関');
+    });
+
+    it('相関なし', () => {
+      expect(MathHelper.getCorrelationLabel(0.1)).toBe('相関なし');
+    });
+
+    it('強い負相関', () => {
+      expect(MathHelper.getCorrelationLabel(-0.8)).toBe('強い負相関');
+    });
+
+    it('弱い負相関', () => {
+      expect(MathHelper.getCorrelationLabel(-0.4)).toBe('弱い負相関');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockTrend.test.ts
+++ b/src/__tests__/domain/entities/StockTrend.test.ts
@@ -1,0 +1,47 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Stock Trend', () => {
+  describe('getStockTrend', () => {
+    it('空配列はstable', () => {
+      expect(StockAlertEntity.getStockTrend([])).toBe('stable');
+    });
+
+    it('1件のみはstable', () => {
+      expect(StockAlertEntity.getStockTrend([10])).toBe('stable');
+    });
+
+    it('増加傾向はincreasing', () => {
+      expect(StockAlertEntity.getStockTrend([10, 20, 30, 40])).toBe('increasing');
+    });
+
+    it('減少傾向はdecreasing', () => {
+      expect(StockAlertEntity.getStockTrend([40, 30, 20, 10])).toBe('decreasing');
+    });
+
+    it('横ばいはstable', () => {
+      expect(StockAlertEntity.getStockTrend([10, 10, 10, 10])).toBe('stable');
+    });
+
+    it('小さな変動はstable', () => {
+      expect(StockAlertEntity.getStockTrend([10, 11, 10, 11])).toBe('stable');
+    });
+
+    it('前半と後半の平均比較', () => {
+      expect(StockAlertEntity.getStockTrend([5, 5, 15, 15])).toBe('increasing');
+    });
+  });
+
+  describe('getStockTrendLabel', () => {
+    it('増加', () => {
+      expect(StockAlertEntity.getStockTrendLabel('increasing')).toBe('在庫増加中');
+    });
+
+    it('減少', () => {
+      expect(StockAlertEntity.getStockTrendLabel('decreasing')).toBe('在庫減少中');
+    });
+
+    it('安定', () => {
+      expect(StockAlertEntity.getStockTrendLabel('stable')).toBe('在庫安定');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/WeekdayRecordBalance.test.ts
+++ b/src/__tests__/domain/entities/WeekdayRecordBalance.test.ts
@@ -1,0 +1,54 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Weekday Record Balance', () => {
+  describe('getWeekdayRecordBalance', () => {
+    it('空配列は0/0', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([]);
+      expect(result).toEqual({ weekdayRate: 0, weekendRate: 0 });
+    });
+
+    it('平日のみ(月-金)は平日100/休日0', () => {
+      // 0=日,1=月,...,6=土 → 平日: 1-5
+      const result = CalendarEntity.getWeekdayRecordBalance([1, 2, 3, 4, 5]);
+      expect(result.weekdayRate).toBe(100);
+      expect(result.weekendRate).toBe(0);
+    });
+
+    it('休日のみ(土日)は平日0/休日100', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([0, 6]);
+      expect(result.weekdayRate).toBe(0);
+      expect(result.weekendRate).toBe(100);
+    });
+
+    it('均等な場合', () => {
+      // 5平日+2休日=7
+      const result = CalendarEntity.getWeekdayRecordBalance([0, 1, 2, 3, 4, 5, 6]);
+      expect(result.weekdayRate).toBe(71);
+      expect(result.weekendRate).toBe(29);
+    });
+
+    it('重複する曜日も個別にカウント', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([1, 1, 1]);
+      expect(result.weekdayRate).toBe(100);
+      expect(result.weekendRate).toBe(0);
+    });
+  });
+
+  describe('getWeekdayBalanceLabel', () => {
+    it('バランスが取れている', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(60, 40)).toBe('バランス良好');
+    });
+
+    it('平日偏り', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(90, 10)).toBe('平日に偏り');
+    });
+
+    it('休日偏り', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(20, 80)).toBe('休日に偏り');
+    });
+
+    it('両方0', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(0, 0)).toBe('データ不足');
+    });
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -461,4 +461,32 @@ export class CalendarEntity {
     if (rate >= CalendarEntity.COMPLETION_FAIR_THRESHOLD) return 'まずまず';
     return '要改善';
   }
+
+  /**
+   * 曜日番号配列(0=日〜6=土)から平日/休日の記録割合を算出する
+   */
+  static getWeekdayRecordBalance(dayOfWeeks: number[]): { weekdayRate: number; weekendRate: number } {
+    if (dayOfWeeks.length === 0) return { weekdayRate: 0, weekendRate: 0 };
+    let weekday = 0;
+    let weekend = 0;
+    for (const d of dayOfWeeks) {
+      if (d >= 1 && d <= 5) weekday++;
+      else weekend++;
+    }
+    const total = dayOfWeeks.length;
+    return {
+      weekdayRate: Math.round((weekday / total) * 100),
+      weekendRate: Math.round((weekend / total) * 100),
+    };
+  }
+
+  /**
+   * 平日/休日バランスに応じたラベルを返す
+   */
+  static getWeekdayBalanceLabel(weekdayRate: number, weekendRate: number): string {
+    if (weekdayRate === 0 && weekendRate === 0) return 'データ不足';
+    if (weekdayRate >= 80) return '平日に偏り';
+    if (weekendRate >= 60) return '休日に偏り';
+    return 'バランス良好';
+  }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -204,4 +204,37 @@ export class MathHelper {
     if (value >= MathHelper.NORMALIZED_LOW_THRESHOLD) return '低い';
     return '非常に低い';
   }
+
+  /**
+   * 2配列間のピアソン相関係数(-1〜1)を算出する
+   */
+  static getCorrelationCoefficient(x: number[], y: number[]): number {
+    const len = Math.min(x.length, y.length);
+    if (len <= 1) return 0;
+    const avgX = x.slice(0, len).reduce((a, b) => a + b, 0) / len;
+    const avgY = y.slice(0, len).reduce((a, b) => a + b, 0) / len;
+    let sumXY = 0;
+    let sumX2 = 0;
+    let sumY2 = 0;
+    for (let i = 0; i < len; i++) {
+      const dx = x[i] - avgX;
+      const dy = y[i] - avgY;
+      sumXY += dx * dy;
+      sumX2 += dx * dx;
+      sumY2 += dy * dy;
+    }
+    const denominator = Math.sqrt(sumX2 * sumY2);
+    if (denominator === 0) return 0;
+    return Math.round((sumXY / denominator) * 100) / 100;
+  }
+
+  /**
+   * 相関係数に応じたラベルを返す
+   */
+  static getCorrelationLabel(r: number): string {
+    const abs = Math.abs(r);
+    if (abs >= 0.7) return r > 0 ? '強い正相関' : '強い負相関';
+    if (abs >= 0.3) return r > 0 ? '弱い正相関' : '弱い負相関';
+    return '相関なし';
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -423,6 +423,34 @@ export class StockAlertEntity {
   /**
    * 補充優先度の順位に応じたラベルを返す
    */
+  /**
+   * 在庫数量の推移配列からトレンドを判定する
+   */
+  static getStockTrend(quantities: number[]): 'increasing' | 'decreasing' | 'stable' {
+    if (quantities.length <= 1) return 'stable';
+    const mid = Math.floor(quantities.length / 2);
+    const firstHalf = quantities.slice(0, mid);
+    const secondHalf = quantities.slice(mid);
+    const firstAvg = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length;
+    const secondAvg = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length;
+    const diff = secondAvg - firstAvg;
+    if (diff > 2) return 'increasing';
+    if (diff < -2) return 'decreasing';
+    return 'stable';
+  }
+
+  /**
+   * 在庫トレンドに応じたラベルを返す
+   */
+  static getStockTrendLabel(trend: string): string {
+    const labels: Record<string, string> = {
+      increasing: '在庫増加中',
+      decreasing: '在庫減少中',
+      stable: '在庫安定',
+    };
+    return labels[trend] ?? '在庫安定';
+  }
+
   static getRefillPriorityLabel(rank: number): string {
     if (rank === 1) return '最優先';
     if (rank === 2) return '優先';


### PR DESCRIPTION
## Summary
- MathHelper: getCorrelationCoefficient / getCorrelationLabel を追加（ピアソン相関係数）
- Calendar: getWeekdayRecordBalance / getWeekdayBalanceLabel を追加（平日/休日記録バランス）
- StockAlert: getStockTrend / getStockTrendLabel を追加（在庫推移トレンド判定）

## Test plan
- [x] getCorrelationCoefficient / getCorrelationLabel のユニットテスト（12件）
- [x] getWeekdayRecordBalance / getWeekdayBalanceLabel のユニットテスト（9件）
- [x] getStockTrend / getStockTrendLabel のユニットテスト（10件）
- [x] 全3929テスト通過確認