### PR TITLE
テスト: 累積和・日付間隔スコア・通院規則性のエッジケース

### DIFF
--- a/src/__tests__/domain/entities/AppointmentRegularity.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentRegularity.edge.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentRegularity - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([30])).toBe(0);
+  });
+
+  it('2件の同じ間隔は100', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([30, 30])).toBe(100);
+  });
+
+  it('全て同じ間隔は100', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([14, 14, 14, 14])).toBe(100);
+  });
+
+  it('全て0は100', () => {
+    expect(AppointmentEntity.getAppointmentRegularity([0, 0, 0])).toBe(100);
+  });
+
+  it('大きなばらつきは低スコア', () => {
+    const result = AppointmentEntity.getAppointmentRegularity([1, 90, 1, 90]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('小さなばらつきは高スコア', () => {
+    const result = AppointmentEntity.getAppointmentRegularity([29, 30, 31]);
+    expect(result).toBeGreaterThan(90);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = AppointmentEntity.getAppointmentRegularity([7, 60, 14, 90]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('規則的な方がスコアが高い', () => {
+    const regular = AppointmentEntity.getAppointmentRegularity([30, 30, 30]);
+    const irregular = AppointmentEntity.getAppointmentRegularity([7, 60, 14]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('大量データでも正常に処理', () => {
+    const data = Array.from({ length: 50 }, () => 28);
+    expect(AppointmentEntity.getAppointmentRegularity(data)).toBe(100);
+  });
+
+  it('2件の大きく異なる間隔', () => {
+    const result = AppointmentEntity.getAppointmentRegularity([7, 90]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('3件中1件だけ異なる', () => {
+    const result = AppointmentEntity.getAppointmentRegularity([30, 30, 60]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentRegularityLabel - 境界値', () => {
+  it('スコア80は規則的(境界値)', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(80)).toBe('規則的');
+  });
+
+  it('スコア79はやや不規則', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(79)).toBe('やや不規則');
+  });
+
+  it('スコア50はやや不規則(境界値)', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(50)).toBe('やや不規則');
+  });
+
+  it('スコア49は不規則', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(49)).toBe('不規則');
+  });
+
+  it('スコア0は不規則', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(0)).toBe('不規則');
+  });
+
+  it('スコア100は規則的', () => {
+    expect(AppointmentEntity.getAppointmentRegularityLabel(100)).toBe('規則的');
+  });
+});

--- a/src/__tests__/domain/entities/CumulativeSum.edge.test.ts
+++ b/src/__tests__/domain/entities/CumulativeSum.edge.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getCumulativeSum - エッジケース', () => {
+  it('空配列は空配列', () => {
+    expect(MathHelper.getCumulativeSum([])).toEqual([]);
+  });
+
+  it('1要素はそのまま', () => {
+    expect(MathHelper.getCumulativeSum([42])).toEqual([42]);
+  });
+
+  it('全て0', () => {
+    expect(MathHelper.getCumulativeSum([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+
+  it('全て1', () => {
+    expect(MathHelper.getCumulativeSum([1, 1, 1, 1])).toEqual([1, 2, 3, 4]);
+  });
+
+  it('負の値のみ', () => {
+    expect(MathHelper.getCumulativeSum([-1, -2, -3])).toEqual([-1, -3, -6]);
+  });
+
+  it('正と負の混合', () => {
+    expect(MathHelper.getCumulativeSum([10, -5, 3, -2])).toEqual([10, 5, 8, 6]);
+  });
+
+  it('大きな値', () => {
+    const result = MathHelper.getCumulativeSum([1000000, 2000000]);
+    expect(result).toEqual([1000000, 3000000]);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getCumulativeSum([0.1, 0.2, 0.3]);
+    expect(result[2]).toBeCloseTo(0.6);
+  });
+
+  it('結果は単調増加(全て正の場合)', () => {
+    const result = MathHelper.getCumulativeSum([1, 2, 3, 4, 5]);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).toBeGreaterThan(result[i - 1]);
+    }
+  });
+
+  it('最後の要素は総和', () => {
+    const values = [5, 10, 15, 20, 25];
+    const result = MathHelper.getCumulativeSum(values);
+    expect(result[result.length - 1]).toBe(75);
+  });
+
+  it('大量データ', () => {
+    const data = Array.from({ length: 100 }, () => 1);
+    const result = MathHelper.getCumulativeSum(data);
+    expect(result).toHaveLength(100);
+    expect(result[99]).toBe(100);
+  });
+
+  it('結果の長さは入力と同じ', () => {
+    const result = MathHelper.getCumulativeSum([1, 2, 3]);
+    expect(result).toHaveLength(3);
+  });
+
+  it('2要素', () => {
+    expect(MathHelper.getCumulativeSum([3, 7])).toEqual([3, 10]);
+  });
+});
+
+describe('MathHelper.getCumulativeSumLabel - 境界値', () => {
+  it('合計が目標以上は達成', () => {
+    expect(MathHelper.getCumulativeSumLabel(100, 100)).toBe('達成');
+  });
+
+  it('合計が目標を超過しても達成', () => {
+    expect(MathHelper.getCumulativeSumLabel(150, 100)).toBe('達成');
+  });
+
+  it('合計が目標の70%ちょうどはあと少し', () => {
+    expect(MathHelper.getCumulativeSumLabel(70, 100)).toBe('あと少し');
+  });
+
+  it('合計が目標の69%は途中', () => {
+    expect(MathHelper.getCumulativeSumLabel(69, 100)).toBe('途中');
+  });
+
+  it('合計0で目標0は達成', () => {
+    expect(MathHelper.getCumulativeSumLabel(0, 0)).toBe('達成');
+  });
+
+  it('目標が負の場合は達成', () => {
+    expect(MathHelper.getCumulativeSumLabel(0, -10)).toBe('達成');
+  });
+});

--- a/src/__tests__/domain/entities/DateGapScore.edge.test.ts
+++ b/src/__tests__/domain/entities/DateGapScore.edge.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateGapScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(DateRangeHelper.getDateGapScore([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(DateRangeHelper.getDateGapScore([7])).toBe(0);
+  });
+
+  it('2件の同じ間隔は100', () => {
+    expect(DateRangeHelper.getDateGapScore([7, 7])).toBe(100);
+  });
+
+  it('全て同じ間隔は100', () => {
+    expect(DateRangeHelper.getDateGapScore([30, 30, 30, 30])).toBe(100);
+  });
+
+  it('全て0は100', () => {
+    expect(DateRangeHelper.getDateGapScore([0, 0, 0])).toBe(100);
+  });
+
+  it('大きなばらつきは低スコア', () => {
+    const result = DateRangeHelper.getDateGapScore([1, 100, 1, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('小さなばらつきは高スコア', () => {
+    const result = DateRangeHelper.getDateGapScore([29, 30, 31, 30]);
+    expect(result).toBeGreaterThan(90);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = DateRangeHelper.getDateGapScore([1, 50, 3, 80]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('規則的な方がスコアが高い', () => {
+    const regular = DateRangeHelper.getDateGapScore([7, 7, 7, 7]);
+    const irregular = DateRangeHelper.getDateGapScore([1, 14, 2, 28]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('大量データでも正常に処理', () => {
+    const data = Array.from({ length: 100 }, () => 7);
+    expect(DateRangeHelper.getDateGapScore(data)).toBe(100);
+  });
+
+  it('2件の異なる間隔', () => {
+    const result = DateRangeHelper.getDateGapScore([10, 20]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('DateRangeHelper.getDateGapScoreLabel - 境界値', () => {
+  it('スコア80は規則的(境界値)', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(80)).toBe('規則的');
+  });
+
+  it('スコア79はやや不規則', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(79)).toBe('やや不規則');
+  });
+
+  it('スコア50はやや不規則(境界値)', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(50)).toBe('やや不規則');
+  });
+
+  it('スコア49は不規則', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(49)).toBe('不規則');
+  });
+
+  it('スコア0は不規則', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(0)).toBe('不規則');
+  });
+
+  it('スコア100は規則的', () => {
+    expect(DateRangeHelper.getDateGapScoreLabel(100)).toBe('規則的');
+  });
+});


### PR DESCRIPTION
## Summary
- CumulativeSum: 19件のエッジケーステスト(負値、大量データ、単調増加検証等)
- DateGapScore: 17件のエッジケーステスト(全等間隔、境界値等)
- AppointmentRegularity: 18件のエッジケーステスト(境界値、ばらつき比較等)
- 54件追加 (合計5426件)

## Test plan
- [x] CumulativeSum.edge: 19件パス
- [x] DateGapScore.edge: 17件パス
- [x] AppointmentRegularity.edge: 18件パス
- [x] 全テスト(5426件)パス確認

closes #856