### PR TITLE
test: RankPercentile・AppointmentFrequencyScore・StockBurnRateのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentFrequencyScore.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentFrequencyScore.edge.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentFrequencyScore - エッジケース', () => {
+  it('空配列は0を返す', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([])).toBe(0);
+  });
+
+  it('1件のみは0を返す', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([14])).toBe(0);
+  });
+
+  it('間隔0日は100を返す', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([0, 0])).toBe(100);
+  });
+
+  it('間隔90日は0を返す(基準値)', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([90, 90])).toBe(0);
+  });
+
+  it('間隔90日超でも0未満にならない', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([180, 180])).toBe(0);
+  });
+
+  it('間隔45日は50を返す', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScore([45, 45])).toBe(50);
+  });
+
+  it('大量データでも正しく計算', () => {
+    const intervals = Array(50).fill(14);
+    const result = AppointmentEntity.getAppointmentFrequencyScore(intervals);
+    expect(result).toBeGreaterThan(80);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result1 = AppointmentEntity.getAppointmentFrequencyScore([1, 1]);
+    const result2 = AppointmentEntity.getAppointmentFrequencyScore([365, 365]);
+    expect(result1).toBeLessThanOrEqual(100);
+    expect(result1).toBeGreaterThanOrEqual(0);
+    expect(result2).toBeGreaterThanOrEqual(0);
+  });
+
+  it('混在した間隔は平均で計算', () => {
+    // [14, 90] -> avg=52 -> 100-(52/90)*100=42
+    const result = AppointmentEntity.getAppointmentFrequencyScore([14, 90]);
+    expect(result).toBe(42);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentFrequencyScoreLabel - 境界値', () => {
+  it('スコア70は高頻度(境界値)', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(70)).toBe('高頻度');
+  });
+
+  it('スコア69は中頻度', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(69)).toBe('中頻度');
+  });
+
+  it('スコア40は中頻度(境界値)', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(40)).toBe('中頻度');
+  });
+
+  it('スコア39は低頻度', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(39)).toBe('低頻度');
+  });
+
+  it('スコア0は低頻度', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(0)).toBe('低頻度');
+  });
+
+  it('スコア100は高頻度', () => {
+    expect(AppointmentEntity.getAppointmentFrequencyScoreLabel(100)).toBe('高頻度');
+  });
+});

--- a/src/__tests__/domain/entities/RankPercentile.edge.test.ts
+++ b/src/__tests__/domain/entities/RankPercentile.edge.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRankPercentile - エッジケース', () => {
+  it('空配列は0を返す', () => {
+    expect(MathHelper.getRankPercentile([], 5)).toBe(0);
+  });
+
+  it('1要素で対象値と一致は50', () => {
+    expect(MathHelper.getRankPercentile([10], 10)).toBe(50);
+  });
+
+  it('対象値が全値より大きい場合100', () => {
+    expect(MathHelper.getRankPercentile([1, 2, 3], 100)).toBe(100);
+  });
+
+  it('対象値が全値より小さい場合0', () => {
+    expect(MathHelper.getRankPercentile([10, 20, 30], 1)).toBe(0);
+  });
+
+  it('全て同じ値で対象一致は50', () => {
+    expect(MathHelper.getRankPercentile([5, 5, 5, 5], 5)).toBe(50);
+  });
+
+  it('重複値がある場合の正しい計算', () => {
+    // [1,1,2,3,3], target=2: below=2, equal=1 -> (2+0.5)/5=50
+    expect(MathHelper.getRankPercentile([1, 1, 2, 3, 3], 2)).toBe(50);
+  });
+
+  it('負の値を含む配列', () => {
+    const result = MathHelper.getRankPercentile([-10, -5, 0, 5, 10], 0);
+    expect(result).toBe(50);
+  });
+
+  it('大量データでの中央値', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i + 1);
+    const result = MathHelper.getRankPercentile(values, 50);
+    expect(result).toBeGreaterThan(45);
+    expect(result).toBeLessThan(55);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = MathHelper.getRankPercentile([1, 2, 3, 4, 5], 3);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('小数値も正しく処理', () => {
+    const result = MathHelper.getRankPercentile([1.5, 2.5, 3.5], 2.5);
+    expect(result).toBe(50);
+  });
+});
+
+describe('MathHelper.getRankPercentileLabel - 境界値', () => {
+  it('百分率80は上位(境界値)', () => {
+    expect(MathHelper.getRankPercentileLabel(80)).toBe('上位');
+  });
+
+  it('百分率79は中位', () => {
+    expect(MathHelper.getRankPercentileLabel(79)).toBe('中位');
+  });
+
+  it('百分率50は中位(境界値)', () => {
+    expect(MathHelper.getRankPercentileLabel(50)).toBe('中位');
+  });
+
+  it('百分率49は下位', () => {
+    expect(MathHelper.getRankPercentileLabel(49)).toBe('下位');
+  });
+
+  it('百分率0は下位', () => {
+    expect(MathHelper.getRankPercentileLabel(0)).toBe('下位');
+  });
+
+  it('百分率100は上位', () => {
+    expect(MathHelper.getRankPercentileLabel(100)).toBe('上位');
+  });
+});

--- a/src/__tests__/domain/entities/StockBurnRate.edge.test.ts
+++ b/src/__tests__/domain/entities/StockBurnRate.edge.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockBurnRate - エッジケース', () => {
+  it('在庫0は0を返す', () => {
+    expect(StockAlertEntity.getStockBurnRate(0, 5)).toBe(0);
+  });
+
+  it('消費量0は0を返す', () => {
+    expect(StockAlertEntity.getStockBurnRate(100, 0)).toBe(0);
+  });
+
+  it('負の在庫は0を返す', () => {
+    expect(StockAlertEntity.getStockBurnRate(-10, 5)).toBe(0);
+  });
+
+  it('負の消費量は0を返す', () => {
+    expect(StockAlertEntity.getStockBurnRate(100, -5)).toBe(0);
+  });
+
+  it('90日分ちょうどは100', () => {
+    expect(StockAlertEntity.getStockBurnRate(90, 1)).toBe(100);
+  });
+
+  it('180日分でも100を超えない', () => {
+    expect(StockAlertEntity.getStockBurnRate(180, 1)).toBe(100);
+  });
+
+  it('1日分は約1', () => {
+    const result = StockAlertEntity.getStockBurnRate(1, 1);
+    expect(result).toBe(1);
+  });
+
+  it('小数の消費量も正しく処理', () => {
+    // 45個在庫、0.5個/日 = 90日分 -> 100
+    expect(StockAlertEntity.getStockBurnRate(45, 0.5)).toBe(100);
+  });
+
+  it('大量在庫でも100を超えない', () => {
+    expect(StockAlertEntity.getStockBurnRate(10000, 1)).toBe(100);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = StockAlertEntity.getStockBurnRate(5, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('StockAlertEntity.getStockBurnRateLabel - 境界値', () => {
+  it('スコア70は余裕あり(境界値)', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(70)).toBe('余裕あり');
+  });
+
+  it('スコア69はやや不足', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(69)).toBe('やや不足');
+  });
+
+  it('スコア40はやや不足(境界値)', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(40)).toBe('やや不足');
+  });
+
+  it('スコア39は不足', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(39)).toBe('不足');
+  });
+
+  it('スコア0は不足', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(0)).toBe('不足');
+  });
+
+  it('スコア100は余裕あり', () => {
+    expect(StockAlertEntity.getStockBurnRateLabel(100)).toBe('余裕あり');
+  });
+});


### PR DESCRIPTION
## Summary
- RankPercentile: 重複値、負値、大量データ、小数値等16テスト追加
- AppointmentFrequencyScore: 間隔0、基準値90日、混在間隔、大量データ等15テスト追加
- StockBurnRate: 負値、小数消費量、大量在庫、範囲制約等16テスト追加

## Test plan
- [x] 新規47テスト全通過
- [x] 全5062テスト通過確認済み