### PR TITLE
べき平均・日数スパンスコア・通院密度スコアのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentDensityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentDensityScore.edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentDensityScore - エッジケース', () => {
+  it('両方0は0', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(0, 0)).toBe(0);
+  });
+
+  it('件数0は0', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(0, 30)).toBe(0);
+  });
+
+  it('日数0は0', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(5, 0)).toBe(0);
+  });
+
+  it('1件/1日は100', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(1, 1)).toBe(100);
+  });
+
+  it('1件/30日', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(1, 30)).toBe(3);
+  });
+
+  it('30件/30日は100', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(30, 30)).toBe(100);
+  });
+
+  it('超過しても100', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(100, 30)).toBe(100);
+  });
+
+  it('件数が多いほどスコアが高い', () => {
+    const low = AppointmentEntity.getAppointmentDensityScore(3, 30);
+    const high = AppointmentEntity.getAppointmentDensityScore(20, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('日数が多いほどスコアが低い', () => {
+    const low = AppointmentEntity.getAppointmentDensityScore(10, 100);
+    const high = AppointmentEntity.getAppointmentDensityScore(10, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AppointmentEntity.getAppointmentDensityScore(7, 20);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大きな値', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(365, 365)).toBe(100);
+  });
+
+  it('負の件数は0', () => {
+    expect(AppointmentEntity.getAppointmentDensityScore(-5, 30)).toBe(0);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentDensityScoreLabel - エッジケース', () => {
+  it('スコア100は密', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(100)).toBe('密');
+  });
+
+  it('スコア70は密', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(70)).toBe('密');
+  });
+
+  it('スコア69は適度', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(69)).toBe('適度');
+  });
+
+  it('スコア30は適度', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(30)).toBe('適度');
+  });
+
+  it('スコア29は疎', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(29)).toBe('疎');
+  });
+
+  it('スコア0は疎', () => {
+    expect(AppointmentEntity.getAppointmentDensityScoreLabel(0)).toBe('疎');
+  });
+});

--- a/src/__tests__/domain/entities/DateSpanScore.edge.test.ts
+++ b/src/__tests__/domain/entities/DateSpanScore.edge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateSpanScore - エッジケース', () => {
+  it('両方0は0', () => {
+    expect(DateRangeHelper.getDateSpanScore(0, 0)).toBe(0);
+  });
+
+  it('日数0・目標ありは0', () => {
+    expect(DateRangeHelper.getDateSpanScore(0, 30)).toBe(0);
+  });
+
+  it('日数あり・目標0は0', () => {
+    expect(DateRangeHelper.getDateSpanScore(10, 0)).toBe(0);
+  });
+
+  it('1日/30日', () => {
+    expect(DateRangeHelper.getDateSpanScore(1, 30)).toBe(3);
+  });
+
+  it('ちょうど目標は100', () => {
+    expect(DateRangeHelper.getDateSpanScore(30, 30)).toBe(100);
+  });
+
+  it('目標の2倍も100', () => {
+    expect(DateRangeHelper.getDateSpanScore(60, 30)).toBe(100);
+  });
+
+  it('1/1は100', () => {
+    expect(DateRangeHelper.getDateSpanScore(1, 1)).toBe(100);
+  });
+
+  it('大きな値', () => {
+    expect(DateRangeHelper.getDateSpanScore(365, 365)).toBe(100);
+  });
+
+  it('日数が多いほどスコアが高い', () => {
+    const low = DateRangeHelper.getDateSpanScore(5, 30);
+    const high = DateRangeHelper.getDateSpanScore(25, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = DateRangeHelper.getDateSpanScore(15, 20);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('負の日数は0', () => {
+    expect(DateRangeHelper.getDateSpanScore(-5, 30)).toBe(0);
+  });
+
+  it('負の目標は0', () => {
+    expect(DateRangeHelper.getDateSpanScore(10, -30)).toBe(0);
+  });
+});
+
+describe('DateRangeHelper.getDateSpanScoreLabel - エッジケース', () => {
+  it('スコア100は十分', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(100)).toBe('十分');
+  });
+
+  it('スコア80は十分', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(80)).toBe('十分');
+  });
+
+  it('スコア79はやや不足', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(79)).toBe('やや不足');
+  });
+
+  it('スコア50はやや不足', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(50)).toBe('やや不足');
+  });
+
+  it('スコア49は不足', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(49)).toBe('不足');
+  });
+
+  it('スコア0は不足', () => {
+    expect(DateRangeHelper.getDateSpanScoreLabel(0)).toBe('不足');
+  });
+});

--- a/src/__tests__/domain/entities/PowerMean.edge.test.ts
+++ b/src/__tests__/domain/entities/PowerMean.edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getPowerMean - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getPowerMean([], 2)).toBe(0);
+  });
+
+  it('p=0は0', () => {
+    expect(MathHelper.getPowerMean([1, 2, 3], 0)).toBe(0);
+  });
+
+  it('1件でp=1', () => {
+    expect(MathHelper.getPowerMean([7], 1)).toBe(7);
+  });
+
+  it('1件でp=2', () => {
+    expect(MathHelper.getPowerMean([7], 2)).toBe(7);
+  });
+
+  it('全て0でp=2', () => {
+    expect(MathHelper.getPowerMean([0, 0, 0], 2)).toBe(0);
+  });
+
+  it('全て同値でp=3', () => {
+    expect(MathHelper.getPowerMean([4, 4, 4], 3)).toBe(4);
+  });
+
+  it('p=1は算術平均', () => {
+    expect(MathHelper.getPowerMean([10, 20, 30], 1)).toBe(20);
+  });
+
+  it('p=2はRMS', () => {
+    const rms = MathHelper.getRootMeanSquare([3, 4]);
+    const pmean = MathHelper.getPowerMean([3, 4], 2);
+    expect(pmean).toBeCloseTo(rms, 1);
+  });
+
+  it('大きなpでは最大値に近づく', () => {
+    const p1 = MathHelper.getPowerMean([1, 100], 1);
+    const p10 = MathHelper.getPowerMean([1, 100], 10);
+    expect(p10).toBeGreaterThan(p1);
+  });
+
+  it('2件で[1,1]はp任意で1', () => {
+    expect(MathHelper.getPowerMean([1, 1], 5)).toBe(1);
+  });
+
+  it('大量データ', () => {
+    const data = Array(100).fill(10);
+    expect(MathHelper.getPowerMean(data, 2)).toBe(10);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getPowerMean([1, 5, 10], 3);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('MathHelper.getPowerMeanLabel - エッジケース', () => {
+  it('0は低い', () => {
+    expect(MathHelper.getPowerMeanLabel(0)).toBe('低い');
+  });
+
+  it('29は低い', () => {
+    expect(MathHelper.getPowerMeanLabel(29)).toBe('低い');
+  });
+
+  it('30は中程度', () => {
+    expect(MathHelper.getPowerMeanLabel(30)).toBe('中程度');
+  });
+
+  it('69は中程度', () => {
+    expect(MathHelper.getPowerMeanLabel(69)).toBe('中程度');
+  });
+
+  it('70は高い', () => {
+    expect(MathHelper.getPowerMeanLabel(70)).toBe('高い');
+  });
+
+  it('100は高い', () => {
+    expect(MathHelper.getPowerMeanLabel(100)).toBe('高い');
+  });
+});


### PR DESCRIPTION
## Summary
- getPowerMean / getPowerMeanLabel のエッジケーステスト18件追加
- getDateSpanScore / getDateSpanScoreLabel のエッジケーステスト18件追加
- getAppointmentDensityScore / getAppointmentDensityScoreLabel のエッジケーステスト18件追加
- 合計54件のエッジケーステスト追加（総テスト数: 6434）

## Test plan
- [x] 全54件のエッジケーステストがパス
- [x] 既存テスト6380件に回帰なし