### PR TITLE
test: 尖度・休日比率・遵守回復力のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/AdherenceResilience.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceResilience.edge.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceResilience - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([80])).toBe(0);
+  });
+
+  it('2件上昇は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([50, 80])).toBe(100);
+  });
+
+  it('2件横ばいは100', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([50, 50])).toBe(100);
+  });
+
+  it('2件低下で回復なし', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([80, 40]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('完全回復は高スコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([100, 50, 100]);
+    expect(result).toBeGreaterThanOrEqual(80);
+  });
+
+  it('部分回復は中スコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([100, 50, 75]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('回復なしは0', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([80, 40, 40]);
+    expect(result).toBe(0);
+  });
+
+  it('連続上昇は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([10, 30, 50, 70, 90])).toBe(100);
+  });
+
+  it('連続低下は低スコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([90, 70, 50, 30]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('V字回復', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([90, 30, 90]);
+    expect(result).toBeGreaterThanOrEqual(80);
+  });
+
+  it('W字パターン', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([80, 40, 70, 30, 60]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 50 }, (_, i) => 50 + Math.sin(i) * 30);
+    const result = AdherenceTrendEntity.getAdherenceResilience(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('全て0は100(低下なし)', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([0, 0, 0])).toBe(100);
+  });
+
+  it('全て100は100(低下なし)', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilience([100, 100, 100])).toBe(100);
+  });
+
+  it('微小な低下と回復', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([80, 79, 80]);
+    expect(result).toBeGreaterThanOrEqual(80);
+  });
+
+  it('結果は0-100', () => {
+    const result = AdherenceTrendEntity.getAdherenceResilience([90, 10, 50, 20, 80]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceResilienceLabel - 境界値', () => {
+  it('スコア70は回復力高(境界値)', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(70)).toBe('回復力高');
+  });
+
+  it('スコア69はやや回復', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(69)).toBe('やや回復');
+  });
+
+  it('スコア40はやや回復(境界値)', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(40)).toBe('やや回復');
+  });
+
+  it('スコア39は回復力低', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(39)).toBe('回復力低');
+  });
+
+  it('スコア0は回復力低', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(0)).toBe('回復力低');
+  });
+
+  it('スコア100は回復力高', () => {
+    expect(AdherenceTrendEntity.getAdherenceResilienceLabel(100)).toBe('回復力高');
+  });
+});

--- a/src/__tests__/domain/entities/Kurtosis.edge.test.ts
+++ b/src/__tests__/domain/entities/Kurtosis.edge.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getKurtosis - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getKurtosis([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getKurtosis([50])).toBe(0);
+  });
+
+  it('2件は0', () => {
+    expect(MathHelper.getKurtosis([10, 90])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getKurtosis([50, 50, 50, 50, 50])).toBe(0);
+  });
+
+  it('全て0は0', () => {
+    expect(MathHelper.getKurtosis([0, 0, 0, 0])).toBe(0);
+  });
+
+  it('3件の最小ケース', () => {
+    const result = MathHelper.getKurtosis([1, 2, 3]);
+    expect(typeof result).toBe('number');
+    expect(isNaN(result)).toBe(false);
+  });
+
+  it('負の値を含む', () => {
+    const result = MathHelper.getKurtosis([-10, -5, 0, 5, 10]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 200 }, (_, i) => i);
+    const result = MathHelper.getKurtosis(data);
+    expect(typeof result).toBe('number');
+    expect(isNaN(result)).toBe(false);
+  });
+
+  it('極端な外れ値は正の尖度', () => {
+    const data = Array.from({ length: 20 }, () => 50);
+    data.push(1000);
+    const result = MathHelper.getKurtosis(data);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('均等分布は負の尖度', () => {
+    const result = MathHelper.getKurtosis([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('尖った分布は正の尖度', () => {
+    const result = MathHelper.getKurtosis([0, 0, 0, 0, 100, 0, 0, 0, 0]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getKurtosis([0.1, 0.2, 0.3, 0.4, 0.5]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('2値分布', () => {
+    const result = MathHelper.getKurtosis([0, 0, 0, 100, 100, 100]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('対称分布', () => {
+    const result = MathHelper.getKurtosis([1, 3, 5, 7, 9, 7, 5, 3, 1]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('重複値が多い', () => {
+    const result = MathHelper.getKurtosis([1, 1, 1, 1, 1, 1, 1, 100]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getKurtosisLabel - 境界値', () => {
+  it('尖度0は正規分布', () => {
+    expect(MathHelper.getKurtosisLabel(0)).toBe('正規分布');
+  });
+
+  it('尖度1は正規分布(境界値)', () => {
+    expect(MathHelper.getKurtosisLabel(1)).toBe('正規分布');
+  });
+
+  it('尖度1.01は尖った分布', () => {
+    expect(MathHelper.getKurtosisLabel(1.01)).toBe('尖った分布');
+  });
+
+  it('尖度-1は正規分布(境界値)', () => {
+    expect(MathHelper.getKurtosisLabel(-1)).toBe('正規分布');
+  });
+
+  it('尖度-1.01は平坦な分布', () => {
+    expect(MathHelper.getKurtosisLabel(-1.01)).toBe('平坦な分布');
+  });
+
+  it('尖度10は尖った分布', () => {
+    expect(MathHelper.getKurtosisLabel(10)).toBe('尖った分布');
+  });
+
+  it('尖度-10は平坦な分布', () => {
+    expect(MathHelper.getKurtosisLabel(-10)).toBe('平坦な分布');
+  });
+});

--- a/src/__tests__/domain/entities/WeekendRatio.edge.test.ts
+++ b/src/__tests__/domain/entities/WeekendRatio.edge.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getWeekendRatio - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(DateRangeHelper.getWeekendRatio([])).toBe(0);
+  });
+
+  it('1件の平日は0', () => {
+    expect(DateRangeHelper.getWeekendRatio([1])).toBe(0);
+  });
+
+  it('1件の日曜は100', () => {
+    expect(DateRangeHelper.getWeekendRatio([0])).toBe(100);
+  });
+
+  it('1件の土曜は100', () => {
+    expect(DateRangeHelper.getWeekendRatio([6])).toBe(100);
+  });
+
+  it('全て月曜は0', () => {
+    expect(DateRangeHelper.getWeekendRatio([1, 1, 1, 1])).toBe(0);
+  });
+
+  it('全て日曜は100', () => {
+    expect(DateRangeHelper.getWeekendRatio([0, 0, 0])).toBe(100);
+  });
+
+  it('全て土曜は100', () => {
+    expect(DateRangeHelper.getWeekendRatio([6, 6, 6])).toBe(100);
+  });
+
+  it('平日5日+休日2日は29', () => {
+    expect(DateRangeHelper.getWeekendRatio([1, 2, 3, 4, 5, 0, 6])).toBe(29);
+  });
+
+  it('結果は0-100', () => {
+    const result = DateRangeHelper.getWeekendRatio([0, 1, 3, 6, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('半々は50', () => {
+    expect(DateRangeHelper.getWeekendRatio([0, 6, 1, 2])).toBe(50);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i % 7);
+    const result = DateRangeHelper.getWeekendRatio(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('全曜日を含む', () => {
+    const result = DateRangeHelper.getWeekendRatio([0, 1, 2, 3, 4, 5, 6]);
+    expect(result).toBe(29);
+  });
+
+  it('休日のみ2件', () => {
+    expect(DateRangeHelper.getWeekendRatio([0, 6])).toBe(100);
+  });
+
+  it('平日のみ2件', () => {
+    expect(DateRangeHelper.getWeekendRatio([1, 5])).toBe(0);
+  });
+
+  it('3件中1件休日', () => {
+    expect(DateRangeHelper.getWeekendRatio([0, 1, 2])).toBe(33);
+  });
+});
+
+describe('DateRangeHelper.getWeekendRatioLabel - 境界値', () => {
+  it('比率0は平日中心', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(0)).toBe('平日中心');
+  });
+
+  it('比率19は平日中心', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(19)).toBe('平日中心');
+  });
+
+  it('比率20は均等(境界値)', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(20)).toBe('均等');
+  });
+
+  it('比率39は均等', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(39)).toBe('均等');
+  });
+
+  it('比率40は休日中心(境界値)', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(40)).toBe('休日中心');
+  });
+
+  it('比率100は休日中心', () => {
+    expect(DateRangeHelper.getWeekendRatioLabel(100)).toBe('休日中心');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getKurtosis / getKurtosisLabel の境界値・エッジケーステスト22件
- DateRangeHelper.getWeekendRatio / getWeekendRatioLabel の境界値・エッジケーステスト21件
- AdherenceTrendEntity.getAdherenceResilience / getAdherenceResilienceLabel の境界値・エッジケーステスト23件
- 合計66テスト追加（全5800テスト通過）

## Test plan
- [x] Kurtosis.edge: 22テスト通過
- [x] WeekendRatio.edge: 21テスト通過
- [x] AdherenceResilience.edge: 23テスト通過
- [x] 全5800テスト通過

closes #872