### PR TITLE
feat: 尖度・休日比率・遵守回復力を追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceResilience.test.ts
+++ b/src/__tests__/domain/entities/AdherenceResilience.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceResilience', () => {
+  it('空配列は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([80])).toBe(0);
+  });
+
+  it('低下なしは100', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([50, 60, 70, 80])).toBe(100);
+  });
+
+  it('低下後に完全回復は高スコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([80, 40, 80]);
+    expect(result).toBeGreaterThanOrEqual(80);
+  });
+
+  it('低下後に回復なしは低スコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([80, 40, 40]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('結果は0-100', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([90, 30, 60, 20, 70]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('横ばいは100', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([50, 50, 50])).toBe(100);
+  });
+
+  it('回復が早いほどスコアが高い', () => {
+    const fast = AdherenceTrendEntity.getAdherenceResilience([80, 40, 80]);
+    const slow = AdherenceTrendEntity.getAdherenceResilience([80, 40, 50]);
+    expect(fast).toBeGreaterThan(slow);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceResilienceLabel', () => {
+  it('スコア70以上は回復力高', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(80)).toBe('回復力高');
+  });
+
+  it('スコア40-70はやや回復', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(50)).toBe('やや回復');
+  });
+
+  it('スコア40未満は回復力低', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(20)).toBe('回復力低');
+  });
+});

--- a/src/__tests__/domain/entities/Kurtosis.test.ts
+++ b/src/__tests__/domain/entities/Kurtosis.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getKurtosis', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getKurtosis([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getKurtosis([50])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getKurtosis([50, 50, 50, 50])).toBe(0);
+  });
+
+  it('正規分布に近いデータは0に近い', () => {
+    const result = MathHelper.getKurtosis([2, 4, 6, 8, 10, 8, 6, 4, 2]);
+    expect(Math.abs(result)).toBeLessThan(3);
+  });
+
+  it('尖った分布は正', () => {
+    const result = MathHelper.getKurtosis([0, 0, 0, 100, 0, 0, 0]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('均等な分布は負に近い', () => {
+    const result = MathHelper.getKurtosis([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result).toBeLessThan(1);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i);
+    const result = MathHelper.getKurtosis(data);
+    expect(typeof result).toBe('number');
+    expect(isNaN(result)).toBe(false);
+  });
+});
+
+describe('MathHelper.getKurtosisLabel', () => {
+  it('正の尖度は尖った分布', () => {
+    expect(MathHelper.getKurtosisLabel(2)).toBe('尖った分布');
+  });
+
+  it('負の尖度は平坦な分布', () => {
+    expect(MathHelper.getKurtosisLabel(-2)).toBe('平坦な分布');
+  });
+
+  it('0付近は正規分布', () => {
+    expect(MathHelper.getKurtosisLabel(0)).toBe('正規分布');
+  });
+});

--- a/src/__tests__/domain/entities/WeekendRatio.test.ts
+++ b/src/__tests__/domain/entities/WeekendRatio.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getWeekendRatio', () => {
+  it('空配列は0', () => {
+    expect(DateRangeHelper.getWeekendRatio([])).toBe(0);
+  });
+
+  it('全て平日は0', () => {
+    // 1=月, 2=火, 3=水, 4=木, 5=金
+    expect(DateRangeHelper.getWeekendRatio([1, 2, 3, 4, 5])).toBe(0);
+  });
+
+  it('全て休日は100', () => {
+    // 0=日, 6=土
+    expect(DateRangeHelper.getWeekendRatio([0, 6, 0, 6])).toBe(100);
+  });
+
+  it('7日間の通常週は約29', () => {
+    const result = DateRangeHelper.getWeekendRatio([0, 1, 2, 3, 4, 5, 6]);
+    expect(result).toBe(29);
+  });
+
+  it('結果は0-100', () => {
+    const result = DateRangeHelper.getWeekendRatio([0, 1, 2, 6]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('休日が多いほどスコアが高い', () => {
+    const few = DateRangeHelper.getWeekendRatio([0, 1, 2, 3, 4]);
+    const many = DateRangeHelper.getWeekendRatio([0, 6, 0, 1, 2]);
+    expect(many).toBeGreaterThan(few);
+  });
+});
+
+describe('DateRangeHelper.getWeekendRatioLabel', () => {
+  it('休日率40以上は休日中心', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(50)).toBe('休日中心');
+  });
+
+  it('休日率20-40は均等', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(30)).toBe('均等');
+  });
+
+  it('休日率20未満は平日中心', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(10)).toBe('平日中心');
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -40,6 +40,8 @@ export class AdherenceTrendEntity {
   private static readonly PEAK_GOOD_THRESHOLD = 70;
   private static readonly PEAK_MODERATE_THRESHOLD = 50;
   private static readonly MOMENTUM_THRESHOLD = 5;
+  private static readonly RESILIENCE_HIGH_THRESHOLD = 70;
+  private static readonly RESILIENCE_MODERATE_THRESHOLD = 40;
 
   constructor(private readonly trend: AdherenceTrend) {}
 
@@ -456,5 +458,41 @@ export class AdherenceTrendEntity {
     if (momentum >= AdherenceTrendEntity.MOMENTUM_THRESHOLD) return '加速改善';
     if (momentum <= -AdherenceTrendEntity.MOMENTUM_THRESHOLD) return '加速悪化';
     return '安定';
+  }
+
+  /**
+   * 遵守率配列から回復力スコア(0-100)を算出する
+   * 低下が発生しない場合は100、低下後の回復度合いを評価
+   */
+  static getAdherenceResilience(rates: number[]): number {
+    if (rates.length <= 1) return 0;
+    let hasDip = false;
+    let totalRecoveryRatio = 0;
+    let dipCount = 0;
+    for (let i = 1; i < rates.length; i++) {
+      if (rates[i] < rates[i - 1]) {
+        hasDip = true;
+        const drop = rates[i - 1] - rates[i];
+        // 低下後の最大回復量を探す
+        let maxRecovery = 0;
+        for (let j = i + 1; j < rates.length; j++) {
+          const recovery = rates[j] - rates[i];
+          if (recovery > maxRecovery) maxRecovery = recovery;
+        }
+        totalRecoveryRatio += drop > 0 ? Math.min(1, maxRecovery / drop) : 0;
+        dipCount++;
+      }
+    }
+    if (!hasDip) return 100;
+    return Math.round((totalRecoveryRatio / dipCount) * 100);
+  }
+
+  /**
+   * 回復力スコアに応じたラベルを返す
+   */
+  static getAdherenceResilienceLabel(score: number): string {
+    if (score >= AdherenceTrendEntity.RESILIENCE_HIGH_THRESHOLD) return '回復力高';
+    if (score >= AdherenceTrendEntity.RESILIENCE_MODERATE_THRESHOLD) return 'やや回復';
+    return '回復力低';
   }
 }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -108,6 +108,8 @@ export class DateRangeHelper {
   private static readonly WEEKDAY_CONCENTRATION_MODERATE_THRESHOLD = 40;
   private static readonly DATE_GAP_REGULAR_THRESHOLD = 80;
   private static readonly DATE_GAP_MODERATE_THRESHOLD = 50;
+  private static readonly WEEKEND_RATIO_HIGH_THRESHOLD = 40;
+  private static readonly WEEKEND_RATIO_LOW_THRESHOLD = 20;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -419,5 +421,23 @@ export class DateRangeHelper {
     if (score >= DateRangeHelper.DATE_GAP_REGULAR_THRESHOLD) return '規則的';
     if (score >= DateRangeHelper.DATE_GAP_MODERATE_THRESHOLD) return 'やや不規則';
     return '不規則';
+  }
+
+  /**
+   * 曜日番号配列(0=日〜6=土)から休日(土日)の割合(0-100)を算出する
+   */
+  static getWeekendRatio(dayOfWeeks: number[]): number {
+    if (dayOfWeeks.length === 0) return 0;
+    const weekendCount = dayOfWeeks.filter((d) => d === 0 || d === 6).length;
+    return Math.round((weekendCount / dayOfWeeks.length) * 100);
+  }
+
+  /**
+   * 休日比率に応じたラベルを返す
+   */
+  static getWeekendRatioLabel(ratio: number): string {
+    if (ratio >= DateRangeHelper.WEEKEND_RATIO_HIGH_THRESHOLD) return '休日中心';
+    if (ratio >= DateRangeHelper.WEEKEND_RATIO_LOW_THRESHOLD) return '均等';
+    return '平日中心';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -32,6 +32,7 @@ export class MathHelper {
   private static readonly IQR_STABLE_THRESHOLD = 5;
   private static readonly IQR_MODERATE_THRESHOLD = 20;
   private static readonly SKEWNESS_THRESHOLD = 0.5;
+  private static readonly KURTOSIS_THRESHOLD = 1;
 
   /**
    * パーセントを算出(0-100%)
@@ -600,5 +601,29 @@ export class MathHelper {
     if (skewness > MathHelper.SKEWNESS_THRESHOLD) return '右偏り';
     if (skewness < -MathHelper.SKEWNESS_THRESHOLD) return '左偏り';
     return '対称';
+  }
+
+  /**
+   * データ分布の尖度(excess kurtosis)を算出する
+   * 正規分布を基準(0)とした超過尖度を返す
+   */
+  static getKurtosis(values: number[]): number {
+    if (values.length < 3) return 0;
+    const n = values.length;
+    const avg = values.reduce((a, b) => a + b, 0) / n;
+    const variance = values.reduce((sum, v) => sum + (v - avg) ** 2, 0) / n;
+    if (variance === 0) return 0;
+    const m4 = values.reduce((sum, v) => sum + ((v - avg) ** 4), 0) / n;
+    const kurtosis = m4 / (variance ** 2) - 3;
+    return Math.round(kurtosis * 100) / 100;
+  }
+
+  /**
+   * 尖度に応じたラベルを返す
+   */
+  static getKurtosisLabel(kurtosis: number): string {
+    if (kurtosis > MathHelper.KURTOSIS_THRESHOLD) return '尖った分布';
+    if (kurtosis < -MathHelper.KURTOSIS_THRESHOLD) return '平坦な分布';
+    return '正規分布';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getKurtosis / getKurtosisLabel（データ分布の超過尖度）
- DateRangeHelper: getWeekendRatio / getWeekendRatioLabel（曜日配列中の休日割合）
- AdherenceTrendEntity: getAdherenceResilience / getAdherenceResilienceLabel（遵守率低下後の回復力）
- テスト30件追加（合計5734件）

## Test plan
- [x] Kurtosis: 10テスト
- [x] WeekendRatio: 9テスト
- [x] AdherenceResilience: 11テスト
- [x] 全5734テスト通過

closes #870