### PR TITLE
平均二乗誤差・通院規則性スコア・挨拶強度スコアの追加

### DIFF
--- a/src/__tests__/domain/entities/GreetingIntensityScore.test.ts
+++ b/src/__tests__/domain/entities/GreetingIntensityScore.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity.getGreetingIntensityScore', () => {
+  it('0時間・0ストリークは0', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScore(0, 0)).toBe(0);
+  });
+
+  it('長時間離脱はスコアが高い', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(48, 0);
+    expect(result).toBeGreaterThan(30);
+  });
+
+  it('ストリークが高いとスコアが高い', () => {
+    const low = GreetingMessageEntity.getGreetingIntensityScore(24, 1);
+    const high = GreetingMessageEntity.getGreetingIntensityScore(24, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('短時間はスコアが低い', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(1, 0);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(24, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('最大値は100を超えない', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScore(1000, 100)).toBeLessThanOrEqual(100);
+  });
+
+  it('時間が長いほどスコアが高い', () => {
+    const short = GreetingMessageEntity.getGreetingIntensityScore(1, 5);
+    const long = GreetingMessageEntity.getGreetingIntensityScore(72, 5);
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it('24時間・ストリーク7', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(24, 7);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('GreetingMessageEntity.getGreetingIntensityScoreLabel', () => {
+  it('スコア高は熱烈', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(80)).toBe('熱烈');
+  });
+
+  it('スコア中は普通', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(50)).toBe('普通');
+  });
+
+  it('スコア低は軽め', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(20)).toBe('軽め');
+  });
+});

--- a/src/__tests__/domain/entities/MeanSquaredError.test.ts
+++ b/src/__tests__/domain/entities/MeanSquaredError.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMeanSquaredError', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getMeanSquaredError([], [])).toBe(0);
+  });
+
+  it('完全一致は0', () => {
+    expect(MathHelper.getMeanSquaredError([1, 2, 3], [1, 2, 3])).toBe(0);
+  });
+
+  it('差がある場合', () => {
+    expect(MathHelper.getMeanSquaredError([1, 2, 3], [2, 3, 4])).toBe(1);
+  });
+
+  it('大きな差', () => {
+    expect(MathHelper.getMeanSquaredError([0, 0], [10, 10])).toBe(100);
+  });
+
+  it('1件', () => {
+    expect(MathHelper.getMeanSquaredError([5], [8])).toBe(9);
+  });
+
+  it('配列長が異なる場合は短い方に合わせる', () => {
+    const result = MathHelper.getMeanSquaredError([1, 2], [1, 2, 3]);
+    expect(result).toBe(0);
+  });
+
+  it('負の値', () => {
+    expect(MathHelper.getMeanSquaredError([-1, -2], [1, 2])).toBe(10);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getMeanSquaredError([1.5], [2.5]);
+    expect(result).toBe(1);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getMeanSquaredError([3, 7, 1], [5, 2, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('差が大きいほどMSEが大きい', () => {
+    const small = MathHelper.getMeanSquaredError([1, 2, 3], [2, 3, 4]);
+    const large = MathHelper.getMeanSquaredError([1, 2, 3], [10, 20, 30]);
+    expect(large).toBeGreaterThan(small);
+  });
+});
+
+describe('MathHelper.getMeanSquaredErrorLabel', () => {
+  it('MSE低は正確', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(3)).toBe('正確');
+  });
+
+  it('MSE中はやや乖離', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(15)).toBe('やや乖離');
+  });
+
+  it('MSE高は乖離大', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(30)).toBe('乖離大');
+  });
+});

--- a/src/__tests__/domain/entities/VisitRegularityScore.test.ts
+++ b/src/__tests__/domain/entities/VisitRegularityScore.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity.getVisitRegularityScore', () => {
+  it('空配列は0', () => {
+    expect(HospitalEntity.getVisitRegularityScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(HospitalEntity.getVisitRegularityScore([30])).toBe(100);
+  });
+
+  it('全て同じ間隔は100', () => {
+    expect(HospitalEntity.getVisitRegularityScore([30, 30, 30])).toBe(100);
+  });
+
+  it('ばらつきがあるとスコアが下がる', () => {
+    const result = HospitalEntity.getVisitRegularityScore([10, 30, 50]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('大きなばらつき', () => {
+    const result = HospitalEntity.getVisitRegularityScore([1, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HospitalEntity.getVisitRegularityScore([7, 14, 21, 28]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('均一なほどスコアが高い', () => {
+    const regular = HospitalEntity.getVisitRegularityScore([30, 30, 30]);
+    const irregular = HospitalEntity.getVisitRegularityScore([5, 30, 60]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('2件で同じ間隔は100', () => {
+    expect(HospitalEntity.getVisitRegularityScore([14, 14])).toBe(100);
+  });
+});
+
+describe('HospitalEntity.getVisitRegularityScoreLabel', () => {
+  it('スコア高は規則的', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(85)).toBe('規則的');
+  });
+
+  it('スコア中はやや不規則', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(60)).toBe('やや不規則');
+  });
+
+  it('スコア低は不規則', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(30)).toBe('不規則');
+  });
+});

--- a/src/domain/entities/GreetingMessage.ts
+++ b/src/domain/entities/GreetingMessage.ts
@@ -3,6 +3,13 @@
  */
 
 export class GreetingMessageEntity {
+  private static readonly GREETING_INTENSITY_HIGH_THRESHOLD = 70;
+  private static readonly GREETING_INTENSITY_MODERATE_THRESHOLD = 40;
+  private static readonly GREETING_INTENSITY_MAX_HOURS = 72;
+  private static readonly GREETING_INTENSITY_MAX_STREAK = 30;
+  private static readonly GREETING_INTENSITY_HOURS_WEIGHT = 0.6;
+  private static readonly GREETING_INTENSITY_STREAK_WEIGHT = 0.4;
+
   /**
    * 時間帯に応じた挨拶を返す
    */
@@ -64,5 +71,36 @@ export class GreetingMessageEntity {
   static formatGreetingWithName(greeting: string, name: string | null): string {
     if (!name || name === '') return greeting;
     return `${name}さん、${greeting}`;
+  }
+
+  /**
+   * ログイン間隔とストリークから挨拶強度スコアを算出する（0-100）
+   */
+  static getGreetingIntensityScore(
+    hoursSinceLastLogin: number,
+    streak: number
+  ): number {
+    if (hoursSinceLastLogin <= 0 && streak <= 0) return 0;
+    const hoursNorm = Math.min(
+      hoursSinceLastLogin / GreetingMessageEntity.GREETING_INTENSITY_MAX_HOURS,
+      1
+    );
+    const streakNorm = Math.min(
+      streak / GreetingMessageEntity.GREETING_INTENSITY_MAX_STREAK,
+      1
+    );
+    const score =
+      hoursNorm * GreetingMessageEntity.GREETING_INTENSITY_HOURS_WEIGHT +
+      streakNorm * GreetingMessageEntity.GREETING_INTENSITY_STREAK_WEIGHT;
+    return Math.max(0, Math.min(100, Math.round(score * 100)));
+  }
+
+  /**
+   * 挨拶強度スコアに応じたラベルを返す
+   */
+  static getGreetingIntensityScoreLabel(score: number): string {
+    if (score >= GreetingMessageEntity.GREETING_INTENSITY_HIGH_THRESHOLD) return '熱烈';
+    if (score >= GreetingMessageEntity.GREETING_INTENSITY_MODERATE_THRESHOLD) return '普通';
+    return '軽め';
   }
 }

--- a/src/domain/entities/Hospital.ts
+++ b/src/domain/entities/Hospital.ts
@@ -19,6 +19,10 @@ export interface Hospital {
  * 病院のビジネスロジック
  */
 export class HospitalEntity {
+  private static readonly VISIT_REGULARITY_HIGH_THRESHOLD = 80;
+  private static readonly VISIT_REGULARITY_MODERATE_THRESHOLD = 50;
+  private static readonly VISIT_REGULARITY_MAX_CV = 100;
+
   private static readonly typeLabels: Record<string, string> = {
     general: '総合病院',
     clinic: 'クリニック',
@@ -174,5 +178,31 @@ export class HospitalEntity {
     if (avgPerMonth >= 2) return '定期的';
     if (avgPerMonth > 0) return '少ない';
     return '通院なし';
+  }
+
+  /**
+   * 通院間隔の規則性スコアを算出する（0-100）
+   * 変動係数(CV)が小さいほどスコアが高い
+   */
+  static getVisitRegularityScore(intervalDays: number[]): number {
+    if (intervalDays.length <= 1) return intervalDays.length === 0 ? 0 : 100;
+    const avg = intervalDays.reduce((a, b) => a + b, 0) / intervalDays.length;
+    if (avg === 0) return 0;
+    const variance =
+      intervalDays.reduce((sum, v) => sum + (v - avg) ** 2, 0) / intervalDays.length;
+    const cv = (Math.sqrt(variance) / avg) * 100;
+    return Math.max(
+      0,
+      Math.min(100, Math.round(100 - (cv / HospitalEntity.VISIT_REGULARITY_MAX_CV) * 100))
+    );
+  }
+
+  /**
+   * 通院規則性スコアに応じたラベルを返す
+   */
+  static getVisitRegularityScoreLabel(score: number): string {
+    if (score >= HospitalEntity.VISIT_REGULARITY_HIGH_THRESHOLD) return '規則的';
+    if (score >= HospitalEntity.VISIT_REGULARITY_MODERATE_THRESHOLD) return 'やや不規則';
+    return '不規則';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -45,6 +45,8 @@ export class MathHelper {
   private static readonly RANGE_MODERATE_THRESHOLD = 25;
   private static readonly PMEAN_HIGH_THRESHOLD = 70;
   private static readonly PMEAN_MEDIUM_THRESHOLD = 30;
+  private static readonly MSE_LOW_THRESHOLD = 5;
+  private static readonly MSE_MODERATE_THRESHOLD = 25;
 
   /**
    * パーセントを算出(0-100%)
@@ -779,5 +781,27 @@ export class MathHelper {
     if (value >= MathHelper.PMEAN_HIGH_THRESHOLD) return '高い';
     if (value >= MathHelper.PMEAN_MEDIUM_THRESHOLD) return '中程度';
     return '低い';
+  }
+
+  /**
+   * 平均二乗誤差(MSE)を算出する
+   * 配列長が異なる場合は短い方に合わせる
+   */
+  static getMeanSquaredError(predictions: number[], actuals: number[]): number {
+    const len = Math.min(predictions.length, actuals.length);
+    if (len === 0) return 0;
+    const sumSqErr = predictions
+      .slice(0, len)
+      .reduce((sum, pred, i) => sum + (pred - actuals[i]) ** 2, 0);
+    return Math.round((sumSqErr / len) * 100) / 100;
+  }
+
+  /**
+   * MSEに応じたラベルを返す
+   */
+  static getMeanSquaredErrorLabel(mse: number): string {
+    if (mse <= MathHelper.MSE_LOW_THRESHOLD) return '正確';
+    if (mse <= MathHelper.MSE_MODERATE_THRESHOLD) return 'やや乖離';
+    return '乖離大';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getMeanSquaredError / getMeanSquaredErrorLabel（平均二乗誤差）追加
- HospitalEntity: getVisitRegularityScore / getVisitRegularityScoreLabel（通院規則性スコア）追加
- GreetingMessageEntity: getGreetingIntensityScore / getGreetingIntensityScoreLabel（挨拶強度スコア）追加
- 35件のユニットテスト追加（総テスト数: 6469）

## Test plan
- [x] 全35件の新規テストがパス
- [x] 既存テスト6434件に回帰なし