### PR TITLE
refactor: 週次変化率・在庫カバレッジ・通院間隔均等度のマジックナンバー定数化

### DIFF
--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -30,6 +30,7 @@ export class AdherenceTrendEntity {
   private static readonly DISTRIBUTION_DOMINANT_THRESHOLD = 50;
   private static readonly FAILURES_WARNING_THRESHOLD = 3;
   private static readonly FAILURES_DANGER_THRESHOLD = 7;
+  private static readonly WOW_CHANGE_THRESHOLD = 5;
 
   constructor(private readonly trend: AdherenceTrend) {}
 
@@ -325,8 +326,8 @@ export class AdherenceTrendEntity {
    * 週次変化量に応じたラベルを返す
    */
   static getWeekOverWeekLabel(change: number): string {
-    if (change >= 5) return '改善';
-    if (change <= -5) return '悪化';
+    if (change >= AdherenceTrendEntity.WOW_CHANGE_THRESHOLD) return '改善';
+    if (change <= -AdherenceTrendEntity.WOW_CHANGE_THRESHOLD) return '悪化';
     return '横ばい';
   }
 }

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -514,6 +514,8 @@ export class AppointmentEntity {
   private static readonly COMPLETION_EXCELLENT_THRESHOLD = 90;
   private static readonly COMPLETION_GOOD_THRESHOLD = 70;
   private static readonly COMPLETION_FAIR_THRESHOLD = 50;
+  private static readonly SPACING_EVEN_THRESHOLD = 80;
+  private static readonly SPACING_MODERATE_THRESHOLD = 50;
 
   /**
    * 通院完了/未完了配列から完了率(0-100)を算出する
@@ -552,8 +554,8 @@ export class AppointmentEntity {
    * 均等度スコアに応じたラベルを返す
    */
   static getAppointmentSpacingLabel(score: number): string {
-    if (score >= 80) return '均等';
-    if (score >= 50) return 'やや不均等';
+    if (score >= AppointmentEntity.SPACING_EVEN_THRESHOLD) return '均等';
+    if (score >= AppointmentEntity.SPACING_MODERATE_THRESHOLD) return 'やや不均等';
     return '不均等';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -28,6 +28,8 @@ export class StockAlertEntity {
   private static readonly STOCK_TREND_THRESHOLD = 2;
   private static readonly ROTATION_HIGH_THRESHOLD = 2;
   private static readonly ROTATION_NORMAL_THRESHOLD = 1;
+  private static readonly COVERAGE_SUFFICIENT_THRESHOLD = 70;
+  private static readonly COVERAGE_LOW_THRESHOLD = 40;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -494,8 +496,8 @@ export class StockAlertEntity {
    * 在庫カバレッジスコアに応じたラベルを返す
    */
   static getStockCoverageLabel(score: number): string {
-    if (score >= 70) return '十分';
-    if (score >= 40) return 'やや不足';
+    if (score >= StockAlertEntity.COVERAGE_SUFFICIENT_THRESHOLD) return '十分';
+    if (score >= StockAlertEntity.COVERAGE_LOW_THRESHOLD) return 'やや不足';
     return '不足';
   }
 }


### PR DESCRIPTION
## Summary
- AdherenceTrend: getWeekOverWeekLabelのマジックナンバー(5)をWOW_CHANGE_THRESHOLDとして定数化
- StockAlert: getStockCoverageLabelのマジックナンバー(70, 40)をCOVERAGE_SUFFICIENT_THRESHOLD, COVERAGE_LOW_THRESHOLDとして定数化
- Appointment: getAppointmentSpacingLabelのマジックナンバー(80, 50)をSPACING_EVEN_THRESHOLD, SPACING_MODERATE_THRESHOLDとして定数化

## Test plan
- [x] 既存テスト4355件が全てパス
- [x] リファクタリング後の動作変更なし

closes #800