### PR TITLE
feat: 順位百分率・通院頻度スコア・在庫消費速度の追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentFrequencyScore.test.ts
+++ b/src/__tests__/domain/entities/AppointmentFrequencyScore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentFrequencyScore', () => {
+  it('空配列は0を返す', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([])).toBe(0);
+  });
+
+  it('1件のみは0を返す(間隔算出不可)', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([30])).toBe(0);
+  });
+
+  it('短い間隔は高スコア', () => {
+    const result = AppointmentEntity.getAppointmentFrequencyScore([7, 7, 7]);
+    expect(result).toBeGreaterThan(70);
+  });
+
+  it('長い間隔は低スコア', () => {
+    const result = AppointmentEntity.getAppointmentFrequencyScore([90, 90, 90]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('中程度の間隔は中程度のスコア', () => {
+    const result = AppointmentEntity.getAppointmentFrequencyScore([30, 30, 30]);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(70);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result1 = AppointmentEntity.getAppointmentFrequencyScore([1, 1]);
+    const result2 = AppointmentEntity.getAppointmentFrequencyScore([365, 365]);
+    expect(result1).toBeGreaterThanOrEqual(0);
+    expect(result1).toBeLessThanOrEqual(100);
+    expect(result2).toBeGreaterThanOrEqual(0);
+    expect(result2).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentFrequencyScoreLabel', () => {
+  it('スコア70以上は高頻度', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(70)).toBe('高頻度');
+  });
+
+  it('スコア40以上は中頻度', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(50)).toBe('中頻度');
+  });
+
+  it('スコア40未満は低頻度', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(20)).toBe('低頻度');
+  });
+});

--- a/src/__tests__/domain/entities/RankPercentile.test.ts
+++ b/src/__tests__/domain/entities/RankPercentile.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRankPercentile', () => {
+  it('空配列は0を返す', () => {
+    expect(MathHelper.getRankPercentile([], 5)).toBe(0);
+  });
+
+  it('1要素で一致は50を返す(中央順位)', () => {
+    expect(MathHelper.getRankPercentile([5], 5)).toBe(50);
+  });
+
+  it('最大値は90を返す(5要素中)', () => {
+    expect(MathHelper.getRankPercentile([1, 2, 3, 4, 5], 5)).toBe(90);
+  });
+
+  it('最小値は低い順位を返す', () => {
+    const result = MathHelper.getRankPercentile([1, 2, 3, 4, 5], 1);
+    expect(result).toBeLessThanOrEqual(20);
+  });
+
+  it('中央値は約50', () => {
+    const result = MathHelper.getRankPercentile([1, 2, 3, 4, 5], 3);
+    expect(result).toBeGreaterThanOrEqual(40);
+    expect(result).toBeLessThanOrEqual(60);
+  });
+
+  it('配列にない値(全より大きい)は100', () => {
+    expect(MathHelper.getRankPercentile([1, 2, 3], 10)).toBe(100);
+  });
+
+  it('配列にない値(全より小さい)は0', () => {
+    expect(MathHelper.getRankPercentile([10, 20, 30], 1)).toBe(0);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = MathHelper.getRankPercentile([5, 10, 15, 20], 12);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MathHelper.getRankPercentileLabel', () => {
+  it('百分率80以上は上位', () => {
+    expect(MathHelper.getRankPercentileLabel(80)).toBe('上位');
+  });
+
+  it('百分率50以上は中位', () => {
+    expect(MathHelper.getRankPercentileLabel(50)).toBe('中位');
+  });
+
+  it('百分率50未満は下位', () => {
+    expect(MathHelper.getRankPercentileLabel(30)).toBe('下位');
+  });
+});

--- a/src/__tests__/domain/entities/StockBurnRate.test.ts
+++ b/src/__tests__/domain/entities/StockBurnRate.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockBurnRate', () => {
+  it('在庫0は0を返す', () => {
+    expect(StockAlertEntity.getStockBurnRate(0, 5)).toBe(0);
+  });
+
+  it('消費量0は0を返す', () => {
+    expect(StockAlertEntity.getStockBurnRate(100, 0)).toBe(0);
+  });
+
+  it('低消費速度は高スコア(余裕あり)', () => {
+    // 100個在庫、1日1個消費 = 100日分 -> 高スコア
+    const result = StockAlertEntity.getStockBurnRate(100, 1);
+    expect(result).toBeGreaterThan(70);
+  });
+
+  it('高消費速度は低スコア(余裕なし)', () => {
+    // 10個在庫、10日消費 = 1日分 -> 低スコア
+    const result = StockAlertEntity.getStockBurnRate(10, 10);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('30日分は33スコア(90日基準)', () => {
+    const result = StockAlertEntity.getStockBurnRate(30, 1);
+    expect(result).toBe(33);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result1 = StockAlertEntity.getStockBurnRate(1000, 1);
+    const result2 = StockAlertEntity.getStockBurnRate(1, 100);
+    expect(result1).toBeGreaterThanOrEqual(0);
+    expect(result1).toBeLessThanOrEqual(100);
+    expect(result2).toBeGreaterThanOrEqual(0);
+    expect(result2).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('StockAlertEntity.getStockBurnRateLabel', () => {
+  it('スコア70以上は余裕あり', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(70)).toBe('余裕あり');
+  });
+
+  it('スコア40以上はやや不足', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(50)).toBe('やや不足');
+  });
+
+  it('スコア40未満は不足', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(20)).toBe('不足');
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -519,6 +519,9 @@ export class AppointmentEntity {
   private static readonly PUNCTUALITY_MAX_DELAY = 30;
   private static readonly PUNCTUALITY_HIGH_THRESHOLD = 80;
   private static readonly PUNCTUALITY_MODERATE_THRESHOLD = 50;
+  private static readonly FREQUENCY_MAX_INTERVAL = 90;
+  private static readonly FREQUENCY_HIGH_THRESHOLD = 70;
+  private static readonly FREQUENCY_MODERATE_THRESHOLD = 40;
 
   /**
    * 通院完了/未完了配列から完了率(0-100)を算出する
@@ -580,5 +583,24 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.PUNCTUALITY_HIGH_THRESHOLD) return '時間厳守';
     if (score >= AppointmentEntity.PUNCTUALITY_MODERATE_THRESHOLD) return 'やや遅れ';
     return '遅刻傾向';
+  }
+
+  /**
+   * 通院間隔(日数)配列から頻度スコア(0-100)を算出する
+   * 間隔が短いほど高スコア（最大間隔90日基準）
+   */
+  static getAppointmentFrequencyScore(intervals: number[]): number {
+    if (intervals.length <= 1) return 0;
+    const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+    return Math.max(0, Math.min(100, Math.round(100 - (avg / AppointmentEntity.FREQUENCY_MAX_INTERVAL) * 100)));
+  }
+
+  /**
+   * 頻度スコアに応じたラベルを返す
+   */
+  static getAppointmentFrequencyScoreLabel(score: number): string {
+    if (score >= AppointmentEntity.FREQUENCY_HIGH_THRESHOLD) return '高頻度';
+    if (score >= AppointmentEntity.FREQUENCY_MODERATE_THRESHOLD) return '中頻度';
+    return '低頻度';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -21,6 +21,8 @@ export class MathHelper {
   private static readonly COSINE_SIMILAR_THRESHOLD = 0.7;
   private static readonly COSINE_SOMEWHAT_THRESHOLD = 0.3;
   private static readonly COSINE_OPPOSITE_THRESHOLD = -0.7;
+  private static readonly RANK_HIGH_THRESHOLD = 80;
+  private static readonly RANK_MEDIUM_THRESHOLD = 50;
 
   /**
    * パーセントを算出(0-100%)
@@ -415,5 +417,25 @@ export class MathHelper {
     if (similarity >= MathHelper.COSINE_SOMEWHAT_THRESHOLD) return 'やや類似';
     if (similarity <= MathHelper.COSINE_OPPOSITE_THRESHOLD) return '正反対';
     return '無関係';
+  }
+
+  /**
+   * 値配列中の対象値の順位百分率(0-100)を算出する
+   * 対象値以下の値の割合を返す
+   */
+  static getRankPercentile(values: number[], target: number): number {
+    if (values.length === 0) return 0;
+    const belowCount = values.filter((v) => v < target).length;
+    const equalCount = values.filter((v) => v === target).length;
+    return Math.round(((belowCount + equalCount * 0.5) / values.length) * 100);
+  }
+
+  /**
+   * 順位百分率に応じたラベルを返す
+   */
+  static getRankPercentileLabel(percentile: number): string {
+    if (percentile >= MathHelper.RANK_HIGH_THRESHOLD) return '上位';
+    if (percentile >= MathHelper.RANK_MEDIUM_THRESHOLD) return '中位';
+    return '下位';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -35,6 +35,9 @@ export class StockAlertEntity {
   private static readonly STABILITY_MAX_CV = 1;
   private static readonly STABILITY_HIGH_THRESHOLD = 80;
   private static readonly STABILITY_MODERATE_THRESHOLD = 50;
+  private static readonly BURN_RATE_MAX_DAYS = 90;
+  private static readonly BURN_RATE_HIGH_THRESHOLD = 70;
+  private static readonly BURN_RATE_MODERATE_THRESHOLD = 40;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -544,5 +547,24 @@ export class StockAlertEntity {
     if (score >= StockAlertEntity.STABILITY_HIGH_THRESHOLD) return '安定';
     if (score >= StockAlertEntity.STABILITY_MODERATE_THRESHOLD) return 'やや不安定';
     return '不安定';
+  }
+
+  /**
+   * 在庫量と日次消費量から消費速度スコア(0-100)を算出する
+   * 在庫日数が多いほど高スコア（最大90日基準）
+   */
+  static getStockBurnRate(stock: number, dailyConsumption: number): number {
+    if (stock <= 0 || dailyConsumption <= 0) return 0;
+    const coverageDays = stock / dailyConsumption;
+    return Math.min(100, Math.round((coverageDays / StockAlertEntity.BURN_RATE_MAX_DAYS) * 100));
+  }
+
+  /**
+   * 消費速度スコアに応じたラベルを返す
+   */
+  static getStockBurnRateLabel(score: number): string {
+    if (score >= StockAlertEntity.BURN_RATE_HIGH_THRESHOLD) return '余裕あり';
+    if (score >= StockAlertEntity.BURN_RATE_MODERATE_THRESHOLD) return 'やや不足';
+    return '不足';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getRankPercentile/getRankPercentileLabel - 値配列中の対象値の順位百分率を算出
- AppointmentEntity: getAppointmentFrequencyScore/getAppointmentFrequencyScoreLabel - 通院間隔から頻度スコアを0-100で算出
- StockAlertEntity: getStockBurnRate/getStockBurnRateLabel - 在庫量と日次消費量から消費速度スコアを算出

## Test plan
- [x] RankPercentile: 11テスト通過
- [x] AppointmentFrequencyScore: 9テスト通過
- [x] StockBurnRate: 9テスト通過
- [x] 全5015テスト通過確認済み