### PR TITLE
test: 相関係数・曜日バランス・在庫トレンドのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/CorrelationCoefficient.edge.test.ts
+++ b/src/__tests__/domain/entities/CorrelationCoefficient.edge.test.ts
@@ -1,0 +1,78 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Correlation Coefficient Edge Cases', () => {
+  describe('getCorrelationCoefficient', () => {
+    it('2件の正相関', () => {
+      const result = MathHelper.getCorrelationCoefficient([1, 2], [3, 4]);
+      expect(result).toBe(1);
+    });
+
+    it('2件の負相関', () => {
+      const result = MathHelper.getCorrelationCoefficient([1, 2], [4, 3]);
+      expect(result).toBe(-1);
+    });
+
+    it('片方が全て同じ値は0', () => {
+      expect(MathHelper.getCorrelationCoefficient([1, 2, 3], [5, 5, 5])).toBe(0);
+    });
+
+    it('大きな値', () => {
+      const result = MathHelper.getCorrelationCoefficient([1000, 2000, 3000], [100, 200, 300]);
+      expect(result).toBe(1);
+    });
+
+    it('負の値を含む', () => {
+      const result = MathHelper.getCorrelationCoefficient([-3, -2, -1, 0, 1], [1, 2, 3, 4, 5]);
+      expect(result).toBe(1);
+    });
+
+    it('結果は-1から1の範囲', () => {
+      const result = MathHelper.getCorrelationCoefficient([4, 2, 7, 1, 5], [3, 8, 1, 6, 2]);
+      expect(result).toBeGreaterThanOrEqual(-1);
+      expect(result).toBeLessThanOrEqual(1);
+    });
+
+    it('小数値', () => {
+      const result = MathHelper.getCorrelationCoefficient([0.1, 0.2, 0.3], [0.3, 0.6, 0.9]);
+      expect(result).toBe(1);
+    });
+  });
+
+  describe('getCorrelationLabel', () => {
+    it('境界値0.7は強い正相関', () => {
+      expect(MathHelper.getCorrelationLabel(0.7)).toBe('強い正相関');
+    });
+
+    it('境界値0.69は弱い正相関', () => {
+      expect(MathHelper.getCorrelationLabel(0.69)).toBe('弱い正相関');
+    });
+
+    it('境界値0.3は弱い正相関', () => {
+      expect(MathHelper.getCorrelationLabel(0.3)).toBe('弱い正相関');
+    });
+
+    it('境界値0.29は相関なし', () => {
+      expect(MathHelper.getCorrelationLabel(0.29)).toBe('相関なし');
+    });
+
+    it('境界値-0.7は強い負相関', () => {
+      expect(MathHelper.getCorrelationLabel(-0.7)).toBe('強い負相関');
+    });
+
+    it('境界値-0.3は弱い負相関', () => {
+      expect(MathHelper.getCorrelationLabel(-0.3)).toBe('弱い負相関');
+    });
+
+    it('0は相関なし', () => {
+      expect(MathHelper.getCorrelationLabel(0)).toBe('相関なし');
+    });
+
+    it('1は強い正相関', () => {
+      expect(MathHelper.getCorrelationLabel(1)).toBe('強い正相関');
+    });
+
+    it('-1は強い負相関', () => {
+      expect(MathHelper.getCorrelationLabel(-1)).toBe('強い負相関');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockTrend.edge.test.ts
+++ b/src/__tests__/domain/entities/StockTrend.edge.test.ts
@@ -1,0 +1,49 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Stock Trend Edge Cases', () => {
+  describe('getStockTrend', () => {
+    it('2件で差が大きいとincreasing', () => {
+      expect(StockAlertEntity.getStockTrend([0, 10])).toBe('increasing');
+    });
+
+    it('2件で差が大きいとdecreasing', () => {
+      expect(StockAlertEntity.getStockTrend([10, 0])).toBe('decreasing');
+    });
+
+    it('2件で差が2以下はstable', () => {
+      expect(StockAlertEntity.getStockTrend([10, 12])).toBe('stable');
+    });
+
+    it('境界値: 差が丁度2はstable', () => {
+      expect(StockAlertEntity.getStockTrend([10, 12])).toBe('stable');
+    });
+
+    it('境界値: 差が2.1はincreasing', () => {
+      expect(StockAlertEntity.getStockTrend([10, 10, 15, 15])).toBe('increasing');
+    });
+
+    it('全て0はstable', () => {
+      expect(StockAlertEntity.getStockTrend([0, 0, 0, 0])).toBe('stable');
+    });
+
+    it('大量データで増加', () => {
+      const data = Array.from({ length: 20 }, (_, i) => i * 2);
+      expect(StockAlertEntity.getStockTrend(data)).toBe('increasing');
+    });
+
+    it('大量データで減少', () => {
+      const data = Array.from({ length: 20 }, (_, i) => 40 - i * 2);
+      expect(StockAlertEntity.getStockTrend(data)).toBe('decreasing');
+    });
+  });
+
+  describe('getStockTrendLabel', () => {
+    it('不明なトレンドはデフォルト', () => {
+      expect(StockAlertEntity.getStockTrendLabel('unknown')).toBe('在庫安定');
+    });
+
+    it('空文字はデフォルト', () => {
+      expect(StockAlertEntity.getStockTrendLabel('')).toBe('在庫安定');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/WeekdayRecordBalance.edge.test.ts
+++ b/src/__tests__/domain/entities/WeekdayRecordBalance.edge.test.ts
@@ -1,0 +1,61 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Weekday Record Balance Edge Cases', () => {
+  describe('getWeekdayRecordBalance', () => {
+    it('1件のみ(平日)', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([3]);
+      expect(result.weekdayRate).toBe(100);
+      expect(result.weekendRate).toBe(0);
+    });
+
+    it('1件のみ(休日)', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([0]);
+      expect(result.weekdayRate).toBe(0);
+      expect(result.weekendRate).toBe(100);
+    });
+
+    it('全て土曜', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([6, 6, 6]);
+      expect(result.weekdayRate).toBe(0);
+      expect(result.weekendRate).toBe(100);
+    });
+
+    it('日曜のみ', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([0]);
+      expect(result.weekendRate).toBe(100);
+    });
+
+    it('大量データ(平日のみ)', () => {
+      const days = Array(100).fill(0).map((_, i) => (i % 5) + 1);
+      const result = CalendarEntity.getWeekdayRecordBalance(days);
+      expect(result.weekdayRate).toBe(100);
+    });
+
+    it('合計が100になる', () => {
+      const result = CalendarEntity.getWeekdayRecordBalance([0, 1, 2, 3, 4, 5, 6]);
+      expect(result.weekdayRate + result.weekendRate).toBe(100);
+    });
+  });
+
+  describe('getWeekdayBalanceLabel', () => {
+    it('境界値80/20は平日に偏り', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(80, 20)).toBe('平日に偏り');
+    });
+
+    it('境界値79/21はバランス良好', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(79, 21)).toBe('バランス良好');
+    });
+
+    it('境界値40/60は休日に偏り', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(40, 60)).toBe('休日に偏り');
+    });
+
+    it('境界値41/59はバランス良好', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(41, 59)).toBe('バランス良好');
+    });
+
+    it('50/50はバランス良好', () => {
+      expect(CalendarEntity.getWeekdayBalanceLabel(50, 50)).toBe('バランス良好');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getCorrelationCoefficient / getCorrelationLabel のエッジケーステスト（16件）
- getWeekdayRecordBalance / getWeekdayBalanceLabel のエッジケーステスト（11件）
- getStockTrend / getStockTrendLabel のエッジケーステスト（10件）

## Test plan
- [x] エッジケーステスト37件全て通過
- [x] 全3966テスト通過確認