### PR TITLE
test: 歪度・服用変動性・在庫変動性のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/DoseVariability.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseVariability.edge.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseVariability - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([480])).toBe(0);
+  });
+
+  it('2件の同値は0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([480, 480])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    const result = MedicationRecordEntity.getDoseVariability([400, 560]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('全て同じは0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([100, 100, 100, 100])).toBe(0);
+  });
+
+  it('全て0は0', () => {
+    expect(MedicationRecordEntity.getDoseVariability([0, 0, 0])).toBe(0);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationRecordEntity.getDoseVariability([100, 200, 300, 400]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('極端なばらつきでも100を超えない', () => {
+    const result = MedicationRecordEntity.getDoseVariability([0, 1440]);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('微小な差', () => {
+    const result = MedicationRecordEntity.getDoseVariability([480, 481, 479]);
+    expect(result).toBeLessThan(5);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => 480 + (i % 10));
+    const result = MedicationRecordEntity.getDoseVariability(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('ばらつき大 > ばらつき小', () => {
+    const stable = MedicationRecordEntity.getDoseVariability([480, 481, 479, 480]);
+    const unstable = MedicationRecordEntity.getDoseVariability([100, 500, 200, 800]);
+    expect(unstable).toBeGreaterThan(stable);
+  });
+
+  it('負の値を含む場合', () => {
+    const result = MedicationRecordEntity.getDoseVariability([-60, 0, 60]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('3件の等差数列', () => {
+    const result = MedicationRecordEntity.getDoseVariability([400, 480, 560]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('同一値の長い配列は0', () => {
+    const data = Array.from({ length: 50 }, () => 480);
+    expect(MedicationRecordEntity.getDoseVariability(data)).toBe(0);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseVariabilityLabel - 境界値', () => {
+  it('スコア0は安定', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(0)).toBe('安定');
+  });
+
+  it('スコア19は安定', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(19)).toBe('安定');
+  });
+
+  it('スコア20はやや不安定(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(20)).toBe('やや不安定');
+  });
+
+  it('スコア49はやや不安定', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(49)).toBe('やや不安定');
+  });
+
+  it('スコア50は不安定(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(50)).toBe('不安定');
+  });
+
+  it('スコア100は不安定', () => {
+    expect(MedicationRecordEntity.getDoseVariabilityLabel(100)).toBe('不安定');
+  });
+});

--- a/src/__tests__/domain/entities/Skewness.edge.test.ts
+++ b/src/__tests__/domain/entities/Skewness.edge.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getSkewness - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getSkewness([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getSkewness([50])).toBe(0);
+  });
+
+  it('2件は0', () => {
+    expect(MathHelper.getSkewness([10, 90])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getSkewness([50, 50, 50, 50, 50])).toBe(0);
+  });
+
+  it('完全対称は0に近い', () => {
+    const result = MathHelper.getSkewness([10, 20, 30, 20, 10]);
+    expect(Math.abs(result)).toBeLessThan(0.5);
+  });
+
+  it('右偏りは正値', () => {
+    const result = MathHelper.getSkewness([1, 2, 3, 4, 100]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('左偏りは負値', () => {
+    const result = MathHelper.getSkewness([100, 96, 97, 98, 1]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i);
+    const result = MathHelper.getSkewness(data);
+    expect(typeof result).toBe('number');
+    expect(isNaN(result)).toBe(false);
+  });
+
+  it('全て0は0', () => {
+    expect(MathHelper.getSkewness([0, 0, 0])).toBe(0);
+  });
+
+  it('負の値を含むデータ', () => {
+    const result = MathHelper.getSkewness([-10, -5, 0, 5, 10]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('3件の最小ケース', () => {
+    const result = MathHelper.getSkewness([1, 2, 3]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('極端な外れ値', () => {
+    const result = MathHelper.getSkewness([1, 1, 1, 1, 1000]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getSkewness([0.1, 0.2, 0.3, 0.4, 0.5]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('右偏りは左偏りと符号が逆', () => {
+    const right = MathHelper.getSkewness([1, 1, 1, 1, 100]);
+    const left = MathHelper.getSkewness([100, 99, 99, 99, 1]);
+    expect(right > 0).toBe(true);
+    expect(left < 0).toBe(true);
+  });
+
+  it('均等分布は0に近い', () => {
+    const result = MathHelper.getSkewness([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(Math.abs(result)).toBeLessThan(0.5);
+  });
+
+  it('重複値が多い場合', () => {
+    const result = MathHelper.getSkewness([5, 5, 5, 5, 100]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getSkewnessLabel - 境界値', () => {
+  it('歪度0は対称', () => {
+    expect(MathHelper.getSkewnessLabel(0)).toBe('対称');
+  });
+
+  it('歪度0.5は対称(境界値)', () => {
+    expect(MathHelper.getSkewnessLabel(0.5)).toBe('対称');
+  });
+
+  it('歪度0.51は右偏り', () => {
+    expect(MathHelper.getSkewnessLabel(0.51)).toBe('右偏り');
+  });
+
+  it('歪度-0.5は対称(境界値)', () => {
+    expect(MathHelper.getSkewnessLabel(-0.5)).toBe('対称');
+  });
+
+  it('歪度-0.51は左偏り', () => {
+    expect(MathHelper.getSkewnessLabel(-0.51)).toBe('左偏り');
+  });
+
+  it('歪度5は右偏り', () => {
+    expect(MathHelper.getSkewnessLabel(5)).toBe('右偏り');
+  });
+
+  it('歪度-5は左偏り', () => {
+    expect(MathHelper.getSkewnessLabel(-5)).toBe('左偏り');
+  });
+});

--- a/src/__tests__/domain/entities/StockVolatility.edge.test.ts
+++ b/src/__tests__/domain/entities/StockVolatility.edge.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockVolatility - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(StockAlertEntity.getStockVolatility([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(StockAlertEntity.getStockVolatility([50])).toBe(0);
+  });
+
+  it('2件の同値は0', () => {
+    expect(StockAlertEntity.getStockVolatility([50, 50])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    const result = StockAlertEntity.getStockVolatility([10, 60]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(StockAlertEntity.getStockVolatility([30, 30, 30, 30])).toBe(0);
+  });
+
+  it('全て0は0', () => {
+    expect(StockAlertEntity.getStockVolatility([0, 0, 0])).toBe(0);
+  });
+
+  it('結果は0-100', () => {
+    const result = StockAlertEntity.getStockVolatility([10, 30, 50, 70]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('極端な変動でも100を超えない', () => {
+    const result = StockAlertEntity.getStockVolatility([0, 1000, 0, 1000]);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('微小な変動', () => {
+    const result = StockAlertEntity.getStockVolatility([50, 51, 49, 50]);
+    expect(result).toBeLessThan(10);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => 50 + (i % 5));
+    const result = StockAlertEntity.getStockVolatility(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('交互パターン', () => {
+    const result = StockAlertEntity.getStockVolatility([10, 90, 10, 90, 10]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('単調増加', () => {
+    const result = StockAlertEntity.getStockVolatility([10, 20, 30, 40, 50]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('単調減少', () => {
+    const result = StockAlertEntity.getStockVolatility([50, 40, 30, 20, 10]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('変動大 > 変動小', () => {
+    const stable = StockAlertEntity.getStockVolatility([49, 50, 51]);
+    const volatile = StockAlertEntity.getStockVolatility([0, 100, 0]);
+    expect(volatile).toBeGreaterThan(stable);
+  });
+
+  it('同一値の長い配列は0', () => {
+    const data = Array.from({ length: 50 }, () => 30);
+    expect(StockAlertEntity.getStockVolatility(data)).toBe(0);
+  });
+
+  it('3件のデータ', () => {
+    const result = StockAlertEntity.getStockVolatility([10, 50, 20]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('StockAlertEntity.getStockVolatilityLabel - 境界値', () => {
+  it('スコア0は安定', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(0)).toBe('安定');
+  });
+
+  it('スコア30は安定(境界値)', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(30)).toBe('安定');
+  });
+
+  it('スコア31はやや変動', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(31)).toBe('やや変動');
+  });
+
+  it('スコア60はやや変動(境界値)', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(60)).toBe('やや変動');
+  });
+
+  it('スコア61は変動大', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(61)).toBe('変動大');
+  });
+
+  it('スコア100は変動大', () => {
+    expect(StockAlertEntity.getStockVolatilityLabel(100)).toBe('変動大');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getSkewness / getSkewnessLabel の境界値・エッジケーステスト23件
- MedicationRecordEntity.getDoseVariability / getDoseVariabilityLabel の境界値・エッジケーステスト20件
- StockAlertEntity.getStockVolatility / getStockVolatilityLabel の境界値・エッジケーステスト22件
- 合計65テスト追加（全5704テスト通過）

## Test plan
- [x] Skewness.edge: 23テスト通過
- [x] DoseVariability.edge: 20テスト通過
- [x] StockVolatility.edge: 22テスト通過
- [x] 全5704テスト通過

closes #868