### PR TITLE
feat: 服薬時刻規則性・症状持続率・記録網羅度の算出メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/DoseRegularity.test.ts
+++ b/src/__tests__/domain/entities/DoseRegularity.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('getDoseRegularity', () => {
+  it('空配列の場合0を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularity([])).toBe(0);
+  });
+
+  it('1要素の場合100を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularity([480])).toBe(100);
+  });
+
+  it('全て同じ時刻の場合100を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularity([480, 480, 480])).toBe(100);
+  });
+
+  it('ばらつきが大きい場合低スコアを返す', () => {
+    const score = MedicationRecordEntity.getDoseRegularity([0, 720, 0, 720]);
+    expect(score).toBeLessThan(50);
+  });
+
+  it('やや均一な時刻の場合中程度のスコアを返す', () => {
+    const score = MedicationRecordEntity.getDoseRegularity([480, 490, 470, 485]);
+    expect(score).toBeGreaterThan(70);
+  });
+
+  it('0-100の範囲に収まる', () => {
+    const score = MedicationRecordEntity.getDoseRegularity([0, 1440, 0, 1440]);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('getDoseRegularityLabel', () => {
+  it('80以上は規則的を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularityLabel(80)).toBe('規則的');
+  });
+
+  it('50以上80未満はやや不規則を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularityLabel(60)).toBe('やや不規則');
+  });
+
+  it('50未満は不規則を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularityLabel(30)).toBe('不規則');
+  });
+
+  it('100は規則的を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularityLabel(100)).toBe('規則的');
+  });
+
+  it('0は不規則を返す', () => {
+    expect(MedicationRecordEntity.getDoseRegularityLabel(0)).toBe('不規則');
+  });
+});

--- a/src/__tests__/domain/entities/RecordCompleteness.test.ts
+++ b/src/__tests__/domain/entities/RecordCompleteness.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('getRecordCompleteness', () => {
+  it('記録日数0・期待日数0の場合0を返す', () => {
+    expect(CalendarEntity.getRecordCompleteness(0, 0)).toBe(0);
+  });
+
+  it('記録日数0・期待日数正の場合0を返す', () => {
+    expect(CalendarEntity.getRecordCompleteness(0, 30)).toBe(0);
+  });
+
+  it('全日記録の場合100を返す', () => {
+    expect(CalendarEntity.getRecordCompleteness(30, 30)).toBe(100);
+  });
+
+  it('半分記録の場合50を返す', () => {
+    expect(CalendarEntity.getRecordCompleteness(15, 30)).toBe(50);
+  });
+
+  it('記録が期待を超える場合100を返す', () => {
+    expect(CalendarEntity.getRecordCompleteness(35, 30)).toBe(100);
+  });
+
+  it('1日中1日記録の場合100を返す', () => {
+    expect(CalendarEntity.getRecordCompleteness(1, 1)).toBe(100);
+  });
+
+  it('期待日数が負の場合0を返す', () => {
+    expect(CalendarEntity.getRecordCompleteness(5, -1)).toBe(0);
+  });
+});
+
+describe('getRecordCompletenessLabel', () => {
+  it('90以上は完璧を返す', () => {
+    expect(CalendarEntity.getRecordCompletenessLabel(90)).toBe('完璧');
+  });
+
+  it('70以上90未満は良好を返す', () => {
+    expect(CalendarEntity.getRecordCompletenessLabel(75)).toBe('良好');
+  });
+
+  it('50以上70未満はまずまずを返す', () => {
+    expect(CalendarEntity.getRecordCompletenessLabel(55)).toBe('まずまず');
+  });
+
+  it('50未満は不足を返す', () => {
+    expect(CalendarEntity.getRecordCompletenessLabel(30)).toBe('不足');
+  });
+
+  it('100は完璧を返す', () => {
+    expect(CalendarEntity.getRecordCompletenessLabel(100)).toBe('完璧');
+  });
+
+  it('0は不足を返す', () => {
+    expect(CalendarEntity.getRecordCompletenessLabel(0)).toBe('不足');
+  });
+});

--- a/src/__tests__/domain/entities/SymptomPersistenceRate.test.ts
+++ b/src/__tests__/domain/entities/SymptomPersistenceRate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('getSymptomPersistenceRate', () => {
+  it('空配列の場合0を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceRate([], 'headache')).toBe(0);
+  });
+
+  it('対象症状がない場合0を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceRate([['fever'], ['cough']], 'headache')).toBe(0);
+  });
+
+  it('全ての記録に含まれる場合100を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceRate([['headache'], ['headache'], ['headache']], 'headache')).toBe(100);
+  });
+
+  it('半分の記録に含まれる場合50を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceRate([['headache'], ['fever'], ['headache'], ['fever']], 'headache')).toBe(50);
+  });
+
+  it('1件中1件の場合100を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceRate([['headache', 'fever']], 'headache')).toBe(100);
+  });
+
+  it('複数症状を含む記録でも正しくカウントする', () => {
+    const records = [['headache', 'fever'], ['fever'], ['headache', 'cough']];
+    expect(HealthLogEntity.getSymptomPersistenceRate(records, 'headache')).toBe(67);
+  });
+});
+
+describe('getSymptomPersistenceLabel', () => {
+  it('70以上は持続的を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceLabel(70)).toBe('持続的');
+  });
+
+  it('40以上70未満は断続的を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceLabel(50)).toBe('断続的');
+  });
+
+  it('40未満は一時的を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceLabel(20)).toBe('一時的');
+  });
+
+  it('0は一時的を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceLabel(0)).toBe('一時的');
+  });
+
+  it('100は持続的を返す', () => {
+    expect(HealthLogEntity.getSymptomPersistenceLabel(100)).toBe('持続的');
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -495,6 +495,25 @@ export class CalendarEntity {
   }
 
   /**
+   * 記録の網羅度スコア(0-100)を算出する
+   * 記録日数/期待日数の割合、100を上限
+   */
+  static getRecordCompleteness(recordDays: number, expectedDays: number): number {
+    if (expectedDays <= 0) return 0;
+    return Math.min(100, Math.round((recordDays / expectedDays) * 100));
+  }
+
+  /**
+   * 記録網羅度スコアに応じたラベルを返す
+   */
+  static getRecordCompletenessLabel(score: number): string {
+    if (score >= 90) return '完璧';
+    if (score >= 70) return '良好';
+    if (score >= 50) return 'まずまず';
+    return '不足';
+  }
+
+  /**
    * 日付キー配列から最大の空白日数（ギャップ）を算出する
    */
   static getRecordGapDays(dateKeys: string[]): number {

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -830,6 +830,25 @@ export class HealthLogEntity {
   }
 
   /**
+   * 症状の持続率(0-100)を算出する
+   * 全記録中に指定症状が含まれる割合
+   */
+  static getSymptomPersistenceRate(symptomLists: string[][], symptom: string): number {
+    if (symptomLists.length === 0) return 0;
+    const count = symptomLists.filter((list) => list.includes(symptom)).length;
+    return Math.round((count / symptomLists.length) * 100);
+  }
+
+  /**
+   * 症状持続率に応じたラベルを返す
+   */
+  static getSymptomPersistenceLabel(rate: number): string {
+    if (rate >= 70) return '持続的';
+    if (rate >= 40) return '断続的';
+    return '一時的';
+  }
+
+  /**
    * 体調レベル配列の分散値を算出する
    */
   static getConditionVariance(conditions: number[]): number {

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -701,6 +701,29 @@ export class MedicationRecordEntity {
   }
 
   /**
+   * 服薬時刻（分単位）配列から規則性スコア(0-100)を算出する
+   * 標準偏差が小さいほど高スコア（最大標準偏差120分基準）
+   */
+  static getDoseRegularity(timesInMinutes: number[]): number {
+    if (timesInMinutes.length === 0) return 0;
+    if (timesInMinutes.length === 1) return 100;
+    const avg = timesInMinutes.reduce((a, b) => a + b, 0) / timesInMinutes.length;
+    const variance = timesInMinutes.reduce((sum, v) => sum + (v - avg) ** 2, 0) / timesInMinutes.length;
+    const stdDev = Math.sqrt(variance);
+    const maxStdDev = 120;
+    return Math.max(0, Math.min(100, Math.round(100 - (stdDev / maxStdDev) * 100)));
+  }
+
+  /**
+   * 服薬時刻規則性スコアに応じたラベルを返す
+   */
+  static getDoseRegularityLabel(score: number): string {
+    if (score >= 80) return '規則的';
+    if (score >= 50) return 'やや不規則';
+    return '不規則';
+  }
+
+  /**
    * 末尾からの連続達成日数を算出する
    */
   static getAdherenceStreak(dailyResults: boolean[]): number {


### PR DESCRIPTION
## Summary
- MedicationRecord: getDoseRegularity / getDoseRegularityLabel（服薬時刻の規則性スコア、標準偏差ベース）
- HealthLog: getSymptomPersistenceRate / getSymptomPersistenceLabel（症状の持続率、出現割合ベース）
- Calendar: getRecordCompleteness / getRecordCompletenessLabel（記録の網羅度スコア）

## Test plan
- [x] DoseRegularity: 11テスト
- [x] SymptomPersistenceRate: 11テスト
- [x] RecordCompleteness: 13テスト
- [x] 全4435テストがパス

closes #804