### PR TITLE
feat: 外れ値分析・体調モメンタム・スケジュール遵守率を追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionMomentum.test.ts
+++ b/src/__tests__/domain/entities/ConditionMomentum.test.ts
@@ -1,0 +1,44 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Momentum', () => {
+  describe('getConditionMomentum', () => {
+    it('空配列は0', () => {
+      expect(HealthLogEntity.getConditionMomentum([])).toBe(0);
+    });
+
+    it('1件のみは0', () => {
+      expect(HealthLogEntity.getConditionMomentum([3])).toBe(0);
+    });
+
+    it('上昇傾向は正', () => {
+      expect(HealthLogEntity.getConditionMomentum([1, 2, 3, 4, 5])).toBeGreaterThan(0);
+    });
+
+    it('下降傾向は負', () => {
+      expect(HealthLogEntity.getConditionMomentum([5, 4, 3, 2, 1])).toBeLessThan(0);
+    });
+
+    it('横ばいは0', () => {
+      expect(HealthLogEntity.getConditionMomentum([3, 3, 3, 3])).toBe(0);
+    });
+
+    it('直近3件の変化を反映', () => {
+      const result = HealthLogEntity.getConditionMomentum([1, 1, 1, 3, 5]);
+      expect(result).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getMomentumLabel', () => {
+    it('正のモメンタム', () => {
+      expect(HealthLogEntity.getMomentumLabel(1.5)).toBe('改善傾向');
+    });
+
+    it('負のモメンタム', () => {
+      expect(HealthLogEntity.getMomentumLabel(-1.5)).toBe('悪化傾向');
+    });
+
+    it('ゼロ付近', () => {
+      expect(HealthLogEntity.getMomentumLabel(0.3)).toBe('変化なし');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/OutlierCount.test.ts
+++ b/src/__tests__/domain/entities/OutlierCount.test.ts
@@ -1,0 +1,47 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Outlier Count', () => {
+  describe('getOutlierCount', () => {
+    it('空配列は0', () => {
+      expect(MathHelper.getOutlierCount([])).toBe(0);
+    });
+
+    it('外れ値なし', () => {
+      expect(MathHelper.getOutlierCount([10, 11, 12, 13, 14])).toBe(0);
+    });
+
+    it('外れ値あり', () => {
+      expect(MathHelper.getOutlierCount([10, 11, 12, 13, 100])).toBe(1);
+    });
+
+    it('複数の外れ値', () => {
+      expect(MathHelper.getOutlierCount([1, 10, 11, 12, 13, 100])).toBe(2);
+    });
+
+    it('全て同じ値は外れ値なし', () => {
+      expect(MathHelper.getOutlierCount([5, 5, 5, 5, 5])).toBe(0);
+    });
+
+    it('1件のみは0', () => {
+      expect(MathHelper.getOutlierCount([42])).toBe(0);
+    });
+  });
+
+  describe('getOutlierSeverityLabel', () => {
+    it('外れ値なし', () => {
+      expect(MathHelper.getOutlierSeverityLabel(0, 10)).toBe('正常');
+    });
+
+    it('少数の外れ値', () => {
+      expect(MathHelper.getOutlierSeverityLabel(1, 20)).toBe('軽微');
+    });
+
+    it('多数の外れ値', () => {
+      expect(MathHelper.getOutlierSeverityLabel(5, 10)).toBe('深刻');
+    });
+
+    it('データなし', () => {
+      expect(MathHelper.getOutlierSeverityLabel(0, 0)).toBe('正常');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleAdherenceRate.test.ts
+++ b/src/__tests__/domain/entities/ScheduleAdherenceRate.test.ts
@@ -1,0 +1,47 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Schedule Adherence Rate', () => {
+  describe('getScheduleAdherenceRate', () => {
+    it('空配列は0', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([])).toBe(0);
+    });
+
+    it('全て完了は100', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true, true, true, true, true])).toBe(100);
+    });
+
+    it('全て未完了は0', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([false, false, false, false])).toBe(0);
+    });
+
+    it('半分完了は50', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true, false, true, false])).toBe(50);
+    });
+
+    it('1件のみ完了', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true])).toBe(100);
+    });
+
+    it('1件のみ未完了', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([false])).toBe(0);
+    });
+  });
+
+  describe('getAdherenceRateLabel', () => {
+    it('高い遵守率', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(90)).toBe('優秀');
+    });
+
+    it('中程度の遵守率', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(70)).toBe('良好');
+    });
+
+    it('低い遵守率', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(50)).toBe('要改善');
+    });
+
+    it('非常に低い遵守率', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(20)).toBe('不十分');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -800,4 +800,29 @@ export class HealthLogEntity {
     if (score >= HealthLogEntity.DIVERSITY_MEDIUM_THRESHOLD) return '中程度';
     return '限定的';
   }
+
+  /**
+   * 体調レベル配列の直近の変化速度（モメンタム）を算出する
+   * 直近3件の傾き（正=改善、負=悪化、0=横ばい）
+   */
+  static getConditionMomentum(conditions: number[]): number {
+    if (conditions.length <= 1) return 0;
+    const recent = conditions.slice(-3);
+    if (recent.length <= 1) return 0;
+    const diffs: number[] = [];
+    for (let i = 1; i < recent.length; i++) {
+      diffs.push(recent[i] - recent[i - 1]);
+    }
+    const avg = diffs.reduce((a, b) => a + b, 0) / diffs.length;
+    return Math.round(avg * 10) / 10;
+  }
+
+  /**
+   * モメンタムに応じたラベルを返す
+   */
+  static getMomentumLabel(momentum: number): string {
+    if (momentum >= 0.5) return '改善傾向';
+    if (momentum <= -0.5) return '悪化傾向';
+    return '変化なし';
+  }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -239,4 +239,24 @@ export class MathHelper {
     if (abs >= MathHelper.CORRELATION_WEAK_THRESHOLD) return r > 0 ? '弱い正相関' : '弱い負相関';
     return '相関なし';
   }
+
+  /**
+   * IQRに基づいて外れ値の件数を返す
+   */
+  static getOutlierCount(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const { lower, upper } = MathHelper.getOutlierBounds(values);
+    return values.filter((v) => v < lower || v > upper).length;
+  }
+
+  /**
+   * 外れ値の件数と全体数から深刻度ラベルを返す
+   */
+  static getOutlierSeverityLabel(outlierCount: number, total: number): string {
+    if (total === 0 || outlierCount === 0) return '正常';
+    const rate = outlierCount / total;
+    if (rate >= 0.2) return '深刻';
+    if (rate >= 0.05) return '軽微';
+    return '正常';
+  }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -831,4 +831,23 @@ export class ScheduleEntity {
     if (score >= ScheduleEntity.EFFICIENCY_NORMAL_THRESHOLD) return '普通';
     return '要改善';
   }
+
+  /**
+   * 完了/未完了配列から遵守率(0-100%)を算出する
+   */
+  static getScheduleAdherenceRate(completions: boolean[]): number {
+    if (completions.length === 0) return 0;
+    const completed = completions.filter(Boolean).length;
+    return Math.round((completed / completions.length) * 100);
+  }
+
+  /**
+   * 遵守率に応じたラベルを返す
+   */
+  static getAdherenceRateLabel(rate: number): string {
+    if (rate >= 90) return '優秀';
+    if (rate >= 70) return '良好';
+    if (rate >= 50) return '要改善';
+    return '不十分';
+  }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getOutlierCount / getOutlierSeverityLabel を追加（IQR外れ値件数と深刻度）
- HealthLog: getConditionMomentum / getMomentumLabel を追加（直近の体調変化速度）
- Schedule: getScheduleAdherenceRate / getAdherenceRateLabel を追加（スケジュール遵守率）

## Test plan
- [x] getOutlierCount / getOutlierSeverityLabel のユニットテスト（10件）
- [x] getConditionMomentum / getMomentumLabel のユニットテスト（9件）
- [x] getScheduleAdherenceRate / getAdherenceRateLabel のユニットテスト（10件）
- [x] 全4057テスト通過確認