### PR TITLE
test: 加重中央値・記録頻度・連続服用のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/DoseConsecutiveScore.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseConsecutiveScore.edge.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseConsecutiveScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([])).toBe(0);
+  });
+
+  it('1件trueは100', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true])).toBe(100);
+  });
+
+  it('1件falseは0', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([false])).toBe(0);
+  });
+
+  it('全trueは100', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true, true, true, true, true])).toBe(100);
+  });
+
+  it('全falseは0', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([false, false, false, false])).toBe(0);
+  });
+
+  it('3件中1件trueは33', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true, false, false])).toBe(33);
+  });
+
+  it('3件中2件trueは67', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true, true, false])).toBe(67);
+  });
+
+  it('交互パターンは50', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true, false, true, false])).toBe(50);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationRecordEntity.getDoseConsecutiveScore([true, false, true, true, false]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i % 2 === 0);
+    const result = MedicationRecordEntity.getDoseConsecutiveScore(data);
+    expect(result).toBe(50);
+  });
+
+  it('先頭のみtrue', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true, false, false, false, false])).toBe(20);
+  });
+
+  it('末尾のみtrue', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([false, false, false, false, true])).toBe(20);
+  });
+
+  it('2件のtrue-false', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScore([true, false])).toBe(50);
+  });
+
+  it('10件中9件trueは90', () => {
+    const data = Array.from({ length: 10 }, (_, i) => i < 9);
+    expect(MedicationRecordEntity.getDoseConsecutiveScore(data)).toBe(90);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseConsecutiveScoreLabel - 境界値', () => {
+  it('スコア80は優秀(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(80)).toBe('優秀');
+  });
+
+  it('スコア79は良好', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(79)).toBe('良好');
+  });
+
+  it('スコア50は良好(境界値)', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(50)).toBe('良好');
+  });
+
+  it('スコア49は要改善', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(49)).toBe('要改善');
+  });
+
+  it('スコア0は要改善', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(0)).toBe('要改善');
+  });
+
+  it('スコア100は優秀', () => {
+    expect(MedicationRecordEntity.getDoseConsecutiveScoreLabel(100)).toBe('優秀');
+  });
+});

--- a/src/__tests__/domain/entities/RecordFrequencyScore.edge.test.ts
+++ b/src/__tests__/domain/entities/RecordFrequencyScore.edge.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getRecordFrequencyScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([])).toBe(0);
+  });
+
+  it('1件の0は0', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([0])).toBe(0);
+  });
+
+  it('1件の正値は100', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([5])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([0, 0, 0, 0])).toBe(0);
+  });
+
+  it('全て正値は100', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([1, 2, 3, 4])).toBe(100);
+  });
+
+  it('3件中1件記録ありは33', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([0, 1, 0])).toBe(33);
+  });
+
+  it('3件中2件記録ありは67', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([1, 0, 1])).toBe(67);
+  });
+
+  it('結果は0-100', () => {
+    const result = CalendarEntity.getRecordFrequencyScore([0, 1, 0, 2, 0]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => (i % 3 === 0 ? 1 : 0));
+    const result = CalendarEntity.getRecordFrequencyScore(data);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('記録件数に関わらず日数ベース', () => {
+    const a = CalendarEntity.getRecordFrequencyScore([1, 0, 1]);
+    const b = CalendarEntity.getRecordFrequencyScore([100, 0, 100]);
+    expect(a).toBe(b);
+  });
+
+  it('交互パターン', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([1, 0, 1, 0])).toBe(50);
+  });
+
+  it('先頭のみ記録あり', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([1, 0, 0, 0, 0])).toBe(20);
+  });
+
+  it('末尾のみ記録あり', () => {
+    expect(CalendarEntity.getRecordFrequencyScore([0, 0, 0, 0, 1])).toBe(20);
+  });
+});
+
+describe('CalendarEntity.getRecordFrequencyScoreLabel - 境界値', () => {
+  it('スコア80は高頻度(境界値)', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(80)).toBe('高頻度');
+  });
+
+  it('スコア79は中頻度', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(79)).toBe('中頻度');
+  });
+
+  it('スコア50は中頻度(境界値)', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(50)).toBe('中頻度');
+  });
+
+  it('スコア49は低頻度', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(49)).toBe('低頻度');
+  });
+
+  it('スコア0は低頻度', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(0)).toBe('低頻度');
+  });
+
+  it('スコア100は高頻度', () => {
+    expect(CalendarEntity.getRecordFrequencyScoreLabel(100)).toBe('高頻度');
+  });
+});

--- a/src/__tests__/domain/entities/WeightedMedian.edge.test.ts
+++ b/src/__tests__/domain/entities/WeightedMedian.edge.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getWeightedMedian - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getWeightedMedian([], [])).toBe(0);
+  });
+
+  it('1件はその値', () => {
+    expect(MathHelper.getWeightedMedian([42], [1])).toBe(42);
+  });
+
+  it('長さ不一致は0', () => {
+    expect(MathHelper.getWeightedMedian([10, 20], [1])).toBe(0);
+    expect(MathHelper.getWeightedMedian([10], [1, 2])).toBe(0);
+  });
+
+  it('全て重み0は0', () => {
+    expect(MathHelper.getWeightedMedian([10, 20, 30], [0, 0, 0])).toBe(0);
+  });
+
+  it('2件の均等重み', () => {
+    const result = MathHelper.getWeightedMedian([10, 90], [1, 1]);
+    expect(result).toBe(10);
+  });
+
+  it('重みが偏ると結果も偏る', () => {
+    const heavyFirst = MathHelper.getWeightedMedian([10, 90], [100, 1]);
+    const heavySecond = MathHelper.getWeightedMedian([10, 90], [1, 100]);
+    expect(heavyFirst).toBe(10);
+    expect(heavySecond).toBe(90);
+  });
+
+  it('全て同値は同値', () => {
+    expect(MathHelper.getWeightedMedian([50, 50, 50], [1, 5, 10])).toBe(50);
+  });
+
+  it('ソートされていないデータ', () => {
+    const result = MathHelper.getWeightedMedian([30, 10, 20], [1, 1, 1]);
+    expect(result).toBe(20);
+  });
+
+  it('負の値', () => {
+    const result = MathHelper.getWeightedMedian([-10, 0, 10], [1, 1, 1]);
+    expect(result).toBe(0);
+  });
+
+  it('大量データでも正常', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i);
+    const weights = Array.from({ length: 100 }, () => 1);
+    const result = MathHelper.getWeightedMedian(values, weights);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(99);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getWeightedMedian([0.1, 0.5, 0.9], [1, 1, 1]);
+    expect(result).toBe(0.5);
+  });
+
+  it('3件で最後の値が重い', () => {
+    const result = MathHelper.getWeightedMedian([10, 50, 90], [1, 1, 10]);
+    expect(result).toBe(90);
+  });
+
+  it('重み1件のみ有効', () => {
+    const result = MathHelper.getWeightedMedian([10, 50, 90], [0, 0, 1]);
+    expect(result).toBe(90);
+  });
+});
+
+describe('MathHelper.getWeightedMedianLabel - 境界値', () => {
+  it('値0は低い', () => {
+    expect(MathHelper.getWeightedMedianLabel(0)).toBe('低い');
+  });
+
+  it('値39は低い', () => {
+    expect(MathHelper.getWeightedMedianLabel(39)).toBe('低い');
+  });
+
+  it('値40は中程度(境界値)', () => {
+    expect(MathHelper.getWeightedMedianLabel(40)).toBe('中程度');
+  });
+
+  it('値69は中程度', () => {
+    expect(MathHelper.getWeightedMedianLabel(69)).toBe('中程度');
+  });
+
+  it('値70は高い(境界値)', () => {
+    expect(MathHelper.getWeightedMedianLabel(70)).toBe('高い');
+  });
+
+  it('値100は高い', () => {
+    expect(MathHelper.getWeightedMedianLabel(100)).toBe('高い');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getWeightedMedian / getWeightedMedianLabel の境界値・エッジケーステスト19件
- CalendarEntity.getRecordFrequencyScore / getRecordFrequencyScoreLabel の境界値・エッジケーステスト19件
- MedicationRecordEntity.getDoseConsecutiveScore / getDoseConsecutiveScoreLabel の境界値・エッジケーステスト20件
- 合計58テスト追加（全5979テスト通過）

## Test plan
- [x] WeightedMedian.edge: 19テスト通過
- [x] RecordFrequencyScore.edge: 19テスト通過
- [x] DoseConsecutiveScore.edge: 20テスト通過
- [x] 全5979テスト通過

closes #880