### PR TITLE
test: 服薬時刻規則性・症状持続率・記録網羅度のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/DoseRegularity.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseRegularity.edge.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('DoseRegularity エッジケーステスト', () => {
+  describe('getDoseRegularity', () => {
+    it('空配列の場合0を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularity([])).toBe(0);
+    });
+
+    it('1要素の場合100を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularity([0])).toBe(100);
+    });
+
+    it('全て0の場合100を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularity([0, 0, 0])).toBe(100);
+    });
+
+    it('最大値1440の同一値で100を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularity([1440, 1440, 1440])).toBe(100);
+    });
+
+    it('2要素で同値の場合100を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularity([300, 300])).toBe(100);
+    });
+
+    it('非常に大きなばらつきでも0以上を返す', () => {
+      const score = MedicationRecordEntity.getDoseRegularity([0, 1440]);
+      expect(score).toBeGreaterThanOrEqual(0);
+    });
+
+    it('負の値を含む場合も計算する', () => {
+      const score = MedicationRecordEntity.getDoseRegularity([-60, 60]);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+    });
+
+    it('大量の均一値で100を返す', () => {
+      const times = Array(100).fill(480);
+      expect(MedicationRecordEntity.getDoseRegularity(times)).toBe(100);
+    });
+
+    it('小さなばらつきで高スコアを返す', () => {
+      const score = MedicationRecordEntity.getDoseRegularity([480, 481, 479, 480]);
+      expect(score).toBeGreaterThan(95);
+    });
+  });
+
+  describe('getDoseRegularityLabel', () => {
+    it('境界値: 80は規則的を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularityLabel(80)).toBe('規則的');
+    });
+
+    it('境界値: 79はやや不規則を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularityLabel(79)).toBe('やや不規則');
+    });
+
+    it('境界値: 50はやや不規則を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularityLabel(50)).toBe('やや不規則');
+    });
+
+    it('境界値: 49は不規則を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularityLabel(49)).toBe('不規則');
+    });
+
+    it('100は規則的を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularityLabel(100)).toBe('規則的');
+    });
+
+    it('0は不規則を返す', () => {
+      expect(MedicationRecordEntity.getDoseRegularityLabel(0)).toBe('不規則');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/RecordCompleteness.edge.test.ts
+++ b/src/__tests__/domain/entities/RecordCompleteness.edge.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('RecordCompleteness エッジケーステスト', () => {
+  describe('getRecordCompleteness', () => {
+    it('両方0の場合0を返す', () => {
+      expect(CalendarEntity.getRecordCompleteness(0, 0)).toBe(0);
+    });
+
+    it('期待日数が負の場合0を返す', () => {
+      expect(CalendarEntity.getRecordCompleteness(5, -1)).toBe(0);
+    });
+
+    it('記録日数が期待日数と等しい場合100を返す', () => {
+      expect(CalendarEntity.getRecordCompleteness(30, 30)).toBe(100);
+    });
+
+    it('記録日数が期待日数を超える場合100を返す', () => {
+      expect(CalendarEntity.getRecordCompleteness(50, 30)).toBe(100);
+    });
+
+    it('記録日数1・期待日数100の場合1を返す', () => {
+      expect(CalendarEntity.getRecordCompleteness(1, 100)).toBe(1);
+    });
+
+    it('記録日数0・期待日数1の場合0を返す', () => {
+      expect(CalendarEntity.getRecordCompleteness(0, 1)).toBe(0);
+    });
+
+    it('大きな数値でも正しく計算する', () => {
+      expect(CalendarEntity.getRecordCompleteness(365, 365)).toBe(100);
+    });
+
+    it('小数の結果は四捨五入される', () => {
+      expect(CalendarEntity.getRecordCompleteness(1, 3)).toBe(33);
+    });
+
+    it('2/3の場合67を返す', () => {
+      expect(CalendarEntity.getRecordCompleteness(2, 3)).toBe(67);
+    });
+  });
+
+  describe('getRecordCompletenessLabel', () => {
+    it('境界値: 90は完璧を返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(90)).toBe('完璧');
+    });
+
+    it('境界値: 89は良好を返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(89)).toBe('良好');
+    });
+
+    it('境界値: 70は良好を返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(70)).toBe('良好');
+    });
+
+    it('境界値: 69はまずまずを返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(69)).toBe('まずまず');
+    });
+
+    it('境界値: 50はまずまずを返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(50)).toBe('まずまず');
+    });
+
+    it('境界値: 49は不足を返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(49)).toBe('不足');
+    });
+
+    it('100は完璧を返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(100)).toBe('完璧');
+    });
+
+    it('0は不足を返す', () => {
+      expect(CalendarEntity.getRecordCompletenessLabel(0)).toBe('不足');
+    });
+  });
+});

--- a/src/__tests__/domain/entities/SymptomPersistenceRate.edge.test.ts
+++ b/src/__tests__/domain/entities/SymptomPersistenceRate.edge.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('SymptomPersistenceRate エッジケーステスト', () => {
+  describe('getSymptomPersistenceRate', () => {
+    it('空配列の場合0を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceRate([], 'headache')).toBe(0);
+    });
+
+    it('全て空の症状リストの場合0を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceRate([[], [], []], 'headache')).toBe(0);
+    });
+
+    it('1件中0件の場合0を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceRate([['fever']], 'headache')).toBe(0);
+    });
+
+    it('大量データでも正しく計算する', () => {
+      const records = Array(100).fill(['headache']);
+      expect(HealthLogEntity.getSymptomPersistenceRate(records, 'headache')).toBe(100);
+    });
+
+    it('1件のみ含む場合の割合を正しく計算する', () => {
+      const records = [['headache'], ['fever'], ['fever'], ['fever'], ['fever']];
+      expect(HealthLogEntity.getSymptomPersistenceRate(records, 'headache')).toBe(20);
+    });
+
+    it('3件中2件の場合67を返す', () => {
+      const records = [['headache'], ['headache'], ['fever']];
+      expect(HealthLogEntity.getSymptomPersistenceRate(records, 'headache')).toBe(67);
+    });
+
+    it('存在しない症状は0を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceRate([['fever']], 'unknown_symptom')).toBe(0);
+    });
+
+    it('同じ症状が複数回含まれる記録でも1回としてカウントする', () => {
+      const records = [['headache', 'headache']];
+      expect(HealthLogEntity.getSymptomPersistenceRate(records, 'headache')).toBe(100);
+    });
+  });
+
+  describe('getSymptomPersistenceLabel', () => {
+    it('境界値: 70は持続的を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceLabel(70)).toBe('持続的');
+    });
+
+    it('境界値: 69は断続的を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceLabel(69)).toBe('断続的');
+    });
+
+    it('境界値: 40は断続的を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceLabel(40)).toBe('断続的');
+    });
+
+    it('境界値: 39は一時的を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceLabel(39)).toBe('一時的');
+    });
+
+    it('100は持続的を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceLabel(100)).toBe('持続的');
+    });
+
+    it('0は一時的を返す', () => {
+      expect(HealthLogEntity.getSymptomPersistenceLabel(0)).toBe('一時的');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- DoseRegularity: 空配列、同一値、大量データ、負の値、境界値テスト(15件)
- SymptomPersistenceRate: 空配列、空症状リスト、大量データ、境界値テスト(14件)
- RecordCompleteness: 0除算、負値、超過、四捨五入、境界値テスト(17件)

## Test plan
- [x] 新規46件のエッジケーステストがパス
- [x] 全4481テストがパス

closes #808