### PR TITLE
feat: MeanAbsoluteDeviation・RecordGapScore・DoseCompletionRate を追加

### DIFF
--- a/src/__tests__/domain/entities/DoseCompletionRate.test.ts
+++ b/src/__tests__/domain/entities/DoseCompletionRate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseCompletionRate', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(0, 0)).toBe(0);
+  });
+
+  it('完了0・予定ありは0', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(0, 10)).toBe(0);
+  });
+
+  it('全て完了は100', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(10, 10)).toBe(100);
+  });
+
+  it('半分完了は50', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(5, 10)).toBe(50);
+  });
+
+  it('予定0は100', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(5, 0)).toBe(100);
+  });
+
+  it('完了が予定を超えた場合は100', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(15, 10)).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MedicationRecordEntity.getDoseCompletionRate(3, 7);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('1件中1件完了は100', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(1, 1)).toBe(100);
+  });
+
+  it('完了が多いほど率が高い', () => {
+    const low = MedicationRecordEntity.getDoseCompletionRate(2, 10);
+    const high = MedicationRecordEntity.getDoseCompletionRate(8, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseCompletionRateLabel', () => {
+  it('率90以上は完璧', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(95)).toBe('完璧');
+  });
+
+  it('率70-90は良好', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(75)).toBe('良好');
+  });
+
+  it('率70未満は要改善', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(50)).toBe('要改善');
+  });
+});

--- a/src/__tests__/domain/entities/MeanAbsoluteDeviation.test.ts
+++ b/src/__tests__/domain/entities/MeanAbsoluteDeviation.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMeanAbsoluteDeviation', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([5])).toBe(0);
+  });
+
+  it('同じ値は0', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([3, 3, 3])).toBe(0);
+  });
+
+  it('対称データ', () => {
+    // [1, 5] -> avg=3, |1-3|+|5-3| = 2+2 = 4, 4/2 = 2
+    expect(MathHelper.getMeanAbsoluteDeviation([1, 5])).toBe(2);
+  });
+
+  it('複数データ', () => {
+    // [2, 4, 6, 8] -> avg=5, |2-5|+|4-5|+|6-5|+|8-5| = 3+1+1+3 = 8, 8/4 = 2
+    expect(MathHelper.getMeanAbsoluteDeviation([2, 4, 6, 8])).toBe(2);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getMeanAbsoluteDeviation([10, 20, 30]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('ばらつきが大きいほど値が大きい', () => {
+    const small = MathHelper.getMeanAbsoluteDeviation([9, 10, 11]);
+    const large = MathHelper.getMeanAbsoluteDeviation([1, 10, 19]);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('負の値を含む', () => {
+    // [-5, 5] -> avg=0, |-5|+|5| = 10, 10/2 = 5
+    expect(MathHelper.getMeanAbsoluteDeviation([-5, 5])).toBe(5);
+  });
+
+  it('小数結果', () => {
+    const result = MathHelper.getMeanAbsoluteDeviation([1, 2, 3]);
+    expect(typeof result).toBe('number');
+  });
+});
+
+describe('MathHelper.getMeanAbsoluteDeviationLabel', () => {
+  it('MADが小さいは安定', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(3)).toBe('安定');
+  });
+
+  it('MADが中程度はやや散布', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(8)).toBe('やや散布');
+  });
+
+  it('MADが大きいは散布', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(20)).toBe('散布');
+  });
+});

--- a/src/__tests__/domain/entities/RecordGapScore.test.ts
+++ b/src/__tests__/domain/entities/RecordGapScore.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getRecordGapScore', () => {
+  it('空配列は0', () => {
+    expect(CalendarEntity.getRecordGapScore([])).toBe(0);
+  });
+
+  it('全て記録ありは100', () => {
+    expect(CalendarEntity.getRecordGapScore([1, 2, 3, 1, 2])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(CalendarEntity.getRecordGapScore([0, 0, 0, 0])).toBe(0);
+  });
+
+  it('半分記録ありは50', () => {
+    expect(CalendarEntity.getRecordGapScore([1, 0, 1, 0])).toBe(50);
+  });
+
+  it('1件のみ記録あり', () => {
+    expect(CalendarEntity.getRecordGapScore([0, 0, 1, 0, 0])).toBe(20);
+  });
+
+  it('1件のみ', () => {
+    expect(CalendarEntity.getRecordGapScore([3])).toBe(100);
+  });
+
+  it('0の1件のみ', () => {
+    expect(CalendarEntity.getRecordGapScore([0])).toBe(0);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = CalendarEntity.getRecordGapScore([1, 0, 2, 0, 3]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('記録が多いほどスコアが高い', () => {
+    const low = CalendarEntity.getRecordGapScore([1, 0, 0, 0, 0]);
+    const high = CalendarEntity.getRecordGapScore([1, 1, 1, 1, 0]);
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
+describe('CalendarEntity.getRecordGapScoreLabel', () => {
+  it('スコア80以上は良好', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(90)).toBe('良好');
+  });
+
+  it('スコア50-80はまずまず', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(60)).toBe('まずまず');
+  });
+
+  it('スコア50未満は空白多い', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(30)).toBe('空白多い');
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -48,6 +48,8 @@ export class CalendarEntity {
   private static readonly RECORD_DENSITY_MEDIUM_THRESHOLD = 50;
   private static readonly RECORD_FREQUENCY_HIGH_THRESHOLD = 80;
   private static readonly RECORD_FREQUENCY_MEDIUM_THRESHOLD = 50;
+  private static readonly RECORD_GAP_SCORE_GOOD_THRESHOLD = 80;
+  private static readonly RECORD_GAP_SCORE_FAIR_THRESHOLD = 50;
 
   /**
    * 指定月のカレンダーデータを生成
@@ -628,5 +630,24 @@ export class CalendarEntity {
     if (score >= CalendarEntity.RECORD_FREQUENCY_HIGH_THRESHOLD) return '高頻度';
     if (score >= CalendarEntity.RECORD_FREQUENCY_MEDIUM_THRESHOLD) return '中頻度';
     return '低頻度';
+  }
+
+  /**
+   * 日別記録件数配列から記録空白スコア(0-100)を算出する
+   * 記録がある日の割合をスコア化
+   */
+  static getRecordGapScore(dailyCounts: number[]): number {
+    if (dailyCounts.length === 0) return 0;
+    const recordDays = dailyCounts.filter((c) => c > 0).length;
+    return Math.round((recordDays / dailyCounts.length) * 100);
+  }
+
+  /**
+   * 記録空白スコアに応じたラベルを返す
+   */
+  static getRecordGapScoreLabel(score: number): string {
+    if (score >= CalendarEntity.RECORD_GAP_SCORE_GOOD_THRESHOLD) return '良好';
+    if (score >= CalendarEntity.RECORD_GAP_SCORE_FAIR_THRESHOLD) return 'まずまず';
+    return '空白多い';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -37,6 +37,8 @@ export class MathHelper {
   private static readonly CV_MODERATE_THRESHOLD = 50;
   private static readonly WMEDIAN_HIGH_THRESHOLD = 70;
   private static readonly WMEDIAN_MEDIUM_THRESHOLD = 40;
+  private static readonly MAD_STABLE_THRESHOLD = 5;
+  private static readonly MAD_MODERATE_THRESHOLD = 15;
 
   /**
    * パーセントを算出(0-100%)
@@ -698,5 +700,24 @@ export class MathHelper {
   static getRunningMinLabel(currentValue: number, minValue: number): string {
     if (currentValue <= minValue) return '最低値';
     return '最低値以上';
+  }
+
+  /**
+   * 平均絶対偏差(MAD)を算出する
+   */
+  static getMeanAbsoluteDeviation(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    const mad = values.reduce((sum, v) => sum + Math.abs(v - avg), 0) / values.length;
+    return Math.round(mad * 100) / 100;
+  }
+
+  /**
+   * 平均絶対偏差に応じたラベルを返す
+   */
+  static getMeanAbsoluteDeviationLabel(mad: number): string {
+    if (mad <= MathHelper.MAD_STABLE_THRESHOLD) return '安定';
+    if (mad <= MathHelper.MAD_MODERATE_THRESHOLD) return 'やや散布';
+    return '散布';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -58,6 +58,8 @@ export class MedicationRecordEntity {
   private static readonly DOSE_VARIABILITY_MODERATE_THRESHOLD = 50;
   private static readonly DOSE_CONSECUTIVE_EXCELLENT_THRESHOLD = 80;
   private static readonly DOSE_CONSECUTIVE_GOOD_THRESHOLD = 50;
+  private static readonly DOSE_COMPLETION_PERFECT_THRESHOLD = 90;
+  private static readonly DOSE_COMPLETION_GOOD_THRESHOLD = 70;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -863,6 +865,24 @@ export class MedicationRecordEntity {
   static getDoseConsecutiveScoreLabel(score: number): string {
     if (score >= MedicationRecordEntity.DOSE_CONSECUTIVE_EXCELLENT_THRESHOLD) return '優秀';
     if (score >= MedicationRecordEntity.DOSE_CONSECUTIVE_GOOD_THRESHOLD) return '良好';
+    return '要改善';
+  }
+
+  /**
+   * 服薬完了率(0-100)を算出する
+   * 完了数/予定数の割合（予定0は100、上限100）
+   */
+  static getDoseCompletionRate(completed: number, scheduled: number): number {
+    if (scheduled <= 0) return completed > 0 ? 100 : 0;
+    return Math.min(100, Math.round((completed / scheduled) * 100));
+  }
+
+  /**
+   * 服薬完了率に応じたラベルを返す
+   */
+  static getDoseCompletionRateLabel(rate: number): string {
+    if (rate >= MedicationRecordEntity.DOSE_COMPLETION_PERFECT_THRESHOLD) return '完璧';
+    if (rate >= MedicationRecordEntity.DOSE_COMPLETION_GOOD_THRESHOLD) return '良好';
     return '要改善';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getMeanAbsoluteDeviation / getMeanAbsoluteDeviationLabel（平均絶対偏差）を追加
- CalendarEntity: getRecordGapScore / getRecordGapScoreLabel（記録空白スコア）を追加
- MedicationRecordEntity: getDoseCompletionRate / getDoseCompletionRateLabel（服薬完了率）を追加

## Test plan
- [x] MeanAbsoluteDeviation テスト 12件 passing
- [x] RecordGapScore テスト 12件 passing
- [x] DoseCompletionRate テスト 12件 passing
- [x] 全テスト 6105件 passing

closes #886