### PR TITLE
テスト: 最小最大正規化・完了率推移方向・服薬正確度のエッジケース

### DIFF
--- a/src/__tests__/domain/entities/DoseAccuracy.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseAccuracy.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseAccuracy - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([])).toBe(0);
+  });
+
+  it('1件の0分差は100', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([0])).toBe(100);
+  });
+
+  it('全て0分差は100', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([0, 0, 0, 0])).toBe(100);
+  });
+
+  it('全て120分差は0', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([120, 120, 120])).toBe(0);
+  });
+
+  it('全て60分差は50', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([60, 60, 60])).toBe(50);
+  });
+
+  it('混合した差分', () => {
+    const result = MedicationRecordEntity.getDoseAccuracy([0, 30, 60]);
+    expect(result).toBe(75);
+  });
+
+  it('0-100の範囲内', () => {
+    const result = MedicationRecordEntity.getDoseAccuracy([10, 20, 30, 40, 50]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('120分超でも0を下回らない', () => {
+    const result = MedicationRecordEntity.getDoseAccuracy([200, 200, 200]);
+    expect(result).toBe(0);
+  });
+
+  it('差が小さい方がスコアが高い', () => {
+    const accurate = MedicationRecordEntity.getDoseAccuracy([5, 5, 5]);
+    const late = MedicationRecordEntity.getDoseAccuracy([60, 60, 60]);
+    expect(accurate).toBeGreaterThan(late);
+  });
+
+  it('1件の30分差', () => {
+    expect(MedicationRecordEntity.getDoseAccuracy([30])).toBe(75);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, () => 10);
+    const result = MedicationRecordEntity.getDoseAccuracy(data);
+    expect(result).toBeGreaterThan(90);
+  });
+
+  it('2件の異なる差分', () => {
+    const result = MedicationRecordEntity.getDoseAccuracy([0, 60]);
+    expect(result).toBe(75);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseAccuracyLabel - 境界値', () => {
+  it('スコア80は正確(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(80)).toBe('正確');
+  });
+
+  it('スコア79はやや遅れ', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(79)).toBe('やや遅れ');
+  });
+
+  it('スコア50はやや遅れ(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(50)).toBe('やや遅れ');
+  });
+
+  it('スコア49は不正確', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(49)).toBe('不正確');
+  });
+
+  it('スコア0は不正確', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(0)).toBe('不正確');
+  });
+
+  it('スコア100は正確', () => {
+    expect(MedicationRecordEntity.getDoseAccuracyLabel(100)).toBe('正確');
+  });
+});

--- a/src/__tests__/domain/entities/MinMaxNormalized.edge.test.ts
+++ b/src/__tests__/domain/entities/MinMaxNormalized.edge.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMinMaxNormalized - エッジケース', () => {
+  it('空配列は空配列', () => {
+    expect(MathHelper.getMinMaxNormalized([])).toEqual([]);
+  });
+
+  it('1要素は[0]', () => {
+    expect(MathHelper.getMinMaxNormalized([42])).toEqual([0]);
+  });
+
+  it('全て同じ値は全て0', () => {
+    expect(MathHelper.getMinMaxNormalized([100, 100, 100])).toEqual([0, 0, 0]);
+  });
+
+  it('2要素の最小最大', () => {
+    expect(MathHelper.getMinMaxNormalized([0, 100])).toEqual([0, 100]);
+  });
+
+  it('逆順でも正しく正規化', () => {
+    expect(MathHelper.getMinMaxNormalized([100, 0])).toEqual([100, 0]);
+  });
+
+  it('負の値を含む', () => {
+    const result = MathHelper.getMinMaxNormalized([-10, 0, 10]);
+    expect(result[0]).toBe(0);
+    expect(result[2]).toBe(100);
+  });
+
+  it('全て負の値', () => {
+    const result = MathHelper.getMinMaxNormalized([-30, -20, -10]);
+    expect(result[0]).toBe(0);
+    expect(result[2]).toBe(100);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getMinMaxNormalized([1.0, 1.5, 2.0]);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(50);
+    expect(result[2]).toBe(100);
+  });
+
+  it('大量データでも正しく処理', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i);
+    const result = MathHelper.getMinMaxNormalized(data);
+    expect(result[0]).toBe(0);
+    expect(result[99]).toBe(100);
+  });
+
+  it('結果は0-100の範囲内', () => {
+    const result = MathHelper.getMinMaxNormalized([5, 15, 25, 35, 45]);
+    for (const v of result) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('最小値は常に0', () => {
+    const result = MathHelper.getMinMaxNormalized([10, 20, 30]);
+    expect(Math.min(...result)).toBe(0);
+  });
+
+  it('最大値は常に100(異なる値がある場合)', () => {
+    const result = MathHelper.getMinMaxNormalized([10, 20, 30]);
+    expect(Math.max(...result)).toBe(100);
+  });
+
+  it('結果の長さは入力と同じ', () => {
+    const result = MathHelper.getMinMaxNormalized([1, 2, 3, 4, 5]);
+    expect(result).toHaveLength(5);
+  });
+});
+
+describe('MathHelper.getMinMaxNormalizedLabel - 境界値', () => {
+  it('値80は高い(境界値)', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(80)).toBe('高い');
+  });
+
+  it('値79は中程度', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(79)).toBe('中程度');
+  });
+
+  it('値40は中程度(境界値)', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(40)).toBe('中程度');
+  });
+
+  it('値39は低い', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(39)).toBe('低い');
+  });
+
+  it('値0は低い', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(0)).toBe('低い');
+  });
+
+  it('値100は高い', () => {
+    expect(MathHelper.getMinMaxNormalizedLabel(100)).toBe('高い');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleCompletionTrend.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleCompletionTrend.edge.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleCompletionTrend - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrend([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrend([80])).toBe(0);
+  });
+
+  it('全て同じ値は0', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrend([50, 50, 50, 50])).toBe(0);
+  });
+
+  it('完全な上昇は正の値', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([0, 25, 50, 75, 100]);
+    expect(result).toBe(25);
+  });
+
+  it('完全な下降は負の値', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([100, 75, 50, 25, 0]);
+    expect(result).toBe(-25);
+  });
+
+  it('V字型は傾き0に近い', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([100, 50, 0, 50, 100]);
+    expect(Math.abs(result)).toBeLessThan(5);
+  });
+
+  it('2件の上昇', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([40, 60]);
+    expect(result).toBe(20);
+  });
+
+  it('2件の下降', () => {
+    const result = ScheduleEntity.getScheduleCompletionTrend([60, 40]);
+    expect(result).toBe(-20);
+  });
+
+  it('急上昇と緩上昇の比較', () => {
+    const steep = ScheduleEntity.getScheduleCompletionTrend([0, 50, 100]);
+    const gentle = ScheduleEntity.getScheduleCompletionTrend([40, 50, 60]);
+    expect(steep).toBeGreaterThan(gentle);
+  });
+
+  it('全て0は0', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrend([0, 0, 0])).toBe(0);
+  });
+
+  it('全て100は0', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrend([100, 100, 100])).toBe(0);
+  });
+
+  it('大量データでも正常に処理', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i);
+    const result = ScheduleEntity.getScheduleCompletionTrend(data);
+    expect(result).toBe(1);
+  });
+});
+
+describe('ScheduleEntity.getScheduleCompletionTrendLabel - 境界値', () => {
+  it('正の値は上昇', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(0.01)).toBe('上昇');
+  });
+
+  it('負の値は下降', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(-0.01)).toBe('下降');
+  });
+
+  it('0は横ばい', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(0)).toBe('横ばい');
+  });
+
+  it('大きな正の値は上昇', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(50)).toBe('上昇');
+  });
+
+  it('大きな負の値は下降', () => {
+    expect(ScheduleEntity.getScheduleCompletionTrendLabel(-50)).toBe('下降');
+  });
+});


### PR DESCRIPTION
## Summary
- MinMaxNormalized: 19件のエッジケーステスト(負値、全同値、結果範囲検証等)
- ScheduleCompletionTrend: 17件のエッジケーステスト(V字型、急上昇比較等)
- DoseAccuracy: 18件のエッジケーステスト(境界値、大量データ等)
- 54件追加 (合計5511件)

## Test plan
- [x] MinMaxNormalized.edge: 19件パス
- [x] ScheduleCompletionTrend.edge: 17件パス
- [x] DoseAccuracy.edge: 18件パス
- [x] 全テスト(5511件)パス確認

closes #860