### PR TITLE
feat: 変動係数・スケジュール競合率・予約集中度を追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentClusterScore.test.ts
+++ b/src/__tests__/domain/entities/AppointmentClusterScore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentClusterScore', () => {
+  it('空配列は0', () => {
+    expect(AppointmentEntity.getAppointmentClusterScore([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AppointmentEntity.getAppointmentClusterScore([30])).toBe(0);
+  });
+
+  it('均等な間隔は低スコア', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([30, 30, 30, 30]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('偏った間隔は高スコア', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([1, 1, 1, 90]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('全て同じ間隔は低スコア', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([14, 14, 14]);
+    expect(result).toBeLessThan(20);
+  });
+
+  it('結果は0-100', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([5, 30, 10, 60]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('ばらつきが大きいほど高スコア', () => {
+    const even = AppointmentEntity.getAppointmentClusterScore([30, 30, 30]);
+    const clustered = AppointmentEntity.getAppointmentClusterScore([1, 1, 90]);
+    expect(clustered).toBeGreaterThan(even);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentClusterScoreLabel', () => {
+  it('スコア30未満は分散', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(15)).toBe('分散');
+  });
+
+  it('スコア30-60はやや集中', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(45)).toBe('やや集中');
+  });
+
+  it('スコア60以上は集中', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(70)).toBe('集中');
+  });
+});

--- a/src/__tests__/domain/entities/CoeffOfVariation.test.ts
+++ b/src/__tests__/domain/entities/CoeffOfVariation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getCoeffOfVariation', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getCoeffOfVariation([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getCoeffOfVariation([50])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getCoeffOfVariation([50, 50, 50])).toBe(0);
+  });
+
+  it('ばらつきがあると正値', () => {
+    const result = MathHelper.getCoeffOfVariation([10, 20, 30]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('ばらつきが大きいほど高い', () => {
+    const small = MathHelper.getCoeffOfVariation([48, 50, 52]);
+    const large = MathHelper.getCoeffOfVariation([10, 50, 90]);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('平均0の場合は0', () => {
+    expect(MathHelper.getCoeffOfVariation([0, 0, 0])).toBe(0);
+  });
+
+  it('結果は非負', () => {
+    const result = MathHelper.getCoeffOfVariation([5, 10, 15, 20]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i + 1);
+    const result = MathHelper.getCoeffOfVariation(data);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getCoeffOfVariationLabel', () => {
+  it('CV 20未満は安定', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(15)).toBe('安定');
+  });
+
+  it('CV 20-50はやや変動', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(30)).toBe('やや変動');
+  });
+
+  it('CV 50以上は変動大', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(60)).toBe('変動大');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleConflictRate.test.ts
+++ b/src/__tests__/domain/entities/ScheduleConflictRate.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleConflictRate', () => {
+  it('空配列は0', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480])).toBe(0);
+  });
+
+  it('全て異なる時刻は0', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480, 720, 960])).toBe(0);
+  });
+
+  it('全て同じ時刻は100', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480, 480, 480])).toBe(100);
+  });
+
+  it('一部が近い時刻', () => {
+    const result = ScheduleEntity.getScheduleConflictRate([480, 485, 720]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('結果は0-100', () => {
+    const result = ScheduleEntity.getScheduleConflictRate([100, 110, 200, 210, 300]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('競合が多いほど高い', () => {
+    const few = ScheduleEntity.getScheduleConflictRate([480, 490, 720, 960]);
+    const many = ScheduleEntity.getScheduleConflictRate([480, 485, 490, 495]);
+    expect(many).toBeGreaterThan(few);
+  });
+});
+
+describe('ScheduleEntity.getScheduleConflictRateLabel', () => {
+  it('スコア10未満は競合なし', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(5)).toBe('競合なし');
+  });
+
+  it('スコア10-30はやや競合', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(20)).toBe('やや競合');
+  });
+
+  it('スコア30以上は競合多い', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(50)).toBe('競合多い');
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -35,6 +35,9 @@ export class AppointmentEntity {
   private static readonly CYCLE_MODERATE_THRESHOLD = 40;
   private static readonly APPT_REGULARITY_HIGH_THRESHOLD = 80;
   private static readonly APPT_REGULARITY_MODERATE_THRESHOLD = 50;
+  private static readonly CLUSTER_SCORE_HIGH_THRESHOLD = 60;
+  private static readonly CLUSTER_SCORE_MODERATE_THRESHOLD = 30;
+  private static readonly CLUSTER_MAX_CV = 2;
 
   constructor(private readonly appointment: Appointment) {}
 
@@ -626,5 +629,27 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.APPT_REGULARITY_HIGH_THRESHOLD) return '規則的';
     if (score >= AppointmentEntity.APPT_REGULARITY_MODERATE_THRESHOLD) return 'やや不規則';
     return '不規則';
+  }
+
+  /**
+   * 通院間隔配列から集中度スコア(0-100)を算出する
+   * 変動係数ベースで間隔のばらつきを評価（ばらつきが大きいほど高スコア）
+   */
+  static getAppointmentClusterScore(intervals: number[]): number {
+    if (intervals.length <= 1) return 0;
+    const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+    if (avg === 0) return 0;
+    const variance = intervals.reduce((sum, v) => sum + (v - avg) ** 2, 0) / intervals.length;
+    const cv = Math.sqrt(variance) / avg;
+    return Math.min(100, Math.round((cv / AppointmentEntity.CLUSTER_MAX_CV) * 100));
+  }
+
+  /**
+   * 集中度スコアに応じたラベルを返す
+   */
+  static getAppointmentClusterScoreLabel(score: number): string {
+    if (score >= AppointmentEntity.CLUSTER_SCORE_HIGH_THRESHOLD) return '集中';
+    if (score >= AppointmentEntity.CLUSTER_SCORE_MODERATE_THRESHOLD) return 'やや集中';
+    return '分散';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -33,6 +33,8 @@ export class MathHelper {
   private static readonly IQR_MODERATE_THRESHOLD = 20;
   private static readonly SKEWNESS_THRESHOLD = 0.5;
   private static readonly KURTOSIS_THRESHOLD = 1;
+  private static readonly CV_STABLE_THRESHOLD = 20;
+  private static readonly CV_MODERATE_THRESHOLD = 50;
 
   /**
    * パーセントを算出(0-100%)
@@ -625,5 +627,27 @@ export class MathHelper {
     if (kurtosis > MathHelper.KURTOSIS_THRESHOLD) return '尖った分布';
     if (kurtosis < -MathHelper.KURTOSIS_THRESHOLD) return '平坦な分布';
     return '正規分布';
+  }
+
+  /**
+   * 変動係数(CV = stdDev/mean * 100)を算出する
+   * 平均0または1件以下は0を返す
+   */
+  static getCoeffOfVariation(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    if (avg === 0) return 0;
+    const variance = values.reduce((sum, v) => sum + (v - avg) ** 2, 0) / values.length;
+    const stdDev = Math.sqrt(variance);
+    return Math.round((stdDev / Math.abs(avg)) * 100 * 100) / 100;
+  }
+
+  /**
+   * 変動係数に応じたラベルを返す
+   */
+  static getCoeffOfVariationLabel(cv: number): string {
+    if (cv < MathHelper.CV_STABLE_THRESHOLD) return '安定';
+    if (cv < MathHelper.CV_MODERATE_THRESHOLD) return 'やや変動';
+    return '変動大';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -795,6 +795,9 @@ export class ScheduleEntity {
   private static readonly BALANCE_HIGH_THRESHOLD = 70;
   private static readonly BALANCE_MODERATE_THRESHOLD = 40;
   private static readonly COMPLETION_TREND_THRESHOLD = 0;
+  private static readonly CONFLICT_PROXIMITY_MINUTES = 15;
+  private static readonly CONFLICT_LOW_THRESHOLD = 10;
+  private static readonly CONFLICT_MODERATE_THRESHOLD = 30;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -998,5 +1001,34 @@ export class ScheduleEntity {
     if (slope > ScheduleEntity.COMPLETION_TREND_THRESHOLD) return '上昇';
     if (slope < ScheduleEntity.COMPLETION_TREND_THRESHOLD) return '下降';
     return '横ばい';
+  }
+
+  /**
+   * スケジュール時刻(分単位)配列から競合率(0-100)を算出する
+   * 15分以内のペア数/全ペア数の割合
+   */
+  static getScheduleConflictRate(timesInMinutes: number[]): number {
+    if (timesInMinutes.length <= 1) return 0;
+    let conflictPairs = 0;
+    let totalPairs = 0;
+    for (let i = 0; i < timesInMinutes.length; i++) {
+      for (let j = i + 1; j < timesInMinutes.length; j++) {
+        totalPairs++;
+        if (Math.abs(timesInMinutes[i] - timesInMinutes[j]) <= ScheduleEntity.CONFLICT_PROXIMITY_MINUTES) {
+          conflictPairs++;
+        }
+      }
+    }
+    if (totalPairs === 0) return 0;
+    return Math.round((conflictPairs / totalPairs) * 100);
+  }
+
+  /**
+   * 競合率に応じたラベルを返す
+   */
+  static getScheduleConflictRateLabel(rate: number): string {
+    if (rate < ScheduleEntity.CONFLICT_LOW_THRESHOLD) return '競合なし';
+    if (rate < ScheduleEntity.CONFLICT_MODERATE_THRESHOLD) return 'やや競合';
+    return '競合多い';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getCoeffOfVariation / getCoeffOfVariationLabel（変動係数によるばらつき評価）
- ScheduleEntity: getScheduleConflictRate / getScheduleConflictRateLabel（15分以内の時刻近接ペア率）
- AppointmentEntity: getAppointmentClusterScore / getAppointmentClusterScoreLabel（通院間隔の集中度）
- テスト31件追加（合計5831件）

## Test plan
- [x] CoeffOfVariation: 11テスト
- [x] ScheduleConflictRate: 10テスト
- [x] AppointmentClusterScore: 10テスト
- [x] 全5831テスト通過

closes #874