### PR TITLE
feat: 体調分散値・スケジュール間隔・幾何平均の算出メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionVariance.test.ts
+++ b/src/__tests__/domain/entities/ConditionVariance.test.ts
@@ -1,0 +1,51 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Variance', () => {
+  describe('getConditionVariance', () => {
+    it('空配列は0', () => {
+      expect(HealthLogEntity.getConditionVariance([])).toBe(0);
+    });
+
+    it('1件のみは0', () => {
+      expect(HealthLogEntity.getConditionVariance([3])).toBe(0);
+    });
+
+    it('全て同じ値は0', () => {
+      expect(HealthLogEntity.getConditionVariance([3, 3, 3, 3])).toBe(0);
+    });
+
+    it('最大と最小のみ', () => {
+      const result = HealthLogEntity.getConditionVariance([1, 5]);
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('分散値が正しく算出される', () => {
+      const result = HealthLogEntity.getConditionVariance([1, 2, 3, 4, 5]);
+      expect(result).toBe(2);
+    });
+
+    it('ばらつきが小さい', () => {
+      const result = HealthLogEntity.getConditionVariance([3, 3, 4, 3, 3]);
+      expect(result).toBeLessThan(1);
+    });
+
+    it('ばらつきが大きい', () => {
+      const result = HealthLogEntity.getConditionVariance([1, 5, 1, 5]);
+      expect(result).toBe(4);
+    });
+  });
+
+  describe('getConditionVarianceLabel', () => {
+    it('低分散は安定', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(0.5)).toBe('安定');
+    });
+
+    it('中程度の分散はやや不安定', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(2)).toBe('やや不安定');
+    });
+
+    it('高分散は不安定', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(4)).toBe('不安定');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/GeometricMean.test.ts
+++ b/src/__tests__/domain/entities/GeometricMean.test.ts
@@ -1,0 +1,52 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Geometric Mean', () => {
+  describe('getGeometricMean', () => {
+    it('空配列は0', () => {
+      expect(MathHelper.getGeometricMean([])).toBe(0);
+    });
+
+    it('1件のみはその値', () => {
+      expect(MathHelper.getGeometricMean([4])).toBe(4);
+    });
+
+    it('同じ値はその値', () => {
+      expect(MathHelper.getGeometricMean([5, 5, 5])).toBe(5);
+    });
+
+    it('2と8の幾何平均は4', () => {
+      expect(MathHelper.getGeometricMean([2, 8])).toBe(4);
+    });
+
+    it('1, 2, 4の幾何平均', () => {
+      expect(MathHelper.getGeometricMean([1, 2, 4])).toBe(2);
+    });
+
+    it('0を含む場合は0', () => {
+      expect(MathHelper.getGeometricMean([0, 5, 10])).toBe(0);
+    });
+
+    it('負の値を含む場合は0', () => {
+      expect(MathHelper.getGeometricMean([-1, 5, 10])).toBe(0);
+    });
+
+    it('小数点第2位で丸められる', () => {
+      const result = MathHelper.getGeometricMean([3, 5, 7]);
+      expect(result).toBe(4.72);
+    });
+  });
+
+  describe('getGeometricMeanLabel', () => {
+    it('高い値', () => {
+      expect(MathHelper.getGeometricMeanLabel(80)).toBe('高い');
+    });
+
+    it('中程度の値', () => {
+      expect(MathHelper.getGeometricMeanLabel(50)).toBe('中程度');
+    });
+
+    it('低い値', () => {
+      expect(MathHelper.getGeometricMeanLabel(20)).toBe('低い');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleGapMinutes.test.ts
+++ b/src/__tests__/domain/entities/ScheduleGapMinutes.test.ts
@@ -1,0 +1,55 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Schedule Gap Minutes', () => {
+  describe('getScheduleGapMinutes', () => {
+    it('空配列は0', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes([])).toBe(0);
+    });
+
+    it('1件のみは0', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['08:00'])).toBe(0);
+    });
+
+    it('2件の間隔', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['08:00', '12:00'])).toBe(240);
+    });
+
+    it('3件で最大間隔を返す', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['08:00', '09:00', '14:00'])).toBe(300);
+    });
+
+    it('同じ時刻は0', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['08:00', '08:00'])).toBe(0);
+    });
+
+    it('順序が不正でも正しくソート', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['14:00', '08:00'])).toBe(360);
+    });
+
+    it('均等間隔', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['06:00', '12:00', '18:00'])).toBe(360);
+    });
+
+    it('1分差', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['08:00', '08:01'])).toBe(1);
+    });
+  });
+
+  describe('getScheduleGapLabel', () => {
+    it('0分は間隔なし', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(0)).toBe('間隔なし');
+    });
+
+    it('120分は短い', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(120)).toBe('短い');
+    });
+
+    it('360分は適切', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(360)).toBe('適切');
+    });
+
+    it('480分以上は長い', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(480)).toBe('長い');
+    });
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -826,4 +826,23 @@ export class HealthLogEntity {
     if (momentum <= -HealthLogEntity.MOMENTUM_THRESHOLD) return '悪化傾向';
     return '変化なし';
   }
+
+  /**
+   * 体調レベル配列の分散値を算出する
+   */
+  static getConditionVariance(conditions: number[]): number {
+    if (conditions.length <= 1) return 0;
+    const avg = conditions.reduce((a, b) => a + b, 0) / conditions.length;
+    const variance = conditions.reduce((sum, c) => sum + (c - avg) ** 2, 0) / conditions.length;
+    return Math.round(variance * 100) / 100;
+  }
+
+  /**
+   * 分散値に応じたラベルを返す
+   */
+  static getConditionVarianceLabel(variance: number): string {
+    if (variance < 1) return '安定';
+    if (variance < 3) return 'やや不安定';
+    return '不安定';
+  }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -261,4 +261,24 @@ export class MathHelper {
     if (rate >= MathHelper.OUTLIER_MINOR_RATE) return '軽微';
     return '正常';
   }
+
+  /**
+   * 幾何平均を算出する（0以下の値を含む場合は0）
+   */
+  static getGeometricMean(values: number[]): number {
+    if (values.length === 0) return 0;
+    if (values.some((v) => v <= 0)) return 0;
+    const logSum = values.reduce((sum, v) => sum + Math.log(v), 0);
+    const mean = Math.exp(logSum / values.length);
+    return Math.round(mean * 100) / 100;
+  }
+
+  /**
+   * 幾何平均に応じたラベルを返す
+   */
+  static getGeometricMeanLabel(mean: number): string {
+    if (mean >= 70) return '高い';
+    if (mean >= 30) return '中程度';
+    return '低い';
+  }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -853,4 +853,28 @@ export class ScheduleEntity {
     if (rate >= ScheduleEntity.ADHERENCE_FAIR_THRESHOLD) return '要改善';
     return '不十分';
   }
+
+  /**
+   * 時刻配列(HH:mm)の最大間隔（分）を算出する
+   */
+  static getScheduleGapMinutes(times: string[]): number {
+    if (times.length <= 1) return 0;
+    const minutes = times.map((t) => ScheduleEntity.timeToMinutes(t)).sort((a, b) => a - b);
+    let maxGap = 0;
+    for (let i = 1; i < minutes.length; i++) {
+      const gap = minutes[i] - minutes[i - 1];
+      if (gap > maxGap) maxGap = gap;
+    }
+    return maxGap;
+  }
+
+  /**
+   * スケジュール間隔に応じたラベルを返す
+   */
+  static getScheduleGapLabel(gapMinutes: number): string {
+    if (gapMinutes === 0) return '間隔なし';
+    if (gapMinutes < 180) return '短い';
+    if (gapMinutes < 480) return '適切';
+    return '長い';
+  }
 }


### PR DESCRIPTION
## Summary
- HealthLog: getConditionVariance / getConditionVarianceLabel（体調レベルの分散値）
- Schedule: getScheduleGapMinutes / getScheduleGapLabel（スケジュール間の最大間隔分数）
- MathHelper: getGeometricMean / getGeometricMeanLabel（幾何平均）

## Test plan
- [x] 全4284件テスト通過確認

closes #792