### PR TITLE
test: MeanAbsoluteDeviation・RecordGapScore・DoseCompletionRate エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/DoseCompletionRate.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseCompletionRate.edge.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseCompletionRate - エッジケース', () => {
+  it('両方0は0', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(0, 0)).toBe(0);
+  });
+
+  it('完了0・予定1は0', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(0, 1)).toBe(0);
+  });
+
+  it('完了1・予定1は100', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(1, 1)).toBe(100);
+  });
+
+  it('完了1・予定0は100', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(1, 0)).toBe(100);
+  });
+
+  it('完了が予定を大幅に超えても100', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(100, 10)).toBe(100);
+  });
+
+  it('1/3は33', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(1, 3)).toBe(33);
+  });
+
+  it('2/3は67', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(2, 3)).toBe(67);
+  });
+
+  it('大きな数値', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(500, 1000)).toBe(50);
+  });
+
+  it('完了と予定が同じ', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(50, 50)).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MedicationRecordEntity.getDoseCompletionRate(7, 15);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('完了が多いほど率が高い', () => {
+    const low = MedicationRecordEntity.getDoseCompletionRate(1, 10);
+    const high = MedicationRecordEntity.getDoseCompletionRate(9, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('予定が多いほど率が低い', () => {
+    const low = MedicationRecordEntity.getDoseCompletionRate(5, 100);
+    const high = MedicationRecordEntity.getDoseCompletionRate(5, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('ほぼ100%の場合', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRate(99, 100)).toBe(99);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseCompletionRateLabel - エッジケース', () => {
+  it('率100は完璧', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(100)).toBe('完璧');
+  });
+
+  it('率90は完璧', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(90)).toBe('完璧');
+  });
+
+  it('率89は良好', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(89)).toBe('良好');
+  });
+
+  it('率70は良好', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(70)).toBe('良好');
+  });
+
+  it('率69は要改善', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(69)).toBe('要改善');
+  });
+
+  it('率0は要改善', () => {
+    expect(MedicationRecordEntity.getDoseCompletionRateLabel(0)).toBe('要改善');
+  });
+});

--- a/src/__tests__/domain/entities/MeanAbsoluteDeviation.edge.test.ts
+++ b/src/__tests__/domain/entities/MeanAbsoluteDeviation.edge.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMeanAbsoluteDeviation - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([42])).toBe(0);
+  });
+
+  it('2件の同値は0', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([7, 7])).toBe(0);
+  });
+
+  it('全て同じ値は0', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([5, 5, 5, 5, 5])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    // [0, 10] -> avg=5, |0-5|+|10-5| = 10, 10/2 = 5
+    expect(MathHelper.getMeanAbsoluteDeviation([0, 10])).toBe(5);
+  });
+
+  it('負の値のみ', () => {
+    // [-10, -20] -> avg=-15, |-10-(-15)|+|-20-(-15)| = 5+5 = 10, 10/2 = 5
+    expect(MathHelper.getMeanAbsoluteDeviation([-10, -20])).toBe(5);
+  });
+
+  it('0のみ', () => {
+    expect(MathHelper.getMeanAbsoluteDeviation([0, 0, 0])).toBe(0);
+  });
+
+  it('大きな値', () => {
+    const result = MathHelper.getMeanAbsoluteDeviation([1000000, 2000000]);
+    expect(result).toBe(500000);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getMeanAbsoluteDeviation([1.5, 2.5]);
+    expect(result).toBe(0.5);
+  });
+
+  it('外れ値を含む', () => {
+    const withoutOutlier = MathHelper.getMeanAbsoluteDeviation([10, 11, 12]);
+    const withOutlier = MathHelper.getMeanAbsoluteDeviation([10, 11, 100]);
+    expect(withOutlier).toBeGreaterThan(withoutOutlier);
+  });
+
+  it('大量データ', () => {
+    const data = Array(100).fill(50);
+    expect(MathHelper.getMeanAbsoluteDeviation(data)).toBe(0);
+  });
+
+  it('昇順データ', () => {
+    // [1,2,3,4,5] -> avg=3, |1-3|+|2-3|+|3-3|+|4-3|+|5-3| = 2+1+0+1+2 = 6, 6/5 = 1.2
+    expect(MathHelper.getMeanAbsoluteDeviation([1, 2, 3, 4, 5])).toBe(1.2);
+  });
+
+  it('結果は常に0以上', () => {
+    const result = MathHelper.getMeanAbsoluteDeviation([-100, 100, -50, 50]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('MathHelper.getMeanAbsoluteDeviationLabel - エッジケース', () => {
+  it('0は安定', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(0)).toBe('安定');
+  });
+
+  it('5は安定', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(5)).toBe('安定');
+  });
+
+  it('5.01はやや散布', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(5.01)).toBe('やや散布');
+  });
+
+  it('15はやや散布', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(15)).toBe('やや散布');
+  });
+
+  it('15.01は散布', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(15.01)).toBe('散布');
+  });
+
+  it('100は散布', () => {
+    expect(MathHelper.getMeanAbsoluteDeviationLabel(100)).toBe('散布');
+  });
+});

--- a/src/__tests__/domain/entities/RecordGapScore.edge.test.ts
+++ b/src/__tests__/domain/entities/RecordGapScore.edge.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getRecordGapScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(CalendarEntity.getRecordGapScore([])).toBe(0);
+  });
+
+  it('1件で0は0', () => {
+    expect(CalendarEntity.getRecordGapScore([0])).toBe(0);
+  });
+
+  it('1件で正値は100', () => {
+    expect(CalendarEntity.getRecordGapScore([5])).toBe(100);
+  });
+
+  it('全て記録ありは100', () => {
+    expect(CalendarEntity.getRecordGapScore([1, 1, 1, 1, 1, 1, 1])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(CalendarEntity.getRecordGapScore([0, 0, 0, 0, 0])).toBe(0);
+  });
+
+  it('最初だけ記録あり', () => {
+    expect(CalendarEntity.getRecordGapScore([1, 0, 0, 0, 0])).toBe(20);
+  });
+
+  it('最後だけ記録あり', () => {
+    expect(CalendarEntity.getRecordGapScore([0, 0, 0, 0, 1])).toBe(20);
+  });
+
+  it('交互パターン', () => {
+    expect(CalendarEntity.getRecordGapScore([1, 0, 1, 0, 1, 0])).toBe(50);
+  });
+
+  it('大きな記録数も1日として扱う', () => {
+    expect(CalendarEntity.getRecordGapScore([10, 0, 20])).toBe(67);
+  });
+
+  it('2件で片方0', () => {
+    expect(CalendarEntity.getRecordGapScore([1, 0])).toBe(50);
+  });
+
+  it('2件で両方あり', () => {
+    expect(CalendarEntity.getRecordGapScore([1, 1])).toBe(100);
+  });
+
+  it('大量データ', () => {
+    const data = Array(100).fill(1);
+    data[50] = 0;
+    expect(CalendarEntity.getRecordGapScore(data)).toBe(99);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = CalendarEntity.getRecordGapScore([3, 0, 1, 0, 2, 0, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('CalendarEntity.getRecordGapScoreLabel - エッジケース', () => {
+  it('スコア100は良好', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(100)).toBe('良好');
+  });
+
+  it('スコア80は良好', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(80)).toBe('良好');
+  });
+
+  it('スコア79はまずまず', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(79)).toBe('まずまず');
+  });
+
+  it('スコア50はまずまず', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(50)).toBe('まずまず');
+  });
+
+  it('スコア49は空白多い', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(49)).toBe('空白多い');
+  });
+
+  it('スコア0は空白多い', () => {
+    expect(CalendarEntity.getRecordGapScoreLabel(0)).toBe('空白多い');
+  });
+});


### PR DESCRIPTION
## Summary
- MeanAbsoluteDeviation エッジケーステスト 19件追加
- RecordGapScore エッジケーステスト 19件追加
- DoseCompletionRate エッジケーステスト 19件追加

## Test plan
- [x] 57件のエッジケーステスト passing
- [x] 全テスト 6162件 passing

closes #888