### PR TITLE
test: 連続達成日数・空白日数・日付範囲のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceStreak.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStreak.edge.test.ts
@@ -1,0 +1,59 @@
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity - Adherence Streak Edge Cases', () => {
+  describe('getAdherenceStreak', () => {
+    it('大量の連続達成', () => {
+      const results = Array.from({ length: 365 }, () => true);
+      expect(MedicationRecordEntity.getAdherenceStreak(results)).toBe(365);
+    });
+
+    it('大量データで末尾1件のみ未達成', () => {
+      const results = Array.from({ length: 99 }, () => true);
+      results.push(false);
+      expect(MedicationRecordEntity.getAdherenceStreak(results)).toBe(0);
+    });
+
+    it('大量データで先頭のみ未達成', () => {
+      const results = [false, ...Array.from({ length: 99 }, () => true)];
+      expect(MedicationRecordEntity.getAdherenceStreak(results)).toBe(99);
+    });
+
+    it('交互パターン', () => {
+      expect(MedicationRecordEntity.getAdherenceStreak([true, false, true, false, true])).toBe(1);
+    });
+
+    it('2件で両方達成', () => {
+      expect(MedicationRecordEntity.getAdherenceStreak([true, true])).toBe(2);
+    });
+
+    it('2件で先頭のみ達成', () => {
+      expect(MedicationRecordEntity.getAdherenceStreak([true, false])).toBe(0);
+    });
+  });
+
+  describe('getAdherenceStreakLabel', () => {
+    it('1日は継続中', () => {
+      expect(MedicationRecordEntity.getAdherenceStreakLabel(1)).toBe('継続中');
+    });
+
+    it('6日は継続中', () => {
+      expect(MedicationRecordEntity.getAdherenceStreakLabel(6)).toBe('継続中');
+    });
+
+    it('7日は好調（閾値境界）', () => {
+      expect(MedicationRecordEntity.getAdherenceStreakLabel(7)).toBe('好調');
+    });
+
+    it('29日は好調', () => {
+      expect(MedicationRecordEntity.getAdherenceStreakLabel(29)).toBe('好調');
+    });
+
+    it('30日は素晴らしい（閾値境界）', () => {
+      expect(MedicationRecordEntity.getAdherenceStreakLabel(30)).toBe('素晴らしい');
+    });
+
+    it('365日は素晴らしい', () => {
+      expect(MedicationRecordEntity.getAdherenceStreakLabel(365)).toBe('素晴らしい');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/DateSpanDays.edge.test.ts
+++ b/src/__tests__/domain/entities/DateSpanDays.edge.test.ts
@@ -1,0 +1,64 @@
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper - Date Span Days Edge Cases', () => {
+  describe('getDateSpanDays', () => {
+    it('2件の同一日付は0', () => {
+      expect(DateRangeHelper.getDateSpanDays(['2026-03-01', '2026-03-01'])).toBe(0);
+    });
+
+    it('年をまたぐ', () => {
+      expect(DateRangeHelper.getDateSpanDays(['2025-12-31', '2026-01-01'])).toBe(1);
+    });
+
+    it('閏年の2月', () => {
+      expect(DateRangeHelper.getDateSpanDays(['2024-02-28', '2024-03-01'])).toBe(2);
+    });
+
+    it('非閏年の2月', () => {
+      expect(DateRangeHelper.getDateSpanDays(['2025-02-28', '2025-03-01'])).toBe(1);
+    });
+
+    it('大量の日付でも最初と最後の差', () => {
+      const dates = Array.from({ length: 100 }, (_, i) => {
+        const d = new Date('2026-01-01');
+        d.setDate(d.getDate() + i);
+        return DateRangeHelper.toDateKey(d);
+      });
+      expect(DateRangeHelper.getDateSpanDays(dates)).toBe(99);
+    });
+
+    it('逆順の3件', () => {
+      expect(DateRangeHelper.getDateSpanDays(['2026-01-30', '2026-01-10', '2026-01-20'])).toBe(20);
+    });
+
+    it('重複を含む', () => {
+      expect(DateRangeHelper.getDateSpanDays(['2026-01-01', '2026-01-01', '2026-01-10'])).toBe(9);
+    });
+  });
+
+  describe('getDateSpanLabel', () => {
+    it('1日は短期間', () => {
+      expect(DateRangeHelper.getDateSpanLabel(1)).toBe('短期間');
+    });
+
+    it('13日は短期間', () => {
+      expect(DateRangeHelper.getDateSpanLabel(13)).toBe('短期間');
+    });
+
+    it('14日は中期間（閾値境界）', () => {
+      expect(DateRangeHelper.getDateSpanLabel(14)).toBe('中期間');
+    });
+
+    it('89日は中期間', () => {
+      expect(DateRangeHelper.getDateSpanLabel(89)).toBe('中期間');
+    });
+
+    it('90日は長期間（閾値境界）', () => {
+      expect(DateRangeHelper.getDateSpanLabel(90)).toBe('長期間');
+    });
+
+    it('365日は長期間', () => {
+      expect(DateRangeHelper.getDateSpanLabel(365)).toBe('長期間');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RecordGapDays.edge.test.ts
+++ b/src/__tests__/domain/entities/RecordGapDays.edge.test.ts
@@ -1,0 +1,63 @@
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity - Record Gap Days Edge Cases', () => {
+  describe('getRecordGapDays', () => {
+    it('全て同じ日付は0', () => {
+      expect(CalendarEntity.getRecordGapDays(['2026-01-01', '2026-01-01', '2026-01-01'])).toBe(0);
+    });
+
+    it('3日連続で空白なし', () => {
+      expect(CalendarEntity.getRecordGapDays(['2026-01-01', '2026-01-02', '2026-01-03'])).toBe(0);
+    });
+
+    it('逆順でも正しく算出', () => {
+      expect(CalendarEntity.getRecordGapDays(['2026-01-10', '2026-01-01', '2026-01-05'])).toBe(4);
+    });
+
+    it('年をまたぐ', () => {
+      expect(CalendarEntity.getRecordGapDays(['2025-12-31', '2026-01-01'])).toBe(0);
+    });
+
+    it('月末と月初', () => {
+      expect(CalendarEntity.getRecordGapDays(['2026-01-31', '2026-02-01'])).toBe(0);
+    });
+
+    it('複数のギャップがある場合は最大を返す', () => {
+      expect(CalendarEntity.getRecordGapDays(['2026-01-01', '2026-01-03', '2026-01-10'])).toBe(6);
+    });
+
+    it('2件で隣接', () => {
+      expect(CalendarEntity.getRecordGapDays(['2026-03-01', '2026-03-02'])).toBe(0);
+    });
+
+    it('大きなギャップ', () => {
+      expect(CalendarEntity.getRecordGapDays(['2025-01-01', '2026-01-01'])).toBe(364);
+    });
+  });
+
+  describe('getRecordGapLabel', () => {
+    it('1日は短い空白', () => {
+      expect(CalendarEntity.getRecordGapLabel(1)).toBe('短い空白');
+    });
+
+    it('2日は短い空白', () => {
+      expect(CalendarEntity.getRecordGapLabel(2)).toBe('短い空白');
+    });
+
+    it('3日は長い空白（閾値境界）', () => {
+      expect(CalendarEntity.getRecordGapLabel(3)).toBe('長い空白');
+    });
+
+    it('13日は長い空白', () => {
+      expect(CalendarEntity.getRecordGapLabel(13)).toBe('長い空白');
+    });
+
+    it('14日は記録途絶（閾値境界）', () => {
+      expect(CalendarEntity.getRecordGapLabel(14)).toBe('記録途絶');
+    });
+
+    it('100日は記録途絶', () => {
+      expect(CalendarEntity.getRecordGapLabel(100)).toBe('記録途絶');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getAdherenceStreak / getAdherenceStreakLabel のエッジケーステスト12件追加
- getRecordGapDays / getRecordGapLabel のエッジケーステスト14件追加
- getDateSpanDays / getDateSpanLabel のエッジケーステスト13件追加

## Test plan
- [x] 全4251件テスト通過確認

closes #790