### PR TITLE
feat: 連続未達成回数・在庫回転率・通院完了率の算出メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentCompletionRate.test.ts
+++ b/src/__tests__/domain/entities/AppointmentCompletionRate.test.ts
@@ -1,0 +1,55 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Appointment Completion Rate', () => {
+  describe('getAppointmentCompletionRate', () => {
+    it('空配列は0', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([])).toBe(0);
+    });
+
+    it('全て完了は100', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([true, true, true])).toBe(100);
+    });
+
+    it('全て未完了は0', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([false, false, false])).toBe(0);
+    });
+
+    it('半分完了は50', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([true, false, true, false])).toBe(50);
+    });
+
+    it('1件完了は100', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([true])).toBe(100);
+    });
+
+    it('1件未完了は0', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([false])).toBe(0);
+    });
+
+    it('3件中1件完了は33', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([true, false, false])).toBe(33);
+    });
+
+    it('3件中2件完了は67', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([true, true, false])).toBe(67);
+    });
+  });
+
+  describe('getAppointmentCompletionLabel', () => {
+    it('90以上は優秀', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(90)).toBe('優秀');
+    });
+
+    it('70以上は良好', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(70)).toBe('良好');
+    });
+
+    it('50以上は要改善', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(50)).toBe('要改善');
+    });
+
+    it('50未満は不十分', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(30)).toBe('不十分');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ConsecutiveFailures.test.ts
+++ b/src/__tests__/domain/entities/ConsecutiveFailures.test.ts
@@ -1,0 +1,59 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Consecutive Failures', () => {
+  describe('getConsecutiveFailures', () => {
+    it('空配列は0', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([])).toBe(0);
+    });
+
+    it('全て達成は0', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([true, true, true])).toBe(0);
+    });
+
+    it('全て未達成は全件数', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([false, false, false])).toBe(3);
+    });
+
+    it('末尾1件が未達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([true, true, false])).toBe(1);
+    });
+
+    it('末尾3件が未達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([true, false, false, false])).toBe(3);
+    });
+
+    it('途中に達成がある場合は末尾からカウント', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([false, false, true, false, false])).toBe(2);
+    });
+
+    it('1件のみ達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([true])).toBe(0);
+    });
+
+    it('1件のみ未達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([false])).toBe(1);
+    });
+
+    it('末尾が達成で終わる場合は0', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([false, false, true])).toBe(0);
+    });
+  });
+
+  describe('getConsecutiveFailuresLabel', () => {
+    it('0回は良好', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(0)).toBe('良好');
+    });
+
+    it('2回は注意', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(2)).toBe('注意');
+    });
+
+    it('5回は警告', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(5)).toBe('警告');
+    });
+
+    it('10回は危険', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(10)).toBe('危険');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockRotationRate.test.ts
+++ b/src/__tests__/domain/entities/StockRotationRate.test.ts
@@ -1,0 +1,59 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Stock Rotation Rate', () => {
+  describe('getStockRotationRate', () => {
+    it('消費0は0', () => {
+      expect(StockAlertEntity.getStockRotationRate(0, 100)).toBe(0);
+    });
+
+    it('平均在庫0はnull', () => {
+      expect(StockAlertEntity.getStockRotationRate(100, 0)).toBeNull();
+    });
+
+    it('消費100/在庫50は2.0', () => {
+      expect(StockAlertEntity.getStockRotationRate(100, 50)).toBe(2);
+    });
+
+    it('消費50/在庫100は0.5', () => {
+      expect(StockAlertEntity.getStockRotationRate(50, 100)).toBe(0.5);
+    });
+
+    it('消費と在庫が同じは1.0', () => {
+      expect(StockAlertEntity.getStockRotationRate(100, 100)).toBe(1);
+    });
+
+    it('小数点第2位で丸められる', () => {
+      expect(StockAlertEntity.getStockRotationRate(100, 30)).toBe(3.33);
+    });
+
+    it('両方0はnull', () => {
+      expect(StockAlertEntity.getStockRotationRate(0, 0)).toBeNull();
+    });
+
+    it('負の消費量は0', () => {
+      expect(StockAlertEntity.getStockRotationRate(-10, 50)).toBe(0);
+    });
+
+    it('負の平均在庫はnull', () => {
+      expect(StockAlertEntity.getStockRotationRate(100, -10)).toBeNull();
+    });
+  });
+
+  describe('getStockRotationLabel', () => {
+    it('nullはデータなし', () => {
+      expect(StockAlertEntity.getStockRotationLabel(null)).toBe('データなし');
+    });
+
+    it('高回転', () => {
+      expect(StockAlertEntity.getStockRotationLabel(3)).toBe('高回転');
+    });
+
+    it('適正回転', () => {
+      expect(StockAlertEntity.getStockRotationLabel(1.5)).toBe('適正');
+    });
+
+    it('低回転', () => {
+      expect(StockAlertEntity.getStockRotationLabel(0.3)).toBe('低回転');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -276,6 +276,31 @@ export class AdherenceTrendEntity {
     return 'ばらつきあり';
   }
 
+  /**
+   * 末尾からの連続未達成回数を算出する
+   */
+  static getConsecutiveFailures(dailyResults: boolean[]): number {
+    let count = 0;
+    for (let i = dailyResults.length - 1; i >= 0; i--) {
+      if (!dailyResults[i]) {
+        count++;
+      } else {
+        break;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * 連続未達成回数に応じたラベルを返す
+   */
+  static getConsecutiveFailuresLabel(count: number): string {
+    if (count === 0) return '良好';
+    if (count < 3) return '注意';
+    if (count < 7) return '警告';
+    return '危険';
+  }
+
   static getPerformanceGradeLabel(grade: string): string {
     const labels: Record<string, string> = {
       A: '優秀',

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -510,4 +510,27 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.CYCLE_MODERATE_THRESHOLD) return 'やや不規則';
     return '不規則';
   }
+
+  private static readonly COMPLETION_EXCELLENT_THRESHOLD = 90;
+  private static readonly COMPLETION_GOOD_THRESHOLD = 70;
+  private static readonly COMPLETION_FAIR_THRESHOLD = 50;
+
+  /**
+   * 通院完了/未完了配列から完了率(0-100)を算出する
+   */
+  static getAppointmentCompletionRate(completions: boolean[]): number {
+    if (completions.length === 0) return 0;
+    const completed = completions.filter(Boolean).length;
+    return Math.round((completed / completions.length) * 100);
+  }
+
+  /**
+   * 通院完了率に応じたラベルを返す
+   */
+  static getAppointmentCompletionLabel(rate: number): string {
+    if (rate >= AppointmentEntity.COMPLETION_EXCELLENT_THRESHOLD) return '優秀';
+    if (rate >= AppointmentEntity.COMPLETION_GOOD_THRESHOLD) return '良好';
+    if (rate >= AppointmentEntity.COMPLETION_FAIR_THRESHOLD) return '要改善';
+    return '不十分';
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -452,6 +452,25 @@ export class StockAlertEntity {
     return labels[trend] ?? '在庫安定';
   }
 
+  /**
+   * 在庫回転率を算出する（消費量 / 平均在庫）
+   */
+  static getStockRotationRate(consumed: number, averageStock: number): number | null {
+    if (averageStock <= 0) return null;
+    if (consumed <= 0) return 0;
+    return Math.round((consumed / averageStock) * 100) / 100;
+  }
+
+  /**
+   * 在庫回転率に応じたラベルを返す
+   */
+  static getStockRotationLabel(rate: number | null): string {
+    if (rate === null) return 'データなし';
+    if (rate >= 2) return '高回転';
+    if (rate >= 1) return '適正';
+    return '低回転';
+  }
+
   static getRefillPriorityLabel(rank: number): string {
     if (rank === 1) return '最優先';
     if (rank === 2) return '優先';


### PR DESCRIPTION
## Summary
- AdherenceTrend: getConsecutiveFailures / getConsecutiveFailuresLabel（末尾からの連続未達成回数）
- StockAlert: getStockRotationRate / getStockRotationLabel（在庫回転率）
- Appointment: getAppointmentCompletionRate / getAppointmentCompletionLabel（通院完了率）

## Test plan
- [x] 全4149件テスト通過確認

closes #780