### PR TITLE
test: IQR・モメンタム・記録密度のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/AdherenceMomentum.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceMomentum.edge.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceMomentum - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentum([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentum([50])).toBe(0);
+  });
+
+  it('2件は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentum([50, 60])).toBe(0);
+  });
+
+  it('3件の上昇は正', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([50, 60, 70]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('3件の下降は負', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([70, 60, 50]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('3件の横ばいは0', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentum([50, 50, 50])).toBe(0);
+  });
+
+  it('全て0は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentum([0, 0, 0, 0])).toBe(0);
+  });
+
+  it('全て100は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentum([100, 100, 100])).toBe(0);
+  });
+
+  it('V字回復は正のモメンタム', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([80, 40, 60, 80]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('逆V字は負のモメンタム', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([40, 80, 60, 40]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('急上昇は大きな正値', () => {
+    const gradual = AdherenceTrendEntity.getAdherenceMomentum([50, 55, 60]);
+    const steep = AdherenceTrendEntity.getAdherenceMomentum([50, 70, 90]);
+    expect(steep).toBeGreaterThan(gradual);
+  });
+
+  it('急下降は大きな負値', () => {
+    const gradual = AdherenceTrendEntity.getAdherenceMomentum([60, 55, 50]);
+    const steep = AdherenceTrendEntity.getAdherenceMomentum([90, 70, 50]);
+    expect(steep).toBeLessThan(gradual);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 50 }, (_, i) => i * 2);
+    const result = AdherenceTrendEntity.getAdherenceMomentum(data);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('交互パターン', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([50, 80, 50, 80]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('微小な変化', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([50, 50.1, 50.2]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('0から100への急上昇', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([0, 50, 100]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('100から0への急下降', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([100, 50, 0]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('同一変化量の長いシーケンス', () => {
+    const result = AdherenceTrendEntity.getAdherenceMomentum([10, 20, 30, 40, 50]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceMomentumLabel - 境界値', () => {
+  it('モメンタム5は加速改善(境界値)', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentumLabel(5)).toBe('加速改善');
+  });
+
+  it('モメンタム4.99は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentumLabel(4.99)).toBe('安定');
+  });
+
+  it('モメンタム-5は加速悪化(境界値)', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentumLabel(-5)).toBe('加速悪化');
+  });
+
+  it('モメンタム-4.99は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentumLabel(-4.99)).toBe('安定');
+  });
+
+  it('モメンタム0は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentumLabel(0)).toBe('安定');
+  });
+
+  it('モメンタム100は加速改善', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentumLabel(100)).toBe('加速改善');
+  });
+
+  it('モメンタム-100は加速悪化', () => {
+    expect(AdherenceTrendEntity.getAdherenceMomentumLabel(-100)).toBe('加速悪化');
+  });
+});

--- a/src/__tests__/domain/entities/InterquartileRange.edge.test.ts
+++ b/src/__tests__/domain/entities/InterquartileRange.edge.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getInterquartileRange - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getInterquartileRange([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getInterquartileRange([50])).toBe(0);
+  });
+
+  it('2件の同値は0', () => {
+    expect(MathHelper.getInterquartileRange([50, 50])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    const result = MathHelper.getInterquartileRange([10, 90]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getInterquartileRange([30, 30, 30, 30, 30])).toBe(0);
+  });
+
+  it('ソート済みデータ', () => {
+    const result = MathHelper.getInterquartileRange([1, 2, 3, 4, 5, 6, 7]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('逆順データも正しい', () => {
+    const sorted = MathHelper.getInterquartileRange([1, 2, 3, 4, 5, 6, 7]);
+    const reversed = MathHelper.getInterquartileRange([7, 6, 5, 4, 3, 2, 1]);
+    expect(reversed).toBe(sorted);
+  });
+
+  it('負の値を含む', () => {
+    const result = MathHelper.getInterquartileRange([-10, -5, 0, 5, 10]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('大きな散布はIQRも大きい', () => {
+    const narrow = MathHelper.getInterquartileRange([49, 50, 50, 51]);
+    const wide = MathHelper.getInterquartileRange([0, 25, 75, 100]);
+    expect(wide).toBeGreaterThan(narrow);
+  });
+
+  it('0-100範囲のデータ', () => {
+    const result = MathHelper.getInterquartileRange([0, 25, 50, 75, 100]);
+    expect(result).toBe(50);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i);
+    const result = MathHelper.getInterquartileRange(data);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('結果は非負', () => {
+    const result = MathHelper.getInterquartileRange([5, 1, 3, 8, 2]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('3件のデータ', () => {
+    const result = MathHelper.getInterquartileRange([10, 20, 30]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('4件の均等データ', () => {
+    const result = MathHelper.getInterquartileRange([0, 10, 20, 30]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('重複値が多いデータ', () => {
+    const result = MathHelper.getInterquartileRange([1, 1, 1, 1, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getInterquartileRange([0.1, 0.2, 0.3, 0.4, 0.5]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getIQRLabel - 境界値', () => {
+  it('IQR 0は安定', () => {
+    expect(MathHelper.getIQRLabel(0)).toBe('安定');
+  });
+
+  it('IQR 5は安定(境界値)', () => {
+    expect(MathHelper.getIQRLabel(5)).toBe('安定');
+  });
+
+  it('IQR 6はやや散布', () => {
+    expect(MathHelper.getIQRLabel(6)).toBe('やや散布');
+  });
+
+  it('IQR 20はやや散布(境界値)', () => {
+    expect(MathHelper.getIQRLabel(20)).toBe('やや散布');
+  });
+
+  it('IQR 21は散布', () => {
+    expect(MathHelper.getIQRLabel(21)).toBe('散布');
+  });
+
+  it('IQR 100は散布', () => {
+    expect(MathHelper.getIQRLabel(100)).toBe('散布');
+  });
+});

--- a/src/__tests__/domain/entities/RecordDensityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/RecordDensityScore.edge.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getRecordDensityScore - エッジケース', () => {
+  it('記録日0は0', () => {
+    expect(CalendarEntity.getRecordDensityScore(0, 30)).toBe(0);
+  });
+
+  it('期間0は0', () => {
+    expect(CalendarEntity.getRecordDensityScore(10, 0)).toBe(0);
+  });
+
+  it('両方0は0', () => {
+    expect(CalendarEntity.getRecordDensityScore(0, 0)).toBe(0);
+  });
+
+  it('負の記録日は0', () => {
+    expect(CalendarEntity.getRecordDensityScore(-5, 30)).toBe(0);
+  });
+
+  it('負の期間は0', () => {
+    expect(CalendarEntity.getRecordDensityScore(10, -5)).toBe(0);
+  });
+
+  it('全日記録は100', () => {
+    expect(CalendarEntity.getRecordDensityScore(30, 30)).toBe(100);
+  });
+
+  it('記録日が期間を超えても100', () => {
+    expect(CalendarEntity.getRecordDensityScore(40, 30)).toBe(100);
+  });
+
+  it('1日/1日は100', () => {
+    expect(CalendarEntity.getRecordDensityScore(1, 1)).toBe(100);
+  });
+
+  it('1日/30日は約3', () => {
+    expect(CalendarEntity.getRecordDensityScore(1, 30)).toBe(3);
+  });
+
+  it('半分記録は50', () => {
+    expect(CalendarEntity.getRecordDensityScore(15, 30)).toBe(50);
+  });
+
+  it('結果は0-100', () => {
+    const result = CalendarEntity.getRecordDensityScore(10, 30);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('1日/365日', () => {
+    const result = CalendarEntity.getRecordDensityScore(1, 365);
+    expect(result).toBe(0);
+  });
+
+  it('364日/365日', () => {
+    const result = CalendarEntity.getRecordDensityScore(364, 365);
+    expect(result).toBe(100);
+  });
+
+  it('大きな値でも正常', () => {
+    const result = CalendarEntity.getRecordDensityScore(1000, 1000);
+    expect(result).toBe(100);
+  });
+
+  it('小さな割合は丸め処理される', () => {
+    const result = CalendarEntity.getRecordDensityScore(1, 3);
+    expect(result).toBe(33);
+  });
+
+  it('2/3は67', () => {
+    expect(CalendarEntity.getRecordDensityScore(2, 3)).toBe(67);
+  });
+});
+
+describe('CalendarEntity.getRecordDensityScoreLabel - 境界値', () => {
+  it('スコア80は高密度(境界値)', () => {
+    expect(CalendarEntity.getRecordDensityScoreLabel(80)).toBe('高密度');
+  });
+
+  it('スコア79は中密度', () => {
+    expect(CalendarEntity.getRecordDensityScoreLabel(79)).toBe('中密度');
+  });
+
+  it('スコア50は中密度(境界値)', () => {
+    expect(CalendarEntity.getRecordDensityScoreLabel(50)).toBe('中密度');
+  });
+
+  it('スコア49は低密度', () => {
+    expect(CalendarEntity.getRecordDensityScoreLabel(49)).toBe('低密度');
+  });
+
+  it('スコア0は低密度', () => {
+    expect(CalendarEntity.getRecordDensityScoreLabel(0)).toBe('低密度');
+  });
+
+  it('スコア100は高密度', () => {
+    expect(CalendarEntity.getRecordDensityScoreLabel(100)).toBe('高密度');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getInterquartileRange / getIQRLabel の境界値・エッジケーステスト22件
- AdherenceTrendEntity.getAdherenceMomentum / getAdherenceMomentumLabel の境界値・エッジケーステスト25件
- CalendarEntity.getRecordDensityScore / getRecordDensityScoreLabel の境界値・エッジケーステスト22件
- 合計69テスト追加（全5609テスト通過）

## Test plan
- [x] InterquartileRange.edge: 22テスト通過
- [x] AdherenceMomentum.edge: 25テスト通過
- [x] RecordDensityScore.edge: 22テスト通過
- [x] 全5609テスト通過

closes #864