### PR TITLE
テスト: 移動標準偏差・体調レンジ・在庫回転率のエッジケース

### DIFF
--- a/src/__tests__/domain/entities/ConditionRange.edge.test.ts
+++ b/src/__tests__/domain/entities/ConditionRange.edge.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionRange - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getConditionRange([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(HealthLogEntity.getConditionRange([3])).toBe(0);
+  });
+
+  it('2件の同じ値は0', () => {
+    expect(HealthLogEntity.getConditionRange([3, 3])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    expect(HealthLogEntity.getConditionRange([1, 5])).toBe(4);
+  });
+
+  it('全て同じ値は0(長い配列)', () => {
+    expect(HealthLogEntity.getConditionRange([3, 3, 3, 3, 3])).toBe(0);
+  });
+
+  it('最大レンジ(1-5)', () => {
+    expect(HealthLogEntity.getConditionRange([1, 2, 3, 4, 5])).toBe(4);
+  });
+
+  it('逆順でも同じ結果', () => {
+    expect(HealthLogEntity.getConditionRange([5, 4, 3, 2, 1])).toBe(4);
+  });
+
+  it('最小と最大が隣接', () => {
+    expect(HealthLogEntity.getConditionRange([1, 2])).toBe(1);
+  });
+
+  it('0を含む場合', () => {
+    expect(HealthLogEntity.getConditionRange([0, 5])).toBe(5);
+  });
+
+  it('負の値を含む場合', () => {
+    expect(HealthLogEntity.getConditionRange([-3, 3])).toBe(6);
+  });
+
+  it('小数値', () => {
+    expect(HealthLogEntity.getConditionRange([1.5, 3.5])).toBe(2);
+  });
+
+  it('大量データでも正しく計算', () => {
+    const data = Array.from({ length: 100 }, (_, i) => (i % 5) + 1);
+    expect(HealthLogEntity.getConditionRange(data)).toBe(4);
+  });
+
+  it('最大値が先頭にある場合', () => {
+    expect(HealthLogEntity.getConditionRange([5, 1, 2, 3])).toBe(4);
+  });
+
+  it('最小値が末尾にある場合', () => {
+    expect(HealthLogEntity.getConditionRange([3, 4, 5, 1])).toBe(4);
+  });
+
+  it('レンジは必ず0以上', () => {
+    const result = HealthLogEntity.getConditionRange([3, 1, 4, 1, 5]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('HealthLogEntity.getConditionRangeLabel - 境界値', () => {
+  it('レンジ0は安定', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(0)).toBe('安定');
+  });
+
+  it('レンジ1は安定(境界値)', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(1)).toBe('安定');
+  });
+
+  it('レンジ2はやや変動', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(2)).toBe('やや変動');
+  });
+
+  it('レンジ3はやや変動(境界値)', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(3)).toBe('やや変動');
+  });
+
+  it('レンジ4は大きな変動', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(4)).toBe('大きな変動');
+  });
+
+  it('レンジ10は大きな変動', () => {
+    expect(HealthLogEntity.getConditionRangeLabel(10)).toBe('大きな変動');
+  });
+});

--- a/src/__tests__/domain/entities/MovingStdDev.edge.test.ts
+++ b/src/__tests__/domain/entities/MovingStdDev.edge.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMovingStdDev - エッジケース', () => {
+  it('空配列は空配列', () => {
+    expect(MathHelper.getMovingStdDev([], 3)).toEqual([]);
+  });
+
+  it('ウィンドウ0は空配列', () => {
+    expect(MathHelper.getMovingStdDev([1, 2, 3], 0)).toEqual([]);
+  });
+
+  it('負のウィンドウは空配列', () => {
+    expect(MathHelper.getMovingStdDev([1, 2, 3], -1)).toEqual([]);
+  });
+
+  it('ウィンドウが配列より長いと空配列', () => {
+    expect(MathHelper.getMovingStdDev([1, 2], 5)).toEqual([]);
+  });
+
+  it('ウィンドウ1は全て0(1要素の標準偏差は0)', () => {
+    const result = MathHelper.getMovingStdDev([10, 20, 30, 40], 1);
+    expect(result).toHaveLength(4);
+    for (const v of result) {
+      expect(v).toBe(0);
+    }
+  });
+
+  it('全て同じ値の場合全て0', () => {
+    const result = MathHelper.getMovingStdDev([100, 100, 100, 100, 100], 3);
+    for (const v of result) {
+      expect(v).toBe(0);
+    }
+  });
+
+  it('2要素ウィンドウで計算', () => {
+    const result = MathHelper.getMovingStdDev([10, 20, 30], 2);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBeGreaterThan(0);
+  });
+
+  it('大きなウィンドウ(配列と同じ長さ)', () => {
+    const result = MathHelper.getMovingStdDev([10, 20, 30, 40, 50], 5);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeGreaterThan(0);
+  });
+
+  it('結果の長さはvalues.length - window + 1', () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const result = MathHelper.getMovingStdDev(values, 4);
+    expect(result).toHaveLength(7);
+  });
+
+  it('全て0の場合全て0', () => {
+    const result = MathHelper.getMovingStdDev([0, 0, 0, 0], 3);
+    for (const v of result) {
+      expect(v).toBe(0);
+    }
+  });
+
+  it('負の値も正しく処理', () => {
+    const result = MathHelper.getMovingStdDev([-10, -20, -30], 3);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeGreaterThan(0);
+  });
+
+  it('大きなばらつきは大きな値', () => {
+    const stable = MathHelper.getMovingStdDev([50, 51, 49], 3);
+    const unstable = MathHelper.getMovingStdDev([0, 100, 0], 3);
+    expect(unstable[0]).toBeGreaterThan(stable[0]);
+  });
+
+  it('結果は全て0以上', () => {
+    const result = MathHelper.getMovingStdDev([5, 3, 8, 1, 9, 2, 7], 3);
+    for (const v of result) {
+      expect(v).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('小数値も正しく処理', () => {
+    const result = MathHelper.getMovingStdDev([0.1, 0.2, 0.3], 3);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getMovingStdDevLabel - 境界値', () => {
+  it('標準偏差0は安定', () => {
+    expect(MathHelper.getMovingStdDevLabel(0)).toBe('安定');
+  });
+
+  it('標準偏差4.99は安定', () => {
+    expect(MathHelper.getMovingStdDevLabel(4.99)).toBe('安定');
+  });
+
+  it('標準偏差5はやや変動(境界値)', () => {
+    expect(MathHelper.getMovingStdDevLabel(5)).toBe('やや変動');
+  });
+
+  it('標準偏差14.99はやや変動', () => {
+    expect(MathHelper.getMovingStdDevLabel(14.99)).toBe('やや変動');
+  });
+
+  it('標準偏差15は大きな変動(境界値)', () => {
+    expect(MathHelper.getMovingStdDevLabel(15)).toBe('大きな変動');
+  });
+
+  it('標準偏差100は大きな変動', () => {
+    expect(MathHelper.getMovingStdDevLabel(100)).toBe('大きな変動');
+  });
+});

--- a/src/__tests__/domain/entities/StockTurnoverRate.edge.test.ts
+++ b/src/__tests__/domain/entities/StockTurnoverRate.edge.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockTurnoverRate - エッジケース', () => {
+  it('消費量0は0', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(0, 100)).toBe(0);
+  });
+
+  it('平均在庫0は0', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(100, 0)).toBe(0);
+  });
+
+  it('両方0は0', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(0, 0)).toBe(0);
+  });
+
+  it('負の消費量は0', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(-50, 100)).toBe(0);
+  });
+
+  it('負の在庫は0', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(50, -100)).toBe(0);
+  });
+
+  it('消費量=在庫で回転率1', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(100, 100)).toBe(1);
+  });
+
+  it('消費量が在庫の10倍で回転率10', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(1000, 100)).toBe(10);
+  });
+
+  it('消費量が在庫の1/10で回転率0.1', () => {
+    expect(StockAlertEntity.getStockTurnoverRate(10, 100)).toBe(0.1);
+  });
+
+  it('小数の消費量', () => {
+    const result = StockAlertEntity.getStockTurnoverRate(1.5, 3);
+    expect(result).toBe(0.5);
+  });
+
+  it('小数の在庫', () => {
+    const result = StockAlertEntity.getStockTurnoverRate(3, 1.5);
+    expect(result).toBe(2);
+  });
+
+  it('非常に小さな在庫で大きな回転率', () => {
+    const result = StockAlertEntity.getStockTurnoverRate(100, 1);
+    expect(result).toBe(100);
+  });
+
+  it('非常に大きな在庫で小さな回転率', () => {
+    const result = StockAlertEntity.getStockTurnoverRate(1, 10000);
+    expect(result).toBe(0);
+  });
+
+  it('結果は小数点2桁に丸められる', () => {
+    const result = StockAlertEntity.getStockTurnoverRate(1, 3);
+    expect(result).toBe(0.33);
+  });
+
+  it('回転率は常に0以上', () => {
+    const result = StockAlertEntity.getStockTurnoverRate(50, 200);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('StockAlertEntity.getStockTurnoverRateLabel - 境界値', () => {
+  it('回転率2は高回転(境界値)', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(2)).toBe('高回転');
+  });
+
+  it('回転率1.99は普通', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(1.99)).toBe('普通');
+  });
+
+  it('回転率0.5は普通(境界値)', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(0.5)).toBe('普通');
+  });
+
+  it('回転率0.49は低回転', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(0.49)).toBe('低回転');
+  });
+
+  it('回転率0は低回転', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(0)).toBe('低回転');
+  });
+
+  it('回転率100は高回転', () => {
+    expect(StockAlertEntity.getStockTurnoverRateLabel(100)).toBe('高回転');
+  });
+});


### PR DESCRIPTION
## Summary
- MovingStdDev: 20件のエッジケーステスト(ウィンドウ境界、負値、小数等)
- ConditionRange: 21件のエッジケーステスト(0/負値、大量データ等)
- StockTurnoverRate: 20件のエッジケーステスト(境界値、丸め精度等)
- 61件追加 (合計5341件)

## Test plan
- [x] MovingStdDev.edge: 20件パス
- [x] ConditionRange.edge: 21件パス
- [x] StockTurnoverRate.edge: 20件パス
- [x] 全テスト(5341件)パス確認

closes #852