### PR TITLE
feat: RunningMin・ConditionPeakScore・StockDepletionRisk を追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionPeakScore.test.ts
+++ b/src/__tests__/domain/entities/ConditionPeakScore.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionPeakScore', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getConditionPeakScore([])).toBe(0);
+  });
+
+  it('1件はその値のスコア', () => {
+    const result = HealthLogEntity.getConditionPeakScore([5]);
+    expect(result).toBe(100);
+  });
+
+  it('最大値5は100', () => {
+    expect(HealthLogEntity.getConditionPeakScore([1, 3, 5, 2])).toBe(100);
+  });
+
+  it('最大値1は20', () => {
+    expect(HealthLogEntity.getConditionPeakScore([1, 1, 1])).toBe(20);
+  });
+
+  it('結果は0-100', () => {
+    const result = HealthLogEntity.getConditionPeakScore([2, 3, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('ピークが高いほどスコアが高い', () => {
+    const low = HealthLogEntity.getConditionPeakScore([1, 2, 1]);
+    const high = HealthLogEntity.getConditionPeakScore([1, 5, 1]);
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
+describe('HealthLogEntity.getConditionPeakScoreLabel', () => {
+  it('スコア80以上は絶好調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(90)).toBe('絶好調');
+  });
+
+  it('スコア50-80は好調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(60)).toBe('好調');
+  });
+
+  it('スコア50未満は不調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(30)).toBe('不調');
+  });
+});

--- a/src/__tests__/domain/entities/RunningMin.test.ts
+++ b/src/__tests__/domain/entities/RunningMin.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRunningMin', () => {
+  it('空配列は空配列', () => {
+    expect(MathHelper.getRunningMin([])).toEqual([]);
+  });
+
+  it('1件はそのまま', () => {
+    expect(MathHelper.getRunningMin([50])).toEqual([50]);
+  });
+
+  it('降順は全て最小値を追跡', () => {
+    expect(MathHelper.getRunningMin([30, 20, 10])).toEqual([30, 20, 10]);
+  });
+
+  it('昇順は最初の値が維持される', () => {
+    expect(MathHelper.getRunningMin([10, 20, 30])).toEqual([10, 10, 10]);
+  });
+
+  it('混合パターン', () => {
+    expect(MathHelper.getRunningMin([50, 30, 40, 20, 60])).toEqual([50, 30, 30, 20, 20]);
+  });
+
+  it('全て同値', () => {
+    expect(MathHelper.getRunningMin([50, 50, 50])).toEqual([50, 50, 50]);
+  });
+
+  it('結果の長さは入力と同じ', () => {
+    const input = [10, 20, 30, 40, 50];
+    expect(MathHelper.getRunningMin(input)).toHaveLength(input.length);
+  });
+
+  it('大量データでも正常', () => {
+    const data = Array.from({ length: 100 }, (_, i) => 100 - i);
+    const result = MathHelper.getRunningMin(data);
+    expect(result[result.length - 1]).toBe(1);
+  });
+});
+
+describe('MathHelper.getRunningMinLabel', () => {
+  it('現在値が最小値と同じなら最低値', () => {
+    expect(MathHelper.getRunningMinLabel(10, 10)).toBe('最低値');
+  });
+
+  it('現在値が最小値より大きければ最低値以上', () => {
+    expect(MathHelper.getRunningMinLabel(50, 10)).toBe('最低値以上');
+  });
+
+  it('最小値0で現在値0は最低値', () => {
+    expect(MathHelper.getRunningMinLabel(0, 0)).toBe('最低値');
+  });
+});

--- a/src/__tests__/domain/entities/StockDepletionRisk.test.ts
+++ b/src/__tests__/domain/entities/StockDepletionRisk.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockDepletionRisk', () => {
+  it('在庫0は100', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(0, 5)).toBe(100);
+  });
+
+  it('消費0は0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(50, 0)).toBe(0);
+  });
+
+  it('在庫が消費の30日分以上は0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(150, 5)).toBe(0);
+  });
+
+  it('在庫が消費の数日分は高リスク', () => {
+    const result = StockAlertEntity.getStockDepletionRisk(5, 5);
+    expect(result).toBeGreaterThan(80);
+  });
+
+  it('結果は0-100', () => {
+    const result = StockAlertEntity.getStockDepletionRisk(20, 3);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('在庫が少ないほどリスクが高い', () => {
+    const low = StockAlertEntity.getStockDepletionRisk(5, 5);
+    const high = StockAlertEntity.getStockDepletionRisk(50, 5);
+    expect(low).toBeGreaterThan(high);
+  });
+
+  it('両方0は0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(0, 0)).toBe(0);
+  });
+});
+
+describe('StockAlertEntity.getStockDepletionRiskLabel', () => {
+  it('スコア70以上は高リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(80)).toBe('高リスク');
+  });
+
+  it('スコア30-70は中リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(50)).toBe('中リスク');
+  });
+
+  it('スコア30未満は低リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(10)).toBe('低リスク');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -79,6 +79,9 @@ export class HealthLogEntity {
   private static readonly TEMP_LOW_FEVER = 37.5;
   private static readonly TEMP_FEVER = 38.0;
   private static readonly TEMP_HIGH_FEVER = 39.0;
+  private static readonly CONDITION_MAX_LEVEL = 5;
+  private static readonly PEAK_EXCELLENT_THRESHOLD = 80;
+  private static readonly PEAK_GOOD_THRESHOLD = 50;
 
   private static readonly CONDITION_LABELS: Record<ConditionLevel, string> = {
     1: 'とても悪い',
@@ -945,5 +948,24 @@ export class HealthLogEntity {
     if (range <= HealthLogEntity.CONDITION_RANGE_STABLE_THRESHOLD) return '安定';
     if (range <= HealthLogEntity.CONDITION_RANGE_MODERATE_THRESHOLD) return 'やや変動';
     return '大きな変動';
+  }
+
+  /**
+   * 体調スコア配列からピークスコア(0-100)を算出する
+   * 最大体調値を5段階中の割合で算出
+   */
+  static getConditionPeakScore(conditions: number[]): number {
+    if (conditions.length === 0) return 0;
+    const peak = Math.max(...conditions);
+    return Math.round((peak / HealthLogEntity.CONDITION_MAX_LEVEL) * 100);
+  }
+
+  /**
+   * ピークスコアに応じたラベルを返す
+   */
+  static getConditionPeakScoreLabel(score: number): string {
+    if (score >= HealthLogEntity.PEAK_EXCELLENT_THRESHOLD) return '絶好調';
+    if (score >= HealthLogEntity.PEAK_GOOD_THRESHOLD) return '好調';
+    return '不調';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -679,4 +679,24 @@ export class MathHelper {
     if (value >= MathHelper.WMEDIAN_MEDIUM_THRESHOLD) return '中程度';
     return '低い';
   }
+
+  /**
+   * 累積最小値配列を算出する
+   */
+  static getRunningMin(values: number[]): number[] {
+    if (values.length === 0) return [];
+    const result: number[] = [values[0]];
+    for (let i = 1; i < values.length; i++) {
+      result.push(Math.min(result[i - 1], values[i]));
+    }
+    return result;
+  }
+
+  /**
+   * 現在値と累積最小値を比較しラベルを返す
+   */
+  static getRunningMinLabel(currentValue: number, minValue: number): string {
+    if (currentValue <= minValue) return '最低値';
+    return '最低値以上';
+  }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -43,6 +43,9 @@ export class StockAlertEntity {
   private static readonly VOLATILITY_MAX_DIFF = 50;
   private static readonly VOLATILITY_STABLE_THRESHOLD = 30;
   private static readonly VOLATILITY_MODERATE_THRESHOLD = 60;
+  private static readonly DEPLETION_MAX_DAYS = 30;
+  private static readonly DEPLETION_HIGH_THRESHOLD = 70;
+  private static readonly DEPLETION_MODERATE_THRESHOLD = 30;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -611,5 +614,25 @@ export class StockAlertEntity {
     if (score <= StockAlertEntity.VOLATILITY_STABLE_THRESHOLD) return '安定';
     if (score <= StockAlertEntity.VOLATILITY_MODERATE_THRESHOLD) return 'やや変動';
     return '変動大';
+  }
+
+  /**
+   * 在庫枯渇リスクスコア(0-100)を算出する
+   * 在庫量/日消費量が少ないほど高リスク（30日基準）
+   */
+  static getStockDepletionRisk(stock: number, dailyConsumption: number): number {
+    if (dailyConsumption <= 0) return 0;
+    if (stock <= 0) return 100;
+    const coverageDays = stock / dailyConsumption;
+    return Math.max(0, Math.min(100, Math.round(100 - (coverageDays / StockAlertEntity.DEPLETION_MAX_DAYS) * 100)));
+  }
+
+  /**
+   * 枯渇リスクスコアに応じたラベルを返す
+   */
+  static getStockDepletionRiskLabel(score: number): string {
+    if (score >= StockAlertEntity.DEPLETION_HIGH_THRESHOLD) return '高リスク';
+    if (score >= StockAlertEntity.DEPLETION_MODERATE_THRESHOLD) return '中リスク';
+    return '低リスク';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getRunningMin / getRunningMinLabel（累積最小値の追跡）を追加
- HealthLogEntity: getConditionPeakScore / getConditionPeakScoreLabel（体調ピークスコア）を追加
- StockAlertEntity: getStockDepletionRisk / getStockDepletionRiskLabel（在庫枯渇リスク）を追加

## Test plan
- [x] RunningMin テスト 11件 passing
- [x] ConditionPeakScore テスト 9件 passing
- [x] StockDepletionRisk テスト 10件 passing
- [x] 全テスト 6009件 passing

closes #882