### PR TITLE
テスト: 累積最大値・連続記録スコア・服薬時刻偏差のエッジケース

### DIFF
--- a/src/__tests__/domain/entities/DoseTimeDeviation.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseTimeDeviation.edge.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseTimeDeviation - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviation([])).toBe(0);
+  });
+
+  it('1件のみは0', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviation([480])).toBe(0);
+  });
+
+  it('全て同じ時刻は0', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviation([480, 480, 480, 480])).toBe(0);
+  });
+
+  it('2件で差が小さい', () => {
+    const result = MedicationRecordEntity.getDoseTimeDeviation([480, 490]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(10);
+  });
+
+  it('2件で差が大きい', () => {
+    const result = MedicationRecordEntity.getDoseTimeDeviation([0, 1440]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('全て0分', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviation([0, 0, 0])).toBe(0);
+  });
+
+  it('0分と1440分の組み合わせ', () => {
+    const result = MedicationRecordEntity.getDoseTimeDeviation([0, 1440]);
+    expect(result).toBe(100);
+  });
+
+  it('小さなばらつきは低スコア', () => {
+    const result = MedicationRecordEntity.getDoseTimeDeviation([480, 481, 479, 480]);
+    expect(result).toBeLessThan(5);
+  });
+
+  it('大きなばらつきは高スコア', () => {
+    const result = MedicationRecordEntity.getDoseTimeDeviation([60, 480, 900, 1200]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = MedicationRecordEntity.getDoseTimeDeviation([100, 200, 300, 400, 500]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データでも正常に処理', () => {
+    const data = Array.from({ length: 100 }, (_, i) => 480 + (i % 10));
+    const result = MedicationRecordEntity.getDoseTimeDeviation(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('同じ2値の繰り返し', () => {
+    const result = MedicationRecordEntity.getDoseTimeDeviation([480, 540, 480, 540, 480, 540]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('ばらつきが小さい方がスコアが低い', () => {
+    const small = MedicationRecordEntity.getDoseTimeDeviation([480, 485, 475]);
+    const large = MedicationRecordEntity.getDoseTimeDeviation([480, 600, 360]);
+    expect(small).toBeLessThan(large);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseTimeDeviationLabel - 境界値', () => {
+  it('スコア0は正確', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviationLabel(0)).toBe('正確');
+  });
+
+  it('スコア19は正確', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviationLabel(19)).toBe('正確');
+  });
+
+  it('スコア20はやや不規則(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviationLabel(20)).toBe('やや不規則');
+  });
+
+  it('スコア49はやや不規則', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviationLabel(49)).toBe('やや不規則');
+  });
+
+  it('スコア50は不規則(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviationLabel(50)).toBe('不規則');
+  });
+
+  it('スコア100は不規則', () => {
+    expect(MedicationRecordEntity.getDoseTimeDeviationLabel(100)).toBe('不規則');
+  });
+});

--- a/src/__tests__/domain/entities/RecordStreakScore.edge.test.ts
+++ b/src/__tests__/domain/entities/RecordStreakScore.edge.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getRecordStreakScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(CalendarEntity.getRecordStreakScore([])).toBe(0);
+  });
+
+  it('1件true', () => {
+    expect(CalendarEntity.getRecordStreakScore([true])).toBe(100);
+  });
+
+  it('1件false', () => {
+    expect(CalendarEntity.getRecordStreakScore([false])).toBe(0);
+  });
+
+  it('全てtrue(長い配列)', () => {
+    expect(CalendarEntity.getRecordStreakScore(Array(30).fill(true))).toBe(100);
+  });
+
+  it('全てfalse(長い配列)', () => {
+    expect(CalendarEntity.getRecordStreakScore(Array(30).fill(false))).toBe(0);
+  });
+
+  it('交互パターン', () => {
+    const pattern = Array.from({ length: 10 }, (_, i) => i % 2 === 0);
+    expect(CalendarEntity.getRecordStreakScore(pattern)).toBe(50);
+  });
+
+  it('最初だけtrue', () => {
+    expect(CalendarEntity.getRecordStreakScore([true, false, false, false, false])).toBe(20);
+  });
+
+  it('最後だけtrue', () => {
+    expect(CalendarEntity.getRecordStreakScore([false, false, false, false, true])).toBe(20);
+  });
+
+  it('中間だけtrue', () => {
+    expect(CalendarEntity.getRecordStreakScore([false, false, true, false, false])).toBe(20);
+  });
+
+  it('2件中1件true', () => {
+    expect(CalendarEntity.getRecordStreakScore([true, false])).toBe(50);
+  });
+
+  it('3件中2件true', () => {
+    expect(CalendarEntity.getRecordStreakScore([true, true, false])).toBe(67);
+  });
+
+  it('3件中1件true', () => {
+    expect(CalendarEntity.getRecordStreakScore([false, true, false])).toBe(33);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = CalendarEntity.getRecordStreakScore([true, false, true, true, false, true]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データでも正常に処理', () => {
+    const data = Array.from({ length: 365 }, (_, i) => i % 3 !== 0);
+    const result = CalendarEntity.getRecordStreakScore(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('CalendarEntity.getRecordStreakScoreLabel - 境界値', () => {
+  it('スコア80は優秀(境界値)', () => {
+    expect(CalendarEntity.getRecordStreakScoreLabel(80)).toBe('優秀');
+  });
+
+  it('スコア79は良好', () => {
+    expect(CalendarEntity.getRecordStreakScoreLabel(79)).toBe('良好');
+  });
+
+  it('スコア50は良好(境界値)', () => {
+    expect(CalendarEntity.getRecordStreakScoreLabel(50)).toBe('良好');
+  });
+
+  it('スコア49は要改善', () => {
+    expect(CalendarEntity.getRecordStreakScoreLabel(49)).toBe('要改善');
+  });
+
+  it('スコア0は要改善', () => {
+    expect(CalendarEntity.getRecordStreakScoreLabel(0)).toBe('要改善');
+  });
+
+  it('スコア100は優秀', () => {
+    expect(CalendarEntity.getRecordStreakScoreLabel(100)).toBe('優秀');
+  });
+});

--- a/src/__tests__/domain/entities/RunningMax.edge.test.ts
+++ b/src/__tests__/domain/entities/RunningMax.edge.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRunningMax - エッジケース', () => {
+  it('空配列は空配列', () => {
+    expect(MathHelper.getRunningMax([])).toEqual([]);
+  });
+
+  it('1要素はそのまま', () => {
+    expect(MathHelper.getRunningMax([42])).toEqual([42]);
+  });
+
+  it('2要素の昇順', () => {
+    expect(MathHelper.getRunningMax([10, 20])).toEqual([10, 20]);
+  });
+
+  it('2要素の降順', () => {
+    expect(MathHelper.getRunningMax([20, 10])).toEqual([20, 20]);
+  });
+
+  it('全て0', () => {
+    expect(MathHelper.getRunningMax([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+
+  it('全て負の値の昇順', () => {
+    expect(MathHelper.getRunningMax([-30, -20, -10])).toEqual([-30, -20, -10]);
+  });
+
+  it('全て負の値の降順', () => {
+    expect(MathHelper.getRunningMax([-10, -20, -30])).toEqual([-10, -10, -10]);
+  });
+
+  it('V字型パターン', () => {
+    expect(MathHelper.getRunningMax([50, 30, 10, 30, 50])).toEqual([50, 50, 50, 50, 50]);
+  });
+
+  it('山型パターン', () => {
+    expect(MathHelper.getRunningMax([10, 30, 50, 30, 10])).toEqual([10, 30, 50, 50, 50]);
+  });
+
+  it('大量データでも正しく処理', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i % 10);
+    const result = MathHelper.getRunningMax(data);
+    expect(result).toHaveLength(100);
+    expect(result[0]).toBe(0);
+    expect(result[9]).toBe(9);
+    expect(result[99]).toBe(9);
+  });
+
+  it('小数値', () => {
+    expect(MathHelper.getRunningMax([1.5, 2.3, 1.8, 3.1])).toEqual([1.5, 2.3, 2.3, 3.1]);
+  });
+
+  it('非常に大きな値', () => {
+    expect(MathHelper.getRunningMax([1000000, 999999])).toEqual([1000000, 1000000]);
+  });
+
+  it('同じ値が続いた後に更新', () => {
+    expect(MathHelper.getRunningMax([5, 5, 5, 10, 10])).toEqual([5, 5, 5, 10, 10]);
+  });
+
+  it('結果は必ず単調非減少', () => {
+    const data = [3, 1, 4, 1, 5, 9, 2, 6];
+    const result = MathHelper.getRunningMax(data);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).toBeGreaterThanOrEqual(result[i - 1]);
+    }
+  });
+});
+
+describe('MathHelper.getRunningMaxLabel - 境界値', () => {
+  it('現在値=最大値は最高値', () => {
+    expect(MathHelper.getRunningMaxLabel(100, 100)).toBe('最高値');
+  });
+
+  it('現在値が最大値の90%ちょうどは最高値付近', () => {
+    expect(MathHelper.getRunningMaxLabel(90, 100)).toBe('最高値付近');
+  });
+
+  it('現在値が最大値の89%は最高値以下', () => {
+    expect(MathHelper.getRunningMaxLabel(89, 100)).toBe('最高値以下');
+  });
+
+  it('最大値0の場合は最高値以下', () => {
+    expect(MathHelper.getRunningMaxLabel(0, 0)).toBe('最高値以下');
+  });
+
+  it('現在値0で最大値が正の場合は最高値以下', () => {
+    expect(MathHelper.getRunningMaxLabel(0, 100)).toBe('最高値以下');
+  });
+});


### PR DESCRIPTION
## Summary
- RunningMax: 19件のエッジケーステスト(単調非減少検証、V字/山型パターン等)
- RecordStreakScore: 20件のエッジケーステスト(交互パターン、大量データ等)
- DoseTimeDeviation: 19件のエッジケーステスト(境界値、ばらつき比較等)
- 58件追加 (合計5247件)

## Test plan
- [x] RunningMax.edge: 19件パス
- [x] RecordStreakScore.edge: 20件パス
- [x] DoseTimeDeviation.edge: 19件パス
- [x] 全テスト(5247件)パス確認

closes #848