### PR TITLE
feat: 歪度・服用変動性・在庫変動性を追加

### DIFF
--- a/src/__tests__/domain/entities/DoseVariability.test.ts
+++ b/src/__tests__/domain/entities/DoseVariability.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseVariability', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([480])).toBe(0);
+  });
+
+  it('全て同じ時刻は0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([480, 480, 480])).toBe(0);
+  });
+
+  it('大きなばらつきは高スコア', () => {
+    const result = MedicationRecordEntity.getDoseVariability([0, 120, 240, 360]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('小さなばらつきは低スコア', () => {
+    const result = MedicationRecordEntity.getDoseVariability([480, 482, 478, 481]);
+    expect(result).toBeLessThan(20);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationRecordEntity.getDoseVariability([100, 200, 300]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('ばらつきが大きい方がスコアが高い', () => {
+    const small = MedicationRecordEntity.getDoseVariability([480, 485, 490]);
+    const large = MedicationRecordEntity.getDoseVariability([100, 400, 700]);
+    expect(large).toBeGreaterThan(small);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseVariabilityLabel', () => {
+  it('スコア20未満は安定', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(10)).toBe('安定');
+  });
+
+  it('スコア20-50はやや不安定', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(35)).toBe('やや不安定');
+  });
+
+  it('スコア50以上は不安定', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(60)).toBe('不安定');
+  });
+});

--- a/src/__tests__/domain/entities/Skewness.test.ts
+++ b/src/__tests__/domain/entities/Skewness.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getSkewness', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getSkewness([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getSkewness([50])).toBe(0);
+  });
+
+  it('2件は0', () => {
+    expect(MathHelper.getSkewness([30, 70])).toBe(0);
+  });
+
+  it('対称分布は0に近い', () => {
+    const result = MathHelper.getSkewness([10, 20, 30, 40, 50]);
+    expect(Math.abs(result)).toBeLessThan(0.5);
+  });
+
+  it('右に偏った分布は正', () => {
+    const result = MathHelper.getSkewness([1, 1, 1, 1, 100]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('左に偏った分布は負', () => {
+    const result = MathHelper.getSkewness([100, 99, 99, 99, 1]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getSkewness([50, 50, 50, 50])).toBe(0);
+  });
+});
+
+describe('MathHelper.getSkewnessLabel', () => {
+  it('正の歪度は右偏り', () => {
+    expect(MathHelper.getSkewnessLabel(1.5)).toBe('右偏り');
+  });
+
+  it('負の歪度は左偏り', () => {
+    expect(MathHelper.getSkewnessLabel(-1.5)).toBe('左偏り');
+  });
+
+  it('0付近は対称', () => {
+    expect(MathHelper.getSkewnessLabel(0)).toBe('対称');
+  });
+});

--- a/src/__tests__/domain/entities/StockVolatility.test.ts
+++ b/src/__tests__/domain/entities/StockVolatility.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockVolatility', () => {
+  it('空配列は0', () => {
+    expect(StockAlertEntity.getStockVolatility([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(StockAlertEntity.getStockVolatility([30])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(StockAlertEntity.getStockVolatility([50, 50, 50])).toBe(0);
+  });
+
+  it('大きな変動は高スコア', () => {
+    const result = StockAlertEntity.getStockVolatility([10, 90, 10, 90]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('小さな変動は低スコア', () => {
+    const result = StockAlertEntity.getStockVolatility([49, 50, 51, 50]);
+    expect(result).toBeLessThan(20);
+  });
+
+  it('結果は0-100', () => {
+    const result = StockAlertEntity.getStockVolatility([10, 30, 50, 70]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('変動が大きい方がスコアが高い', () => {
+    const stable = StockAlertEntity.getStockVolatility([48, 50, 52]);
+    const volatile = StockAlertEntity.getStockVolatility([10, 80, 20]);
+    expect(volatile).toBeGreaterThan(stable);
+  });
+});
+
+describe('StockAlertEntity.getStockVolatilityLabel', () => {
+  it('スコア30以下は安定', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(20)).toBe('安定');
+  });
+
+  it('スコア30-60はやや変動', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(45)).toBe('やや変動');
+  });
+
+  it('スコア60超は変動大', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(70)).toBe('変動大');
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -31,6 +31,7 @@ export class MathHelper {
   private static readonly MINMAX_MEDIUM_THRESHOLD = 40;
   private static readonly IQR_STABLE_THRESHOLD = 5;
   private static readonly IQR_MODERATE_THRESHOLD = 20;
+  private static readonly SKEWNESS_THRESHOLD = 0.5;
 
   /**
    * パーセントを算出(0-100%)
@@ -575,5 +576,29 @@ export class MathHelper {
     if (iqr <= MathHelper.IQR_STABLE_THRESHOLD) return '安定';
     if (iqr <= MathHelper.IQR_MODERATE_THRESHOLD) return 'やや散布';
     return '散布';
+  }
+
+  /**
+   * データ分布の歪度(skewness)を算出する
+   * 3件未満の場合は0を返す
+   */
+  static getSkewness(values: number[]): number {
+    if (values.length < 3) return 0;
+    const n = values.length;
+    const avg = values.reduce((a, b) => a + b, 0) / n;
+    const variance = values.reduce((sum, v) => sum + (v - avg) ** 2, 0) / n;
+    if (variance === 0) return 0;
+    const stdDev = Math.sqrt(variance);
+    const m3 = values.reduce((sum, v) => sum + ((v - avg) / stdDev) ** 3, 0) / n;
+    return Math.round(m3 * 100) / 100;
+  }
+
+  /**
+   * 歪度に応じたラベルを返す
+   */
+  static getSkewnessLabel(skewness: number): string {
+    if (skewness > MathHelper.SKEWNESS_THRESHOLD) return '右偏り';
+    if (skewness < -MathHelper.SKEWNESS_THRESHOLD) return '左偏り';
+    return '対称';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -53,6 +53,9 @@ export class MedicationRecordEntity {
   private static readonly DOSE_ACCURACY_MAX_DELAY = 120;
   private static readonly DOSE_ACCURACY_HIGH_THRESHOLD = 80;
   private static readonly DOSE_ACCURACY_MODERATE_THRESHOLD = 50;
+  private static readonly DOSE_VARIABILITY_MAX_STDDEV = 120;
+  private static readonly DOSE_VARIABILITY_STABLE_THRESHOLD = 20;
+  private static readonly DOSE_VARIABILITY_MODERATE_THRESHOLD = 50;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -819,5 +822,26 @@ export class MedicationRecordEntity {
     if (score >= MedicationRecordEntity.DOSE_ACCURACY_HIGH_THRESHOLD) return '正確';
     if (score >= MedicationRecordEntity.DOSE_ACCURACY_MODERATE_THRESHOLD) return 'やや遅れ';
     return '不正確';
+  }
+
+  /**
+   * 服用時刻(分単位)配列から変動性スコア(0-100)を算出する
+   * 標準偏差ベースで変動性を数値化（最大120分基準）
+   */
+  static getDoseVariability(timesInMinutes: number[]): number {
+    if (timesInMinutes.length <= 1) return 0;
+    const avg = timesInMinutes.reduce((a, b) => a + b, 0) / timesInMinutes.length;
+    const variance = timesInMinutes.reduce((sum, v) => sum + (v - avg) ** 2, 0) / timesInMinutes.length;
+    const stdDev = Math.sqrt(variance);
+    return Math.min(100, Math.round((stdDev / MedicationRecordEntity.DOSE_VARIABILITY_MAX_STDDEV) * 100));
+  }
+
+  /**
+   * 服用変動性スコアに応じたラベルを返す
+   */
+  static getDoseVariabilityLabel(score: number): string {
+    if (score < MedicationRecordEntity.DOSE_VARIABILITY_STABLE_THRESHOLD) return '安定';
+    if (score < MedicationRecordEntity.DOSE_VARIABILITY_MODERATE_THRESHOLD) return 'やや不安定';
+    return '不安定';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -40,6 +40,9 @@ export class StockAlertEntity {
   private static readonly BURN_RATE_MODERATE_THRESHOLD = 40;
   private static readonly TURNOVER_HIGH_THRESHOLD = 2;
   private static readonly TURNOVER_MODERATE_THRESHOLD = 0.5;
+  private static readonly VOLATILITY_MAX_DIFF = 50;
+  private static readonly VOLATILITY_STABLE_THRESHOLD = 30;
+  private static readonly VOLATILITY_MODERATE_THRESHOLD = 60;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -585,5 +588,28 @@ export class StockAlertEntity {
     if (rate >= StockAlertEntity.TURNOVER_HIGH_THRESHOLD) return '高回転';
     if (rate >= StockAlertEntity.TURNOVER_MODERATE_THRESHOLD) return '普通';
     return '低回転';
+  }
+
+  /**
+   * 在庫量配列から変動性スコア(0-100)を算出する
+   * 隣接値の差分の平均をスコア化（最大差50基準）
+   */
+  static getStockVolatility(stockLevels: number[]): number {
+    if (stockLevels.length <= 1) return 0;
+    let totalDiff = 0;
+    for (let i = 1; i < stockLevels.length; i++) {
+      totalDiff += Math.abs(stockLevels[i] - stockLevels[i - 1]);
+    }
+    const avgDiff = totalDiff / (stockLevels.length - 1);
+    return Math.min(100, Math.round((avgDiff / StockAlertEntity.VOLATILITY_MAX_DIFF) * 100));
+  }
+
+  /**
+   * 在庫変動性スコアに応じたラベルを返す
+   */
+  static getStockVolatilityLabel(score: number): string {
+    if (score <= StockAlertEntity.VOLATILITY_STABLE_THRESHOLD) return '安定';
+    if (score <= StockAlertEntity.VOLATILITY_MODERATE_THRESHOLD) return 'やや変動';
+    return '変動大';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getSkewness / getSkewnessLabel（データ分布の歪度算出）
- MedicationRecordEntity: getDoseVariability / getDoseVariabilityLabel（服用時間の変動性スコア）
- StockAlertEntity: getStockVolatility / getStockVolatilityLabel（在庫数量の変動性スコア）
- テスト30件追加（合計5639件）

## Test plan
- [x] Skewness: 10テスト
- [x] DoseVariability: 10テスト
- [x] StockVolatility: 10テスト
- [x] 全5639テスト通過

closes #866