### PR TITLE
refactor: DateDensityLabel・AppointmentPunctualityLabelのマジックナンバー定数化

### DIFF
--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -517,6 +517,8 @@ export class AppointmentEntity {
   private static readonly SPACING_EVEN_THRESHOLD = 80;
   private static readonly SPACING_MODERATE_THRESHOLD = 50;
   private static readonly PUNCTUALITY_MAX_DELAY = 30;
+  private static readonly PUNCTUALITY_HIGH_THRESHOLD = 80;
+  private static readonly PUNCTUALITY_MODERATE_THRESHOLD = 50;
 
   /**
    * 通院完了/未完了配列から完了率(0-100)を算出する
@@ -575,8 +577,8 @@ export class AppointmentEntity {
    * 時間厳守度スコアに応じたラベルを返す
    */
   static getAppointmentPunctualityLabel(score: number): string {
-    if (score >= 80) return '時間厳守';
-    if (score >= 50) return 'やや遅れ';
+    if (score >= AppointmentEntity.PUNCTUALITY_HIGH_THRESHOLD) return '時間厳守';
+    if (score >= AppointmentEntity.PUNCTUALITY_MODERATE_THRESHOLD) return 'やや遅れ';
     return '遅刻傾向';
   }
 }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -102,6 +102,8 @@ export class DateRangeHelper {
   private static readonly CLUSTER_MODERATE_THRESHOLD = 40;
   private static readonly SPAN_SHORT_THRESHOLD = 14;
   private static readonly SPAN_LONG_THRESHOLD = 90;
+  private static readonly DENSITY_HIGH_THRESHOLD = 80;
+  private static readonly DENSITY_MODERATE_THRESHOLD = 50;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -351,8 +353,8 @@ export class DateRangeHelper {
    * 日付密度スコアに応じたラベルを返す
    */
   static getDateDensityLabel(score: number): string {
-    if (score >= 80) return '高密度';
-    if (score >= 50) return '中密度';
+    if (score >= DateRangeHelper.DENSITY_HIGH_THRESHOLD) return '高密度';
+    if (score >= DateRangeHelper.DENSITY_MODERATE_THRESHOLD) return '中密度';
     return '低密度';
   }
 


### PR DESCRIPTION
## Summary
- DateRangeHelper: getDateDensityLabelのマジックナンバー(80, 50)をDENSITY_HIGH_THRESHOLD, DENSITY_MODERATE_THRESHOLDとして定数化
- AppointmentEntity: getAppointmentPunctualityLabelのマジックナンバー(80, 50)をPUNCTUALITY_HIGH_THRESHOLD, PUNCTUALITY_MODERATE_THRESHOLDとして定数化
- getHarmonicMeanLabelは既存GEOMETRIC定数を再利用済みのため対応不要

## Test plan
- [x] 全4581テスト通過確認済み