### PR TITLE
test: 体調分散値・スケジュール間隔・幾何平均のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionVariance.edge.test.ts
+++ b/src/__tests__/domain/entities/ConditionVariance.edge.test.ts
@@ -1,0 +1,63 @@
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity - Condition Variance Edge Cases', () => {
+  describe('getConditionVariance', () => {
+    it('2件で同値は0', () => {
+      expect(HealthLogEntity.getConditionVariance([3, 3])).toBe(0);
+    });
+
+    it('2件で最大差', () => {
+      const result = HealthLogEntity.getConditionVariance([1, 5]);
+      expect(result).toBe(4);
+    });
+
+    it('大量データで同値', () => {
+      const data = Array.from({ length: 100 }, () => 3);
+      expect(HealthLogEntity.getConditionVariance(data)).toBe(0);
+    });
+
+    it('大量データでばらつき', () => {
+      const data = Array.from({ length: 100 }, (_, i) => (i % 5) + 1);
+      expect(HealthLogEntity.getConditionVariance(data)).toBeGreaterThan(0);
+    });
+
+    it('全て最小値', () => {
+      expect(HealthLogEntity.getConditionVariance([1, 1, 1, 1])).toBe(0);
+    });
+
+    it('全て最大値', () => {
+      expect(HealthLogEntity.getConditionVariance([5, 5, 5, 5])).toBe(0);
+    });
+
+    it('小数点第2位で丸められる', () => {
+      const result = HealthLogEntity.getConditionVariance([1, 2, 3]);
+      expect(result).toBe(0.67);
+    });
+  });
+
+  describe('getConditionVarianceLabel', () => {
+    it('0は安定', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(0)).toBe('安定');
+    });
+
+    it('0.99は安定', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(0.99)).toBe('安定');
+    });
+
+    it('1はやや不安定（閾値境界）', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(1)).toBe('やや不安定');
+    });
+
+    it('2.99はやや不安定', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(2.99)).toBe('やや不安定');
+    });
+
+    it('3は不安定（閾値境界）', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(3)).toBe('不安定');
+    });
+
+    it('10は不安定', () => {
+      expect(HealthLogEntity.getConditionVarianceLabel(10)).toBe('不安定');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/GeometricMean.edge.test.ts
+++ b/src/__tests__/domain/entities/GeometricMean.edge.test.ts
@@ -1,0 +1,65 @@
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper - Geometric Mean Edge Cases', () => {
+  describe('getGeometricMean', () => {
+    it('全て1は1', () => {
+      expect(MathHelper.getGeometricMean([1, 1, 1])).toBe(1);
+    });
+
+    it('大きな値', () => {
+      expect(MathHelper.getGeometricMean([100, 100, 100])).toBe(100);
+    });
+
+    it('小数値', () => {
+      expect(MathHelper.getGeometricMean([0.5, 2])).toBe(1);
+    });
+
+    it('非常に小さい正の値', () => {
+      const result = MathHelper.getGeometricMean([0.01, 0.01]);
+      expect(result).toBe(0.01);
+    });
+
+    it('1件で0は0', () => {
+      expect(MathHelper.getGeometricMean([0])).toBe(0);
+    });
+
+    it('2件で片方0は0', () => {
+      expect(MathHelper.getGeometricMean([100, 0])).toBe(0);
+    });
+
+    it('負の値のみは0', () => {
+      expect(MathHelper.getGeometricMean([-5, -3])).toBe(0);
+    });
+
+    it('大量データ', () => {
+      const values = Array.from({ length: 100 }, () => 10);
+      expect(MathHelper.getGeometricMean(values)).toBe(10);
+    });
+  });
+
+  describe('getGeometricMeanLabel', () => {
+    it('70は高い（閾値境界）', () => {
+      expect(MathHelper.getGeometricMeanLabel(70)).toBe('高い');
+    });
+
+    it('69は中程度', () => {
+      expect(MathHelper.getGeometricMeanLabel(69)).toBe('中程度');
+    });
+
+    it('30は中程度（閾値境界）', () => {
+      expect(MathHelper.getGeometricMeanLabel(30)).toBe('中程度');
+    });
+
+    it('29は低い', () => {
+      expect(MathHelper.getGeometricMeanLabel(29)).toBe('低い');
+    });
+
+    it('0は低い', () => {
+      expect(MathHelper.getGeometricMeanLabel(0)).toBe('低い');
+    });
+
+    it('100は高い', () => {
+      expect(MathHelper.getGeometricMeanLabel(100)).toBe('高い');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleGapMinutes.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleGapMinutes.edge.test.ts
@@ -1,0 +1,56 @@
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity - Schedule Gap Minutes Edge Cases', () => {
+  describe('getScheduleGapMinutes', () => {
+    it('全て同じ時刻', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['12:00', '12:00', '12:00'])).toBe(0);
+    });
+
+    it('深夜と朝', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['00:00', '06:00'])).toBe(360);
+    });
+
+    it('1日の端から端', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['00:00', '23:59'])).toBe(1439);
+    });
+
+    it('4件で不均等', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['08:00', '08:30', '12:00', '20:00'])).toBe(480);
+    });
+
+    it('2件で1分差', () => {
+      expect(ScheduleEntity.getScheduleGapMinutes(['12:00', '12:01'])).toBe(1);
+    });
+
+    it('大量の同一時刻', () => {
+      const times = Array.from({ length: 50 }, () => '08:00');
+      expect(ScheduleEntity.getScheduleGapMinutes(times)).toBe(0);
+    });
+  });
+
+  describe('getScheduleGapLabel', () => {
+    it('1分は短い', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(1)).toBe('短い');
+    });
+
+    it('179分は短い', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(179)).toBe('短い');
+    });
+
+    it('180分は適切（閾値境界）', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(180)).toBe('適切');
+    });
+
+    it('479分は適切', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(479)).toBe('適切');
+    });
+
+    it('480分は長い（閾値境界）', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(480)).toBe('長い');
+    });
+
+    it('1440分は長い', () => {
+      expect(ScheduleEntity.getScheduleGapLabel(1440)).toBe('長い');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- getConditionVariance / getConditionVarianceLabel のエッジケーステスト13件追加
- getScheduleGapMinutes / getScheduleGapLabel のエッジケーステスト12件追加
- getGeometricMean / getGeometricMeanLabel のエッジケーステスト14件追加

## Test plan
- [x] 全4323件テスト通過確認

closes #796