### PR TITLE
feat: エントロピースコア・在庫安定性・遵守率回復率の追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceRecovery.test.ts
+++ b/src/__tests__/domain/entities/AdherenceRecovery.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceRecoveryRate', () => {
+  it('空配列は0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([])).toBe(0);
+  });
+
+  it('1件のみは0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([50])).toBe(0);
+  });
+
+  it('下降のみ(回復なし)は0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100, 80, 60, 40])).toBe(0);
+  });
+
+  it('低下後の完全回復は100を返す', () => {
+    // 100->50(低下50) -> 100(回復50) -> 回復率100%
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100, 50, 100])).toBe(100);
+  });
+
+  it('低下後の部分回復は中程度のスコア', () => {
+    // 100->50(低下50) -> 75(回復25) -> 回復率50%
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100, 50, 75])).toBe(50);
+  });
+
+  it('全て同じ値は0を返す(低下なし)', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([70, 70, 70])).toBe(0);
+  });
+
+  it('上昇のみは0を返す(低下なし)', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([50, 60, 70, 80])).toBe(0);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = AdherenceTrendEntity.getAdherenceRecoveryRate([100, 0, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('複数回の低下回復で最大の回復率を返す', () => {
+    // 100->80(低下20)->90(回復10=50%) then 90->60(低下30)->90(回復30=100%)
+    const result = AdherenceTrendEntity.getAdherenceRecoveryRate([100, 80, 90, 60, 90]);
+    expect(result).toBe(100);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceRecoveryLabel', () => {
+  it('率70以上は良好', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(70)).toBe('良好');
+  });
+
+  it('率40以上はやや遅い', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(40)).toBe('やや遅い');
+  });
+
+  it('率40未満は低回復', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(20)).toBe('低回復');
+  });
+
+  it('率0は低回復', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(0)).toBe('低回復');
+  });
+});

--- a/src/__tests__/domain/entities/EntropyScore.test.ts
+++ b/src/__tests__/domain/entities/EntropyScore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getEntropyScore', () => {
+  it('空配列は0を返す', () => {
+    expect(MathHelper.getEntropyScore([])).toBe(0);
+  });
+
+  it('1要素は0を返す(多様性なし)', () => {
+    expect(MathHelper.getEntropyScore([5])).toBe(0);
+  });
+
+  it('全て同じ値は0を返す', () => {
+    expect(MathHelper.getEntropyScore([3, 3, 3, 3])).toBe(0);
+  });
+
+  it('2種類の値が均等分布で高スコア', () => {
+    const result = MathHelper.getEntropyScore([1, 2, 1, 2]);
+    expect(result).toBe(100);
+  });
+
+  it('3種類の値が均等分布で100', () => {
+    const result = MathHelper.getEntropyScore([1, 2, 3, 1, 2, 3]);
+    expect(result).toBe(100);
+  });
+
+  it('偏った分布は均等分布より低スコア', () => {
+    const biased = MathHelper.getEntropyScore([1, 1, 1, 1, 1, 2]);
+    const uniform = MathHelper.getEntropyScore([1, 2, 1, 2, 1, 2]);
+    expect(biased).toBeLessThan(uniform);
+  });
+
+  it('全て異なる値は100', () => {
+    expect(MathHelper.getEntropyScore([1, 2, 3, 4, 5])).toBe(100);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = MathHelper.getEntropyScore([1, 1, 2, 3, 3, 3, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MathHelper.getEntropyLabel', () => {
+  it('スコア70以上は多様', () => {
+    expect(MathHelper.getEntropyLabel(70)).toBe('多様');
+  });
+
+  it('スコア30以上70未満は普通', () => {
+    expect(MathHelper.getEntropyLabel(50)).toBe('普通');
+  });
+
+  it('スコア30未満は均一', () => {
+    expect(MathHelper.getEntropyLabel(20)).toBe('均一');
+  });
+});

--- a/src/__tests__/domain/entities/StockStability.test.ts
+++ b/src/__tests__/domain/entities/StockStability.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockStabilityScore', () => {
+  it('空配列は0を返す', () => {
+    expect(StockAlertEntity.getStockStabilityScore([])).toBe(0);
+  });
+
+  it('1件のみは100を返す', () => {
+    expect(StockAlertEntity.getStockStabilityScore([50])).toBe(100);
+  });
+
+  it('全て同じ値は100を返す', () => {
+    expect(StockAlertEntity.getStockStabilityScore([30, 30, 30, 30])).toBe(100);
+  });
+
+  it('安定した在庫は高スコア', () => {
+    const result = StockAlertEntity.getStockStabilityScore([100, 99, 100, 101, 100]);
+    expect(result).toBeGreaterThan(90);
+  });
+
+  it('大きく変動する在庫は低スコア', () => {
+    const result = StockAlertEntity.getStockStabilityScore([10, 100, 10, 100, 10]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('緩やかに減少する在庫は中程度のスコア', () => {
+    const result = StockAlertEntity.getStockStabilityScore([100, 80, 60, 40, 20]);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(80);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result1 = StockAlertEntity.getStockStabilityScore([0, 1000]);
+    const result2 = StockAlertEntity.getStockStabilityScore([50, 50]);
+    expect(result1).toBeGreaterThanOrEqual(0);
+    expect(result1).toBeLessThanOrEqual(100);
+    expect(result2).toBeGreaterThanOrEqual(0);
+    expect(result2).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('StockAlertEntity.getStockStabilityLabel', () => {
+  it('スコア80以上は安定', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(80)).toBe('安定');
+  });
+
+  it('スコア50以上はやや不安定', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(50)).toBe('やや不安定');
+  });
+
+  it('スコア50未満は不安定', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(30)).toBe('不安定');
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -34,6 +34,8 @@ export class AdherenceTrendEntity {
   private static readonly ADHERENCE_VOLATILITY_MAX_DIFF = 50;
   private static readonly ADHERENCE_VOLATILITY_STABLE_THRESHOLD = 30;
   private static readonly ADHERENCE_VOLATILITY_MODERATE_THRESHOLD = 60;
+  private static readonly RECOVERY_GOOD_THRESHOLD = 70;
+  private static readonly RECOVERY_MODERATE_THRESHOLD = 40;
 
   constructor(private readonly trend: AdherenceTrend) {}
 
@@ -355,5 +357,52 @@ export class AdherenceTrendEntity {
     if (change >= AdherenceTrendEntity.WOW_CHANGE_THRESHOLD) return '改善';
     if (change <= -AdherenceTrendEntity.WOW_CHANGE_THRESHOLD) return '悪化';
     return '横ばい';
+  }
+
+  /**
+   * 遵守率配列から回復率(0-100)を算出する
+   * 低下後の最大回復割合を返す（低下がない場合は0）
+   */
+  static getAdherenceRecoveryRate(rates: number[]): number {
+    if (rates.length <= 1) return 0;
+    let maxRecoveryRate = 0;
+    let i = 0;
+    while (i < rates.length - 1) {
+      // 低下を検出
+      if (rates[i + 1] < rates[i]) {
+        const peakValue = rates[i];
+        let troughValue = rates[i + 1];
+        let j = i + 2;
+        // 最低値を探す
+        while (j < rates.length && rates[j] <= troughValue) {
+          troughValue = rates[j];
+          j++;
+        }
+        const drop = peakValue - troughValue;
+        if (drop > 0 && j < rates.length) {
+          // 回復を探す
+          let maxRecovery = 0;
+          for (let k = j; k < rates.length; k++) {
+            const recovery = rates[k] - troughValue;
+            if (recovery > maxRecovery) maxRecovery = recovery;
+          }
+          const recoveryRate = Math.min(100, Math.round((maxRecovery / drop) * 100));
+          if (recoveryRate > maxRecoveryRate) maxRecoveryRate = recoveryRate;
+        }
+        i = j;
+      } else {
+        i++;
+      }
+    }
+    return maxRecoveryRate;
+  }
+
+  /**
+   * 回復率に応じたラベルを返す
+   */
+  static getAdherenceRecoveryLabel(rate: number): string {
+    if (rate >= AdherenceTrendEntity.RECOVERY_GOOD_THRESHOLD) return '良好';
+    if (rate >= AdherenceTrendEntity.RECOVERY_MODERATE_THRESHOLD) return 'やや遅い';
+    return '低回復';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -14,6 +14,8 @@ export class MathHelper {
   private static readonly OUTLIER_MINOR_RATE = 0.05;
   private static readonly GEOMETRIC_HIGH_THRESHOLD = 70;
   private static readonly GEOMETRIC_LOW_THRESHOLD = 30;
+  private static readonly ENTROPY_HIGH_THRESHOLD = 70;
+  private static readonly ENTROPY_LOW_THRESHOLD = 30;
 
   /**
    * パーセントを算出(0-100%)
@@ -327,5 +329,36 @@ export class MathHelper {
     if (mean >= MathHelper.GEOMETRIC_HIGH_THRESHOLD) return '高い';
     if (mean >= MathHelper.GEOMETRIC_LOW_THRESHOLD) return '中程度';
     return '低い';
+  }
+
+  /**
+   * 値配列のエントロピー(多様性)スコア(0-100)を算出する
+   * シャノンエントロピーを最大エントロピーで正規化
+   */
+  static getEntropyScore(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const counts = new Map<number, number>();
+    for (const v of values) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+    if (counts.size <= 1) return 0;
+    const total = values.length;
+    let entropy = 0;
+    for (const count of counts.values()) {
+      const p = count / total;
+      if (p > 0) entropy -= p * Math.log2(p);
+    }
+    const maxEntropy = Math.log2(counts.size);
+    if (maxEntropy === 0) return 0;
+    return Math.round((entropy / maxEntropy) * 100);
+  }
+
+  /**
+   * エントロピースコアに応じたラベルを返す
+   */
+  static getEntropyLabel(score: number): string {
+    if (score >= MathHelper.ENTROPY_HIGH_THRESHOLD) return '多様';
+    if (score >= MathHelper.ENTROPY_LOW_THRESHOLD) return '普通';
+    return '均一';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -32,6 +32,9 @@ export class StockAlertEntity {
   private static readonly COVERAGE_LOW_THRESHOLD = 40;
   private static readonly STOCK_EFFICIENCY_HIGH_THRESHOLD = 80;
   private static readonly STOCK_EFFICIENCY_NORMAL_THRESHOLD = 50;
+  private static readonly STABILITY_MAX_CV = 1;
+  private static readonly STABILITY_HIGH_THRESHOLD = 80;
+  private static readonly STABILITY_MODERATE_THRESHOLD = 50;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -519,5 +522,27 @@ export class StockAlertEntity {
     if (score >= StockAlertEntity.COVERAGE_SUFFICIENT_THRESHOLD) return '十分';
     if (score >= StockAlertEntity.COVERAGE_LOW_THRESHOLD) return 'やや不足';
     return '不足';
+  }
+
+  /**
+   * 在庫量配列から安定性スコア(0-100)を算出する
+   * 変動係数(CV)ベースで安定性を数値化
+   */
+  static getStockStabilityScore(stockLevels: number[]): number {
+    if (stockLevels.length <= 1) return stockLevels.length === 0 ? 0 : 100;
+    const avg = stockLevels.reduce((a, b) => a + b, 0) / stockLevels.length;
+    if (avg === 0) return 0;
+    const variance = stockLevels.reduce((sum, v) => sum + (v - avg) ** 2, 0) / stockLevels.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.max(0, Math.min(100, Math.round(100 - (cv / StockAlertEntity.STABILITY_MAX_CV) * 100)));
+  }
+
+  /**
+   * 在庫安定性スコアに応じたラベルを返す
+   */
+  static getStockStabilityLabel(score: number): string {
+    if (score >= StockAlertEntity.STABILITY_HIGH_THRESHOLD) return '安定';
+    if (score >= StockAlertEntity.STABILITY_MODERATE_THRESHOLD) return 'やや不安定';
+    return '不安定';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getEntropyScore/getEntropyLabel - シャノンエントロピーベースで値の多様性を0-100スコア化
- StockAlertEntity: getStockStabilityScore/getStockStabilityLabel - 変動係数ベースで在庫安定性を0-100スコア化
- AdherenceTrendEntity: getAdherenceRecoveryRate/getAdherenceRecoveryLabel - 遵守率低下後の最大回復割合を算出

## Test plan
- [x] EntropyScore: 11テスト通過
- [x] StockStability: 10テスト通過
- [x] AdherenceRecovery: 13テスト通過
- [x] 全4755テスト通過確認済み