### PR TITLE
feat: Range・AdherenceStabilityScore・ScheduleLoadScore を追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceStabilityScore.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStabilityScore.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceStabilityScore', () => {
+  it('空配列は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([80])).toBe(100);
+  });
+
+  it('全て同じは100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([50, 50, 50])).toBe(100);
+  });
+
+  it('大きな変動は低スコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([0, 100, 0, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('小さな変動は高スコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([48, 50, 52, 50]);
+    expect(result).toBeGreaterThan(80);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([30, 50, 70, 90]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('安定なほどスコアが高い', () => {
+    const stable = AdherenceTrendEntity.getAdherenceStabilityScore([50, 51, 50, 49]);
+    const unstable = AdherenceTrendEntity.getAdherenceStabilityScore([10, 90, 20, 80]);
+    expect(stable).toBeGreaterThan(unstable);
+  });
+
+  it('緩やかな変化', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([60, 65, 70, 75]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('2件で同値は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([70, 70])).toBe(100);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceStabilityScoreLabel', () => {
+  it('スコア80以上は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(90)).toBe('安定');
+  });
+
+  it('スコア50-80はやや不安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(60)).toBe('やや不安定');
+  });
+
+  it('スコア50未満は不安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(30)).toBe('不安定');
+  });
+});

--- a/src/__tests__/domain/entities/Range.test.ts
+++ b/src/__tests__/domain/entities/Range.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRange', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getRange([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getRange([5])).toBe(0);
+  });
+
+  it('同じ値は0', () => {
+    expect(MathHelper.getRange([3, 3, 3])).toBe(0);
+  });
+
+  it('正値の範囲', () => {
+    expect(MathHelper.getRange([1, 5, 3])).toBe(4);
+  });
+
+  it('負値を含む範囲', () => {
+    expect(MathHelper.getRange([-5, 5])).toBe(10);
+  });
+
+  it('全て負値', () => {
+    expect(MathHelper.getRange([-10, -3, -7])).toBe(7);
+  });
+
+  it('昇順データ', () => {
+    expect(MathHelper.getRange([1, 2, 3, 4, 5])).toBe(4);
+  });
+
+  it('降順データ', () => {
+    expect(MathHelper.getRange([10, 8, 6, 4, 2])).toBe(8);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getRange([100, 50, 75]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('MathHelper.getRangeLabel', () => {
+  it('小さい範囲は狭い', () => {
+    expect(MathHelper.getRangeLabel(3)).toBe('狭い');
+  });
+
+  it('中程度の範囲はやや広い', () => {
+    expect(MathHelper.getRangeLabel(15)).toBe('やや広い');
+  });
+
+  it('大きい範囲は広い', () => {
+    expect(MathHelper.getRangeLabel(30)).toBe('広い');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleLoadScore.test.ts
+++ b/src/__tests__/domain/entities/ScheduleLoadScore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleLoadScore', () => {
+  it('0件は0', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(0, 24)).toBe(0);
+  });
+
+  it('24件/24時間は100', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(24, 24)).toBe(100);
+  });
+
+  it('12件/24時間は50', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(12, 24)).toBe(50);
+  });
+
+  it('時間0は0', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(5, 0)).toBe(0);
+  });
+
+  it('件数が多いほど負荷が高い', () => {
+    const low = ScheduleEntity.getScheduleLoadScore(2, 24);
+    const high = ScheduleEntity.getScheduleLoadScore(20, 24);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('上限100', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(50, 24)).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = ScheduleEntity.getScheduleLoadScore(5, 12);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('1件', () => {
+    const result = ScheduleEntity.getScheduleLoadScore(1, 24);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(50);
+  });
+});
+
+describe('ScheduleEntity.getScheduleLoadScoreLabel', () => {
+  it('スコア70以上は過密', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(80)).toBe('過密');
+  });
+
+  it('スコア30-70は適度', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(50)).toBe('適度');
+  });
+
+  it('スコア30未満は余裕', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(20)).toBe('余裕');
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -42,6 +42,9 @@ export class AdherenceTrendEntity {
   private static readonly MOMENTUM_THRESHOLD = 5;
   private static readonly RESILIENCE_HIGH_THRESHOLD = 70;
   private static readonly RESILIENCE_MODERATE_THRESHOLD = 40;
+  private static readonly STABILITY_MAX_STDDEV = 30;
+  private static readonly STABILITY_HIGH_THRESHOLD = 80;
+  private static readonly STABILITY_MODERATE_THRESHOLD = 50;
 
   constructor(private readonly trend: AdherenceTrend) {}
 
@@ -494,5 +497,27 @@ export class AdherenceTrendEntity {
     if (score >= AdherenceTrendEntity.RESILIENCE_HIGH_THRESHOLD) return '回復力高';
     if (score >= AdherenceTrendEntity.RESILIENCE_MODERATE_THRESHOLD) return 'やや回復';
     return '回復力低';
+  }
+
+  /**
+   * 服薬遵守率配列から安定性スコア(0-100)を算出する
+   * 標準偏差が小さいほど高スコア（最大30基準）
+   */
+  static getAdherenceStabilityScore(rates: number[]): number {
+    if (rates.length === 0) return 0;
+    if (rates.length === 1) return 100;
+    const avg = rates.reduce((a, b) => a + b, 0) / rates.length;
+    const variance = rates.reduce((sum, v) => sum + (v - avg) ** 2, 0) / rates.length;
+    const stdDev = Math.sqrt(variance);
+    return Math.max(0, Math.min(100, Math.round(100 - (stdDev / AdherenceTrendEntity.STABILITY_MAX_STDDEV) * 100)));
+  }
+
+  /**
+   * 服薬遵守安定性スコアに応じたラベルを返す
+   */
+  static getAdherenceStabilityScoreLabel(score: number): string {
+    if (score >= AdherenceTrendEntity.STABILITY_HIGH_THRESHOLD) return '安定';
+    if (score >= AdherenceTrendEntity.STABILITY_MODERATE_THRESHOLD) return 'やや不安定';
+    return '不安定';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -41,6 +41,8 @@ export class MathHelper {
   private static readonly MAD_MODERATE_THRESHOLD = 15;
   private static readonly RMS_HIGH_THRESHOLD = 70;
   private static readonly RMS_MEDIUM_THRESHOLD = 30;
+  private static readonly RANGE_NARROW_THRESHOLD = 10;
+  private static readonly RANGE_MODERATE_THRESHOLD = 25;
 
   /**
    * パーセントを算出(0-100%)
@@ -739,5 +741,22 @@ export class MathHelper {
     if (rms >= MathHelper.RMS_HIGH_THRESHOLD) return '高い';
     if (rms >= MathHelper.RMS_MEDIUM_THRESHOLD) return '中程度';
     return '低い';
+  }
+
+  /**
+   * 値域（最大値-最小値）を算出する
+   */
+  static getRange(values: number[]): number {
+    if (values.length <= 1) return 0;
+    return Math.max(...values) - Math.min(...values);
+  }
+
+  /**
+   * 値域に応じたラベルを返す
+   */
+  static getRangeLabel(range: number): string {
+    if (range < MathHelper.RANGE_NARROW_THRESHOLD) return '狭い';
+    if (range < MathHelper.RANGE_MODERATE_THRESHOLD) return 'やや広い';
+    return '広い';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -798,6 +798,9 @@ export class ScheduleEntity {
   private static readonly CONFLICT_PROXIMITY_MINUTES = 15;
   private static readonly CONFLICT_LOW_THRESHOLD = 10;
   private static readonly CONFLICT_MODERATE_THRESHOLD = 30;
+  private static readonly LOAD_MAX_PER_HOUR = 1;
+  private static readonly LOAD_HIGH_THRESHOLD = 70;
+  private static readonly LOAD_MODERATE_THRESHOLD = 30;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -1030,5 +1033,24 @@ export class ScheduleEntity {
     if (rate < ScheduleEntity.CONFLICT_LOW_THRESHOLD) return '競合なし';
     if (rate < ScheduleEntity.CONFLICT_MODERATE_THRESHOLD) return 'やや競合';
     return '競合多い';
+  }
+
+  /**
+   * スケジュール負荷スコア(0-100)を算出する
+   * スケジュール件数/時間帯の密度（1件/時間を100%基準）
+   */
+  static getScheduleLoadScore(scheduleCount: number, totalHours: number): number {
+    if (totalHours <= 0) return 0;
+    const density = scheduleCount / totalHours / ScheduleEntity.LOAD_MAX_PER_HOUR;
+    return Math.max(0, Math.min(100, Math.round(density * 100)));
+  }
+
+  /**
+   * スケジュール負荷スコアに応じたラベルを返す
+   */
+  static getScheduleLoadScoreLabel(score: number): string {
+    if (score >= ScheduleEntity.LOAD_HIGH_THRESHOLD) return '過密';
+    if (score >= ScheduleEntity.LOAD_MODERATE_THRESHOLD) return '適度';
+    return '余裕';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getRange / getRangeLabel（値域）を追加
- AdherenceTrendEntity: getAdherenceStabilityScore / getAdherenceStabilityScoreLabel（服薬遵守安定性スコア）を追加
- ScheduleEntity: getScheduleLoadScore / getScheduleLoadScoreLabel（スケジュール負荷スコア）を追加

## Test plan
- [x] Range テスト 12件 passing
- [x] AdherenceStabilityScore テスト 12件 passing
- [x] ScheduleLoadScore テスト 11件 passing
- [x] 全テスト 6291件 passing

closes #894