### PR TITLE
feat: コサイン類似度・月間記録ばらつき・体調傾き分析の追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionTrendSlope.test.ts
+++ b/src/__tests__/domain/entities/ConditionTrendSlope.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionTrendSlope', () => {
+  it('空配列は0を返す', () => {
+    expect(HealthLogEntity.getConditionTrendSlope([])).toBe(0);
+  });
+
+  it('1件は0を返す', () => {
+    expect(HealthLogEntity.getConditionTrendSlope([3])).toBe(0);
+  });
+
+  it('全て同じ値は0を返す', () => {
+    expect(HealthLogEntity.getConditionTrendSlope([3, 3, 3, 3])).toBe(0);
+  });
+
+  it('上昇傾向は正の値', () => {
+    expect(HealthLogEntity.getConditionTrendSlope([1, 2, 3, 4, 5])).toBeGreaterThan(0);
+  });
+
+  it('下降傾向は負の値', () => {
+    expect(HealthLogEntity.getConditionTrendSlope([5, 4, 3, 2, 1])).toBeLessThan(0);
+  });
+
+  it('完全な線形上昇の傾きは1', () => {
+    expect(HealthLogEntity.getConditionTrendSlope([1, 2, 3, 4, 5])).toBe(1);
+  });
+
+  it('完全な線形下降の傾きは-1', () => {
+    expect(HealthLogEntity.getConditionTrendSlope([5, 4, 3, 2, 1])).toBe(-1);
+  });
+
+  it('ノイズがある上昇傾向も正の値', () => {
+    const result = HealthLogEntity.getConditionTrendSlope([1, 3, 2, 4, 3, 5]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('小数点2桁に丸められる', () => {
+    const result = HealthLogEntity.getConditionTrendSlope([1, 3, 2, 5]);
+    const decimalPart = result.toString().split('.')[1] || '';
+    expect(decimalPart.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('HealthLogEntity.getConditionTrendSlopeLabel', () => {
+  it('傾き0.3以上は改善傾向', () => {
+    expect(HealthLogEntity.getConditionTrendSlopeLabel(0.5)).toBe('改善傾向');
+  });
+
+  it('傾き-0.3以下は悪化傾向', () => {
+    expect(HealthLogEntity.getConditionTrendSlopeLabel(-0.5)).toBe('悪化傾向');
+  });
+
+  it('傾き0は横ばい', () => {
+    expect(HealthLogEntity.getConditionTrendSlopeLabel(0)).toBe('横ばい');
+  });
+
+  it('傾き0.2は横ばい', () => {
+    expect(HealthLogEntity.getConditionTrendSlopeLabel(0.2)).toBe('横ばい');
+  });
+});

--- a/src/__tests__/domain/entities/CosineSimilarity.test.ts
+++ b/src/__tests__/domain/entities/CosineSimilarity.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getCosineSimilarity', () => {
+  it('空配列は0を返す', () => {
+    expect(MathHelper.getCosineSimilarity([], [])).toBe(0);
+  });
+
+  it('長さが異なる場合は短い方に合わせる', () => {
+    const result = MathHelper.getCosineSimilarity([1, 0], [1]);
+    expect(result).toBe(1);
+  });
+
+  it('同じベクトルは1を返す', () => {
+    expect(MathHelper.getCosineSimilarity([1, 2, 3], [1, 2, 3])).toBe(1);
+  });
+
+  it('正反対のベクトルは-1を返す', () => {
+    expect(MathHelper.getCosineSimilarity([1, 2, 3], [-1, -2, -3])).toBe(-1);
+  });
+
+  it('直交ベクトルは0を返す', () => {
+    expect(MathHelper.getCosineSimilarity([1, 0], [0, 1])).toBe(0);
+  });
+
+  it('ゼロベクトルは0を返す', () => {
+    expect(MathHelper.getCosineSimilarity([0, 0], [1, 2])).toBe(0);
+  });
+
+  it('スカラー倍は1を返す', () => {
+    expect(MathHelper.getCosineSimilarity([1, 2, 3], [2, 4, 6])).toBe(1);
+  });
+
+  it('-1から1の範囲内', () => {
+    const result = MathHelper.getCosineSimilarity([3, 1, 5], [2, 7, 1]);
+    expect(result).toBeGreaterThanOrEqual(-1);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('小数点2桁に丸められる', () => {
+    const result = MathHelper.getCosineSimilarity([1, 3], [2, 5]);
+    const decimalPart = result.toString().split('.')[1] || '';
+    expect(decimalPart.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('MathHelper.getCosineSimilarityLabel', () => {
+  it('類似度0.7以上は類似', () => {
+    expect(MathHelper.getCosineSimilarityLabel(0.8)).toBe('類似');
+  });
+
+  it('類似度0.3以上はやや類似', () => {
+    expect(MathHelper.getCosineSimilarityLabel(0.5)).toBe('やや類似');
+  });
+
+  it('類似度0.3未満で-0.3超は無関係', () => {
+    expect(MathHelper.getCosineSimilarityLabel(0)).toBe('無関係');
+  });
+
+  it('類似度-0.7以下は正反対', () => {
+    expect(MathHelper.getCosineSimilarityLabel(-0.8)).toBe('正反対');
+  });
+});

--- a/src/__tests__/domain/entities/MonthlyVariance.test.ts
+++ b/src/__tests__/domain/entities/MonthlyVariance.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getMonthlyVariance', () => {
+  it('空配列は0を返す', () => {
+    expect(CalendarEntity.getMonthlyVariance([])).toBe(0);
+  });
+
+  it('1件のみは0を返す', () => {
+    expect(CalendarEntity.getMonthlyVariance([10])).toBe(0);
+  });
+
+  it('全て同じ値は0を返す', () => {
+    expect(CalendarEntity.getMonthlyVariance([20, 20, 20])).toBe(0);
+  });
+
+  it('安定した記録数は低スコア', () => {
+    const result = CalendarEntity.getMonthlyVariance([28, 29, 30, 31]);
+    expect(result).toBeLessThan(20);
+  });
+
+  it('大きくばらつく記録数は高スコア', () => {
+    const result = CalendarEntity.getMonthlyVariance([5, 30, 5, 30]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = CalendarEntity.getMonthlyVariance([0, 100, 0, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('CalendarEntity.getMonthlyVarianceLabel', () => {
+  it('スコア0は安定', () => {
+    expect(CalendarEntity.getMonthlyVarianceLabel(0)).toBe('安定');
+  });
+
+  it('スコア40はやや不安定', () => {
+    expect(CalendarEntity.getMonthlyVarianceLabel(40)).toBe('やや不安定');
+  });
+
+  it('スコア70は不安定', () => {
+    expect(CalendarEntity.getMonthlyVarianceLabel(70)).toBe('不安定');
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -39,6 +39,9 @@ export class CalendarEntity {
   private static readonly COMPLETENESS_PERFECT_THRESHOLD = 90;
   private static readonly COMPLETENESS_GOOD_THRESHOLD = 70;
   private static readonly COMPLETENESS_FAIR_THRESHOLD = 50;
+  private static readonly MONTHLY_VARIANCE_MAX_CV = 1;
+  private static readonly MONTHLY_VARIANCE_HIGH_THRESHOLD = 60;
+  private static readonly MONTHLY_VARIANCE_MODERATE_THRESHOLD = 30;
 
   /**
    * 指定月のカレンダーデータを生成
@@ -540,5 +543,27 @@ export class CalendarEntity {
     if (gapDays < CalendarEntity.GAP_SHORT_THRESHOLD) return '短い空白';
     if (gapDays < CalendarEntity.GAP_LONG_THRESHOLD) return '長い空白';
     return '記録途絶';
+  }
+
+  /**
+   * 月間記録数配列からばらつき度(0-100)を算出する
+   * 変動係数ベースで数値化
+   */
+  static getMonthlyVariance(monthlyCounts: number[]): number {
+    if (monthlyCounts.length <= 1) return 0;
+    const avg = monthlyCounts.reduce((a, b) => a + b, 0) / monthlyCounts.length;
+    if (avg === 0) return 0;
+    const variance = monthlyCounts.reduce((sum, v) => sum + (v - avg) ** 2, 0) / monthlyCounts.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.min(100, Math.round((cv / CalendarEntity.MONTHLY_VARIANCE_MAX_CV) * 100));
+  }
+
+  /**
+   * 月間記録ばらつき度に応じたラベルを返す
+   */
+  static getMonthlyVarianceLabel(score: number): string {
+    if (score >= CalendarEntity.MONTHLY_VARIANCE_HIGH_THRESHOLD) return '不安定';
+    if (score >= CalendarEntity.MONTHLY_VARIANCE_MODERATE_THRESHOLD) return 'やや不安定';
+    return '安定';
   }
 }

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -72,6 +72,7 @@ export class HealthLogEntity {
   private static readonly CONSISTENCY_MAX_AVG_DIFF = 4;
   private static readonly CONSISTENCY_HIGH_THRESHOLD = 80;
   private static readonly CONSISTENCY_MODERATE_THRESHOLD = 50;
+  private static readonly TREND_SLOPE_THRESHOLD = 0.3;
   private static readonly TEMP_HYPOTHERMIA = 35.0;
   private static readonly TEMP_LOW_FEVER = 37.5;
   private static readonly TEMP_FEVER = 38.0;
@@ -893,5 +894,37 @@ export class HealthLogEntity {
     if (score >= HealthLogEntity.CONSISTENCY_HIGH_THRESHOLD) return '安定';
     if (score >= HealthLogEntity.CONSISTENCY_MODERATE_THRESHOLD) return '変動あり';
     return '不安定';
+  }
+
+  /**
+   * 体調値配列の線形回帰傾きを算出する
+   * 最小二乗法による傾き（正=改善、負=悪化）
+   */
+  static getConditionTrendSlope(conditions: number[]): number {
+    if (conditions.length <= 1) return 0;
+    const n = conditions.length;
+    let sumX = 0;
+    let sumY = 0;
+    let sumXY = 0;
+    let sumX2 = 0;
+    for (let i = 0; i < n; i++) {
+      sumX += i;
+      sumY += conditions[i];
+      sumXY += i * conditions[i];
+      sumX2 += i * i;
+    }
+    const denominator = n * sumX2 - sumX * sumX;
+    if (denominator === 0) return 0;
+    const slope = (n * sumXY - sumX * sumY) / denominator;
+    return Math.round(slope * 100) / 100;
+  }
+
+  /**
+   * 傾きに応じたラベルを返す
+   */
+  static getConditionTrendSlopeLabel(slope: number): string {
+    if (slope >= HealthLogEntity.TREND_SLOPE_THRESHOLD) return '改善傾向';
+    if (slope <= -HealthLogEntity.TREND_SLOPE_THRESHOLD) return '悪化傾向';
+    return '横ばい';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -18,6 +18,9 @@ export class MathHelper {
   private static readonly ENTROPY_LOW_THRESHOLD = 30;
   private static readonly ZSCORE_ABNORMAL_THRESHOLD = 2;
   private static readonly ZSCORE_OUTLIER_THRESHOLD = 1;
+  private static readonly COSINE_SIMILAR_THRESHOLD = 0.7;
+  private static readonly COSINE_SOMEWHAT_THRESHOLD = 0.3;
+  private static readonly COSINE_OPPOSITE_THRESHOLD = -0.7;
 
   /**
    * パーセントを算出(0-100%)
@@ -383,5 +386,34 @@ export class MathHelper {
     if (abs >= MathHelper.ZSCORE_ABNORMAL_THRESHOLD) return '異常';
     if (abs >= MathHelper.ZSCORE_OUTLIER_THRESHOLD) return 'やや外れ値';
     return '正常';
+  }
+
+  /**
+   * 2つの数値配列のコサイン類似度(-1〜1)を算出する
+   */
+  static getCosineSimilarity(a: number[], b: number[]): number {
+    const len = Math.min(a.length, b.length);
+    if (len === 0) return 0;
+    let dotProduct = 0;
+    let normA = 0;
+    let normB = 0;
+    for (let i = 0; i < len; i++) {
+      dotProduct += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
+    const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+    if (denominator === 0) return 0;
+    return Math.round((dotProduct / denominator) * 100) / 100;
+  }
+
+  /**
+   * コサイン類似度に応じたラベルを返す
+   */
+  static getCosineSimilarityLabel(similarity: number): string {
+    if (similarity >= MathHelper.COSINE_SIMILAR_THRESHOLD) return '類似';
+    if (similarity >= MathHelper.COSINE_SOMEWHAT_THRESHOLD) return 'やや類似';
+    if (similarity <= MathHelper.COSINE_OPPOSITE_THRESHOLD) return '正反対';
+    return '無関係';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getCosineSimilarity/getCosineSimilarityLabel - 2つの数値配列のコサイン類似度(-1〜1)算出
- CalendarEntity: getMonthlyVariance/getMonthlyVarianceLabel - 変動係数ベースで月間記録数のばらつきを0-100スコア化
- HealthLogEntity: getConditionTrendSlope/getConditionTrendSlopeLabel - 最小二乗法で体調値の線形回帰傾きを算出

## Test plan
- [x] CosineSimilarity: 13テスト通過
- [x] MonthlyVariance: 9テスト通過
- [x] ConditionTrendSlope: 13テスト通過
- [x] 全4929テスト通過確認済み