### PR TITLE
test: 連続未達成回数・在庫回転率・通院完了率のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentCompletionRate.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentCompletionRate.edge.test.ts
@@ -1,0 +1,67 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Appointment Completion Rate Edge Cases', () => {
+  describe('getAppointmentCompletionRate', () => {
+    it('大量データで全完了', () => {
+      const completions = Array.from({ length: 1000 }, () => true);
+      expect(AppointmentEntity.getAppointmentCompletionRate(completions)).toBe(100);
+    });
+
+    it('大量データで全未完了', () => {
+      const completions = Array.from({ length: 1000 }, () => false);
+      expect(AppointmentEntity.getAppointmentCompletionRate(completions)).toBe(0);
+    });
+
+    it('7件中5件完了は71', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([true, true, true, true, true, false, false])).toBe(71);
+    });
+
+    it('交互パターン奇数個で末尾true', () => {
+      expect(AppointmentEntity.getAppointmentCompletionRate([true, false, true, false, true])).toBe(60);
+    });
+
+    it('10件中1件完了は10', () => {
+      const completions = [true, ...Array.from({ length: 9 }, () => false)];
+      expect(AppointmentEntity.getAppointmentCompletionRate(completions)).toBe(10);
+    });
+
+    it('10件中9件完了は90', () => {
+      const completions = [...Array.from({ length: 9 }, () => true), false];
+      expect(AppointmentEntity.getAppointmentCompletionRate(completions)).toBe(90);
+    });
+  });
+
+  describe('getAppointmentCompletionLabel', () => {
+    it('100は優秀', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(100)).toBe('優秀');
+    });
+
+    it('90は優秀（閾値境界）', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(90)).toBe('優秀');
+    });
+
+    it('89は良好', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(89)).toBe('良好');
+    });
+
+    it('70は良好（閾値境界）', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(70)).toBe('良好');
+    });
+
+    it('69は要改善', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(69)).toBe('要改善');
+    });
+
+    it('50は要改善（閾値境界）', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(50)).toBe('要改善');
+    });
+
+    it('49は不十分', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(49)).toBe('不十分');
+    });
+
+    it('0は不十分', () => {
+      expect(AppointmentEntity.getAppointmentCompletionLabel(0)).toBe('不十分');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ConsecutiveFailures.edge.test.ts
+++ b/src/__tests__/domain/entities/ConsecutiveFailures.edge.test.ts
@@ -1,0 +1,58 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Consecutive Failures Edge Cases', () => {
+  describe('getConsecutiveFailures', () => {
+    it('大量の未達成', () => {
+      const results = Array.from({ length: 100 }, () => false);
+      expect(AdherenceTrendEntity.getConsecutiveFailures(results)).toBe(100);
+    });
+
+    it('大量の達成後に1件未達成', () => {
+      const results = Array.from({ length: 99 }, () => true);
+      results.push(false);
+      expect(AdherenceTrendEntity.getConsecutiveFailures(results)).toBe(1);
+    });
+
+    it('交互パターンで末尾が未達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([true, false, true, false])).toBe(1);
+    });
+
+    it('交互パターンで末尾が達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([false, true, false, true])).toBe(0);
+    });
+
+    it('先頭のみ達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([true, false, false, false, false])).toBe(4);
+    });
+
+    it('末尾のみ達成', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailures([false, false, false, false, true])).toBe(0);
+    });
+  });
+
+  describe('getConsecutiveFailuresLabel', () => {
+    it('1回は注意', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(1)).toBe('注意');
+    });
+
+    it('2回は注意', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(2)).toBe('注意');
+    });
+
+    it('3回は警告（閾値境界）', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(3)).toBe('警告');
+    });
+
+    it('6回は警告', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(6)).toBe('警告');
+    });
+
+    it('7回は危険（閾値境界）', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(7)).toBe('危険');
+    });
+
+    it('100回は危険', () => {
+      expect(AdherenceTrendEntity.getConsecutiveFailuresLabel(100)).toBe('危険');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockRotationRate.edge.test.ts
+++ b/src/__tests__/domain/entities/StockRotationRate.edge.test.ts
@@ -1,0 +1,63 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Stock Rotation Rate Edge Cases', () => {
+  describe('getStockRotationRate', () => {
+    it('非常に大きな消費量', () => {
+      expect(StockAlertEntity.getStockRotationRate(1000000, 100)).toBe(10000);
+    });
+
+    it('非常に小さな平均在庫', () => {
+      expect(StockAlertEntity.getStockRotationRate(100, 0.01)).toBe(10000);
+    });
+
+    it('消費と在庫が小数', () => {
+      expect(StockAlertEntity.getStockRotationRate(1.5, 0.5)).toBe(3);
+    });
+
+    it('消費0で平均在庫が正', () => {
+      expect(StockAlertEntity.getStockRotationRate(0, 50)).toBe(0);
+    });
+
+    it('平均在庫がちょうど0はnull', () => {
+      expect(StockAlertEntity.getStockRotationRate(50, 0)).toBeNull();
+    });
+
+    it('両方が非常に大きい値', () => {
+      expect(StockAlertEntity.getStockRotationRate(999999, 999999)).toBe(1);
+    });
+
+    it('丸め処理の確認', () => {
+      expect(StockAlertEntity.getStockRotationRate(1, 3)).toBe(0.33);
+    });
+
+    it('丸め処理2', () => {
+      expect(StockAlertEntity.getStockRotationRate(2, 3)).toBe(0.67);
+    });
+  });
+
+  describe('getStockRotationLabel', () => {
+    it('ちょうど2.0は高回転', () => {
+      expect(StockAlertEntity.getStockRotationLabel(2)).toBe('高回転');
+    });
+
+    it('1.99は適正', () => {
+      expect(StockAlertEntity.getStockRotationLabel(1.99)).toBe('適正');
+    });
+
+    it('ちょうど1.0は適正', () => {
+      expect(StockAlertEntity.getStockRotationLabel(1)).toBe('適正');
+    });
+
+    it('0.99は低回転', () => {
+      expect(StockAlertEntity.getStockRotationLabel(0.99)).toBe('低回転');
+    });
+
+    it('0は低回転', () => {
+      expect(StockAlertEntity.getStockRotationLabel(0)).toBe('低回転');
+    });
+
+    it('非常に高い回転率', () => {
+      expect(StockAlertEntity.getStockRotationLabel(100)).toBe('高回転');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getConsecutiveFailures / getConsecutiveFailuresLabel のエッジケーステスト12件追加
- getStockRotationRate / getStockRotationLabel のエッジケーステスト14件追加
- getAppointmentCompletionRate / getAppointmentCompletionLabel のエッジケーステスト14件追加

## Test plan
- [x] 全4189件テスト通過確認

closes #784