### PR TITLE
feat: 日付密度スコア・調和平均・通院時間厳守度の算出メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentPunctuality.test.ts
+++ b/src/__tests__/domain/entities/AppointmentPunctuality.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('getAppointmentPunctuality', () => {
+  it('空配列の場合0を返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctuality([])).toBe(0);
+  });
+
+  it('全て遅刻なしの場合100を返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctuality([0, 0, 0])).toBe(100);
+  });
+
+  it('全て大幅遅刻の場合低スコアを返す', () => {
+    const score = AppointmentEntity.getAppointmentPunctuality([60, 60, 60]);
+    expect(score).toBeLessThan(50);
+  });
+
+  it('1要素0分遅れの場合100を返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctuality([0])).toBe(100);
+  });
+
+  it('平均15分遅れの場合中程度のスコアを返す', () => {
+    const score = AppointmentEntity.getAppointmentPunctuality([15, 15, 15]);
+    expect(score).toBeGreaterThan(30);
+    expect(score).toBeLessThan(80);
+  });
+
+  it('0-100の範囲に収まる', () => {
+    const score = AppointmentEntity.getAppointmentPunctuality([120, 120, 120]);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('getAppointmentPunctualityLabel', () => {
+  it('80以上は時間厳守を返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctualityLabel(85)).toBe('時間厳守');
+  });
+
+  it('50以上80未満はやや遅れを返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctualityLabel(60)).toBe('やや遅れ');
+  });
+
+  it('50未満は遅刻傾向を返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctualityLabel(30)).toBe('遅刻傾向');
+  });
+
+  it('100は時間厳守を返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctualityLabel(100)).toBe('時間厳守');
+  });
+
+  it('0は遅刻傾向を返す', () => {
+    expect(AppointmentEntity.getAppointmentPunctualityLabel(0)).toBe('遅刻傾向');
+  });
+});

--- a/src/__tests__/domain/entities/DateDensityScore.test.ts
+++ b/src/__tests__/domain/entities/DateDensityScore.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('getDateDensityScore', () => {
+  it('空配列の場合0を返す', () => {
+    expect(DateRangeHelper.getDateDensityScore([])).toBe(0);
+  });
+
+  it('1日のみの場合100を返す', () => {
+    expect(DateRangeHelper.getDateDensityScore(['2026-01-01'])).toBe(100);
+  });
+
+  it('連続2日の場合100を返す', () => {
+    expect(DateRangeHelper.getDateDensityScore(['2026-01-01', '2026-01-02'])).toBe(100);
+  });
+
+  it('2日間隔の場合50を返す', () => {
+    expect(DateRangeHelper.getDateDensityScore(['2026-01-01', '2026-01-03'])).toBe(67);
+  });
+
+  it('31日間で毎日記録の場合100を返す', () => {
+    const keys = Array.from({ length: 31 }, (_, i) => {
+      const d = new Date(2026, 0, i + 1);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    });
+    expect(DateRangeHelper.getDateDensityScore(keys)).toBe(100);
+  });
+
+  it('重複日付は1回としてカウントする', () => {
+    expect(DateRangeHelper.getDateDensityScore(['2026-01-01', '2026-01-01', '2026-01-03'])).toBe(67);
+  });
+});
+
+describe('getDateDensityLabel', () => {
+  it('80以上は高密度を返す', () => {
+    expect(DateRangeHelper.getDateDensityLabel(80)).toBe('高密度');
+  });
+
+  it('50以上80未満は中密度を返す', () => {
+    expect(DateRangeHelper.getDateDensityLabel(60)).toBe('中密度');
+  });
+
+  it('50未満は低密度を返す', () => {
+    expect(DateRangeHelper.getDateDensityLabel(30)).toBe('低密度');
+  });
+
+  it('100は高密度を返す', () => {
+    expect(DateRangeHelper.getDateDensityLabel(100)).toBe('高密度');
+  });
+
+  it('0は低密度を返す', () => {
+    expect(DateRangeHelper.getDateDensityLabel(0)).toBe('低密度');
+  });
+});

--- a/src/__tests__/domain/entities/HarmonicMean.test.ts
+++ b/src/__tests__/domain/entities/HarmonicMean.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('getHarmonicMean', () => {
+  it('空配列の場合0を返す', () => {
+    expect(MathHelper.getHarmonicMean([])).toBe(0);
+  });
+
+  it('1要素の場合その値を返す', () => {
+    expect(MathHelper.getHarmonicMean([5])).toBe(5);
+  });
+
+  it('0を含む場合0を返す', () => {
+    expect(MathHelper.getHarmonicMean([0, 5, 10])).toBe(0);
+  });
+
+  it('負の値を含む場合0を返す', () => {
+    expect(MathHelper.getHarmonicMean([-1, 5, 10])).toBe(0);
+  });
+
+  it('全て同じ値の場合その値を返す', () => {
+    expect(MathHelper.getHarmonicMean([4, 4, 4])).toBe(4);
+  });
+
+  it('[1, 2, 4]の調和平均を正しく計算する', () => {
+    const result = MathHelper.getHarmonicMean([1, 2, 4]);
+    expect(result).toBeCloseTo(1.71, 1);
+  });
+
+  it('[2, 3]の調和平均を正しく計算する', () => {
+    const result = MathHelper.getHarmonicMean([2, 3]);
+    expect(result).toBe(2.4);
+  });
+});
+
+describe('getHarmonicMeanLabel', () => {
+  it('70以上は高いを返す', () => {
+    expect(MathHelper.getHarmonicMeanLabel(80)).toBe('高い');
+  });
+
+  it('30以上70未満は中程度を返す', () => {
+    expect(MathHelper.getHarmonicMeanLabel(50)).toBe('中程度');
+  });
+
+  it('30未満は低いを返す', () => {
+    expect(MathHelper.getHarmonicMeanLabel(10)).toBe('低い');
+  });
+
+  it('0は低いを返す', () => {
+    expect(MathHelper.getHarmonicMeanLabel(0)).toBe('低い');
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -516,6 +516,7 @@ export class AppointmentEntity {
   private static readonly COMPLETION_FAIR_THRESHOLD = 50;
   private static readonly SPACING_EVEN_THRESHOLD = 80;
   private static readonly SPACING_MODERATE_THRESHOLD = 50;
+  private static readonly PUNCTUALITY_MAX_DELAY = 30;
 
   /**
    * 通院完了/未完了配列から完了率(0-100)を算出する
@@ -557,5 +558,25 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.SPACING_EVEN_THRESHOLD) return '均等';
     if (score >= AppointmentEntity.SPACING_MODERATE_THRESHOLD) return 'やや不均等';
     return '不均等';
+  }
+
+  /**
+   * 遅刻分数配列(絶対値)から時間厳守度スコア(0-100)を算出する
+   * 平均遅刻分数が少ないほど高スコア（最大30分基準）
+   */
+  static getAppointmentPunctuality(delayMinutes: number[]): number {
+    if (delayMinutes.length === 0) return 0;
+    const absDelays = delayMinutes.map(Math.abs);
+    const avg = absDelays.reduce((a, b) => a + b, 0) / absDelays.length;
+    return Math.max(0, Math.min(100, Math.round(100 - (avg / AppointmentEntity.PUNCTUALITY_MAX_DELAY) * 100)));
+  }
+
+  /**
+   * 時間厳守度スコアに応じたラベルを返す
+   */
+  static getAppointmentPunctualityLabel(score: number): string {
+    if (score >= 80) return '時間厳守';
+    if (score >= 50) return 'やや遅れ';
+    return '遅刻傾向';
   }
 }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -333,6 +333,30 @@ export class DateRangeHelper {
   }
 
   /**
+   * 日付キー配列の密度スコア(0-100)を算出する
+   * ユニーク日数 / (最初〜最後の全日数) * 100
+   */
+  static getDateDensityScore(dateKeys: string[]): number {
+    if (dateKeys.length === 0) return 0;
+    const unique = [...new Set(dateKeys)].sort();
+    if (unique.length === 1) return 100;
+    const first = new Date(unique[0] + 'T00:00:00');
+    const last = new Date(unique[unique.length - 1] + 'T00:00:00');
+    const totalDays = Math.round((last.getTime() - first.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    if (totalDays <= 0) return 100;
+    return Math.min(100, Math.round((unique.length / totalDays) * 100));
+  }
+
+  /**
+   * 日付密度スコアに応じたラベルを返す
+   */
+  static getDateDensityLabel(score: number): string {
+    if (score >= 80) return '高密度';
+    if (score >= 50) return '中密度';
+    return '低密度';
+  }
+
+  /**
    * 日付範囲日数に応じたラベルを返す
    */
   static getDateSpanLabel(days: number): string {

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -276,6 +276,26 @@ export class MathHelper {
   }
 
   /**
+   * 調和平均を算出する（0以下の値を含む場合は0）
+   */
+  static getHarmonicMean(values: number[]): number {
+    if (values.length === 0) return 0;
+    if (values.some((v) => v <= 0)) return 0;
+    const sumReciprocals = values.reduce((sum, v) => sum + 1 / v, 0);
+    const mean = values.length / sumReciprocals;
+    return Math.round(mean * 100) / 100;
+  }
+
+  /**
+   * 調和平均に応じたラベルを返す
+   */
+  static getHarmonicMeanLabel(mean: number): string {
+    if (mean >= MathHelper.GEOMETRIC_HIGH_THRESHOLD) return '高い';
+    if (mean >= MathHelper.GEOMETRIC_LOW_THRESHOLD) return '中程度';
+    return '低い';
+  }
+
+  /**
    * 幾何平均に応じたラベルを返す
    */
   static getGeometricMeanLabel(mean: number): string {


### PR DESCRIPTION
## Summary
- DateRange: getDateDensityScore / getDateDensityLabel（日付配列の密度スコア、ユニーク日数/全期間日数ベース）
- MathHelper: getHarmonicMean / getHarmonicMeanLabel（調和平均、逆数の平均の逆数）
- Appointment: getAppointmentPunctuality / getAppointmentPunctualityLabel（通院時間厳守度、平均遅刻分数ベース）

## Test plan
- [x] DateDensityScore: 11テスト
- [x] HarmonicMean: 11テスト
- [x] AppointmentPunctuality: 11テスト
- [x] 全4581テストがパス

closes #816