### PR TITLE
test: RunningMin・ConditionPeakScore・StockDepletionRisk エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionPeakScore.edge.test.ts
+++ b/src/__tests__/domain/entities/ConditionPeakScore.edge.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionPeakScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getConditionPeakScore([])).toBe(0);
+  });
+
+  it('1件のみ', () => {
+    expect(HealthLogEntity.getConditionPeakScore([3])).toBe(60);
+  });
+
+  it('最低値1のみ', () => {
+    expect(HealthLogEntity.getConditionPeakScore([1])).toBe(20);
+  });
+
+  it('最高値5のみ', () => {
+    expect(HealthLogEntity.getConditionPeakScore([5])).toBe(100);
+  });
+
+  it('全て同じ値3', () => {
+    expect(HealthLogEntity.getConditionPeakScore([3, 3, 3])).toBe(60);
+  });
+
+  it('全て最低値1', () => {
+    expect(HealthLogEntity.getConditionPeakScore([1, 1, 1])).toBe(20);
+  });
+
+  it('全て最高値5', () => {
+    expect(HealthLogEntity.getConditionPeakScore([5, 5, 5])).toBe(100);
+  });
+
+  it('混合値で最大値を使う', () => {
+    expect(HealthLogEntity.getConditionPeakScore([1, 2, 4, 2, 1])).toBe(80);
+  });
+
+  it('ピークが最後にある', () => {
+    expect(HealthLogEntity.getConditionPeakScore([1, 2, 3, 4, 5])).toBe(100);
+  });
+
+  it('ピークが最初にある', () => {
+    expect(HealthLogEntity.getConditionPeakScore([5, 4, 3, 2, 1])).toBe(100);
+  });
+
+  it('レベル2のピーク', () => {
+    expect(HealthLogEntity.getConditionPeakScore([1, 2, 1])).toBe(40);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HealthLogEntity.getConditionPeakScore([2, 3, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2件の配列', () => {
+    expect(HealthLogEntity.getConditionPeakScore([2, 4])).toBe(80);
+  });
+
+  it('大量データ', () => {
+    const data = Array(100).fill(3);
+    data[50] = 5;
+    expect(HealthLogEntity.getConditionPeakScore(data)).toBe(100);
+  });
+});
+
+describe('HealthLogEntity.getConditionPeakScoreLabel - エッジケース', () => {
+  it('スコア100は絶好調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(100)).toBe('絶好調');
+  });
+
+  it('スコア80は絶好調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(80)).toBe('絶好調');
+  });
+
+  it('スコア79は好調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(79)).toBe('好調');
+  });
+
+  it('スコア50は好調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(50)).toBe('好調');
+  });
+
+  it('スコア49は不調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(49)).toBe('不調');
+  });
+
+  it('スコア0は不調', () => {
+    expect(HealthLogEntity.getConditionPeakScoreLabel(0)).toBe('不調');
+  });
+});

--- a/src/__tests__/domain/entities/RunningMin.edge.test.ts
+++ b/src/__tests__/domain/entities/RunningMin.edge.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRunningMin - エッジケース', () => {
+  it('空配列は空配列', () => {
+    expect(MathHelper.getRunningMin([])).toEqual([]);
+  });
+
+  it('1件は同値配列', () => {
+    expect(MathHelper.getRunningMin([42])).toEqual([42]);
+  });
+
+  it('全て同じ値は同値配列', () => {
+    expect(MathHelper.getRunningMin([5, 5, 5, 5])).toEqual([5, 5, 5, 5]);
+  });
+
+  it('昇順は最初の値で固定', () => {
+    expect(MathHelper.getRunningMin([1, 2, 3, 4, 5])).toEqual([1, 1, 1, 1, 1]);
+  });
+
+  it('降順は各値が最小', () => {
+    expect(MathHelper.getRunningMin([5, 4, 3, 2, 1])).toEqual([5, 4, 3, 2, 1]);
+  });
+
+  it('負の値を含む場合', () => {
+    expect(MathHelper.getRunningMin([3, -1, 5, -3, 2])).toEqual([3, -1, -1, -3, -3]);
+  });
+
+  it('0を含む場合', () => {
+    expect(MathHelper.getRunningMin([3, 0, 5, 0, 2])).toEqual([3, 0, 0, 0, 0]);
+  });
+
+  it('大きな値の配列', () => {
+    expect(MathHelper.getRunningMin([1000000, 500000, 750000])).toEqual([1000000, 500000, 500000]);
+  });
+
+  it('小数値', () => {
+    expect(MathHelper.getRunningMin([1.5, 0.5, 2.5])).toEqual([1.5, 0.5, 0.5]);
+  });
+
+  it('2件で前が小さい', () => {
+    expect(MathHelper.getRunningMin([1, 10])).toEqual([1, 1]);
+  });
+
+  it('2件で後が小さい', () => {
+    expect(MathHelper.getRunningMin([10, 1])).toEqual([10, 1]);
+  });
+
+  it('最後に最小値が来る場合', () => {
+    expect(MathHelper.getRunningMin([10, 8, 6, 4, 2, 0])).toEqual([10, 8, 6, 4, 2, 0]);
+  });
+
+  it('V字パターン', () => {
+    expect(MathHelper.getRunningMin([5, 3, 1, 3, 5])).toEqual([5, 3, 1, 1, 1]);
+  });
+
+  it('最小値が途中にある場合', () => {
+    expect(MathHelper.getRunningMin([10, 5, 1, 5, 10])).toEqual([10, 5, 1, 1, 1]);
+  });
+});
+
+describe('MathHelper.getRunningMinLabel - エッジケース', () => {
+  it('同値は最低値', () => {
+    expect(MathHelper.getRunningMinLabel(5, 5)).toBe('最低値');
+  });
+
+  it('現在値が最低値より小さい場合は最低値', () => {
+    expect(MathHelper.getRunningMinLabel(3, 5)).toBe('最低値');
+  });
+
+  it('現在値が最低値より大きい場合は最低値以上', () => {
+    expect(MathHelper.getRunningMinLabel(10, 5)).toBe('最低値以上');
+  });
+
+  it('0同士は最低値', () => {
+    expect(MathHelper.getRunningMinLabel(0, 0)).toBe('最低値');
+  });
+
+  it('負の値で最低値', () => {
+    expect(MathHelper.getRunningMinLabel(-5, -3)).toBe('最低値');
+  });
+
+  it('負の値で最低値以上', () => {
+    expect(MathHelper.getRunningMinLabel(-1, -5)).toBe('最低値以上');
+  });
+});

--- a/src/__tests__/domain/entities/StockDepletionRisk.edge.test.ts
+++ b/src/__tests__/domain/entities/StockDepletionRisk.edge.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockDepletionRisk - エッジケース', () => {
+  it('在庫0・消費0は0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(0, 0)).toBe(0);
+  });
+
+  it('在庫あり・消費0は0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(100, 0)).toBe(0);
+  });
+
+  it('在庫0・消費ありは100', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(0, 5)).toBe(100);
+  });
+
+  it('30日分ちょうどは0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(150, 5)).toBe(0);
+  });
+
+  it('30日分以上は0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(300, 5)).toBe(0);
+  });
+
+  it('15日分は50', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(75, 5)).toBe(50);
+  });
+
+  it('1日分は高リスク', () => {
+    const result = StockAlertEntity.getStockDepletionRisk(5, 5);
+    expect(result).toBeGreaterThanOrEqual(90);
+  });
+
+  it('消費量が非常に小さい場合', () => {
+    const result = StockAlertEntity.getStockDepletionRisk(10, 0.1);
+    expect(result).toBe(0);
+  });
+
+  it('消費量が非常に大きい場合', () => {
+    const result = StockAlertEntity.getStockDepletionRisk(10, 100);
+    expect(result).toBeGreaterThanOrEqual(90);
+  });
+
+  it('在庫が少ないほどリスクが高い', () => {
+    const low = StockAlertEntity.getStockDepletionRisk(10, 5);
+    const high = StockAlertEntity.getStockDepletionRisk(100, 5);
+    expect(low).toBeGreaterThan(high);
+  });
+
+  it('消費が多いほどリスクが高い', () => {
+    const fast = StockAlertEntity.getStockDepletionRisk(50, 10);
+    const slow = StockAlertEntity.getStockDepletionRisk(50, 1);
+    expect(fast).toBeGreaterThan(slow);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = StockAlertEntity.getStockDepletionRisk(20, 3);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('負の消費量は0', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(50, -5)).toBe(0);
+  });
+
+  it('負の在庫は100', () => {
+    expect(StockAlertEntity.getStockDepletionRisk(-10, 5)).toBe(100);
+  });
+});
+
+describe('StockAlertEntity.getStockDepletionRiskLabel - エッジケース', () => {
+  it('スコア100は高リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(100)).toBe('高リスク');
+  });
+
+  it('スコア70は高リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(70)).toBe('高リスク');
+  });
+
+  it('スコア69は中リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(69)).toBe('中リスク');
+  });
+
+  it('スコア30は中リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(30)).toBe('中リスク');
+  });
+
+  it('スコア29は低リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(29)).toBe('低リスク');
+  });
+
+  it('スコア0は低リスク', () => {
+    expect(StockAlertEntity.getStockDepletionRiskLabel(0)).toBe('低リスク');
+  });
+});


### PR DESCRIPTION
## Summary
- RunningMin エッジケーステスト 20件追加
- ConditionPeakScore エッジケーステスト 20件追加
- StockDepletionRisk エッジケーステスト 20件追加

## Test plan
- [x] 60件のエッジケーステスト passing
- [x] 全テスト 6069件 passing

closes #884