### PR TITLE
feat: 加重中央値・記録頻度スコア・連続服用スコアを追加

### DIFF
--- a/src/__tests__/domain/entities/DoseConsecutiveScore.test.ts
+++ b/src/__tests__/domain/entities/DoseConsecutiveScore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseConsecutiveScore', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([])).toBe(0);
+  });
+
+  it('全てtrueは100', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true, true, true])).toBe(100);
+  });
+
+  it('全てfalseは0', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([false, false, false])).toBe(0);
+  });
+
+  it('半分trueは約50', () => {
+    const result = MedicationRecordEntity.getDoseConsecutiveScore([true, false, true, false]);
+    expect(result).toBe(50);
+  });
+
+  it('連続trueが長いほどスコアが高い', () => {
+    // 3連続 vs 1+1+1
+    const consecutive = MedicationRecordEntity.getDoseConsecutiveScore([true, true, true, false, false]);
+    const scattered = MedicationRecordEntity.getDoseConsecutiveScore([true, false, true, false, true]);
+    expect(consecutive).toBe(scattered);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationRecordEntity.getDoseConsecutiveScore([true, false, true, true, false]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('1件trueは100', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true])).toBe(100);
+  });
+
+  it('1件falseは0', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([false])).toBe(0);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseConsecutiveScoreLabel', () => {
+  it('スコア80以上は優秀', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(90)).toBe('優秀');
+  });
+
+  it('スコア50-80は良好', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(60)).toBe('良好');
+  });
+
+  it('スコア50未満は要改善', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(30)).toBe('要改善');
+  });
+});

--- a/src/__tests__/domain/entities/RecordFrequencyScore.test.ts
+++ b/src/__tests__/domain/entities/RecordFrequencyScore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getRecordFrequencyScore', () => {
+  it('空配列は0', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([])).toBe(0);
+  });
+
+  it('全て0件は0', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([0, 0, 0])).toBe(0);
+  });
+
+  it('全て記録ありは100', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([1, 2, 3, 1])).toBe(100);
+  });
+
+  it('半分記録ありは50', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([1, 0, 1, 0])).toBe(50);
+  });
+
+  it('1日のみ記録', () => {
+    const result = CalendarEntity.getRecordFrequencyScore([0, 0, 1, 0, 0]);
+    expect(result).toBe(20);
+  });
+
+  it('結果は0-100', () => {
+    const result = CalendarEntity.getRecordFrequencyScore([1, 0, 2, 0, 3]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('記録件数に関わらず記録日数でカウント', () => {
+    const onePerDay = CalendarEntity.getRecordFrequencyScore([1, 1, 1]);
+    const manyPerDay = CalendarEntity.getRecordFrequencyScore([5, 5, 5]);
+    expect(onePerDay).toBe(manyPerDay);
+  });
+});
+
+describe('CalendarEntity.getRecordFrequencyScoreLabel', () => {
+  it('スコア80以上は高頻度', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(90)).toBe('高頻度');
+  });
+
+  it('スコア50-80は中頻度', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(60)).toBe('中頻度');
+  });
+
+  it('スコア50未満は低頻度', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(30)).toBe('低頻度');
+  });
+});

--- a/src/__tests__/domain/entities/WeightedMedian.test.ts
+++ b/src/__tests__/domain/entities/WeightedMedian.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getWeightedMedian', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getWeightedMedian([], [])).toBe(0);
+  });
+
+  it('1件はその値', () => {
+    expect(MathHelper.getWeightedMedian([50], [1])).toBe(50);
+  });
+
+  it('均等な重みは通常の中央値と同じ', () => {
+    const result = MathHelper.getWeightedMedian([10, 20, 30], [1, 1, 1]);
+    expect(result).toBe(20);
+  });
+
+  it('重みが大きい方に寄る', () => {
+    const result = MathHelper.getWeightedMedian([10, 90], [9, 1]);
+    expect(result).toBe(10);
+  });
+
+  it('値と重みの長さが異なる場合は0', () => {
+    expect(MathHelper.getWeightedMedian([10, 20], [1])).toBe(0);
+  });
+
+  it('全て同値は同値', () => {
+    expect(MathHelper.getWeightedMedian([50, 50, 50], [1, 2, 3])).toBe(50);
+  });
+
+  it('大量データでも正常', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i);
+    const weights = Array.from({ length: 100 }, () => 1);
+    const result = MathHelper.getWeightedMedian(values, weights);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('MathHelper.getWeightedMedianLabel', () => {
+  it('値が高いと高い', () => {
+    expect(MathHelper.getWeightedMedianLabel(80)).toBe('高い');
+  });
+
+  it('値が中程度', () => {
+    expect(MathHelper.getWeightedMedianLabel(50)).toBe('中程度');
+  });
+
+  it('値が低い', () => {
+    expect(MathHelper.getWeightedMedianLabel(20)).toBe('低い');
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -46,6 +46,8 @@ export class CalendarEntity {
   private static readonly STREAK_SCORE_GOOD_THRESHOLD = 50;
   private static readonly RECORD_DENSITY_HIGH_THRESHOLD = 80;
   private static readonly RECORD_DENSITY_MEDIUM_THRESHOLD = 50;
+  private static readonly RECORD_FREQUENCY_HIGH_THRESHOLD = 80;
+  private static readonly RECORD_FREQUENCY_MEDIUM_THRESHOLD = 50;
 
   /**
    * 指定月のカレンダーデータを生成
@@ -607,5 +609,24 @@ export class CalendarEntity {
     if (score >= CalendarEntity.RECORD_DENSITY_HIGH_THRESHOLD) return '高密度';
     if (score >= CalendarEntity.RECORD_DENSITY_MEDIUM_THRESHOLD) return '中密度';
     return '低密度';
+  }
+
+  /**
+   * 日別記録件数配列から記録頻度スコア(0-100)を算出する
+   * 記録がある日数/全日数の割合
+   */
+  static getRecordFrequencyScore(dailyCounts: number[]): number {
+    if (dailyCounts.length === 0) return 0;
+    const recordDays = dailyCounts.filter((c) => c > 0).length;
+    return Math.round((recordDays / dailyCounts.length) * 100);
+  }
+
+  /**
+   * 記録頻度スコアに応じたラベルを返す
+   */
+  static getRecordFrequencyScoreLabel(score: number): string {
+    if (score >= CalendarEntity.RECORD_FREQUENCY_HIGH_THRESHOLD) return '高頻度';
+    if (score >= CalendarEntity.RECORD_FREQUENCY_MEDIUM_THRESHOLD) return '中頻度';
+    return '低頻度';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -35,6 +35,8 @@ export class MathHelper {
   private static readonly KURTOSIS_THRESHOLD = 1;
   private static readonly CV_STABLE_THRESHOLD = 20;
   private static readonly CV_MODERATE_THRESHOLD = 50;
+  private static readonly WMEDIAN_HIGH_THRESHOLD = 70;
+  private static readonly WMEDIAN_MEDIUM_THRESHOLD = 40;
 
   /**
    * パーセントを算出(0-100%)
@@ -649,5 +651,32 @@ export class MathHelper {
     if (cv < MathHelper.CV_STABLE_THRESHOLD) return '安定';
     if (cv < MathHelper.CV_MODERATE_THRESHOLD) return 'やや変動';
     return '変動大';
+  }
+
+  /**
+   * 加重中央値を算出する
+   * 値と重みの配列長が異なる場合は0を返す
+   */
+  static getWeightedMedian(values: number[], weights: number[]): number {
+    if (values.length === 0 || values.length !== weights.length) return 0;
+    const pairs = values.map((v, i) => ({ value: v, weight: weights[i] }));
+    pairs.sort((a, b) => a.value - b.value);
+    const totalWeight = pairs.reduce((sum, p) => sum + p.weight, 0);
+    if (totalWeight === 0) return 0;
+    let cumWeight = 0;
+    for (const pair of pairs) {
+      cumWeight += pair.weight;
+      if (cumWeight >= totalWeight / 2) return pair.value;
+    }
+    return pairs[pairs.length - 1].value;
+  }
+
+  /**
+   * 加重中央値に応じたラベルを返す
+   */
+  static getWeightedMedianLabel(value: number): string {
+    if (value >= MathHelper.WMEDIAN_HIGH_THRESHOLD) return '高い';
+    if (value >= MathHelper.WMEDIAN_MEDIUM_THRESHOLD) return '中程度';
+    return '低い';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -56,6 +56,8 @@ export class MedicationRecordEntity {
   private static readonly DOSE_VARIABILITY_MAX_STDDEV = 120;
   private static readonly DOSE_VARIABILITY_STABLE_THRESHOLD = 20;
   private static readonly DOSE_VARIABILITY_MODERATE_THRESHOLD = 50;
+  private static readonly DOSE_CONSECUTIVE_EXCELLENT_THRESHOLD = 80;
+  private static readonly DOSE_CONSECUTIVE_GOOD_THRESHOLD = 50;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -843,5 +845,24 @@ export class MedicationRecordEntity {
     if (score < MedicationRecordEntity.DOSE_VARIABILITY_STABLE_THRESHOLD) return '安定';
     if (score < MedicationRecordEntity.DOSE_VARIABILITY_MODERATE_THRESHOLD) return 'やや不安定';
     return '不安定';
+  }
+
+  /**
+   * 服用達成フラグ配列から連続服用スコア(0-100)を算出する
+   * 達成日数/全日数の割合
+   */
+  static getDoseConsecutiveScore(dailyResults: boolean[]): number {
+    if (dailyResults.length === 0) return 0;
+    const achieved = dailyResults.filter(Boolean).length;
+    return Math.round((achieved / dailyResults.length) * 100);
+  }
+
+  /**
+   * 連続服用スコアに応じたラベルを返す
+   */
+  static getDoseConsecutiveScoreLabel(score: number): string {
+    if (score >= MedicationRecordEntity.DOSE_CONSECUTIVE_EXCELLENT_THRESHOLD) return '優秀';
+    if (score >= MedicationRecordEntity.DOSE_CONSECUTIVE_GOOD_THRESHOLD) return '良好';
+    return '要改善';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getWeightedMedian / getWeightedMedianLabel（加重中央値の算出）
- CalendarEntity: getRecordFrequencyScore / getRecordFrequencyScoreLabel（記録日数の頻度スコア）
- MedicationRecordEntity: getDoseConsecutiveScore / getDoseConsecutiveScoreLabel（服用達成率スコア）
- テスト31件追加（合計5921件）

## Test plan
- [x] WeightedMedian: 10テスト
- [x] RecordFrequencyScore: 10テスト
- [x] DoseConsecutiveScore: 11テスト
- [x] 全5921テスト通過

closes #878