### PR TITLE
test: サイクル安定度・時間一貫性・クラスタ分析のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentCycleScore.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentCycleScore.edge.test.ts
@@ -1,0 +1,59 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Appointment Cycle Score Edge Cases', () => {
+  describe('getAppointmentCycleScore', () => {
+    it('2件で異なる値', () => {
+      const result = AppointmentEntity.getAppointmentCycleScore([10, 30]);
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThan(100);
+    });
+
+    it('全て0は100', () => {
+      expect(AppointmentEntity.getAppointmentCycleScore([0, 0, 0])).toBe(100);
+    });
+
+    it('大量データで均等', () => {
+      const intervals = Array(50).fill(14);
+      expect(AppointmentEntity.getAppointmentCycleScore(intervals)).toBe(100);
+    });
+
+    it('大量データでばらつき', () => {
+      const intervals = Array.from({ length: 50 }, (_, i) => i % 2 === 0 ? 7 : 21);
+      const result = AppointmentEntity.getAppointmentCycleScore(intervals);
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThan(100);
+    });
+
+    it('結果は0-100の範囲内', () => {
+      const result = AppointmentEntity.getAppointmentCycleScore([1, 100, 1, 100]);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(100);
+    });
+  });
+
+  describe('getCycleScoreLabel', () => {
+    it('境界値70は規則的', () => {
+      expect(AppointmentEntity.getCycleScoreLabel(70)).toBe('規則的');
+    });
+
+    it('境界値69はやや不規則', () => {
+      expect(AppointmentEntity.getCycleScoreLabel(69)).toBe('やや不規則');
+    });
+
+    it('境界値40はやや不規則', () => {
+      expect(AppointmentEntity.getCycleScoreLabel(40)).toBe('やや不規則');
+    });
+
+    it('境界値39は不規則', () => {
+      expect(AppointmentEntity.getCycleScoreLabel(39)).toBe('不規則');
+    });
+
+    it('0は不規則', () => {
+      expect(AppointmentEntity.getCycleScoreLabel(0)).toBe('不規則');
+    });
+
+    it('100は規則的', () => {
+      expect(AppointmentEntity.getCycleScoreLabel(100)).toBe('規則的');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/DateClusterAnalysis.edge.test.ts
+++ b/src/__tests__/domain/entities/DateClusterAnalysis.edge.test.ts
@@ -1,0 +1,60 @@
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper - Date Cluster Analysis Edge Cases', () => {
+  describe('getDateClusterAnalysis', () => {
+    it('間隔0のみは100', () => {
+      expect(DateRangeHelper.getDateClusterAnalysis([0, 0, 0])).toBe(100);
+    });
+
+    it('間隔30は0', () => {
+      expect(DateRangeHelper.getDateClusterAnalysis([30, 30, 30])).toBe(0);
+    });
+
+    it('間隔30超は0にクランプ', () => {
+      expect(DateRangeHelper.getDateClusterAnalysis([60, 60])).toBe(0);
+    });
+
+    it('2件で小さい間隔', () => {
+      const result = DateRangeHelper.getDateClusterAnalysis([3, 3]);
+      expect(result).toBe(90);
+    });
+
+    it('大量データで一定間隔', () => {
+      const intervals = Array(100).fill(7);
+      const result = DateRangeHelper.getDateClusterAnalysis(intervals);
+      expect(result).toBe(77);
+    });
+
+    it('混在した間隔', () => {
+      const result = DateRangeHelper.getDateClusterAnalysis([1, 7, 1, 14]);
+      expect(result).toBeGreaterThan(0);
+      expect(result).toBeLessThan(100);
+    });
+  });
+
+  describe('getClusterLabel', () => {
+    it('境界値70は密集', () => {
+      expect(DateRangeHelper.getClusterLabel(70)).toBe('密集');
+    });
+
+    it('境界値69は中程度', () => {
+      expect(DateRangeHelper.getClusterLabel(69)).toBe('中程度');
+    });
+
+    it('境界値40は中程度', () => {
+      expect(DateRangeHelper.getClusterLabel(40)).toBe('中程度');
+    });
+
+    it('境界値39は疎ら', () => {
+      expect(DateRangeHelper.getClusterLabel(39)).toBe('疎ら');
+    });
+
+    it('0は疎ら', () => {
+      expect(DateRangeHelper.getClusterLabel(0)).toBe('疎ら');
+    });
+
+    it('100は密集', () => {
+      expect(DateRangeHelper.getClusterLabel(100)).toBe('密集');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/DoseTimingConsistency.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseTimingConsistency.edge.test.ts
@@ -1,0 +1,61 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Dose Timing Consistency Edge Cases', () => {
+  describe('getDoseTimingConsistency', () => {
+    it('負の値を含む', () => {
+      const result = MedicationRecordEntity.getDoseTimingConsistency([-10, -10, -10]);
+      expect(result).toBe(100);
+    });
+
+    it('正負混在で同じ絶対値', () => {
+      const result = MedicationRecordEntity.getDoseTimingConsistency([-5, 5, -5, 5]);
+      expect(result).toBe(100);
+    });
+
+    it('大きな値', () => {
+      const result = MedicationRecordEntity.getDoseTimingConsistency([120, 0, 120, 0]);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(100);
+    });
+
+    it('2件で同じ値', () => {
+      expect(MedicationRecordEntity.getDoseTimingConsistency([10, 10])).toBe(100);
+    });
+
+    it('2件で異なる値', () => {
+      const result = MedicationRecordEntity.getDoseTimingConsistency([0, 60]);
+      expect(result).toBeLessThan(100);
+    });
+
+    it('大量データで一定', () => {
+      const data = Array(100).fill(5);
+      expect(MedicationRecordEntity.getDoseTimingConsistency(data)).toBe(100);
+    });
+  });
+
+  describe('getDoseTimingLabel', () => {
+    it('境界値70は安定', () => {
+      expect(MedicationRecordEntity.getDoseTimingLabel(70)).toBe('安定');
+    });
+
+    it('境界値69はやや不安定', () => {
+      expect(MedicationRecordEntity.getDoseTimingLabel(69)).toBe('やや不安定');
+    });
+
+    it('境界値40はやや不安定', () => {
+      expect(MedicationRecordEntity.getDoseTimingLabel(40)).toBe('やや不安定');
+    });
+
+    it('境界値39は不安定', () => {
+      expect(MedicationRecordEntity.getDoseTimingLabel(39)).toBe('不安定');
+    });
+
+    it('0は不安定', () => {
+      expect(MedicationRecordEntity.getDoseTimingLabel(0)).toBe('不安定');
+    });
+
+    it('100は安定', () => {
+      expect(MedicationRecordEntity.getDoseTimingLabel(100)).toBe('安定');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getAppointmentCycleScore / getCycleScoreLabel のエッジケーステスト（11件）
- getDoseTimingConsistency / getDoseTimingLabel のエッジケーステスト（12件）
- getDateClusterAnalysis / getClusterLabel のエッジケーステスト（12件）

## Test plan
- [x] エッジケーステスト35件全て通過
- [x] 全4028テスト通過確認