### PR TITLE
指数移動平均・AM/PMバランス・遵守率ピークを追加

### DIFF
--- a/src/__tests__/domain/entities/AdherencePeakRate.test.ts
+++ b/src/__tests__/domain/entities/AdherencePeakRate.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherencePeakRate', () => {
+  it('空配列は0を返す', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakRate([])).toBe(0);
+  });
+
+  it('1件はその値を返す', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakRate([80])).toBe(80);
+  });
+
+  it('最大値を返す', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakRate([50, 70, 90, 60])).toBe(90);
+  });
+
+  it('全て同じ値ならその値', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakRate([75, 75, 75])).toBe(75);
+  });
+
+  it('100を含む場合は100', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakRate([80, 100, 90])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakRate([0, 0, 0])).toBe(0);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherencePeakLabel', () => {
+  it('ピーク率90以上は優秀', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakLabel(90)).toBe('優秀');
+  });
+
+  it('ピーク率70以上は良好', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakLabel(70)).toBe('良好');
+  });
+
+  it('ピーク率50以上は普通', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakLabel(50)).toBe('普通');
+  });
+
+  it('ピーク率50未満は低調', () => {
+    expect(AdherenceTrendEntity.getAdherencePeakLabel(30)).toBe('低調');
+  });
+});

--- a/src/__tests__/domain/entities/ExponentialMovingAverage.test.ts
+++ b/src/__tests__/domain/entities/ExponentialMovingAverage.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getExponentialMovingAverage', () => {
+  it('空配列は空配列を返す', () => {
+    expect(MathHelper.getExponentialMovingAverage([], 3)).toEqual([]);
+  });
+
+  it('1要素はその値を返す', () => {
+    expect(MathHelper.getExponentialMovingAverage([5], 3)).toEqual([5]);
+  });
+
+  it('全て同じ値ならEMAも同じ', () => {
+    const result = MathHelper.getExponentialMovingAverage([10, 10, 10, 10], 3);
+    result.forEach((v) => expect(v).toBe(10));
+  });
+
+  it('EMAは直近の値に重みをかける', () => {
+    const values = [10, 20, 30, 40, 50];
+    const ema = MathHelper.getExponentialMovingAverage(values, 3);
+    // 最後のEMAは単純平均より大きい（上昇トレンドなので）
+    const simpleAvg = values.reduce((a, b) => a + b, 0) / values.length;
+    expect(ema[ema.length - 1]).toBeGreaterThan(simpleAvg);
+  });
+
+  it('出力配列は入力と同じ長さ', () => {
+    const values = [1, 2, 3, 4, 5];
+    expect(MathHelper.getExponentialMovingAverage(values, 3)).toHaveLength(5);
+  });
+
+  it('period=1は元の値と同じ', () => {
+    const values = [1, 5, 3, 7, 2];
+    const ema = MathHelper.getExponentialMovingAverage(values, 1);
+    expect(ema).toEqual(values);
+  });
+
+  it('小数点1桁に丸められる', () => {
+    const ema = MathHelper.getExponentialMovingAverage([10, 20, 30], 2);
+    ema.forEach((v) => {
+      const decimalPart = v.toString().split('.')[1] || '';
+      expect(decimalPart.length).toBeLessThanOrEqual(1);
+    });
+  });
+});
+
+describe('MathHelper.getEMALabel', () => {
+  it('現在値がEMAより高いなら上昇基調', () => {
+    expect(MathHelper.getEMALabel(50, 40)).toBe('上昇基調');
+  });
+
+  it('現在値がEMAより低いなら下降基調', () => {
+    expect(MathHelper.getEMALabel(30, 40)).toBe('下降基調');
+  });
+
+  it('現在値がEMAと同じなら横ばい', () => {
+    expect(MathHelper.getEMALabel(40, 40)).toBe('横ばい');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleBalance.test.ts
+++ b/src/__tests__/domain/entities/ScheduleBalance.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleBalance', () => {
+  it('空配列は0を返す', () => {
+    expect(ScheduleEntity.getScheduleBalance([])).toBe(0);
+  });
+
+  it('午前のみは0', () => {
+    expect(ScheduleEntity.getScheduleBalance([480, 540, 600])).toBe(0);
+  });
+
+  it('午後のみは0', () => {
+    expect(ScheduleEntity.getScheduleBalance([780, 840, 900])).toBe(0);
+  });
+
+  it('午前午後均等は100', () => {
+    // 8:00, 9:00 (AM) + 14:00, 15:00 (PM)
+    expect(ScheduleEntity.getScheduleBalance([480, 540, 840, 900])).toBe(100);
+  });
+
+  it('午前多めは100未満', () => {
+    // 3AM + 1PM
+    const result = ScheduleEntity.getScheduleBalance([480, 540, 600, 840]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('1件のみは0(バランス判定不可)', () => {
+    expect(ScheduleEntity.getScheduleBalance([480])).toBe(0);
+  });
+
+  it('0-100の範囲内に収まる', () => {
+    const result = ScheduleEntity.getScheduleBalance([480, 540, 840, 900, 960]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('ScheduleEntity.getScheduleBalanceLabel', () => {
+  it('スコア70以上は均衡', () => {
+    expect(ScheduleEntity.getScheduleBalanceLabel(70)).toBe('均衡');
+  });
+
+  it('スコア40以上はやや偏り', () => {
+    expect(ScheduleEntity.getScheduleBalanceLabel(50)).toBe('やや偏り');
+  });
+
+  it('スコア40未満は偏り', () => {
+    expect(ScheduleEntity.getScheduleBalanceLabel(20)).toBe('偏り');
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -36,6 +36,9 @@ export class AdherenceTrendEntity {
   private static readonly ADHERENCE_VOLATILITY_MODERATE_THRESHOLD = 60;
   private static readonly RECOVERY_GOOD_THRESHOLD = 70;
   private static readonly RECOVERY_MODERATE_THRESHOLD = 40;
+  private static readonly PEAK_EXCELLENT_THRESHOLD = 90;
+  private static readonly PEAK_GOOD_THRESHOLD = 70;
+  private static readonly PEAK_MODERATE_THRESHOLD = 50;
 
   constructor(private readonly trend: AdherenceTrend) {}
 
@@ -404,5 +407,23 @@ export class AdherenceTrendEntity {
     if (rate >= AdherenceTrendEntity.RECOVERY_GOOD_THRESHOLD) return '良好';
     if (rate >= AdherenceTrendEntity.RECOVERY_MODERATE_THRESHOLD) return 'やや遅い';
     return '低回復';
+  }
+
+  /**
+   * 遵守率配列からピーク値(最大値)を返す
+   */
+  static getAdherencePeakRate(rates: number[]): number {
+    if (rates.length === 0) return 0;
+    return Math.max(...rates);
+  }
+
+  /**
+   * ピーク率に応じたラベルを返す
+   */
+  static getAdherencePeakLabel(rate: number): string {
+    if (rate >= AdherenceTrendEntity.PEAK_EXCELLENT_THRESHOLD) return '優秀';
+    if (rate >= AdherenceTrendEntity.PEAK_GOOD_THRESHOLD) return '良好';
+    if (rate >= AdherenceTrendEntity.PEAK_MODERATE_THRESHOLD) return '普通';
+    return '低調';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -438,4 +438,27 @@ export class MathHelper {
     if (percentile >= MathHelper.RANK_MEDIUM_THRESHOLD) return '中位';
     return '下位';
   }
+
+  /**
+   * 指数移動平均(EMA)を算出する
+   */
+  static getExponentialMovingAverage(values: number[], period: number): number[] {
+    if (values.length === 0) return [];
+    const multiplier = 2 / (period + 1);
+    const result: number[] = [values[0]];
+    for (let i = 1; i < values.length; i++) {
+      const ema = (values[i] - result[i - 1]) * multiplier + result[i - 1];
+      result.push(Math.round(ema * 10) / 10);
+    }
+    return result;
+  }
+
+  /**
+   * 現在値とEMAの比較でトレンドラベルを返す
+   */
+  static getEMALabel(currentValue: number, emaValue: number): string {
+    if (currentValue > emaValue) return '上昇基調';
+    if (currentValue < emaValue) return '下降基調';
+    return '横ばい';
+  }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -791,6 +791,9 @@ export class ScheduleEntity {
   private static readonly FRAGMENTATION_MAX_STDDEV = 720;
   private static readonly FRAGMENTATION_HIGH_THRESHOLD = 60;
   private static readonly FRAGMENTATION_MODERATE_THRESHOLD = 30;
+  private static readonly BALANCE_NOON_BOUNDARY = 720;
+  private static readonly BALANCE_HIGH_THRESHOLD = 70;
+  private static readonly BALANCE_MODERATE_THRESHOLD = 40;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -934,5 +937,34 @@ export class ScheduleEntity {
     if (score >= ScheduleEntity.FRAGMENTATION_HIGH_THRESHOLD) return '分散';
     if (score >= ScheduleEntity.FRAGMENTATION_MODERATE_THRESHOLD) return 'やや分散';
     return '集中';
+  }
+
+  /**
+   * AM/PMバランススコア(0-100)を算出する
+   * 午前(0-719分)と午後(720-1439分)の件数比率でバランスを評価
+   */
+  static getScheduleBalance(timesInMinutes: number[]): number {
+    if (timesInMinutes.length <= 1) return 0;
+    let amCount = 0;
+    let pmCount = 0;
+    for (const t of timesInMinutes) {
+      if (t < ScheduleEntity.BALANCE_NOON_BOUNDARY) {
+        amCount++;
+      } else {
+        pmCount++;
+      }
+    }
+    if (amCount === 0 || pmCount === 0) return 0;
+    const ratio = Math.min(amCount, pmCount) / Math.max(amCount, pmCount);
+    return Math.round(ratio * 100);
+  }
+
+  /**
+   * バランススコアに応じたラベルを返す
+   */
+  static getScheduleBalanceLabel(score: number): string {
+    if (score >= ScheduleEntity.BALANCE_HIGH_THRESHOLD) return '均衡';
+    if (score >= ScheduleEntity.BALANCE_MODERATE_THRESHOLD) return 'やや偏り';
+    return '偏り';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getExponentialMovingAverage / getEMALabel (指数移動平均の算出)
- ScheduleEntity: getScheduleBalance / getScheduleBalanceLabel (AM/PMバランス評価)
- AdherenceTrendEntity: getAdherencePeakRate / getAdherencePeakLabel (遵守率ピーク値)
- 30件のテスト追加 (合計5092件)

## Test plan
- [x] ExponentialMovingAverage: 10件のテスト
- [x] ScheduleBalance: 10件のテスト
- [x] AdherencePeakRate: 10件のテスト
- [x] 全テスト(5092件)パス確認

closes #842