### PR TITLE
refactor: 相関係数・曜日バランス・在庫トレンドのマジックナンバー定数化

### DIFF
--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -32,6 +32,8 @@ export class CalendarEntity {
   private static readonly COMPLETION_PERFECT_THRESHOLD = 90;
   private static readonly COMPLETION_GOOD_THRESHOLD = 70;
   private static readonly COMPLETION_FAIR_THRESHOLD = 50;
+  private static readonly WEEKDAY_BIAS_THRESHOLD = 80;
+  private static readonly WEEKEND_BIAS_THRESHOLD = 60;
 
   /**
    * 指定月のカレンダーデータを生成
@@ -485,8 +487,8 @@ export class CalendarEntity {
    */
   static getWeekdayBalanceLabel(weekdayRate: number, weekendRate: number): string {
     if (weekdayRate === 0 && weekendRate === 0) return 'データ不足';
-    if (weekdayRate >= 80) return '平日に偏り';
-    if (weekendRate >= 60) return '休日に偏り';
+    if (weekdayRate >= CalendarEntity.WEEKDAY_BIAS_THRESHOLD) return '平日に偏り';
+    if (weekendRate >= CalendarEntity.WEEKEND_BIAS_THRESHOLD) return '休日に偏り';
     return 'バランス良好';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -8,6 +8,8 @@ export class MathHelper {
   private static readonly NORMALIZED_HIGH_THRESHOLD = 80;
   private static readonly NORMALIZED_MEDIUM_THRESHOLD = 50;
   private static readonly NORMALIZED_LOW_THRESHOLD = 20;
+  private static readonly CORRELATION_STRONG_THRESHOLD = 0.7;
+  private static readonly CORRELATION_WEAK_THRESHOLD = 0.3;
 
   /**
    * パーセントを算出(0-100%)
@@ -233,8 +235,8 @@ export class MathHelper {
    */
   static getCorrelationLabel(r: number): string {
     const abs = Math.abs(r);
-    if (abs >= 0.7) return r > 0 ? '強い正相関' : '強い負相関';
-    if (abs >= 0.3) return r > 0 ? '弱い正相関' : '弱い負相関';
+    if (abs >= MathHelper.CORRELATION_STRONG_THRESHOLD) return r > 0 ? '強い正相関' : '強い負相関';
+    if (abs >= MathHelper.CORRELATION_WEAK_THRESHOLD) return r > 0 ? '弱い正相関' : '弱い負相関';
     return '相関なし';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -25,6 +25,7 @@ export class StockAlertEntity {
   private static readonly COST_MODERATE_THRESHOLD = 10000;
   private static readonly DAYS_PER_MONTH = 30;
   private static readonly DEPLETION_COMFORT_THRESHOLD = 14;
+  private static readonly STOCK_TREND_THRESHOLD = 2;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -434,8 +435,8 @@ export class StockAlertEntity {
     const firstAvg = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length;
     const secondAvg = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length;
     const diff = secondAvg - firstAvg;
-    if (diff > 2) return 'increasing';
-    if (diff < -2) return 'decreasing';
+    if (diff > StockAlertEntity.STOCK_TREND_THRESHOLD) return 'increasing';
+    if (diff < -StockAlertEntity.STOCK_TREND_THRESHOLD) return 'decreasing';
     return 'stable';
   }
 


### PR DESCRIPTION
## Summary
- MathHelper: CORRELATION_STRONG_THRESHOLD(0.7), CORRELATION_WEAK_THRESHOLD(0.3) を追加
- Calendar: WEEKDAY_BIAS_THRESHOLD(80), WEEKEND_BIAS_THRESHOLD(60) を追加
- StockAlert: STOCK_TREND_THRESHOLD(2) を追加

## Test plan
- [x] 全3929テスト通過確認（振る舞い変更なし）