### PR TITLE
test: 外れ値件数・体調モメンタム・遵守率のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionMomentum.edge.test.ts
+++ b/src/__tests__/domain/entities/ConditionMomentum.edge.test.ts
@@ -1,0 +1,90 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Momentum Edge Cases', () => {
+  describe('getConditionMomentum', () => {
+    it('2件のみで正の変化', () => {
+      expect(HealthLogEntity.getConditionMomentum([1, 5])).toBe(4);
+    });
+
+    it('2件のみで負の変化', () => {
+      expect(HealthLogEntity.getConditionMomentum([5, 1])).toBe(-4);
+    });
+
+    it('2件で同値', () => {
+      expect(HealthLogEntity.getConditionMomentum([3, 3])).toBe(0);
+    });
+
+    it('直近3件のみ使用される（4件以上）', () => {
+      const result = HealthLogEntity.getConditionMomentum([1, 1, 1, 3, 5]);
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('先頭が異なっても直近3件が横ばいなら0', () => {
+      expect(HealthLogEntity.getConditionMomentum([1, 5, 3, 3, 3])).toBe(0);
+    });
+
+    it('最小値のみの配列', () => {
+      expect(HealthLogEntity.getConditionMomentum([1, 1, 1])).toBe(0);
+    });
+
+    it('最大値のみの配列', () => {
+      expect(HealthLogEntity.getConditionMomentum([5, 5, 5])).toBe(0);
+    });
+
+    it('急激な上昇', () => {
+      expect(HealthLogEntity.getConditionMomentum([1, 3, 5])).toBe(2);
+    });
+
+    it('急激な下降', () => {
+      expect(HealthLogEntity.getConditionMomentum([5, 3, 1])).toBe(-2);
+    });
+
+    it('V字回復は差分が相殺され0', () => {
+      expect(HealthLogEntity.getConditionMomentum([5, 1, 5])).toBe(0);
+    });
+
+    it('逆V字は差分が相殺され0', () => {
+      expect(HealthLogEntity.getConditionMomentum([1, 5, 1])).toBe(0);
+    });
+
+    it('小数の平均が正しく丸められる', () => {
+      const result = HealthLogEntity.getConditionMomentum([1, 2, 4]);
+      expect(result).toBe(1.5);
+    });
+
+    it('長い配列でも直近3件のみ', () => {
+      const result = HealthLogEntity.getConditionMomentum([5, 4, 3, 2, 1, 2, 3]);
+      expect(result).toBe(1);
+    });
+  });
+
+  describe('getMomentumLabel', () => {
+    it('閾値ちょうど0.5は改善傾向', () => {
+      expect(HealthLogEntity.getMomentumLabel(0.5)).toBe('改善傾向');
+    });
+
+    it('閾値ちょうど-0.5は悪化傾向', () => {
+      expect(HealthLogEntity.getMomentumLabel(-0.5)).toBe('悪化傾向');
+    });
+
+    it('0.49は変化なし', () => {
+      expect(HealthLogEntity.getMomentumLabel(0.49)).toBe('変化なし');
+    });
+
+    it('-0.49は変化なし', () => {
+      expect(HealthLogEntity.getMomentumLabel(-0.49)).toBe('変化なし');
+    });
+
+    it('大きな正の値は改善傾向', () => {
+      expect(HealthLogEntity.getMomentumLabel(10)).toBe('改善傾向');
+    });
+
+    it('大きな負の値は悪化傾向', () => {
+      expect(HealthLogEntity.getMomentumLabel(-10)).toBe('悪化傾向');
+    });
+
+    it('ちょうど0は変化なし', () => {
+      expect(HealthLogEntity.getMomentumLabel(0)).toBe('変化なし');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/OutlierCount.edge.test.ts
+++ b/src/__tests__/domain/entities/OutlierCount.edge.test.ts
@@ -1,0 +1,75 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Outlier Count Edge Cases', () => {
+  describe('getOutlierCount', () => {
+    it('2件のみは外れ値なし', () => {
+      expect(MathHelper.getOutlierCount([1, 100])).toBe(0);
+    });
+
+    it('3件で外れ値なし', () => {
+      expect(MathHelper.getOutlierCount([10, 11, 12])).toBe(0);
+    });
+
+    it('負の値を含む配列', () => {
+      expect(MathHelper.getOutlierCount([-100, 1, 2, 3, 4, 5])).toBe(1);
+    });
+
+    it('全て負の値', () => {
+      expect(MathHelper.getOutlierCount([-5, -4, -3, -2, -1])).toBe(0);
+    });
+
+    it('小数値の配列', () => {
+      expect(MathHelper.getOutlierCount([1.1, 1.2, 1.3, 1.4, 100.5])).toBe(1);
+    });
+
+    it('0を含む配列', () => {
+      expect(MathHelper.getOutlierCount([0, 0, 0, 0, 100])).toBe(1);
+    });
+
+    it('大きな値の配列', () => {
+      expect(MathHelper.getOutlierCount([1000, 1001, 1002, 1003, 9999])).toBe(1);
+    });
+
+    it('IQR境界上の値は外れ値ではない', () => {
+      const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+      const count = MathHelper.getOutlierCount(values);
+      expect(count).toBe(0);
+    });
+
+    it('2件の同一値', () => {
+      expect(MathHelper.getOutlierCount([5, 5])).toBe(0);
+    });
+
+    it('大量データで外れ値検出', () => {
+      const values = Array.from({ length: 100 }, (_, i) => i + 1);
+      values.push(10000);
+      expect(MathHelper.getOutlierCount(values)).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getOutlierSeverityLabel', () => {
+    it('外れ値率ちょうど20%は深刻', () => {
+      expect(MathHelper.getOutlierSeverityLabel(2, 10)).toBe('深刻');
+    });
+
+    it('外れ値率ちょうど5%は軽微', () => {
+      expect(MathHelper.getOutlierSeverityLabel(1, 20)).toBe('軽微');
+    });
+
+    it('外れ値率5%未満は正常', () => {
+      expect(MathHelper.getOutlierSeverityLabel(1, 100)).toBe('正常');
+    });
+
+    it('全件外れ値は深刻', () => {
+      expect(MathHelper.getOutlierSeverityLabel(10, 10)).toBe('深刻');
+    });
+
+    it('外れ値1件で全体1件は深刻', () => {
+      expect(MathHelper.getOutlierSeverityLabel(1, 1)).toBe('深刻');
+    });
+
+    it('外れ値が全体より多くても深刻', () => {
+      expect(MathHelper.getOutlierSeverityLabel(20, 10)).toBe('深刻');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleAdherenceRate.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleAdherenceRate.edge.test.ts
@@ -1,0 +1,82 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Schedule Adherence Rate Edge Cases', () => {
+  describe('getScheduleAdherenceRate', () => {
+    it('1件完了で100', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true])).toBe(100);
+    });
+
+    it('1件未完了で0', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([false])).toBe(0);
+    });
+
+    it('大量データで全完了', () => {
+      const completions = Array.from({ length: 1000 }, () => true);
+      expect(ScheduleEntity.getScheduleAdherenceRate(completions)).toBe(100);
+    });
+
+    it('大量データで全未完了', () => {
+      const completions = Array.from({ length: 1000 }, () => false);
+      expect(ScheduleEntity.getScheduleAdherenceRate(completions)).toBe(0);
+    });
+
+    it('3件中1件完了は33', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true, false, false])).toBe(33);
+    });
+
+    it('3件中2件完了は67', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true, true, false])).toBe(67);
+    });
+
+    it('7件中3件完了は43', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true, true, true, false, false, false, false])).toBe(43);
+    });
+
+    it('交互パターン', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true, false, true, false, true, false])).toBe(50);
+    });
+
+    it('2件中1件完了は50', () => {
+      expect(ScheduleEntity.getScheduleAdherenceRate([true, false])).toBe(50);
+    });
+
+    it('10件中9件完了は90', () => {
+      const completions = [true, true, true, true, true, true, true, true, true, false];
+      expect(ScheduleEntity.getScheduleAdherenceRate(completions)).toBe(90);
+    });
+  });
+
+  describe('getAdherenceRateLabel', () => {
+    it('90は優秀', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(90)).toBe('優秀');
+    });
+
+    it('89は良好', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(89)).toBe('良好');
+    });
+
+    it('70は良好', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(70)).toBe('良好');
+    });
+
+    it('69は要改善', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(69)).toBe('要改善');
+    });
+
+    it('50は要改善', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(50)).toBe('要改善');
+    });
+
+    it('49は不十分', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(49)).toBe('不十分');
+    });
+
+    it('0は不十分', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(0)).toBe('不十分');
+    });
+
+    it('100は優秀', () => {
+      expect(ScheduleEntity.getAdherenceRateLabel(100)).toBe('優秀');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getOutlierCount / getOutlierSeverityLabel のエッジケーステスト16件追加
- getConditionMomentum / getMomentumLabel のエッジケーステスト20件追加
- getScheduleAdherenceRate / getAdherenceRateLabel のエッジケーステスト18件追加

## Test plan
- [x] 全4111件テスト通過確認

closes #778