### PR TITLE
累積和・日付間隔スコア・通院規則性を追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentRegularity.test.ts
+++ b/src/__tests__/domain/entities/AppointmentRegularity.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentRegularity', () => {
+  it('空配列は0を返す', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([])).toBe(0);
+  });
+
+  it('1件は0を返す', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([30])).toBe(0);
+  });
+
+  it('全て等間隔は100', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([30, 30, 30])).toBe(100);
+  });
+
+  it('ばらつきがあると100未満', () => {
+    const result = AppointmentEntity.getAppointmentRegularity([7, 30, 14, 60]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('大きなばらつきは低スコア', () => {
+    const regular = AppointmentEntity.getAppointmentRegularity([30, 30, 30]);
+    const irregular = AppointmentEntity.getAppointmentRegularity([7, 90, 14]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = AppointmentEntity.getAppointmentRegularity([1, 100, 5, 80]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2件でも計算可能', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([30, 30])).toBe(100);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentRegularityLabel', () => {
+  it('スコア80以上は規則的', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(85)).toBe('規則的');
+  });
+
+  it('スコア50以上はやや不規則', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(60)).toBe('やや不規則');
+  });
+
+  it('スコア50未満は不規則', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(30)).toBe('不規則');
+  });
+});

--- a/src/__tests__/domain/entities/CumulativeSum.test.ts
+++ b/src/__tests__/domain/entities/CumulativeSum.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getCumulativeSum', () => {
+  it('空配列は空配列を返す', () => {
+    expect(MathHelper.getCumulativeSum([])).toEqual([]);
+  });
+
+  it('1要素はそのまま', () => {
+    expect(MathHelper.getCumulativeSum([5])).toEqual([5]);
+  });
+
+  it('昇順の累積和', () => {
+    expect(MathHelper.getCumulativeSum([1, 2, 3])).toEqual([1, 3, 6]);
+  });
+
+  it('全て同じ値', () => {
+    expect(MathHelper.getCumulativeSum([10, 10, 10])).toEqual([10, 20, 30]);
+  });
+
+  it('全て0', () => {
+    expect(MathHelper.getCumulativeSum([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+
+  it('負の値も処理', () => {
+    expect(MathHelper.getCumulativeSum([5, -3, 2])).toEqual([5, 2, 4]);
+  });
+
+  it('結果の長さは入力と同じ', () => {
+    const result = MathHelper.getCumulativeSum([1, 2, 3, 4, 5]);
+    expect(result).toHaveLength(5);
+  });
+
+  it('最後の要素は合計と一致', () => {
+    const values = [10, 20, 30];
+    const result = MathHelper.getCumulativeSum(values);
+    expect(result[result.length - 1]).toBe(60);
+  });
+});
+
+describe('MathHelper.getCumulativeSumLabel', () => {
+  it('合計が目標以上は達成', () => {
+    expect(MathHelper.getCumulativeSumLabel(100, 100)).toBe('達成');
+  });
+
+  it('合計が目標の70%以上はあと少し', () => {
+    expect(MathHelper.getCumulativeSumLabel(75, 100)).toBe('あと少し');
+  });
+
+  it('合計が目標の70%未満は途中', () => {
+    expect(MathHelper.getCumulativeSumLabel(50, 100)).toBe('途中');
+  });
+});

--- a/src/__tests__/domain/entities/DateGapScore.test.ts
+++ b/src/__tests__/domain/entities/DateGapScore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateGapScore', () => {
+  it('空配列は0を返す', () => {
+    expect(DateRangeHelper.getDateGapScore([])).toBe(0);
+  });
+
+  it('1件は0を返す', () => {
+    expect(DateRangeHelper.getDateGapScore([1])).toBe(0);
+  });
+
+  it('全て等間隔は100', () => {
+    expect(DateRangeHelper.getDateGapScore([1, 1, 1, 1])).toBe(100);
+  });
+
+  it('ばらつきがあると100未満', () => {
+    const result = DateRangeHelper.getDateGapScore([1, 5, 2, 10]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('全て同じ間隔は100', () => {
+    expect(DateRangeHelper.getDateGapScore([7, 7, 7])).toBe(100);
+  });
+
+  it('大きなばらつきは低スコア', () => {
+    const small = DateRangeHelper.getDateGapScore([5, 6, 5, 6]);
+    const large = DateRangeHelper.getDateGapScore([1, 30, 1, 30]);
+    expect(small).toBeGreaterThan(large);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = DateRangeHelper.getDateGapScore([1, 100, 1]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('DateRangeHelper.getDateGapScoreLabel', () => {
+  it('スコア80以上は規則的', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(85)).toBe('規則的');
+  });
+
+  it('スコア50以上はやや不規則', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(60)).toBe('やや不規則');
+  });
+
+  it('スコア50未満は不規則', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(30)).toBe('不規則');
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -33,6 +33,8 @@ export class AppointmentEntity {
   private static readonly DENSITY_REGULAR_THRESHOLD = 2;
   private static readonly CYCLE_REGULAR_THRESHOLD = 70;
   private static readonly CYCLE_MODERATE_THRESHOLD = 40;
+  private static readonly APPT_REGULARITY_HIGH_THRESHOLD = 80;
+  private static readonly APPT_REGULARITY_MODERATE_THRESHOLD = 50;
 
   constructor(private readonly appointment: Appointment) {}
 
@@ -602,5 +604,27 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.FREQUENCY_HIGH_THRESHOLD) return '高頻度';
     if (score >= AppointmentEntity.FREQUENCY_MODERATE_THRESHOLD) return '中頻度';
     return '低頻度';
+  }
+
+  /**
+   * 通院間隔配列から規則性スコア(0-100)を算出する
+   * 変動係数ベースで間隔の均一性を評価
+   */
+  static getAppointmentRegularity(intervals: number[]): number {
+    if (intervals.length <= 1) return 0;
+    const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+    if (avg === 0) return 100;
+    const variance = intervals.reduce((sum, v) => sum + (v - avg) ** 2, 0) / intervals.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.max(0, Math.min(100, Math.round((1 - cv) * 100)));
+  }
+
+  /**
+   * 通院規則性スコアに応じたラベルを返す
+   */
+  static getAppointmentRegularityLabel(score: number): string {
+    if (score >= AppointmentEntity.APPT_REGULARITY_HIGH_THRESHOLD) return '規則的';
+    if (score >= AppointmentEntity.APPT_REGULARITY_MODERATE_THRESHOLD) return 'やや不規則';
+    return '不規則';
   }
 }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -106,6 +106,8 @@ export class DateRangeHelper {
   private static readonly DENSITY_MODERATE_THRESHOLD = 50;
   private static readonly WEEKDAY_CONCENTRATION_HIGH_THRESHOLD = 70;
   private static readonly WEEKDAY_CONCENTRATION_MODERATE_THRESHOLD = 40;
+  private static readonly DATE_GAP_REGULAR_THRESHOLD = 80;
+  private static readonly DATE_GAP_MODERATE_THRESHOLD = 50;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -395,5 +397,27 @@ export class DateRangeHelper {
     if (score >= DateRangeHelper.WEEKDAY_CONCENTRATION_HIGH_THRESHOLD) return '集中';
     if (score >= DateRangeHelper.WEEKDAY_CONCENTRATION_MODERATE_THRESHOLD) return 'やや偏り';
     return '分散';
+  }
+
+  /**
+   * 日付間隔配列の規則性スコア(0-100)を算出する
+   * 変動係数ベースで間隔の均一性を評価
+   */
+  static getDateGapScore(gaps: number[]): number {
+    if (gaps.length <= 1) return 0;
+    const avg = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+    if (avg === 0) return 100;
+    const variance = gaps.reduce((sum, v) => sum + (v - avg) ** 2, 0) / gaps.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.max(0, Math.min(100, Math.round((1 - cv) * 100)));
+  }
+
+  /**
+   * 日付間隔スコアに応じたラベルを返す
+   */
+  static getDateGapScoreLabel(score: number): string {
+    if (score >= DateRangeHelper.DATE_GAP_REGULAR_THRESHOLD) return '規則的';
+    if (score >= DateRangeHelper.DATE_GAP_MODERATE_THRESHOLD) return 'やや不規則';
+    return '不規則';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -26,6 +26,7 @@ export class MathHelper {
   private static readonly RUNNING_MAX_NEAR_RATIO = 0.9;
   private static readonly MOVING_STDDEV_STABLE_THRESHOLD = 5;
   private static readonly MOVING_STDDEV_MODERATE_THRESHOLD = 15;
+  private static readonly CUMSUM_NEAR_RATIO = 0.7;
 
   /**
    * パーセントを算出(0-100%)
@@ -510,5 +511,27 @@ export class MathHelper {
     if (stdDev < MathHelper.MOVING_STDDEV_STABLE_THRESHOLD) return '安定';
     if (stdDev < MathHelper.MOVING_STDDEV_MODERATE_THRESHOLD) return 'やや変動';
     return '大きな変動';
+  }
+
+  /**
+   * 累積和配列を算出する
+   */
+  static getCumulativeSum(values: number[]): number[] {
+    if (values.length === 0) return [];
+    const result: number[] = [values[0]];
+    for (let i = 1; i < values.length; i++) {
+      result.push(result[i - 1] + values[i]);
+    }
+    return result;
+  }
+
+  /**
+   * 累積合計と目標値の比較でラベルを返す
+   */
+  static getCumulativeSumLabel(currentSum: number, target: number): string {
+    if (target <= 0) return '達成';
+    if (currentSum >= target) return '達成';
+    if (currentSum >= target * MathHelper.CUMSUM_NEAR_RATIO) return 'あと少し';
+    return '途中';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getCumulativeSum / getCumulativeSumLabel (累積和の算出)
- DateRangeHelper: getDateGapScore / getDateGapScoreLabel (日付間隔の規則性評価)
- AppointmentEntity: getAppointmentRegularity / getAppointmentRegularityLabel (通院間隔の規則性)
- 31件のテスト追加 (合計5372件)

## Test plan
- [x] CumulativeSum: 11件のテスト
- [x] DateGapScore: 10件のテスト
- [x] AppointmentRegularity: 10件のテスト
- [x] 全テスト(5372件)パス確認

closes #854