### PR TITLE
feat: トリム平均・スケジュール断片化・体調一貫性スコアの追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionConsistency.test.ts
+++ b/src/__tests__/domain/entities/ConditionConsistency.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionConsistency', () => {
+  it('空配列は0を返す', () => {
+    expect(HealthLogEntity.getConditionConsistency([])).toBe(0);
+  });
+
+  it('1件のみは100を返す', () => {
+    expect(HealthLogEntity.getConditionConsistency([3])).toBe(100);
+  });
+
+  it('全て同じ値なら100を返す', () => {
+    expect(HealthLogEntity.getConditionConsistency([3, 3, 3, 3])).toBe(100);
+  });
+
+  it('連続する値の差が小さいほど高スコア', () => {
+    const stable = HealthLogEntity.getConditionConsistency([3, 3, 4, 3, 3]);
+    const unstable = HealthLogEntity.getConditionConsistency([1, 5, 1, 5, 1]);
+    expect(stable).toBeGreaterThan(unstable);
+  });
+
+  it('最大差(1-5交互)は低スコア', () => {
+    const result = HealthLogEntity.getConditionConsistency([1, 5, 1, 5]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('緩やかに変化する値は中程度のスコア', () => {
+    const result = HealthLogEntity.getConditionConsistency([1, 2, 3, 4, 5]);
+    expect(result).toBeGreaterThan(50);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result1 = HealthLogEntity.getConditionConsistency([1, 5, 1, 5, 1, 5]);
+    const result2 = HealthLogEntity.getConditionConsistency([3, 3, 3]);
+    expect(result1).toBeGreaterThanOrEqual(0);
+    expect(result1).toBeLessThanOrEqual(100);
+    expect(result2).toBeGreaterThanOrEqual(0);
+    expect(result2).toBeLessThanOrEqual(100);
+  });
+
+  it('2件で差1は高スコア', () => {
+    const result = HealthLogEntity.getConditionConsistency([3, 4]);
+    expect(result).toBeGreaterThan(70);
+  });
+});
+
+describe('HealthLogEntity.getConditionConsistencyLabel', () => {
+  it('スコア80以上は安定', () => {
+    expect(HealthLogEntity.getConditionConsistencyLabel(80)).toBe('安定');
+  });
+
+  it('スコア50以上は変動あり', () => {
+    expect(HealthLogEntity.getConditionConsistencyLabel(50)).toBe('変動あり');
+  });
+
+  it('スコア50未満は不安定', () => {
+    expect(HealthLogEntity.getConditionConsistencyLabel(30)).toBe('不安定');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleFragmentation.test.ts
+++ b/src/__tests__/domain/entities/ScheduleFragmentation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleFragmentation', () => {
+  it('空配列は0を返す', () => {
+    expect(ScheduleEntity.getScheduleFragmentation([])).toBe(0);
+  });
+
+  it('1件のみは0を返す', () => {
+    expect(ScheduleEntity.getScheduleFragmentation([480])).toBe(0);
+  });
+
+  it('同じ時刻は0を返す', () => {
+    expect(ScheduleEntity.getScheduleFragmentation([480, 480, 480])).toBe(0);
+  });
+
+  it('適度に分散した時刻は中程度のスコア', () => {
+    // 8:00, 12:00, 18:00 -> 間隔[240,360], stddev基準で算出
+    const result = ScheduleEntity.getScheduleFragmentation([480, 720, 1080]);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(80);
+  });
+
+  it('極端に分散した時刻は高スコア', () => {
+    // 0:00, 23:59 -> 最大分散
+    const result = ScheduleEntity.getScheduleFragmentation([0, 1439]);
+    expect(result).toBeGreaterThan(70);
+  });
+
+  it('近接した時刻は低スコア', () => {
+    // 8:00, 8:30, 9:00
+    const result = ScheduleEntity.getScheduleFragmentation([480, 510, 540]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = ScheduleEntity.getScheduleFragmentation([0, 720, 1439]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('全24時間に均等分散で高スコア', () => {
+    // 0:00, 6:00, 12:00, 18:00
+    const result = ScheduleEntity.getScheduleFragmentation([0, 360, 720, 1080]);
+    expect(result).toBeGreaterThan(50);
+  });
+});
+
+describe('ScheduleEntity.getScheduleFragmentationLabel', () => {
+  it('スコア0は集中', () => {
+    expect(ScheduleEntity.getScheduleFragmentationLabel(0)).toBe('集中');
+  });
+
+  it('スコア40はやや分散', () => {
+    expect(ScheduleEntity.getScheduleFragmentationLabel(40)).toBe('やや分散');
+  });
+
+  it('スコア70は分散', () => {
+    expect(ScheduleEntity.getScheduleFragmentationLabel(70)).toBe('分散');
+  });
+});

--- a/src/__tests__/domain/entities/TrimmedMean.test.ts
+++ b/src/__tests__/domain/entities/TrimmedMean.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getTrimmedMean', () => {
+  it('空配列は0を返す', () => {
+    expect(MathHelper.getTrimmedMean([], 10)).toBe(0);
+  });
+
+  it('1要素はその値を返す', () => {
+    expect(MathHelper.getTrimmedMean([5], 10)).toBe(5);
+  });
+
+  it('トリム0%は通常の平均と同じ', () => {
+    expect(MathHelper.getTrimmedMean([1, 2, 3, 4, 5], 0)).toBe(3);
+  });
+
+  it('トリム10%で上下を除外した平均を返す', () => {
+    // 10要素、上下10%=各1要素除外 -> [2,3,4,5,6,7,8,9] -> avg=5.5
+    expect(MathHelper.getTrimmedMean([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10)).toBe(5.5);
+  });
+
+  it('トリム25%で上下を除外した平均を返す', () => {
+    // 8要素、上下25%=各2要素除外 -> [3,4,5,6] -> avg=4.5
+    expect(MathHelper.getTrimmedMean([1, 2, 3, 4, 5, 6, 7, 8], 25)).toBe(4.5);
+  });
+
+  it('外れ値がある場合にロバストな結果を返す', () => {
+    const values = [10, 11, 12, 13, 14, 100];
+    const trimmed = MathHelper.getTrimmedMean(values, 20);
+    const normal = MathHelper.calculateAverage(values);
+    expect(trimmed).toBeLessThan(normal);
+  });
+
+  it('ソートされていない配列も正しく処理する', () => {
+    expect(MathHelper.getTrimmedMean([5, 1, 3, 2, 4], 0)).toBe(3);
+  });
+
+  it('全て同じ値なら結果も同じ', () => {
+    expect(MathHelper.getTrimmedMean([7, 7, 7, 7], 25)).toBe(7);
+  });
+
+  it('トリム率が高くても少なくとも1要素残る', () => {
+    const result = MathHelper.getTrimmedMean([1, 2, 3], 40);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('小数点1桁に丸められる', () => {
+    const result = MathHelper.getTrimmedMean([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10);
+    const decimalPart = result.toString().split('.')[1] || '';
+    expect(decimalPart.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('MathHelper.getTrimmedMeanLabel', () => {
+  it('値70以上は高い', () => {
+    expect(MathHelper.getTrimmedMeanLabel(70)).toBe('高い');
+  });
+
+  it('値30以上70未満は中程度', () => {
+    expect(MathHelper.getTrimmedMeanLabel(50)).toBe('中程度');
+  });
+
+  it('値30未満は低い', () => {
+    expect(MathHelper.getTrimmedMeanLabel(20)).toBe('低い');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -69,6 +69,9 @@ export class HealthLogEntity {
   private static readonly VARIANCE_UNSTABLE_THRESHOLD = 3;
   private static readonly PERSISTENCE_HIGH_THRESHOLD = 70;
   private static readonly PERSISTENCE_MODERATE_THRESHOLD = 40;
+  private static readonly CONSISTENCY_MAX_AVG_DIFF = 4;
+  private static readonly CONSISTENCY_HIGH_THRESHOLD = 80;
+  private static readonly CONSISTENCY_MODERATE_THRESHOLD = 50;
   private static readonly TEMP_HYPOTHERMIA = 35.0;
   private static readonly TEMP_LOW_FEVER = 37.5;
   private static readonly TEMP_FEVER = 38.0;
@@ -866,6 +869,29 @@ export class HealthLogEntity {
   static getConditionVarianceLabel(variance: number): string {
     if (variance < HealthLogEntity.VARIANCE_STABLE_THRESHOLD) return '安定';
     if (variance < HealthLogEntity.VARIANCE_UNSTABLE_THRESHOLD) return 'やや不安定';
+    return '不安定';
+  }
+
+  /**
+   * 体調値配列から一貫性スコア(0-100)を算出する
+   * 連続する値の差の平均が小さいほど高スコア
+   */
+  static getConditionConsistency(conditions: number[]): number {
+    if (conditions.length <= 1) return conditions.length === 0 ? 0 : 100;
+    let totalDiff = 0;
+    for (let i = 1; i < conditions.length; i++) {
+      totalDiff += Math.abs(conditions[i] - conditions[i - 1]);
+    }
+    const avgDiff = totalDiff / (conditions.length - 1);
+    return Math.max(0, Math.min(100, Math.round(100 - (avgDiff / HealthLogEntity.CONSISTENCY_MAX_AVG_DIFF) * 100)));
+  }
+
+  /**
+   * 一貫性スコアに応じたラベルを返す
+   */
+  static getConditionConsistencyLabel(score: number): string {
+    if (score >= HealthLogEntity.CONSISTENCY_HIGH_THRESHOLD) return '安定';
+    if (score >= HealthLogEntity.CONSISTENCY_MODERATE_THRESHOLD) return '変動あり';
     return '不安定';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -298,6 +298,31 @@ export class MathHelper {
   /**
    * 幾何平均に応じたラベルを返す
    */
+  /**
+   * トリム平均を算出する（上下指定%を除外した平均）
+   * @param values 数値配列
+   * @param trimPercent 上下から除外する割合(0-49)
+   */
+  static getTrimmedMean(values: number[], trimPercent: number): number {
+    if (values.length === 0) return 0;
+    if (values.length === 1) return values[0];
+    const sorted = [...values].sort((a, b) => a - b);
+    const trimCount = Math.floor(sorted.length * (trimPercent / 100));
+    const trimmed = sorted.slice(trimCount, sorted.length - trimCount);
+    if (trimmed.length === 0) return sorted[Math.floor(sorted.length / 2)];
+    const sum = trimmed.reduce((a, b) => a + b, 0);
+    return Math.round((sum / trimmed.length) * 10) / 10;
+  }
+
+  /**
+   * トリム平均値に応じたラベルを返す
+   */
+  static getTrimmedMeanLabel(mean: number): string {
+    if (mean >= MathHelper.GEOMETRIC_HIGH_THRESHOLD) return '高い';
+    if (mean >= MathHelper.GEOMETRIC_LOW_THRESHOLD) return '中程度';
+    return '低い';
+  }
+
   static getGeometricMeanLabel(mean: number): string {
     if (mean >= MathHelper.GEOMETRIC_HIGH_THRESHOLD) return '高い';
     if (mean >= MathHelper.GEOMETRIC_LOW_THRESHOLD) return '中程度';

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -788,6 +788,9 @@ export class ScheduleEntity {
   private static readonly SCHEDULE_GAP_LONG_THRESHOLD = 480;
   private static readonly OVERLAP_MINOR_THRESHOLD = 30;
   private static readonly OVERLAP_WARNING_THRESHOLD = 60;
+  private static readonly FRAGMENTATION_MAX_STDDEV = 720;
+  private static readonly FRAGMENTATION_HIGH_THRESHOLD = 60;
+  private static readonly FRAGMENTATION_MODERATE_THRESHOLD = 30;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -910,5 +913,26 @@ export class ScheduleEntity {
     if (score < ScheduleEntity.OVERLAP_MINOR_THRESHOLD) return '軽微';
     if (score < ScheduleEntity.OVERLAP_WARNING_THRESHOLD) return '注意';
     return '要調整';
+  }
+
+  /**
+   * スケジュール時刻(分単位)配列から断片化スコア(0-100)を算出する
+   * 標準偏差ベースで時間帯の分散度を数値化
+   */
+  static getScheduleFragmentation(timesInMinutes: number[]): number {
+    if (timesInMinutes.length <= 1) return 0;
+    const avg = timesInMinutes.reduce((a, b) => a + b, 0) / timesInMinutes.length;
+    const variance = timesInMinutes.reduce((sum, v) => sum + (v - avg) ** 2, 0) / timesInMinutes.length;
+    const stdDev = Math.sqrt(variance);
+    return Math.min(100, Math.round((stdDev / ScheduleEntity.FRAGMENTATION_MAX_STDDEV) * 100));
+  }
+
+  /**
+   * 断片化スコアに応じたラベルを返す
+   */
+  static getScheduleFragmentationLabel(score: number): string {
+    if (score >= ScheduleEntity.FRAGMENTATION_HIGH_THRESHOLD) return '分散';
+    if (score >= ScheduleEntity.FRAGMENTATION_MODERATE_THRESHOLD) return 'やや分散';
+    return '集中';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getTrimmedMean/getTrimmedMeanLabel - 上下指定%を除外したロバストな平均値算出
- ScheduleEntity: getScheduleFragmentation/getScheduleFragmentationLabel - 時刻配列の標準偏差ベースで分散度を0-100スコア化
- HealthLogEntity: getConditionConsistency/getConditionConsistencyLabel - 連続する体調値の差から一貫性を0-100スコア化

## Test plan
- [x] TrimmedMean: 13テスト通過
- [x] ScheduleFragmentation: 11テスト通過
- [x] ConditionConsistency: 11テスト通過
- [x] 全4669テスト通過確認済み