### PR TITLE
最小最大正規化・完了率推移方向・服薬正確度を追加

### DIFF
--- a/src/__tests__/domain/entities/DoseAccuracy.test.ts
+++ b/src/__tests__/domain/entities/DoseAccuracy.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseAccuracy', () => {
+  it('空配列は0を返す', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([])).toBe(0);
+  });
+
+  it('全て0分差は100', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([0, 0, 0])).toBe(100);
+  });
+
+  it('全て30分差', () => {
+    const result = MedicationRecordEntity.getDoseAccuracy([30, 30, 30]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('差が大きいほどスコアが低い', () => {
+    const small = MedicationRecordEntity.getDoseAccuracy([5, 5, 5]);
+    const large = MedicationRecordEntity.getDoseAccuracy([60, 60, 60]);
+    expect(small).toBeGreaterThan(large);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = MedicationRecordEntity.getDoseAccuracy([10, 20, 30, 40]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('1件でも計算可能', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([0])).toBe(100);
+  });
+
+  it('非常に大きな差は0に近い', () => {
+    const result = MedicationRecordEntity.getDoseAccuracy([120, 120, 120]);
+    expect(result).toBeLessThanOrEqual(0);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseAccuracyLabel', () => {
+  it('スコア80以上は正確', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(85)).toBe('正確');
+  });
+
+  it('スコア50以上はやや遅れ', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(60)).toBe('やや遅れ');
+  });
+
+  it('スコア50未満は不正確', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(30)).toBe('不正確');
+  });
+});

--- a/src/__tests__/domain/entities/MinMaxNormalized.test.ts
+++ b/src/__tests__/domain/entities/MinMaxNormalized.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMinMaxNormalized', () => {
+  it('空配列は空配列を返す', () => {
+    expect(MathHelper.getMinMaxNormalized([])).toEqual([]);
+  });
+
+  it('1要素は[0]を返す', () => {
+    expect(MathHelper.getMinMaxNormalized([50])).toEqual([0]);
+  });
+
+  it('全て同じ値は全て0', () => {
+    expect(MathHelper.getMinMaxNormalized([5, 5, 5])).toEqual([0, 0, 0]);
+  });
+
+  it('2要素は[0, 100]', () => {
+    expect(MathHelper.getMinMaxNormalized([10, 20])).toEqual([0, 100]);
+  });
+
+  it('昇順の正規化', () => {
+    expect(MathHelper.getMinMaxNormalized([0, 50, 100])).toEqual([0, 50, 100]);
+  });
+
+  it('降順の正規化', () => {
+    expect(MathHelper.getMinMaxNormalized([100, 50, 0])).toEqual([100, 50, 0]);
+  });
+
+  it('中間値は比率に応じた値', () => {
+    const result = MathHelper.getMinMaxNormalized([10, 30, 50]);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(50);
+    expect(result[2]).toBe(100);
+  });
+
+  it('結果は0-100の範囲内', () => {
+    const result = MathHelper.getMinMaxNormalized([5, 15, 25, 35]);
+    for (const v of result) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe('MathHelper.getMinMaxNormalizedLabel', () => {
+  it('値80以上は高い', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(85)).toBe('高い');
+  });
+
+  it('値40以上は中程度', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(50)).toBe('中程度');
+  });
+
+  it('値40未満は低い', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(20)).toBe('低い');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleCompletionTrend.test.ts
+++ b/src/__tests__/domain/entities/ScheduleCompletionTrend.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleCompletionTrend', () => {
+  it('空配列は0を返す', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrend([])).toBe(0);
+  });
+
+  it('1件は0を返す', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrend([80])).toBe(0);
+  });
+
+  it('上昇傾向は正の値', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([50, 60, 70, 80]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('下降傾向は負の値', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([80, 70, 60, 50]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('横ばいは0に近い', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([50, 50, 50, 50]);
+    expect(result).toBe(0);
+  });
+
+  it('2件でも計算可能', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([40, 60]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('急上昇は大きな正の値', () => {
+    const slow = ScheduleEntity.getScheduleCompletionTrend([50, 55, 60]);
+    const fast = ScheduleEntity.getScheduleCompletionTrend([20, 60, 100]);
+    expect(fast).toBeGreaterThan(slow);
+  });
+});
+
+describe('ScheduleEntity.getScheduleCompletionTrendLabel', () => {
+  it('正の値は上昇', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(5)).toBe('上昇');
+  });
+
+  it('負の値は下降', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(-5)).toBe('下降');
+  });
+
+  it('0は横ばい', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(0)).toBe('横ばい');
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -27,6 +27,8 @@ export class MathHelper {
   private static readonly MOVING_STDDEV_STABLE_THRESHOLD = 5;
   private static readonly MOVING_STDDEV_MODERATE_THRESHOLD = 15;
   private static readonly CUMSUM_NEAR_RATIO = 0.7;
+  private static readonly MINMAX_HIGH_THRESHOLD = 80;
+  private static readonly MINMAX_MEDIUM_THRESHOLD = 40;
 
   /**
    * パーセントを算出(0-100%)
@@ -533,5 +535,25 @@ export class MathHelper {
     if (currentSum >= target) return '達成';
     if (currentSum >= target * MathHelper.CUMSUM_NEAR_RATIO) return 'あと少し';
     return '途中';
+  }
+
+  /**
+   * 配列を0-100の範囲に最小最大正規化する
+   */
+  static getMinMaxNormalized(values: number[]): number[] {
+    if (values.length === 0) return [];
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    if (max === min) return values.map(() => 0);
+    return values.map((v) => Math.round(((v - min) / (max - min)) * 100));
+  }
+
+  /**
+   * 正規化された値に応じたラベルを返す
+   */
+  static getMinMaxNormalizedLabel(value: number): string {
+    if (value >= MathHelper.MINMAX_HIGH_THRESHOLD) return '高い';
+    if (value >= MathHelper.MINMAX_MEDIUM_THRESHOLD) return '中程度';
+    return '低い';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -50,6 +50,9 @@ export class MedicationRecordEntity {
   private static readonly DOSE_TIME_MAX_STDDEV = 180;
   private static readonly DOSE_TIME_ACCURATE_THRESHOLD = 20;
   private static readonly DOSE_TIME_SOMEWHAT_THRESHOLD = 50;
+  private static readonly DOSE_ACCURACY_MAX_DELAY = 120;
+  private static readonly DOSE_ACCURACY_HIGH_THRESHOLD = 80;
+  private static readonly DOSE_ACCURACY_MODERATE_THRESHOLD = 50;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -797,5 +800,24 @@ export class MedicationRecordEntity {
     if (score < MedicationRecordEntity.DOSE_TIME_ACCURATE_THRESHOLD) return '正確';
     if (score < MedicationRecordEntity.DOSE_TIME_SOMEWHAT_THRESHOLD) return 'やや不規則';
     return '不規則';
+  }
+
+  /**
+   * 予定時刻との差分(分)配列から服薬正確度(0-100)を算出する
+   * 差分が小さいほど高スコア
+   */
+  static getDoseAccuracy(delayMinutes: number[]): number {
+    if (delayMinutes.length === 0) return 0;
+    const avgDelay = delayMinutes.reduce((a, b) => a + b, 0) / delayMinutes.length;
+    return Math.max(0, Math.round(100 - (avgDelay / MedicationRecordEntity.DOSE_ACCURACY_MAX_DELAY) * 100));
+  }
+
+  /**
+   * 服薬正確度に応じたラベルを返す
+   */
+  static getDoseAccuracyLabel(score: number): string {
+    if (score >= MedicationRecordEntity.DOSE_ACCURACY_HIGH_THRESHOLD) return '正確';
+    if (score >= MedicationRecordEntity.DOSE_ACCURACY_MODERATE_THRESHOLD) return 'やや遅れ';
+    return '不正確';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -794,6 +794,7 @@ export class ScheduleEntity {
   private static readonly BALANCE_NOON_BOUNDARY = 720;
   private static readonly BALANCE_HIGH_THRESHOLD = 70;
   private static readonly BALANCE_MODERATE_THRESHOLD = 40;
+  private static readonly COMPLETION_TREND_THRESHOLD = 0;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -966,5 +967,36 @@ export class ScheduleEntity {
     if (score >= ScheduleEntity.BALANCE_HIGH_THRESHOLD) return '均衡';
     if (score >= ScheduleEntity.BALANCE_MODERATE_THRESHOLD) return 'やや偏り';
     return '偏り';
+  }
+
+  /**
+   * 完了率配列から線形回帰の傾きを算出する
+   */
+  static getScheduleCompletionTrend(rates: number[]): number {
+    if (rates.length <= 1) return 0;
+    const n = rates.length;
+    let sumX = 0;
+    let sumY = 0;
+    let sumXY = 0;
+    let sumX2 = 0;
+    for (let i = 0; i < n; i++) {
+      sumX += i;
+      sumY += rates[i];
+      sumXY += i * rates[i];
+      sumX2 += i * i;
+    }
+    const denominator = n * sumX2 - sumX * sumX;
+    if (denominator === 0) return 0;
+    const slope = (n * sumXY - sumX * sumY) / denominator;
+    return Math.round(slope * 100) / 100;
+  }
+
+  /**
+   * 完了率推移方向に応じたラベルを返す
+   */
+  static getScheduleCompletionTrendLabel(slope: number): string {
+    if (slope > ScheduleEntity.COMPLETION_TREND_THRESHOLD) return '上昇';
+    if (slope < ScheduleEntity.COMPLETION_TREND_THRESHOLD) return '下降';
+    return '横ばい';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getMinMaxNormalized / getMinMaxNormalizedLabel (最小最大正規化)
- ScheduleEntity: getScheduleCompletionTrend / getScheduleCompletionTrendLabel (完了率推移方向)
- MedicationRecordEntity: getDoseAccuracy / getDoseAccuracyLabel (服薬正確度)
- 31件のテスト追加 (合計5457件)

## Test plan
- [x] MinMaxNormalized: 11件のテスト
- [x] ScheduleCompletionTrend: 10件のテスト
- [x] DoseAccuracy: 10件のテスト
- [x] 全テスト(5457件)パス確認

closes #858