### PR TITLE
feat: 週次変化率・在庫カバレッジ・通院間隔均等度の算出メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentSpacing.test.ts
+++ b/src/__tests__/domain/entities/AppointmentSpacing.test.ts
@@ -1,0 +1,50 @@
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity - Appointment Spacing', () => {
+  describe('getAppointmentSpacing', () => {
+    it('空配列は0', () => {
+      expect(AppointmentEntity.getAppointmentSpacing([])).toBe(0);
+    });
+
+    it('1件のみは100', () => {
+      expect(AppointmentEntity.getAppointmentSpacing([30])).toBe(100);
+    });
+
+    it('均等間隔は100', () => {
+      expect(AppointmentEntity.getAppointmentSpacing([30, 30, 30])).toBe(100);
+    });
+
+    it('不均等間隔', () => {
+      const result = AppointmentEntity.getAppointmentSpacing([7, 30, 60]);
+      expect(result).toBeLessThan(100);
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('全て同じ間隔は100', () => {
+      expect(AppointmentEntity.getAppointmentSpacing([14, 14, 14, 14])).toBe(100);
+    });
+
+    it('2件で差が大きい', () => {
+      const result = AppointmentEntity.getAppointmentSpacing([1, 100]);
+      expect(result).toBeLessThan(50);
+    });
+
+    it('全て0は100', () => {
+      expect(AppointmentEntity.getAppointmentSpacing([0, 0, 0])).toBe(100);
+    });
+  });
+
+  describe('getAppointmentSpacingLabel', () => {
+    it('均等', () => {
+      expect(AppointmentEntity.getAppointmentSpacingLabel(85)).toBe('均等');
+    });
+
+    it('やや不均等', () => {
+      expect(AppointmentEntity.getAppointmentSpacingLabel(60)).toBe('やや不均等');
+    });
+
+    it('不均等', () => {
+      expect(AppointmentEntity.getAppointmentSpacingLabel(30)).toBe('不均等');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/StockCoverageScore.test.ts
+++ b/src/__tests__/domain/entities/StockCoverageScore.test.ts
@@ -1,0 +1,47 @@
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity - Stock Coverage Score', () => {
+  describe('getStockCoverageScore', () => {
+    it('在庫0は0', () => {
+      expect(StockAlertEntity.getStockCoverageScore(0, 1)).toBe(0);
+    });
+
+    it('日消費0は100', () => {
+      expect(StockAlertEntity.getStockCoverageScore(10, 0)).toBe(100);
+    });
+
+    it('30日分ちょうどは100', () => {
+      expect(StockAlertEntity.getStockCoverageScore(30, 1)).toBe(100);
+    });
+
+    it('15日分は50', () => {
+      expect(StockAlertEntity.getStockCoverageScore(15, 1)).toBe(50);
+    });
+
+    it('60日分は100（上限）', () => {
+      expect(StockAlertEntity.getStockCoverageScore(60, 1)).toBe(100);
+    });
+
+    it('1日分で日消費2', () => {
+      expect(StockAlertEntity.getStockCoverageScore(1, 2)).toBe(2);
+    });
+
+    it('両方0は100', () => {
+      expect(StockAlertEntity.getStockCoverageScore(0, 0)).toBe(100);
+    });
+  });
+
+  describe('getStockCoverageLabel', () => {
+    it('高カバレッジ', () => {
+      expect(StockAlertEntity.getStockCoverageLabel(80)).toBe('十分');
+    });
+
+    it('中カバレッジ', () => {
+      expect(StockAlertEntity.getStockCoverageLabel(50)).toBe('やや不足');
+    });
+
+    it('低カバレッジ', () => {
+      expect(StockAlertEntity.getStockCoverageLabel(20)).toBe('不足');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/WeekOverWeekChange.test.ts
+++ b/src/__tests__/domain/entities/WeekOverWeekChange.test.ts
@@ -1,0 +1,55 @@
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity - Week Over Week Change', () => {
+  describe('getWeekOverWeekChange', () => {
+    it('空配列は0', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([])).toBe(0);
+    });
+
+    it('1件のみは0', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([50])).toBe(0);
+    });
+
+    it('増加', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([50, 70])).toBe(20);
+    });
+
+    it('減少', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([70, 50])).toBe(-20);
+    });
+
+    it('変化なし', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([60, 60])).toBe(0);
+    });
+
+    it('3件以上は最後2件の差', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([30, 50, 80])).toBe(30);
+    });
+
+    it('0から100', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([0, 100])).toBe(100);
+    });
+
+    it('100から0', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekChange([100, 0])).toBe(-100);
+    });
+  });
+
+  describe('getWeekOverWeekLabel', () => {
+    it('正の変化は改善', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekLabel(15)).toBe('改善');
+    });
+
+    it('負の変化は悪化', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekLabel(-15)).toBe('悪化');
+    });
+
+    it('小さな変化は横ばい', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekLabel(3)).toBe('横ばい');
+    });
+
+    it('0は横ばい', () => {
+      expect(AdherenceTrendEntity.getWeekOverWeekLabel(0)).toBe('横ばい');
+    });
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -312,4 +312,21 @@ export class AdherenceTrendEntity {
     };
     return labels[grade] ?? '要注意';
   }
+
+  /**
+   * 週次遵守率配列の直近2週間の変化量を算出する
+   */
+  static getWeekOverWeekChange(weeklyRates: number[]): number {
+    if (weeklyRates.length < 2) return 0;
+    return weeklyRates[weeklyRates.length - 1] - weeklyRates[weeklyRates.length - 2];
+  }
+
+  /**
+   * 週次変化量に応じたラベルを返す
+   */
+  static getWeekOverWeekLabel(change: number): string {
+    if (change >= 5) return '改善';
+    if (change <= -5) return '悪化';
+    return '横ばい';
+  }
 }

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -533,4 +533,27 @@ export class AppointmentEntity {
     if (rate >= AppointmentEntity.COMPLETION_FAIR_THRESHOLD) return '要改善';
     return '不十分';
   }
+
+  /**
+   * 通院間隔配列の均等度スコア(0-100)を算出する
+   * 変動係数が小さいほど高スコア
+   */
+  static getAppointmentSpacing(intervals: number[]): number {
+    if (intervals.length === 0) return 0;
+    if (intervals.length === 1) return 100;
+    const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+    if (avg === 0) return 100;
+    const variance = intervals.reduce((sum, v) => sum + (v - avg) ** 2, 0) / intervals.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.max(0, Math.min(100, Math.round(100 - cv * 100)));
+  }
+
+  /**
+   * 均等度スコアに応じたラベルを返す
+   */
+  static getAppointmentSpacingLabel(score: number): string {
+    if (score >= 80) return '均等';
+    if (score >= 50) return 'やや不均等';
+    return '不均等';
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -479,4 +479,23 @@ export class StockAlertEntity {
     if (rank === 3) return '通常';
     return '低優先';
   }
+
+  /**
+   * 在庫カバレッジスコア(0-100)を算出する
+   * 30日分を100%とし、在庫数/日消費量で算出
+   */
+  static getStockCoverageScore(stock: number, dailyConsumption: number): number {
+    if (dailyConsumption <= 0) return 100;
+    const coverageDays = stock / dailyConsumption;
+    return Math.min(100, Math.max(0, Math.round((coverageDays / StockAlertEntity.DAYS_PER_MONTH) * 100)));
+  }
+
+  /**
+   * 在庫カバレッジスコアに応じたラベルを返す
+   */
+  static getStockCoverageLabel(score: number): string {
+    if (score >= 70) return '十分';
+    if (score >= 40) return 'やや不足';
+    return '不足';
+  }
 }


### PR DESCRIPTION
## Summary
- AdherenceTrend: getWeekOverWeekChange / getWeekOverWeekLabel（直近2週間の変化量）
- StockAlert: getStockCoverageScore / getStockCoverageLabel（30日基準の在庫カバレッジ）
- Appointment: getAppointmentSpacing / getAppointmentSpacingLabel（CV基準の均等度）

## Test plan
- [x] 全4355件テスト通過確認

closes #798