### PR TITLE
test: EntropyScore・StockStability・AdherenceRecoveryのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceRecovery.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceRecovery.edge.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceRecoveryRate - エッジケース', () => {
+  it('空配列は0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([])).toBe(0);
+  });
+
+  it('1件のみは0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100])).toBe(0);
+  });
+
+  it('2件で低下のみは0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100, 50])).toBe(0);
+  });
+
+  it('2件で上昇のみは0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([50, 100])).toBe(0);
+  });
+
+  it('3件で完全回復は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100, 0, 100])).toBe(100);
+  });
+
+  it('3件で半分回復は50', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100, 0, 50])).toBe(50);
+  });
+
+  it('全て同じ値は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([70, 70, 70, 70])).toBe(0);
+  });
+
+  it('連続低下のみは0', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([100, 80, 60, 40, 20])).toBe(0);
+  });
+
+  it('連続上昇のみは0', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryRate([20, 40, 60, 80, 100])).toBe(0);
+  });
+
+  it('V字回復パターン', () => {
+    const result = AdherenceTrendEntity.getAdherenceRecoveryRate([90, 80, 70, 60, 70, 80, 90]);
+    expect(result).toBe(100);
+  });
+
+  it('部分回復パターン', () => {
+    // 100->40(低下60), 40->70(回復30) = 50%
+    const result = AdherenceTrendEntity.getAdherenceRecoveryRate([100, 40, 70]);
+    expect(result).toBe(50);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = AdherenceTrendEntity.getAdherenceRecoveryRate([100, 0, 200]);
+    expect(result).toBeLessThanOrEqual(100);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('微小な低下と完全回復', () => {
+    const result = AdherenceTrendEntity.getAdherenceRecoveryRate([100, 99, 100]);
+    expect(result).toBe(100);
+  });
+
+  it('複数回低下の最大回復率', () => {
+    // 第1回: 100->90(低下10)->92(回復2=20%)
+    // 第2回: 92->50(低下42)->80(回復30=71%)
+    const result = AdherenceTrendEntity.getAdherenceRecoveryRate([100, 90, 92, 50, 80]);
+    expect(result).toBeGreaterThan(60);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceRecoveryLabel - 境界値', () => {
+  it('率70は良好(境界値)', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(70)).toBe('良好');
+  });
+
+  it('率69はやや遅い', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(69)).toBe('やや遅い');
+  });
+
+  it('率40はやや遅い(境界値)', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(40)).toBe('やや遅い');
+  });
+
+  it('率39は低回復', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(39)).toBe('低回復');
+  });
+
+  it('率0は低回復', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(0)).toBe('低回復');
+  });
+
+  it('率100は良好', () => {
+    expect(AdherenceTrendEntity.getAdherenceRecoveryLabel(100)).toBe('良好');
+  });
+});

--- a/src/__tests__/domain/entities/EntropyScore.edge.test.ts
+++ b/src/__tests__/domain/entities/EntropyScore.edge.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getEntropyScore - エッジケース', () => {
+  it('空配列は0を返す', () => {
+    expect(MathHelper.getEntropyScore([])).toBe(0);
+  });
+
+  it('1要素は0を返す', () => {
+    expect(MathHelper.getEntropyScore([42])).toBe(0);
+  });
+
+  it('2つの同じ値は0を返す', () => {
+    expect(MathHelper.getEntropyScore([5, 5])).toBe(0);
+  });
+
+  it('2つの異なる値で均等は100', () => {
+    expect(MathHelper.getEntropyScore([1, 2])).toBe(100);
+  });
+
+  it('大量の同一値は0', () => {
+    expect(MathHelper.getEntropyScore(Array(1000).fill(7))).toBe(0);
+  });
+
+  it('大量の全異なる値は100', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i);
+    expect(MathHelper.getEntropyScore(values)).toBe(100);
+  });
+
+  it('1つだけ異なる値を持つ大量データ', () => {
+    const values = [...Array(99).fill(1), 2];
+    const result = MathHelper.getEntropyScore(values);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('負の値も正しく処理する', () => {
+    expect(MathHelper.getEntropyScore([-1, -2, -3])).toBe(100);
+  });
+
+  it('0を含む配列', () => {
+    expect(MathHelper.getEntropyScore([0, 0, 1])).toBeGreaterThan(0);
+  });
+
+  it('小数値も正しく区別する', () => {
+    expect(MathHelper.getEntropyScore([1.1, 1.2, 1.3])).toBe(100);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = MathHelper.getEntropyScore([1, 1, 1, 2, 2, 3]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('均等に3種類分布で100', () => {
+    expect(MathHelper.getEntropyScore([1, 2, 3, 1, 2, 3, 1, 2, 3])).toBe(100);
+  });
+
+  it('1種類が支配的な場合でも0より大きい', () => {
+    const values = [...Array(90).fill(1), ...Array(10).fill(2)];
+    const result = MathHelper.getEntropyScore(values);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getEntropyLabel - 境界値', () => {
+  it('スコア70は多様(境界値)', () => {
+    expect(MathHelper.getEntropyLabel(70)).toBe('多様');
+  });
+
+  it('スコア69は普通', () => {
+    expect(MathHelper.getEntropyLabel(69)).toBe('普通');
+  });
+
+  it('スコア30は普通(境界値)', () => {
+    expect(MathHelper.getEntropyLabel(30)).toBe('普通');
+  });
+
+  it('スコア29は均一', () => {
+    expect(MathHelper.getEntropyLabel(29)).toBe('均一');
+  });
+
+  it('スコア0は均一', () => {
+    expect(MathHelper.getEntropyLabel(0)).toBe('均一');
+  });
+
+  it('スコア100は多様', () => {
+    expect(MathHelper.getEntropyLabel(100)).toBe('多様');
+  });
+});

--- a/src/__tests__/domain/entities/StockStability.edge.test.ts
+++ b/src/__tests__/domain/entities/StockStability.edge.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockStabilityScore - エッジケース', () => {
+  it('空配列は0を返す', () => {
+    expect(StockAlertEntity.getStockStabilityScore([])).toBe(0);
+  });
+
+  it('1件は100を返す', () => {
+    expect(StockAlertEntity.getStockStabilityScore([50])).toBe(100);
+  });
+
+  it('2件で同じ値は100', () => {
+    expect(StockAlertEntity.getStockStabilityScore([30, 30])).toBe(100);
+  });
+
+  it('全て0は0を返す(avg=0)', () => {
+    expect(StockAlertEntity.getStockStabilityScore([0, 0, 0])).toBe(0);
+  });
+
+  it('非常に大きな値でも正しく計算', () => {
+    const result = StockAlertEntity.getStockStabilityScore([1000000, 1000001]);
+    expect(result).toBe(100);
+  });
+
+  it('1と1000000の極端な差は低スコア', () => {
+    const result = StockAlertEntity.getStockStabilityScore([1, 1000000]);
+    expect(result).toBe(0);
+  });
+
+  it('100件の安定データは高スコア', () => {
+    const values = Array.from({ length: 100 }, () => 50 + Math.floor(Math.random() * 3) - 1);
+    // 微小な変動なので高スコアになるはず
+    const result = StockAlertEntity.getStockStabilityScore(values);
+    expect(result).toBeGreaterThan(90);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result1 = StockAlertEntity.getStockStabilityScore([1, 100]);
+    const result2 = StockAlertEntity.getStockStabilityScore([50, 50]);
+    expect(result1).toBeGreaterThanOrEqual(0);
+    expect(result1).toBeLessThanOrEqual(100);
+    expect(result2).toBeLessThanOrEqual(100);
+  });
+
+  it('緩やかな増加は比較的安定', () => {
+    const result = StockAlertEntity.getStockStabilityScore([100, 105, 110, 115, 120]);
+    expect(result).toBeGreaterThan(80);
+  });
+
+  it('急激な増減は低スコア', () => {
+    const result = StockAlertEntity.getStockStabilityScore([10, 100, 10, 100]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('小数値も正しく処理', () => {
+    const result = StockAlertEntity.getStockStabilityScore([10.5, 10.6, 10.4, 10.5]);
+    expect(result).toBeGreaterThan(95);
+  });
+});
+
+describe('StockAlertEntity.getStockStabilityLabel - 境界値', () => {
+  it('スコア80は安定(境界値)', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(80)).toBe('安定');
+  });
+
+  it('スコア79はやや不安定', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(79)).toBe('やや不安定');
+  });
+
+  it('スコア50はやや不安定(境界値)', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(50)).toBe('やや不安定');
+  });
+
+  it('スコア49は不安定', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(49)).toBe('不安定');
+  });
+
+  it('スコア0は不安定', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(0)).toBe('不安定');
+  });
+
+  it('スコア100は安定', () => {
+    expect(StockAlertEntity.getStockStabilityLabel(100)).toBe('安定');
+  });
+});


### PR DESCRIPTION
## Summary
- EntropyScore: 大量データ、負値、小数値、均等/偏り分布等19テスト追加
- StockStability: 全0、極端な差、小数値、急激な増減等17テスト追加
- AdherenceRecovery: V字回復、部分回復、複数回低下、連続低下等20テスト追加

## Test plan
- [x] 新規56テスト全通過
- [x] 全4811テスト通過確認済み