### PR TITLE
test: Range・AdherenceStabilityScore・ScheduleLoadScore エッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceStabilityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStabilityScore.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceStabilityScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([50])).toBe(100);
+  });
+
+  it('2件の同値は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([80, 80])).toBe(100);
+  });
+
+  it('全て0は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([0, 0, 0])).toBe(100);
+  });
+
+  it('全て100は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore([100, 100, 100])).toBe(100);
+  });
+
+  it('最大変動[0,100]', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([0, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('緩やかな上昇', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([50, 55, 60, 65]);
+    expect(result).toBeGreaterThan(70);
+  });
+
+  it('急激な変動', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([0, 100, 0, 100, 0]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('小さな変動', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([49, 50, 51, 50]);
+    expect(result).toBeGreaterThan(95);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceTrendEntity.getAdherenceStabilityScore([10, 90, 30, 70, 50]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('安定なほどスコアが高い', () => {
+    const stable = AdherenceTrendEntity.getAdherenceStabilityScore([50, 50, 50]);
+    const unstable = AdherenceTrendEntity.getAdherenceStabilityScore([10, 90, 50]);
+    expect(stable).toBeGreaterThan(unstable);
+  });
+
+  it('大量データで安定', () => {
+    const data = Array(50).fill(75);
+    expect(AdherenceTrendEntity.getAdherenceStabilityScore(data)).toBe(100);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceStabilityScoreLabel - エッジケース', () => {
+  it('スコア100は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(100)).toBe('安定');
+  });
+
+  it('スコア80は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(80)).toBe('安定');
+  });
+
+  it('スコア79はやや不安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(79)).toBe('やや不安定');
+  });
+
+  it('スコア50はやや不安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(50)).toBe('やや不安定');
+  });
+
+  it('スコア49は不安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(49)).toBe('不安定');
+  });
+
+  it('スコア0は不安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceStabilityScoreLabel(0)).toBe('不安定');
+  });
+});

--- a/src/__tests__/domain/entities/Range.edge.test.ts
+++ b/src/__tests__/domain/entities/Range.edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getRange - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getRange([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getRange([42])).toBe(0);
+  });
+
+  it('2件の同値は0', () => {
+    expect(MathHelper.getRange([7, 7])).toBe(0);
+  });
+
+  it('全て同じ値は0', () => {
+    expect(MathHelper.getRange([5, 5, 5, 5, 5])).toBe(0);
+  });
+
+  it('2件の異なる値', () => {
+    expect(MathHelper.getRange([3, 8])).toBe(5);
+  });
+
+  it('負の値のみ', () => {
+    expect(MathHelper.getRange([-10, -3])).toBe(7);
+  });
+
+  it('0を含む', () => {
+    expect(MathHelper.getRange([-5, 0, 5])).toBe(10);
+  });
+
+  it('大きな値', () => {
+    expect(MathHelper.getRange([0, 1000000])).toBe(1000000);
+  });
+
+  it('小数値', () => {
+    expect(MathHelper.getRange([0.1, 0.9])).toBeCloseTo(0.8, 5);
+  });
+
+  it('順序に依存しない', () => {
+    const a = MathHelper.getRange([5, 1, 3]);
+    const b = MathHelper.getRange([1, 3, 5]);
+    expect(a).toBe(b);
+  });
+
+  it('結果は常に0以上', () => {
+    const result = MathHelper.getRange([-100, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('大量データ', () => {
+    const data = Array(100).fill(50);
+    data[0] = 0;
+    data[99] = 100;
+    expect(MathHelper.getRange(data)).toBe(100);
+  });
+});
+
+describe('MathHelper.getRangeLabel - エッジケース', () => {
+  it('0は狭い', () => {
+    expect(MathHelper.getRangeLabel(0)).toBe('狭い');
+  });
+
+  it('9は狭い', () => {
+    expect(MathHelper.getRangeLabel(9)).toBe('狭い');
+  });
+
+  it('10はやや広い', () => {
+    expect(MathHelper.getRangeLabel(10)).toBe('やや広い');
+  });
+
+  it('24はやや広い', () => {
+    expect(MathHelper.getRangeLabel(24)).toBe('やや広い');
+  });
+
+  it('25は広い', () => {
+    expect(MathHelper.getRangeLabel(25)).toBe('広い');
+  });
+
+  it('100は広い', () => {
+    expect(MathHelper.getRangeLabel(100)).toBe('広い');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleLoadScore.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleLoadScore.edge.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleLoadScore - エッジケース', () => {
+  it('0件・0時間は0', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(0, 0)).toBe(0);
+  });
+
+  it('件数あり・0時間は0', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(10, 0)).toBe(0);
+  });
+
+  it('0件・時間ありは0', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(0, 24)).toBe(0);
+  });
+
+  it('1件/1時間は100', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(1, 1)).toBe(100);
+  });
+
+  it('1件/2時間は50', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(1, 2)).toBe(50);
+  });
+
+  it('2件/1時間は100(上限)', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(2, 1)).toBe(100);
+  });
+
+  it('大量件数は100', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(100, 10)).toBe(100);
+  });
+
+  it('1件/24時間', () => {
+    const result = ScheduleEntity.getScheduleLoadScore(1, 24);
+    expect(result).toBe(4);
+  });
+
+  it('6件/24時間は25', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(6, 24)).toBe(25);
+  });
+
+  it('12件/24時間は50', () => {
+    expect(ScheduleEntity.getScheduleLoadScore(12, 24)).toBe(50);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = ScheduleEntity.getScheduleLoadScore(5, 12);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('件数が多いほど負荷が高い', () => {
+    const low = ScheduleEntity.getScheduleLoadScore(3, 24);
+    const high = ScheduleEntity.getScheduleLoadScore(18, 24);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('時間が多いほど負荷が低い', () => {
+    const low = ScheduleEntity.getScheduleLoadScore(6, 24);
+    const high = ScheduleEntity.getScheduleLoadScore(6, 6);
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
+describe('ScheduleEntity.getScheduleLoadScoreLabel - エッジケース', () => {
+  it('スコア100は過密', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(100)).toBe('過密');
+  });
+
+  it('スコア70は過密', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(70)).toBe('過密');
+  });
+
+  it('スコア69は適度', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(69)).toBe('適度');
+  });
+
+  it('スコア30は適度', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(30)).toBe('適度');
+  });
+
+  it('スコア29は余裕', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(29)).toBe('余裕');
+  });
+
+  it('スコア0は余裕', () => {
+    expect(ScheduleEntity.getScheduleLoadScoreLabel(0)).toBe('余裕');
+  });
+});


### PR DESCRIPTION
## Summary
- Range エッジケーステスト 18件追加
- AdherenceStabilityScore エッジケーステスト 18件追加
- ScheduleLoadScore エッジケーステスト 19件追加

## Test plan
- [x] 55件のエッジケーステスト passing
- [x] 全テスト 6346件 passing

closes #896