### PR TITLE
feat: PowerMean・DateSpanScore・AppointmentDensityScore を追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentDensityScore.test.ts
+++ b/src/__tests__/domain/entities/AppointmentDensityScore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentDensityScore', () => {
+  it('0件は0', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(0, 30)).toBe(0);
+  });
+
+  it('30件/30日は100', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(30, 30)).toBe(100);
+  });
+
+  it('15件/30日は50', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(15, 30)).toBe(50);
+  });
+
+  it('日数0は0', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(5, 0)).toBe(0);
+  });
+
+  it('件数が日数を超えても100', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(60, 30)).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AppointmentEntity.getAppointmentDensityScore(5, 20);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('件数が多いほどスコアが高い', () => {
+    const low = AppointmentEntity.getAppointmentDensityScore(2, 30);
+    const high = AppointmentEntity.getAppointmentDensityScore(20, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('1件/30日', () => {
+    const result = AppointmentEntity.getAppointmentDensityScore(1, 30);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(10);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentDensityScoreLabel', () => {
+  it('スコア70以上は密', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(80)).toBe('密');
+  });
+
+  it('スコア30-70は適度', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(50)).toBe('適度');
+  });
+
+  it('スコア30未満は疎', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(20)).toBe('疎');
+  });
+});

--- a/src/__tests__/domain/entities/DateSpanScore.test.ts
+++ b/src/__tests__/domain/entities/DateSpanScore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateSpanScore', () => {
+  it('0日は0', () => {
+    expect(DateRangeHelper.getDateSpanScore(0, 30)).toBe(0);
+  });
+
+  it('目標と同じ日数は100', () => {
+    expect(DateRangeHelper.getDateSpanScore(30, 30)).toBe(100);
+  });
+
+  it('目標以上も100', () => {
+    expect(DateRangeHelper.getDateSpanScore(60, 30)).toBe(100);
+  });
+
+  it('半分は50', () => {
+    expect(DateRangeHelper.getDateSpanScore(15, 30)).toBe(50);
+  });
+
+  it('目標0は0', () => {
+    expect(DateRangeHelper.getDateSpanScore(10, 0)).toBe(0);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = DateRangeHelper.getDateSpanScore(10, 20);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('日数が多いほどスコアが高い', () => {
+    const low = DateRangeHelper.getDateSpanScore(5, 30);
+    const high = DateRangeHelper.getDateSpanScore(25, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('1日', () => {
+    const result = DateRangeHelper.getDateSpanScore(1, 30);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(10);
+  });
+});
+
+describe('DateRangeHelper.getDateSpanScoreLabel', () => {
+  it('スコア80以上は十分', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(90)).toBe('十分');
+  });
+
+  it('スコア50-80はやや不足', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(60)).toBe('やや不足');
+  });
+
+  it('スコア50未満は不足', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(30)).toBe('不足');
+  });
+});

--- a/src/__tests__/domain/entities/PowerMean.test.ts
+++ b/src/__tests__/domain/entities/PowerMean.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getPowerMean', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getPowerMean([], 2)).toBe(0);
+  });
+
+  it('1件はその値', () => {
+    expect(MathHelper.getPowerMean([5], 2)).toBe(5);
+  });
+
+  it('p=1は算術平均', () => {
+    // [2, 4, 6] -> mean = 4
+    expect(MathHelper.getPowerMean([2, 4, 6], 1)).toBe(4);
+  });
+
+  it('p=2は二乗平均', () => {
+    // [3, 4] -> sqrt((9+16)/2) = sqrt(12.5) ≈ 3.54
+    const result = MathHelper.getPowerMean([3, 4], 2);
+    expect(result).toBeCloseTo(3.54, 1);
+  });
+
+  it('同じ値はその値', () => {
+    expect(MathHelper.getPowerMean([5, 5, 5], 3)).toBe(5);
+  });
+
+  it('p=0は0を返す', () => {
+    expect(MathHelper.getPowerMean([2, 4, 6], 0)).toBe(0);
+  });
+
+  it('結果は0以上(正値入力)', () => {
+    const result = MathHelper.getPowerMean([1, 2, 3], 2);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('pが大きいほど大きい値に近づく', () => {
+    const p1 = MathHelper.getPowerMean([1, 10], 1);
+    const p2 = MathHelper.getPowerMean([1, 10], 2);
+    expect(p2).toBeGreaterThanOrEqual(p1);
+  });
+
+  it('全て0は0', () => {
+    expect(MathHelper.getPowerMean([0, 0, 0], 2)).toBe(0);
+  });
+});
+
+describe('MathHelper.getPowerMeanLabel', () => {
+  it('小さい値は低い', () => {
+    expect(MathHelper.getPowerMeanLabel(20)).toBe('低い');
+  });
+
+  it('中程度は中程度', () => {
+    expect(MathHelper.getPowerMeanLabel(50)).toBe('中程度');
+  });
+
+  it('大きい値は高い', () => {
+    expect(MathHelper.getPowerMeanLabel(80)).toBe('高い');
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -38,6 +38,8 @@ export class AppointmentEntity {
   private static readonly CLUSTER_SCORE_HIGH_THRESHOLD = 60;
   private static readonly CLUSTER_SCORE_MODERATE_THRESHOLD = 30;
   private static readonly CLUSTER_MAX_CV = 2;
+  private static readonly DENSITY_HIGH_THRESHOLD = 70;
+  private static readonly DENSITY_MODERATE_THRESHOLD = 30;
 
   constructor(private readonly appointment: Appointment) {}
 
@@ -651,5 +653,23 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.CLUSTER_SCORE_HIGH_THRESHOLD) return '集中';
     if (score >= AppointmentEntity.CLUSTER_SCORE_MODERATE_THRESHOLD) return 'やや集中';
     return '分散';
+  }
+
+  /**
+   * 予約密度スコア(0-100)を算出する
+   * 予約件数/日数の割合（1件/日を100%基準）
+   */
+  static getAppointmentDensityScore(appointmentCount: number, totalDays: number): number {
+    if (totalDays <= 0 || appointmentCount <= 0) return 0;
+    return Math.min(100, Math.round((appointmentCount / totalDays) * 100));
+  }
+
+  /**
+   * 予約密度スコアに応じたラベルを返す
+   */
+  static getAppointmentDensityScoreLabel(score: number): string {
+    if (score >= AppointmentEntity.DENSITY_HIGH_THRESHOLD) return '密';
+    if (score >= AppointmentEntity.DENSITY_MODERATE_THRESHOLD) return '適度';
+    return '疎';
   }
 }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -110,6 +110,8 @@ export class DateRangeHelper {
   private static readonly DATE_GAP_MODERATE_THRESHOLD = 50;
   private static readonly WEEKEND_RATIO_HIGH_THRESHOLD = 40;
   private static readonly WEEKEND_RATIO_LOW_THRESHOLD = 20;
+  private static readonly DATE_SPAN_SUFFICIENT_THRESHOLD = 80;
+  private static readonly DATE_SPAN_MODERATE_THRESHOLD = 50;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -439,5 +441,23 @@ export class DateRangeHelper {
     if (ratio >= DateRangeHelper.WEEKEND_RATIO_HIGH_THRESHOLD) return '休日中心';
     if (ratio >= DateRangeHelper.WEEKEND_RATIO_LOW_THRESHOLD) return '均等';
     return '平日中心';
+  }
+
+  /**
+   * 日付スパンスコア(0-100)を算出する
+   * 実日数/目標日数の割合（上限100）
+   */
+  static getDateSpanScore(actualDays: number, targetDays: number): number {
+    if (targetDays <= 0 || actualDays <= 0) return 0;
+    return Math.min(100, Math.round((actualDays / targetDays) * 100));
+  }
+
+  /**
+   * 日付スパンスコアに応じたラベルを返す
+   */
+  static getDateSpanScoreLabel(score: number): string {
+    if (score >= DateRangeHelper.DATE_SPAN_SUFFICIENT_THRESHOLD) return '十分';
+    if (score >= DateRangeHelper.DATE_SPAN_MODERATE_THRESHOLD) return 'やや不足';
+    return '不足';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -43,6 +43,8 @@ export class MathHelper {
   private static readonly RMS_MEDIUM_THRESHOLD = 30;
   private static readonly RANGE_NARROW_THRESHOLD = 10;
   private static readonly RANGE_MODERATE_THRESHOLD = 25;
+  private static readonly PMEAN_HIGH_THRESHOLD = 70;
+  private static readonly PMEAN_MEDIUM_THRESHOLD = 30;
 
   /**
    * パーセントを算出(0-100%)
@@ -758,5 +760,24 @@ export class MathHelper {
     if (range < MathHelper.RANGE_NARROW_THRESHOLD) return '狭い';
     if (range < MathHelper.RANGE_MODERATE_THRESHOLD) return 'やや広い';
     return '広い';
+  }
+
+  /**
+   * べき平均（一般化平均）を算出する
+   * p=0の場合は0を返す
+   */
+  static getPowerMean(values: number[], p: number): number {
+    if (values.length === 0 || p === 0) return 0;
+    const sumPow = values.reduce((sum, v) => sum + Math.pow(Math.abs(v), p), 0);
+    return Math.round(Math.pow(sumPow / values.length, 1 / p) * 100) / 100;
+  }
+
+  /**
+   * べき平均に応じたラベルを返す
+   */
+  static getPowerMeanLabel(value: number): string {
+    if (value >= MathHelper.PMEAN_HIGH_THRESHOLD) return '高い';
+    if (value >= MathHelper.PMEAN_MEDIUM_THRESHOLD) return '中程度';
+    return '低い';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getPowerMean / getPowerMeanLabel（べき平均）を追加
- DateRangeHelper: getDateSpanScore / getDateSpanScoreLabel（日付スパンスコア）を追加
- AppointmentEntity: getAppointmentDensityScore / getAppointmentDensityScoreLabel（予約密度スコア）を追加

## Test plan
- [x] PowerMean テスト 12件 passing
- [x] DateSpanScore テスト 11件 passing
- [x] AppointmentDensityScore テスト 11件 passing
- [x] 全テスト 6380件 passing

closes #898