### PR TITLE
refactor: 外れ値深刻度・モメンタム・遵守率のマジックナンバー定数化

### DIFF
--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -61,6 +61,7 @@ export class HealthLogEntity {
   private static readonly VOLATILITY_STABLE_THRESHOLD = 30;
   private static readonly VOLATILITY_MODERATE_THRESHOLD = 60;
   private static readonly DIVERSITY_HIGH_THRESHOLD = 70;
+  private static readonly MOMENTUM_THRESHOLD = 0.5;
   private static readonly DIVERSITY_MEDIUM_THRESHOLD = 30;
   private static readonly RECOVERY_GOOD_THRESHOLD = 70;
   private static readonly RECOVERY_MODERATE_THRESHOLD = 40;
@@ -821,8 +822,8 @@ export class HealthLogEntity {
    * モメンタムに応じたラベルを返す
    */
   static getMomentumLabel(momentum: number): string {
-    if (momentum >= 0.5) return '改善傾向';
-    if (momentum <= -0.5) return '悪化傾向';
+    if (momentum >= HealthLogEntity.MOMENTUM_THRESHOLD) return '改善傾向';
+    if (momentum <= -HealthLogEntity.MOMENTUM_THRESHOLD) return '悪化傾向';
     return '変化なし';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -10,6 +10,8 @@ export class MathHelper {
   private static readonly NORMALIZED_LOW_THRESHOLD = 20;
   private static readonly CORRELATION_STRONG_THRESHOLD = 0.7;
   private static readonly CORRELATION_WEAK_THRESHOLD = 0.3;
+  private static readonly OUTLIER_SEVERE_RATE = 0.2;
+  private static readonly OUTLIER_MINOR_RATE = 0.05;
 
   /**
    * パーセントを算出(0-100%)
@@ -255,8 +257,8 @@ export class MathHelper {
   static getOutlierSeverityLabel(outlierCount: number, total: number): string {
     if (total === 0 || outlierCount === 0) return '正常';
     const rate = outlierCount / total;
-    if (rate >= 0.2) return '深刻';
-    if (rate >= 0.05) return '軽微';
+    if (rate >= MathHelper.OUTLIER_SEVERE_RATE) return '深刻';
+    if (rate >= MathHelper.OUTLIER_MINOR_RATE) return '軽微';
     return '正常';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -777,6 +777,9 @@ export class ScheduleEntity {
 
   private static readonly COVERAGE_HIGH_THRESHOLD = 80;
   private static readonly COVERAGE_NORMAL_THRESHOLD = 50;
+  private static readonly ADHERENCE_EXCELLENT_THRESHOLD = 90;
+  private static readonly ADHERENCE_GOOD_THRESHOLD = 70;
+  private static readonly ADHERENCE_FAIR_THRESHOLD = 50;
   private static readonly EFFICIENCY_MAX_DELAY = 120;
   private static readonly EFFICIENCY_EXCELLENT_THRESHOLD = 90;
   private static readonly EFFICIENCY_GOOD_THRESHOLD = 70;
@@ -845,9 +848,9 @@ export class ScheduleEntity {
    * 遵守率に応じたラベルを返す
    */
   static getAdherenceRateLabel(rate: number): string {
-    if (rate >= 90) return '優秀';
-    if (rate >= 70) return '良好';
-    if (rate >= 50) return '要改善';
+    if (rate >= ScheduleEntity.ADHERENCE_EXCELLENT_THRESHOLD) return '優秀';
+    if (rate >= ScheduleEntity.ADHERENCE_GOOD_THRESHOLD) return '良好';
+    if (rate >= ScheduleEntity.ADHERENCE_FAIR_THRESHOLD) return '要改善';
     return '不十分';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: OUTLIER_SEVERE_RATE(0.2), OUTLIER_MINOR_RATE(0.05) を追加
- HealthLog: MOMENTUM_THRESHOLD(0.5) を追加
- Schedule: ADHERENCE_EXCELLENT_THRESHOLD(90), ADHERENCE_GOOD_THRESHOLD(70), ADHERENCE_FAIR_THRESHOLD(50) を追加

## Test plan
- [x] 全4057テスト通過確認（振る舞い変更なし）