### PR TITLE
feat: Zスコア・服薬間隔ばらつき・曜日集中度の追加

### DIFF
--- a/src/__tests__/domain/entities/DoseGapVariability.test.ts
+++ b/src/__tests__/domain/entities/DoseGapVariability.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseGapVariability', () => {
+  it('空配列は0を返す', () => {
+    expect(MedicationRecordEntity.getDoseGapVariability([])).toBe(0);
+  });
+
+  it('1件のみは0を返す', () => {
+    expect(MedicationRecordEntity.getDoseGapVariability([60])).toBe(0);
+  });
+
+  it('全て同じ間隔は0を返す', () => {
+    expect(MedicationRecordEntity.getDoseGapVariability([60, 60, 60])).toBe(0);
+  });
+
+  it('間隔が均一に近いほど低スコア', () => {
+    const result = MedicationRecordEntity.getDoseGapVariability([58, 60, 62]);
+    expect(result).toBeLessThan(20);
+  });
+
+  it('間隔がばらつく場合は高スコア', () => {
+    const result = MedicationRecordEntity.getDoseGapVariability([30, 120, 30, 120]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = MedicationRecordEntity.getDoseGapVariability([1, 1000, 1, 1000]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2件で異なる値はばらつきあり', () => {
+    const result = MedicationRecordEntity.getDoseGapVariability([30, 90]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseGapVariabilityLabel', () => {
+  it('スコア0は規則的', () => {
+    expect(MedicationRecordEntity.getDoseGapVariabilityLabel(0)).toBe('規則的');
+  });
+
+  it('スコア40はやや不規則', () => {
+    expect(MedicationRecordEntity.getDoseGapVariabilityLabel(40)).toBe('やや不規則');
+  });
+
+  it('スコア70は不規則', () => {
+    expect(MedicationRecordEntity.getDoseGapVariabilityLabel(70)).toBe('不規則');
+  });
+});

--- a/src/__tests__/domain/entities/WeekdayConcentration.test.ts
+++ b/src/__tests__/domain/entities/WeekdayConcentration.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getWeekdayConcentration', () => {
+  it('空配列は0を返す', () => {
+    expect(DateRangeHelper.getWeekdayConcentration([])).toBe(0);
+  });
+
+  it('全て同じ曜日は100', () => {
+    // 全て月曜日
+    expect(DateRangeHelper.getWeekdayConcentration([1, 1, 1, 1])).toBe(100);
+  });
+
+  it('7曜日均等分布は低スコア', () => {
+    const result = DateRangeHelper.getWeekdayConcentration([0, 1, 2, 3, 4, 5, 6]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('2曜日に集中は中程度', () => {
+    const result = DateRangeHelper.getWeekdayConcentration([1, 1, 5, 5, 1, 5]);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(80);
+  });
+
+  it('1件のみは100', () => {
+    expect(DateRangeHelper.getWeekdayConcentration([3])).toBe(100);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = DateRangeHelper.getWeekdayConcentration([0, 1, 2, 3, 4, 5, 6, 0, 1]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データで均等分布', () => {
+    const days = Array.from({ length: 70 }, (_, i) => i % 7);
+    const result = DateRangeHelper.getWeekdayConcentration(days);
+    expect(result).toBeLessThan(20);
+  });
+});
+
+describe('DateRangeHelper.getWeekdayConcentrationLabel', () => {
+  it('スコア70以上は集中', () => {
+    expect(DateRangeHelper.getWeekdayConcentrationLabel(70)).toBe('集中');
+  });
+
+  it('スコア40以上はやや偏り', () => {
+    expect(DateRangeHelper.getWeekdayConcentrationLabel(40)).toBe('やや偏り');
+  });
+
+  it('スコア40未満は分散', () => {
+    expect(DateRangeHelper.getWeekdayConcentrationLabel(20)).toBe('分散');
+  });
+});

--- a/src/__tests__/domain/entities/ZScore.test.ts
+++ b/src/__tests__/domain/entities/ZScore.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getZScore', () => {
+  it('空配列は0を返す', () => {
+    expect(MathHelper.getZScore([], 5)).toBe(0);
+  });
+
+  it('1要素は0を返す', () => {
+    expect(MathHelper.getZScore([5], 5)).toBe(0);
+  });
+
+  it('全て同じ値でstddev=0の場合0を返す', () => {
+    expect(MathHelper.getZScore([5, 5, 5], 5)).toBe(0);
+  });
+
+  it('平均値のZ値は0', () => {
+    expect(MathHelper.getZScore([10, 20, 30], 20)).toBe(0);
+  });
+
+  it('平均+1stddevのZ値は1', () => {
+    // [10,20,30], avg=20, stddev=8.16..., value=28.16... -> z=1
+    const values = [10, 20, 30];
+    const avg = 20;
+    const stdDev = MathHelper.calculateStdDev(values);
+    const result = MathHelper.getZScore(values, avg + stdDev);
+    expect(result).toBe(1);
+  });
+
+  it('平均より大きい値は正のZ値', () => {
+    expect(MathHelper.getZScore([10, 20, 30], 25)).toBeGreaterThan(0);
+  });
+
+  it('平均より小さい値は負のZ値', () => {
+    expect(MathHelper.getZScore([10, 20, 30], 15)).toBeLessThan(0);
+  });
+
+  it('小数点2桁に丸められる', () => {
+    const result = MathHelper.getZScore([10, 20, 30], 25);
+    const decimalPart = result.toString().split('.')[1] || '';
+    expect(decimalPart.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('MathHelper.getZScoreLabel', () => {
+  it('Z値0は正常', () => {
+    expect(MathHelper.getZScoreLabel(0)).toBe('正常');
+  });
+
+  it('Z値2以上は異常', () => {
+    expect(MathHelper.getZScoreLabel(2)).toBe('異常');
+  });
+
+  it('Z値-2以下は異常', () => {
+    expect(MathHelper.getZScoreLabel(-2)).toBe('異常');
+  });
+
+  it('Z値1.5はやや外れ値', () => {
+    expect(MathHelper.getZScoreLabel(1.5)).toBe('やや外れ値');
+  });
+
+  it('Z値-1.5はやや外れ値', () => {
+    expect(MathHelper.getZScoreLabel(-1.5)).toBe('やや外れ値');
+  });
+});

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -104,6 +104,8 @@ export class DateRangeHelper {
   private static readonly SPAN_LONG_THRESHOLD = 90;
   private static readonly DENSITY_HIGH_THRESHOLD = 80;
   private static readonly DENSITY_MODERATE_THRESHOLD = 50;
+  private static readonly WEEKDAY_CONCENTRATION_HIGH_THRESHOLD = 70;
+  private static readonly WEEKDAY_CONCENTRATION_MODERATE_THRESHOLD = 40;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -366,5 +368,32 @@ export class DateRangeHelper {
     if (days < DateRangeHelper.SPAN_SHORT_THRESHOLD) return '短期間';
     if (days < DateRangeHelper.SPAN_LONG_THRESHOLD) return '中期間';
     return '長期間';
+  }
+
+  /**
+   * 曜日インデックス配列(0=日〜6=土)から集中度(0-100)を算出する
+   * 最頻曜日の出現率を100点満点で正規化（均等=1/7=14.3%→0, 全集中=100%→100）
+   */
+  static getWeekdayConcentration(dayIndices: number[]): number {
+    if (dayIndices.length === 0) return 0;
+    if (dayIndices.length === 1) return 100;
+    const counts = new Array(DateRangeHelper.DAYS_IN_WEEK).fill(0);
+    for (const d of dayIndices) {
+      if (d >= 0 && d < DateRangeHelper.DAYS_IN_WEEK) counts[d]++;
+    }
+    const maxCount = Math.max(...counts);
+    const maxRatio = maxCount / dayIndices.length;
+    const minRatio = 1 / DateRangeHelper.DAYS_IN_WEEK;
+    if (maxRatio <= minRatio) return 0;
+    return Math.round(((maxRatio - minRatio) / (1 - minRatio)) * 100);
+  }
+
+  /**
+   * 曜日集中度に応じたラベルを返す
+   */
+  static getWeekdayConcentrationLabel(score: number): string {
+    if (score >= DateRangeHelper.WEEKDAY_CONCENTRATION_HIGH_THRESHOLD) return '集中';
+    if (score >= DateRangeHelper.WEEKDAY_CONCENTRATION_MODERATE_THRESHOLD) return 'やや偏り';
+    return '分散';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -16,6 +16,8 @@ export class MathHelper {
   private static readonly GEOMETRIC_LOW_THRESHOLD = 30;
   private static readonly ENTROPY_HIGH_THRESHOLD = 70;
   private static readonly ENTROPY_LOW_THRESHOLD = 30;
+  private static readonly ZSCORE_ABNORMAL_THRESHOLD = 2;
+  private static readonly ZSCORE_OUTLIER_THRESHOLD = 1;
 
   /**
    * パーセントを算出(0-100%)
@@ -360,5 +362,26 @@ export class MathHelper {
     if (score >= MathHelper.ENTROPY_HIGH_THRESHOLD) return '多様';
     if (score >= MathHelper.ENTROPY_LOW_THRESHOLD) return '普通';
     return '均一';
+  }
+
+  /**
+   * 値配列と対象値からZ値（標準化スコア）を算出する
+   */
+  static getZScore(values: number[], target: number): number {
+    if (values.length <= 1) return 0;
+    const stdDev = MathHelper.calculateStdDev(values);
+    if (stdDev === 0) return 0;
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    return Math.round(((target - avg) / stdDev) * 100) / 100;
+  }
+
+  /**
+   * Z値に応じた異常度ラベルを返す
+   */
+  static getZScoreLabel(z: number): string {
+    const abs = Math.abs(z);
+    if (abs >= MathHelper.ZSCORE_ABNORMAL_THRESHOLD) return '異常';
+    if (abs >= MathHelper.ZSCORE_OUTLIER_THRESHOLD) return 'やや外れ値';
+    return '正常';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -44,6 +44,9 @@ export class MedicationRecordEntity {
   private static readonly REGULARITY_MAX_STDDEV = 120;
   private static readonly REGULARITY_HIGH_THRESHOLD = 80;
   private static readonly REGULARITY_MODERATE_THRESHOLD = 50;
+  private static readonly GAP_VARIABILITY_MAX_CV = 1;
+  private static readonly GAP_VARIABILITY_HIGH_THRESHOLD = 60;
+  private static readonly GAP_VARIABILITY_MODERATE_THRESHOLD = 30;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -748,5 +751,27 @@ export class MedicationRecordEntity {
     if (days < MedicationRecordEntity.STREAK_GOOD_THRESHOLD) return '継続中';
     if (days < MedicationRecordEntity.STREAK_EXCELLENT_THRESHOLD) return '好調';
     return '素晴らしい';
+  }
+
+  /**
+   * 服薬間隔配列(分単位)からばらつき度(0-100)を算出する
+   * 変動係数ベースで数値化
+   */
+  static getDoseGapVariability(gaps: number[]): number {
+    if (gaps.length <= 1) return 0;
+    const avg = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+    if (avg === 0) return 0;
+    const variance = gaps.reduce((sum, v) => sum + (v - avg) ** 2, 0) / gaps.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.min(100, Math.round((cv / MedicationRecordEntity.GAP_VARIABILITY_MAX_CV) * 100));
+  }
+
+  /**
+   * 服薬間隔ばらつき度に応じたラベルを返す
+   */
+  static getDoseGapVariabilityLabel(score: number): string {
+    if (score >= MedicationRecordEntity.GAP_VARIABILITY_HIGH_THRESHOLD) return '不規則';
+    if (score >= MedicationRecordEntity.GAP_VARIABILITY_MODERATE_THRESHOLD) return 'やや不規則';
+    return '規則的';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getZScore/getZScoreLabel - 値配列と対象値からZ値を算出し異常度を判定
- MedicationRecordEntity: getDoseGapVariability/getDoseGapVariabilityLabel - 変動係数ベースで服薬間隔のばらつきを0-100スコア化
- DateRangeHelper: getWeekdayConcentration/getWeekdayConcentrationLabel - 最頻曜日の出現率から集中度を0-100スコア化

## Test plan
- [x] ZScore: 13テスト通過
- [x] DoseGapVariability: 10テスト通過
- [x] WeekdayConcentration: 10テスト通過
- [x] 全4844テスト通過確認済み