### PR TITLE
test: 変動係数・スケジュール競合率・予約集中度のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/AppointmentClusterScore.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentClusterScore.edge.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentClusterScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(AppointmentEntity.getAppointmentClusterScore([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AppointmentEntity.getAppointmentClusterScore([30])).toBe(0);
+  });
+
+  it('2件の同値は0', () => {
+    expect(AppointmentEntity.getAppointmentClusterScore([30, 30])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(AppointmentEntity.getAppointmentClusterScore([14, 14, 14, 14])).toBe(0);
+  });
+
+  it('全て0は0', () => {
+    expect(AppointmentEntity.getAppointmentClusterScore([0, 0, 0])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([1, 90]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('結果は0-100', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([5, 10, 50, 80]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('極端なばらつきでも100を超えない', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([1, 1000]);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 50 }, (_, i) => (i % 3 === 0 ? 1 : 30));
+    const result = AppointmentEntity.getAppointmentClusterScore(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('ばらつき大 > ばらつき小', () => {
+    const even = AppointmentEntity.getAppointmentClusterScore([30, 30, 30]);
+    const clustered = AppointmentEntity.getAppointmentClusterScore([1, 1, 90]);
+    expect(clustered).toBeGreaterThan(even);
+  });
+
+  it('3件の等差数列', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([10, 20, 30]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('交互パターン', () => {
+    const result = AppointmentEntity.getAppointmentClusterScore([7, 60, 7, 60]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('同一値の長い配列は0', () => {
+    const data = Array.from({ length: 20 }, () => 14);
+    expect(AppointmentEntity.getAppointmentClusterScore(data)).toBe(0);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentClusterScoreLabel - 境界値', () => {
+  it('スコア0は分散', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(0)).toBe('分散');
+  });
+
+  it('スコア29は分散', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(29)).toBe('分散');
+  });
+
+  it('スコア30はやや集中(境界値)', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(30)).toBe('やや集中');
+  });
+
+  it('スコア59はやや集中', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(59)).toBe('やや集中');
+  });
+
+  it('スコア60は集中(境界値)', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(60)).toBe('集中');
+  });
+
+  it('スコア100は集中', () => {
+    expect(AppointmentEntity.getAppointmentClusterScoreLabel(100)).toBe('集中');
+  });
+});

--- a/src/__tests__/domain/entities/CoeffOfVariation.edge.test.ts
+++ b/src/__tests__/domain/entities/CoeffOfVariation.edge.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getCoeffOfVariation - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getCoeffOfVariation([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getCoeffOfVariation([50])).toBe(0);
+  });
+
+  it('2件の同値は0', () => {
+    expect(MathHelper.getCoeffOfVariation([50, 50])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getCoeffOfVariation([30, 30, 30, 30])).toBe(0);
+  });
+
+  it('全て0は0', () => {
+    expect(MathHelper.getCoeffOfVariation([0, 0, 0])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    const result = MathHelper.getCoeffOfVariation([10, 90]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('結果は非負', () => {
+    const result = MathHelper.getCoeffOfVariation([5, 10, 15, 20, 25]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i + 1);
+    const result = MathHelper.getCoeffOfVariation(data);
+    expect(result).toBeGreaterThan(0);
+    expect(isNaN(result)).toBe(false);
+  });
+
+  it('ばらつき大 > ばらつき小', () => {
+    const small = MathHelper.getCoeffOfVariation([49, 50, 51]);
+    const large = MathHelper.getCoeffOfVariation([10, 50, 90]);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('負の値を含む場合', () => {
+    const result = MathHelper.getCoeffOfVariation([-10, 0, 10]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getCoeffOfVariation([0.1, 0.2, 0.3]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('非常に大きな値', () => {
+    const result = MathHelper.getCoeffOfVariation([1000000, 2000000, 3000000]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('同一値の長い配列は0', () => {
+    const data = Array.from({ length: 50 }, () => 100);
+    expect(MathHelper.getCoeffOfVariation(data)).toBe(0);
+  });
+
+  it('3件の等差数列', () => {
+    const result = MathHelper.getCoeffOfVariation([10, 20, 30]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getCoeffOfVariationLabel - 境界値', () => {
+  it('CV 0は安定', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(0)).toBe('安定');
+  });
+
+  it('CV 19は安定', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(19)).toBe('安定');
+  });
+
+  it('CV 20はやや変動(境界値)', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(20)).toBe('やや変動');
+  });
+
+  it('CV 49はやや変動', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(49)).toBe('やや変動');
+  });
+
+  it('CV 50は変動大(境界値)', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(50)).toBe('変動大');
+  });
+
+  it('CV 100は変動大', () => {
+    expect(MathHelper.getCoeffOfVariationLabel(100)).toBe('変動大');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleConflictRate.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleConflictRate.edge.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleConflictRate - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480])).toBe(0);
+  });
+
+  it('2件の同値は100', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480, 480])).toBe(100);
+  });
+
+  it('2件の15分差は100(境界値)', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480, 495])).toBe(100);
+  });
+
+  it('2件の16分差は0', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480, 496])).toBe(0);
+  });
+
+  it('全て離れている場合は0', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([100, 200, 300, 400])).toBe(0);
+  });
+
+  it('全て同じ時刻は100', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480, 480, 480, 480])).toBe(100);
+  });
+
+  it('結果は0-100', () => {
+    const result = ScheduleEntity.getScheduleConflictRate([100, 110, 200, 210, 300]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 50 }, (_, i) => i * 60);
+    const result = ScheduleEntity.getScheduleConflictRate(data);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('隣接のみ近い', () => {
+    const result = ScheduleEntity.getScheduleConflictRate([480, 490, 720, 730]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('3件中2件が近い', () => {
+    const result = ScheduleEntity.getScheduleConflictRate([480, 485, 960]);
+    expect(result).toBe(33);
+  });
+
+  it('全て1分差', () => {
+    expect(ScheduleEntity.getScheduleConflictRate([480, 481, 482])).toBe(100);
+  });
+
+  it('0分の時刻', () => {
+    const result = ScheduleEntity.getScheduleConflictRate([0, 15, 30]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('1440分(24時)付近', () => {
+    const result = ScheduleEntity.getScheduleConflictRate([1430, 1440, 100]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('ScheduleEntity.getScheduleConflictRateLabel - 境界値', () => {
+  it('スコア0は競合なし', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(0)).toBe('競合なし');
+  });
+
+  it('スコア9は競合なし', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(9)).toBe('競合なし');
+  });
+
+  it('スコア10はやや競合(境界値)', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(10)).toBe('やや競合');
+  });
+
+  it('スコア29はやや競合', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(29)).toBe('やや競合');
+  });
+
+  it('スコア30は競合多い(境界値)', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(30)).toBe('競合多い');
+  });
+
+  it('スコア100は競合多い', () => {
+    expect(ScheduleEntity.getScheduleConflictRateLabel(100)).toBe('競合多い');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getCoeffOfVariation / getCoeffOfVariationLabel の境界値・エッジケーステスト20件
- ScheduleEntity.getScheduleConflictRate / getScheduleConflictRateLabel の境界値・エッジケーステスト20件
- AppointmentEntity.getAppointmentClusterScore / getAppointmentClusterScoreLabel の境界値・エッジケーステスト19件
- 合計59テスト追加（全5890テスト通過）

## Test plan
- [x] CoeffOfVariation.edge: 20テスト通過
- [x] ScheduleConflictRate.edge: 20テスト通過
- [x] AppointmentClusterScore.edge: 19テスト通過
- [x] 全5890テスト通過

closes #876