### PR TITLE
refactor: 服薬時刻規則性・症状持続率・記録網羅度のマジックナンバー定数化

### DIFF
--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -36,6 +36,9 @@ export class CalendarEntity {
   private static readonly WEEKEND_BIAS_THRESHOLD = 60;
   private static readonly GAP_SHORT_THRESHOLD = 3;
   private static readonly GAP_LONG_THRESHOLD = 14;
+  private static readonly COMPLETENESS_PERFECT_THRESHOLD = 90;
+  private static readonly COMPLETENESS_GOOD_THRESHOLD = 70;
+  private static readonly COMPLETENESS_FAIR_THRESHOLD = 50;
 
   /**
    * 指定月のカレンダーデータを生成
@@ -507,9 +510,9 @@ export class CalendarEntity {
    * 記録網羅度スコアに応じたラベルを返す
    */
   static getRecordCompletenessLabel(score: number): string {
-    if (score >= 90) return '完璧';
-    if (score >= 70) return '良好';
-    if (score >= 50) return 'まずまず';
+    if (score >= CalendarEntity.COMPLETENESS_PERFECT_THRESHOLD) return '完璧';
+    if (score >= CalendarEntity.COMPLETENESS_GOOD_THRESHOLD) return '良好';
+    if (score >= CalendarEntity.COMPLETENESS_FAIR_THRESHOLD) return 'まずまず';
     return '不足';
   }
 

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -67,6 +67,8 @@ export class HealthLogEntity {
   private static readonly RECOVERY_MODERATE_THRESHOLD = 40;
   private static readonly VARIANCE_STABLE_THRESHOLD = 1;
   private static readonly VARIANCE_UNSTABLE_THRESHOLD = 3;
+  private static readonly PERSISTENCE_HIGH_THRESHOLD = 70;
+  private static readonly PERSISTENCE_MODERATE_THRESHOLD = 40;
   private static readonly TEMP_HYPOTHERMIA = 35.0;
   private static readonly TEMP_LOW_FEVER = 37.5;
   private static readonly TEMP_FEVER = 38.0;
@@ -843,8 +845,8 @@ export class HealthLogEntity {
    * 症状持続率に応じたラベルを返す
    */
   static getSymptomPersistenceLabel(rate: number): string {
-    if (rate >= 70) return '持続的';
-    if (rate >= 40) return '断続的';
+    if (rate >= HealthLogEntity.PERSISTENCE_HIGH_THRESHOLD) return '持続的';
+    if (rate >= HealthLogEntity.PERSISTENCE_MODERATE_THRESHOLD) return '断続的';
     return '一時的';
   }
 

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -41,6 +41,9 @@ export class MedicationRecordEntity {
   private static readonly TIMING_MODERATE_THRESHOLD = 40;
   private static readonly STREAK_GOOD_THRESHOLD = 7;
   private static readonly STREAK_EXCELLENT_THRESHOLD = 30;
+  private static readonly REGULARITY_MAX_STDDEV = 120;
+  private static readonly REGULARITY_HIGH_THRESHOLD = 80;
+  private static readonly REGULARITY_MODERATE_THRESHOLD = 50;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -710,16 +713,15 @@ export class MedicationRecordEntity {
     const avg = timesInMinutes.reduce((a, b) => a + b, 0) / timesInMinutes.length;
     const variance = timesInMinutes.reduce((sum, v) => sum + (v - avg) ** 2, 0) / timesInMinutes.length;
     const stdDev = Math.sqrt(variance);
-    const maxStdDev = 120;
-    return Math.max(0, Math.min(100, Math.round(100 - (stdDev / maxStdDev) * 100)));
+    return Math.max(0, Math.min(100, Math.round(100 - (stdDev / MedicationRecordEntity.REGULARITY_MAX_STDDEV) * 100)));
   }
 
   /**
    * 服薬時刻規則性スコアに応じたラベルを返す
    */
   static getDoseRegularityLabel(score: number): string {
-    if (score >= 80) return '規則的';
-    if (score >= 50) return 'やや不規則';
+    if (score >= MedicationRecordEntity.REGULARITY_HIGH_THRESHOLD) return '規則的';
+    if (score >= MedicationRecordEntity.REGULARITY_MODERATE_THRESHOLD) return 'やや不規則';
     return '不規則';
   }
 


### PR DESCRIPTION
## Summary
- MedicationRecord: REGULARITY_MAX_STDDEV(120), REGULARITY_HIGH_THRESHOLD(80), REGULARITY_MODERATE_THRESHOLD(50)を定数化
- HealthLog: PERSISTENCE_HIGH_THRESHOLD(70), PERSISTENCE_MODERATE_THRESHOLD(40)を定数化
- Calendar: COMPLETENESS_PERFECT_THRESHOLD(90), COMPLETENESS_GOOD_THRESHOLD(70), COMPLETENESS_FAIR_THRESHOLD(50)を定数化

## Test plan
- [x] 全4435テストがパス

closes #806