### PR TITLE
feat: RootMeanSquare・ConditionImprovementScore・StockSafetyMargin を追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionImprovementScore.test.ts
+++ b/src/__tests__/domain/entities/ConditionImprovementScore.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionImprovementScore', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getConditionImprovementScore([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(HealthLogEntity.getConditionImprovementScore([3])).toBe(0);
+  });
+
+  it('改善（1→5）は100', () => {
+    expect(HealthLogEntity.getConditionImprovementScore([1, 5])).toBe(100);
+  });
+
+  it('悪化（5→1）は0', () => {
+    expect(HealthLogEntity.getConditionImprovementScore([5, 1])).toBe(0);
+  });
+
+  it('変化なしは50', () => {
+    expect(HealthLogEntity.getConditionImprovementScore([3, 3])).toBe(50);
+  });
+
+  it('やや改善', () => {
+    const result = HealthLogEntity.getConditionImprovementScore([2, 3, 4]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('やや悪化', () => {
+    const result = HealthLogEntity.getConditionImprovementScore([4, 3, 2]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HealthLogEntity.getConditionImprovementScore([3, 2, 4, 1, 5]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('全て同じ値は50', () => {
+    expect(HealthLogEntity.getConditionImprovementScore([3, 3, 3, 3])).toBe(50);
+  });
+});
+
+describe('HealthLogEntity.getConditionImprovementScoreLabel', () => {
+  it('スコア70以上は改善', () => {
+    expect(HealthLogEntity.getConditionImprovementScoreLabel(80)).toBe('改善');
+  });
+
+  it('スコア30-70は横ばい', () => {
+    expect(HealthLogEntity.getConditionImprovementScoreLabel(50)).toBe('横ばい');
+  });
+
+  it('スコア30未満は悪化', () => {
+    expect(HealthLogEntity.getConditionImprovementScoreLabel(20)).toBe('悪化');
+  });
+});

--- a/src/__tests__/domain/entities/RootMeanSquare.test.ts
+++ b/src/__tests__/domain/entities/RootMeanSquare.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRootMeanSquare', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getRootMeanSquare([])).toBe(0);
+  });
+
+  it('1件はその値の絶対値', () => {
+    expect(MathHelper.getRootMeanSquare([5])).toBe(5);
+  });
+
+  it('全て0は0', () => {
+    expect(MathHelper.getRootMeanSquare([0, 0, 0])).toBe(0);
+  });
+
+  it('同じ値はその値', () => {
+    expect(MathHelper.getRootMeanSquare([3, 3, 3])).toBe(3);
+  });
+
+  it('正の値の配列', () => {
+    // [1, 2, 3] -> sqrt((1+4+9)/3) = sqrt(14/3) = sqrt(4.667) ≈ 2.16
+    const result = MathHelper.getRootMeanSquare([1, 2, 3]);
+    expect(result).toBeCloseTo(2.16, 1);
+  });
+
+  it('負の値を含む', () => {
+    // [-3, 3] -> sqrt((9+9)/2) = sqrt(9) = 3
+    expect(MathHelper.getRootMeanSquare([-3, 3])).toBe(3);
+  });
+
+  it('RMSは常に平均以上', () => {
+    const values = [1, 2, 3, 4, 5];
+    const rms = MathHelper.getRootMeanSquare(values);
+    const avg = values.reduce((a, b) => a + b, 0) / values.length;
+    expect(rms).toBeGreaterThanOrEqual(avg);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getRootMeanSquare([-5, -3, -1]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('MathHelper.getRootMeanSquareLabel', () => {
+  it('RMSが小さいは低い', () => {
+    expect(MathHelper.getRootMeanSquareLabel(20)).toBe('低い');
+  });
+
+  it('RMSが中程度は中程度', () => {
+    expect(MathHelper.getRootMeanSquareLabel(50)).toBe('中程度');
+  });
+
+  it('RMSが大きいは高い', () => {
+    expect(MathHelper.getRootMeanSquareLabel(80)).toBe('高い');
+  });
+});

--- a/src/__tests__/domain/entities/StockSafetyMargin.test.ts
+++ b/src/__tests__/domain/entities/StockSafetyMargin.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockSafetyMargin', () => {
+  it('消費0は100', () => {
+    expect(StockAlertEntity.getStockSafetyMargin(100, 0)).toBe(100);
+  });
+
+  it('在庫0は0', () => {
+    expect(StockAlertEntity.getStockSafetyMargin(0, 5)).toBe(0);
+  });
+
+  it('両方0は100', () => {
+    expect(StockAlertEntity.getStockSafetyMargin(0, 0)).toBe(100);
+  });
+
+  it('30日分以上は100', () => {
+    expect(StockAlertEntity.getStockSafetyMargin(150, 5)).toBe(100);
+  });
+
+  it('15日分は50', () => {
+    expect(StockAlertEntity.getStockSafetyMargin(75, 5)).toBe(50);
+  });
+
+  it('1日分は低スコア', () => {
+    const result = StockAlertEntity.getStockSafetyMargin(5, 5);
+    expect(result).toBeLessThanOrEqual(10);
+  });
+
+  it('在庫が多いほどスコアが高い', () => {
+    const low = StockAlertEntity.getStockSafetyMargin(10, 5);
+    const high = StockAlertEntity.getStockSafetyMargin(100, 5);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('消費が多いほどスコアが低い', () => {
+    const low = StockAlertEntity.getStockSafetyMargin(50, 10);
+    const high = StockAlertEntity.getStockSafetyMargin(50, 1);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = StockAlertEntity.getStockSafetyMargin(20, 3);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('StockAlertEntity.getStockSafetyMarginLabel', () => {
+  it('スコア70以上は安全', () => {
+    expect(StockAlertEntity.getStockSafetyMarginLabel(80)).toBe('安全');
+  });
+
+  it('スコア30-70は注意', () => {
+    expect(StockAlertEntity.getStockSafetyMarginLabel(50)).toBe('注意');
+  });
+
+  it('スコア30未満は危険', () => {
+    expect(StockAlertEntity.getStockSafetyMarginLabel(20)).toBe('危険');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -82,6 +82,9 @@ export class HealthLogEntity {
   private static readonly CONDITION_MAX_LEVEL = 5;
   private static readonly PEAK_EXCELLENT_THRESHOLD = 80;
   private static readonly PEAK_GOOD_THRESHOLD = 50;
+  private static readonly IMPROVEMENT_IMPROVED_THRESHOLD = 70;
+  private static readonly IMPROVEMENT_DECLINED_THRESHOLD = 30;
+  private static readonly IMPROVEMENT_MAX_DIFF = 4;
 
   private static readonly CONDITION_LABELS: Record<ConditionLevel, string> = {
     1: 'とても悪い',
@@ -967,5 +970,27 @@ export class HealthLogEntity {
     if (score >= HealthLogEntity.PEAK_EXCELLENT_THRESHOLD) return '絶好調';
     if (score >= HealthLogEntity.PEAK_GOOD_THRESHOLD) return '好調';
     return '不調';
+  }
+
+  /**
+   * 体調改善スコア(0-100)を算出する
+   * 最初と最後の体調値の差をスコア化（改善=高、悪化=低、変化なし=50）
+   */
+  static getConditionImprovementScore(conditions: number[]): number {
+    if (conditions.length <= 1) return 0;
+    const first = conditions[0];
+    const last = conditions[conditions.length - 1];
+    const diff = last - first;
+    const normalized = (diff / HealthLogEntity.IMPROVEMENT_MAX_DIFF + 1) / 2;
+    return Math.max(0, Math.min(100, Math.round(normalized * 100)));
+  }
+
+  /**
+   * 体調改善スコアに応じたラベルを返す
+   */
+  static getConditionImprovementScoreLabel(score: number): string {
+    if (score >= HealthLogEntity.IMPROVEMENT_IMPROVED_THRESHOLD) return '改善';
+    if (score >= HealthLogEntity.IMPROVEMENT_DECLINED_THRESHOLD) return '横ばい';
+    return '悪化';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -39,6 +39,8 @@ export class MathHelper {
   private static readonly WMEDIAN_MEDIUM_THRESHOLD = 40;
   private static readonly MAD_STABLE_THRESHOLD = 5;
   private static readonly MAD_MODERATE_THRESHOLD = 15;
+  private static readonly RMS_HIGH_THRESHOLD = 70;
+  private static readonly RMS_MEDIUM_THRESHOLD = 30;
 
   /**
    * パーセントを算出(0-100%)
@@ -719,5 +721,23 @@ export class MathHelper {
     if (mad <= MathHelper.MAD_STABLE_THRESHOLD) return '安定';
     if (mad <= MathHelper.MAD_MODERATE_THRESHOLD) return 'やや散布';
     return '散布';
+  }
+
+  /**
+   * 二乗平均平方根(RMS)を算出する
+   */
+  static getRootMeanSquare(values: number[]): number {
+    if (values.length === 0) return 0;
+    const sumSquares = values.reduce((sum, v) => sum + v * v, 0);
+    return Math.round(Math.sqrt(sumSquares / values.length) * 100) / 100;
+  }
+
+  /**
+   * RMSに応じたラベルを返す
+   */
+  static getRootMeanSquareLabel(rms: number): string {
+    if (rms >= MathHelper.RMS_HIGH_THRESHOLD) return '高い';
+    if (rms >= MathHelper.RMS_MEDIUM_THRESHOLD) return '中程度';
+    return '低い';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -46,6 +46,9 @@ export class StockAlertEntity {
   private static readonly DEPLETION_MAX_DAYS = 30;
   private static readonly DEPLETION_HIGH_THRESHOLD = 70;
   private static readonly DEPLETION_MODERATE_THRESHOLD = 30;
+  private static readonly SAFETY_MARGIN_MAX_DAYS = 30;
+  private static readonly SAFETY_MARGIN_SAFE_THRESHOLD = 70;
+  private static readonly SAFETY_MARGIN_CAUTION_THRESHOLD = 30;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -634,5 +637,25 @@ export class StockAlertEntity {
     if (score >= StockAlertEntity.DEPLETION_HIGH_THRESHOLD) return '高リスク';
     if (score >= StockAlertEntity.DEPLETION_MODERATE_THRESHOLD) return '中リスク';
     return '低リスク';
+  }
+
+  /**
+   * 在庫安全余裕度(0-100)を算出する
+   * 在庫量/日消費量の日数カバー率（30日基準）
+   */
+  static getStockSafetyMargin(stock: number, dailyConsumption: number): number {
+    if (dailyConsumption <= 0) return 100;
+    if (stock <= 0) return 0;
+    const coverageDays = stock / dailyConsumption;
+    return Math.max(0, Math.min(100, Math.round((coverageDays / StockAlertEntity.SAFETY_MARGIN_MAX_DAYS) * 100)));
+  }
+
+  /**
+   * 在庫安全余裕度に応じたラベルを返す
+   */
+  static getStockSafetyMarginLabel(score: number): string {
+    if (score >= StockAlertEntity.SAFETY_MARGIN_SAFE_THRESHOLD) return '安全';
+    if (score >= StockAlertEntity.SAFETY_MARGIN_CAUTION_THRESHOLD) return '注意';
+    return '危険';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getRootMeanSquare / getRootMeanSquareLabel（二乗平均平方根）を追加
- HealthLogEntity: getConditionImprovementScore / getConditionImprovementScoreLabel（体調改善スコア）を追加
- StockAlertEntity: getStockSafetyMargin / getStockSafetyMarginLabel（在庫安全余裕度）を追加

## Test plan
- [x] RootMeanSquare テスト 11件 passing
- [x] ConditionImprovementScore テスト 12件 passing
- [x] StockSafetyMargin テスト 12件 passing
- [x] 全テスト 6197件 passing

closes #890