### PR TITLE
移動標準偏差・体調レンジ・在庫回転率を追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionRange.test.ts
+++ b/src/__tests__/domain/entities/ConditionRange.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionRange', () => {
+  it('空配列は0を返す', () => {
+    expect(HealthLogEntity.getConditionRange([])).toBe(0);
+  });
+
+  it('1件は0を返す', () => {
+    expect(HealthLogEntity.getConditionRange([3])).toBe(0);
+  });
+
+  it('全て同じ値は0', () => {
+    expect(HealthLogEntity.getConditionRange([3, 3, 3])).toBe(0);
+  });
+
+  it('最大値と最小値の差を返す', () => {
+    expect(HealthLogEntity.getConditionRange([1, 3, 5])).toBe(4);
+  });
+
+  it('2件の差を返す', () => {
+    expect(HealthLogEntity.getConditionRange([2, 4])).toBe(2);
+  });
+
+  it('順序に関係なく正しいレンジ', () => {
+    expect(HealthLogEntity.getConditionRange([5, 1, 3, 2, 4])).toBe(4);
+  });
+
+  it('0を含む場合', () => {
+    expect(HealthLogEntity.getConditionRange([0, 5])).toBe(5);
+  });
+
+  it('負の値を含む場合', () => {
+    expect(HealthLogEntity.getConditionRange([-2, 3])).toBe(5);
+  });
+});
+
+describe('HealthLogEntity.getConditionRangeLabel', () => {
+  it('レンジ1以下は安定', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(1)).toBe('安定');
+  });
+
+  it('レンジ3以下はやや変動', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(2)).toBe('やや変動');
+  });
+
+  it('レンジ3超は大きな変動', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(4)).toBe('大きな変動');
+  });
+});

--- a/src/__tests__/domain/entities/MovingStdDev.test.ts
+++ b/src/__tests__/domain/entities/MovingStdDev.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMovingStdDev', () => {
+  it('空配列は空配列を返す', () => {
+    expect(MathHelper.getMovingStdDev([], 3)).toEqual([]);
+  });
+
+  it('ウィンドウより短い配列は空配列', () => {
+    expect(MathHelper.getMovingStdDev([1, 2], 3)).toEqual([]);
+  });
+
+  it('全て同じ値は全て0', () => {
+    const result = MathHelper.getMovingStdDev([50, 50, 50, 50], 3);
+    for (const v of result) {
+      expect(v).toBe(0);
+    }
+  });
+
+  it('ばらつきがあると正の値', () => {
+    const result = MathHelper.getMovingStdDev([10, 20, 30], 3);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeGreaterThan(0);
+  });
+
+  it('結果の長さはvalues.length - window + 1', () => {
+    const result = MathHelper.getMovingStdDev([1, 2, 3, 4, 5], 3);
+    expect(result).toHaveLength(3);
+  });
+
+  it('ウィンドウ1は全て0', () => {
+    const result = MathHelper.getMovingStdDev([10, 20, 30], 1);
+    for (const v of result) {
+      expect(v).toBe(0);
+    }
+  });
+
+  it('大きなばらつきは大きな値', () => {
+    const result = MathHelper.getMovingStdDev([0, 100, 0], 3);
+    expect(result[0]).toBeGreaterThan(0);
+  });
+
+  it('ウィンドウが配列と同じ長さ', () => {
+    const result = MathHelper.getMovingStdDev([10, 20, 30], 3);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('MathHelper.getMovingStdDevLabel', () => {
+  it('標準偏差5未満は安定', () => {
+    expect(MathHelper.getMovingStdDevLabel(3)).toBe('安定');
+  });
+
+  it('標準偏差15未満はやや変動', () => {
+    expect(MathHelper.getMovingStdDevLabel(10)).toBe('やや変動');
+  });
+
+  it('標準偏差15以上は大きな変動', () => {
+    expect(MathHelper.getMovingStdDevLabel(20)).toBe('大きな変動');
+  });
+});

--- a/src/__tests__/domain/entities/StockTurnoverRate.test.ts
+++ b/src/__tests__/domain/entities/StockTurnoverRate.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockTurnoverRate', () => {
+  it('平均在庫0は0を返す', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(100, 0)).toBe(0);
+  });
+
+  it('消費量0は0を返す', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(0, 100)).toBe(0);
+  });
+
+  it('消費量と在庫が同じなら回転率1', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(100, 100)).toBe(1);
+  });
+
+  it('消費量が在庫の2倍なら回転率2', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(200, 100)).toBe(2);
+  });
+
+  it('消費量が在庫の半分なら回転率0.5', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(50, 100)).toBe(0.5);
+  });
+
+  it('小数の結果も正しく返す', () => {
+    const result = StockAlertEntity.getStockTurnoverRate(100, 300);
+    expect(result).toBeCloseTo(0.33, 1);
+  });
+
+  it('負の消費量は0', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(-100, 50)).toBe(0);
+  });
+
+  it('負の在庫は0', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(100, -50)).toBe(0);
+  });
+});
+
+describe('StockAlertEntity.getStockTurnoverRateLabel', () => {
+  it('回転率2以上は高回転', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(3)).toBe('高回転');
+  });
+
+  it('回転率0.5以上は普通', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(1)).toBe('普通');
+  });
+
+  it('回転率0.5未満は低回転', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(0.3)).toBe('低回転');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -73,6 +73,8 @@ export class HealthLogEntity {
   private static readonly CONSISTENCY_HIGH_THRESHOLD = 80;
   private static readonly CONSISTENCY_MODERATE_THRESHOLD = 50;
   private static readonly TREND_SLOPE_THRESHOLD = 0.3;
+  private static readonly CONDITION_RANGE_STABLE_THRESHOLD = 1;
+  private static readonly CONDITION_RANGE_MODERATE_THRESHOLD = 3;
   private static readonly TEMP_HYPOTHERMIA = 35.0;
   private static readonly TEMP_LOW_FEVER = 37.5;
   private static readonly TEMP_FEVER = 38.0;
@@ -926,5 +928,22 @@ export class HealthLogEntity {
     if (slope >= HealthLogEntity.TREND_SLOPE_THRESHOLD) return '改善傾向';
     if (slope <= -HealthLogEntity.TREND_SLOPE_THRESHOLD) return '悪化傾向';
     return '横ばい';
+  }
+
+  /**
+   * 体調値配列のレンジ(最大値-最小値)を返す
+   */
+  static getConditionRange(conditions: number[]): number {
+    if (conditions.length <= 1) return 0;
+    return Math.max(...conditions) - Math.min(...conditions);
+  }
+
+  /**
+   * 体調レンジに応じたラベルを返す
+   */
+  static getConditionRangeLabel(range: number): string {
+    if (range <= HealthLogEntity.CONDITION_RANGE_STABLE_THRESHOLD) return '安定';
+    if (range <= HealthLogEntity.CONDITION_RANGE_MODERATE_THRESHOLD) return 'やや変動';
+    return '大きな変動';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -24,6 +24,8 @@ export class MathHelper {
   private static readonly RANK_HIGH_THRESHOLD = 80;
   private static readonly RANK_MEDIUM_THRESHOLD = 50;
   private static readonly RUNNING_MAX_NEAR_RATIO = 0.9;
+  private static readonly MOVING_STDDEV_STABLE_THRESHOLD = 5;
+  private static readonly MOVING_STDDEV_MODERATE_THRESHOLD = 15;
 
   /**
    * パーセントを算出(0-100%)
@@ -484,5 +486,29 @@ export class MathHelper {
     if (currentValue >= maxValue) return '最高値';
     if (currentValue >= maxValue * MathHelper.RUNNING_MAX_NEAR_RATIO) return '最高値付近';
     return '最高値以下';
+  }
+
+  /**
+   * 移動標準偏差を算出する
+   */
+  static getMovingStdDev(values: number[], window: number): number[] {
+    if (values.length < window || window <= 0) return [];
+    const result: number[] = [];
+    for (let i = 0; i <= values.length - window; i++) {
+      const slice = values.slice(i, i + window);
+      const avg = slice.reduce((a, b) => a + b, 0) / slice.length;
+      const variance = slice.reduce((sum, v) => sum + (v - avg) ** 2, 0) / slice.length;
+      result.push(Math.round(Math.sqrt(variance) * 100) / 100);
+    }
+    return result;
+  }
+
+  /**
+   * 移動標準偏差に応じたラベルを返す
+   */
+  static getMovingStdDevLabel(stdDev: number): string {
+    if (stdDev < MathHelper.MOVING_STDDEV_STABLE_THRESHOLD) return '安定';
+    if (stdDev < MathHelper.MOVING_STDDEV_MODERATE_THRESHOLD) return 'やや変動';
+    return '大きな変動';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -38,6 +38,8 @@ export class StockAlertEntity {
   private static readonly BURN_RATE_MAX_DAYS = 90;
   private static readonly BURN_RATE_HIGH_THRESHOLD = 70;
   private static readonly BURN_RATE_MODERATE_THRESHOLD = 40;
+  private static readonly TURNOVER_HIGH_THRESHOLD = 2;
+  private static readonly TURNOVER_MODERATE_THRESHOLD = 0.5;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -566,5 +568,22 @@ export class StockAlertEntity {
     if (score >= StockAlertEntity.BURN_RATE_HIGH_THRESHOLD) return '余裕あり';
     if (score >= StockAlertEntity.BURN_RATE_MODERATE_THRESHOLD) return 'やや不足';
     return '不足';
+  }
+
+  /**
+   * 在庫回転率を算出する(消費量/平均在庫)
+   */
+  static getStockTurnoverRate(consumed: number, averageStock: number): number {
+    if (consumed <= 0 || averageStock <= 0) return 0;
+    return Math.round((consumed / averageStock) * 100) / 100;
+  }
+
+  /**
+   * 在庫回転率に応じたラベルを返す
+   */
+  static getStockTurnoverRateLabel(rate: number): string {
+    if (rate >= StockAlertEntity.TURNOVER_HIGH_THRESHOLD) return '高回転';
+    if (rate >= StockAlertEntity.TURNOVER_MODERATE_THRESHOLD) return '普通';
+    return '低回転';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getMovingStdDev / getMovingStdDevLabel (移動標準偏差の算出)
- HealthLogEntity: getConditionRange / getConditionRangeLabel (体調レンジ評価)
- StockAlertEntity: getStockTurnoverRate / getStockTurnoverRateLabel (在庫回転率)
- 33件のテスト追加 (合計5280件)

## Test plan
- [x] MovingStdDev: 11件のテスト
- [x] ConditionRange: 11件のテスト
- [x] StockTurnoverRate: 11件のテスト
- [x] 全テスト(5280件)パス確認

closes #850