### PR TITLE
平均二乗誤差・通院規則性スコア・挨拶強度スコアのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/GreetingIntensityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/GreetingIntensityScore.edge.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity.getGreetingIntensityScore - エッジケース', () => {
+  it('両方0は0', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScore(0, 0)).toBe(0);
+  });
+
+  it('時間0・ストリークありはストリーク分のみ', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(0, 15);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('時間あり・ストリーク0は時間分のみ', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(36, 0);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('最大時間・最大ストリークは100', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScore(72, 30)).toBe(100);
+  });
+
+  it('超過しても100', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScore(200, 100)).toBe(100);
+  });
+
+  it('1時間は低い', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(1, 0);
+    expect(result).toBeLessThan(10);
+  });
+
+  it('時間が長いほどスコアが高い', () => {
+    const short = GreetingMessageEntity.getGreetingIntensityScore(1, 5);
+    const long = GreetingMessageEntity.getGreetingIntensityScore(60, 5);
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it('ストリークが多いほどスコアが高い', () => {
+    const low = GreetingMessageEntity.getGreetingIntensityScore(24, 1);
+    const high = GreetingMessageEntity.getGreetingIntensityScore(24, 25);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(12, 7);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('ちょうど半分の入力', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(36, 15);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(70);
+  });
+
+  it('24時間・ストリーク0', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(24, 0);
+    expect(result).toBeGreaterThan(10);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('0時間・ストリーク30', () => {
+    const result = GreetingMessageEntity.getGreetingIntensityScore(0, 30);
+    expect(result).toBe(40);
+  });
+});
+
+describe('GreetingMessageEntity.getGreetingIntensityScoreLabel - エッジケース', () => {
+  it('スコア100は熱烈', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(100)).toBe('熱烈');
+  });
+
+  it('スコア70は熱烈', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(70)).toBe('熱烈');
+  });
+
+  it('スコア69は普通', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(69)).toBe('普通');
+  });
+
+  it('スコア40は普通', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(40)).toBe('普通');
+  });
+
+  it('スコア39は軽め', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(39)).toBe('軽め');
+  });
+
+  it('スコア0は軽め', () => {
+    expect(GreetingMessageEntity.getGreetingIntensityScoreLabel(0)).toBe('軽め');
+  });
+});

--- a/src/__tests__/domain/entities/MeanSquaredError.edge.test.ts
+++ b/src/__tests__/domain/entities/MeanSquaredError.edge.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMeanSquaredError - エッジケース', () => {
+  it('両方空は0', () => {
+    expect(MathHelper.getMeanSquaredError([], [])).toBe(0);
+  });
+
+  it('片方空は0', () => {
+    expect(MathHelper.getMeanSquaredError([1, 2], [])).toBe(0);
+  });
+
+  it('完全一致1件は0', () => {
+    expect(MathHelper.getMeanSquaredError([42], [42])).toBe(0);
+  });
+
+  it('完全一致複数は0', () => {
+    expect(MathHelper.getMeanSquaredError([1, 2, 3, 4, 5], [1, 2, 3, 4, 5])).toBe(0);
+  });
+
+  it('差1の場合', () => {
+    expect(MathHelper.getMeanSquaredError([0], [1])).toBe(1);
+  });
+
+  it('対称的な差', () => {
+    const a = MathHelper.getMeanSquaredError([0, 10], [10, 0]);
+    expect(a).toBe(100);
+  });
+
+  it('配列長が異なる（短い方に合わせる）', () => {
+    expect(MathHelper.getMeanSquaredError([1], [1, 2, 3])).toBe(0);
+  });
+
+  it('全て0同士は0', () => {
+    expect(MathHelper.getMeanSquaredError([0, 0, 0], [0, 0, 0])).toBe(0);
+  });
+
+  it('大きな値', () => {
+    expect(MathHelper.getMeanSquaredError([0], [1000])).toBe(1000000);
+  });
+
+  it('小数の精度', () => {
+    const result = MathHelper.getMeanSquaredError([0.1], [0.2]);
+    expect(result).toBeCloseTo(0.01, 2);
+  });
+
+  it('負同士の差', () => {
+    expect(MathHelper.getMeanSquaredError([-5], [-5])).toBe(0);
+  });
+
+  it('結果は常に0以上', () => {
+    const result = MathHelper.getMeanSquaredError([100, -100], [-100, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('大量データ', () => {
+    const a = Array(100).fill(10);
+    const b = Array(100).fill(10);
+    expect(MathHelper.getMeanSquaredError(a, b)).toBe(0);
+  });
+
+  it('差が大きいほどMSEが大きい', () => {
+    const small = MathHelper.getMeanSquaredError([5], [6]);
+    const large = MathHelper.getMeanSquaredError([5], [50]);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('順序を入れ替えても同値', () => {
+    const a = MathHelper.getMeanSquaredError([1, 2], [3, 4]);
+    const b = MathHelper.getMeanSquaredError([3, 4], [1, 2]);
+    expect(a).toBe(b);
+  });
+});
+
+describe('MathHelper.getMeanSquaredErrorLabel - エッジケース', () => {
+  it('MSE 0は正確', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(0)).toBe('正確');
+  });
+
+  it('MSE 5は正確', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(5)).toBe('正確');
+  });
+
+  it('MSE 6はやや乖離', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(6)).toBe('やや乖離');
+  });
+
+  it('MSE 25はやや乖離', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(25)).toBe('やや乖離');
+  });
+
+  it('MSE 26は乖離大', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(26)).toBe('乖離大');
+  });
+
+  it('MSE 1000は乖離大', () => {
+    expect(MathHelper.getMeanSquaredErrorLabel(1000)).toBe('乖離大');
+  });
+});

--- a/src/__tests__/domain/entities/VisitRegularityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/VisitRegularityScore.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity.getVisitRegularityScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(HospitalEntity.getVisitRegularityScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(HospitalEntity.getVisitRegularityScore([7])).toBe(100);
+  });
+
+  it('全て同じ値は100', () => {
+    expect(HospitalEntity.getVisitRegularityScore([14, 14, 14, 14])).toBe(100);
+  });
+
+  it('2件同値は100', () => {
+    expect(HospitalEntity.getVisitRegularityScore([30, 30])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(HospitalEntity.getVisitRegularityScore([0, 0, 0])).toBe(0);
+  });
+
+  it('わずかなばらつき', () => {
+    const result = HospitalEntity.getVisitRegularityScore([29, 30, 31]);
+    expect(result).toBeGreaterThan(90);
+  });
+
+  it('大きなばらつき', () => {
+    const result = HospitalEntity.getVisitRegularityScore([1, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('均一なほどスコアが高い', () => {
+    const regular = HospitalEntity.getVisitRegularityScore([10, 10, 10]);
+    const irregular = HospitalEntity.getVisitRegularityScore([1, 10, 30]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HospitalEntity.getVisitRegularityScore([5, 15, 25, 35]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(50).fill(14);
+    expect(HospitalEntity.getVisitRegularityScore(data)).toBe(100);
+  });
+
+  it('大きな値', () => {
+    expect(HospitalEntity.getVisitRegularityScore([365, 365])).toBe(100);
+  });
+
+  it('1と2の2件', () => {
+    const result = HospitalEntity.getVisitRegularityScore([1, 2]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+});
+
+describe('HospitalEntity.getVisitRegularityScoreLabel - エッジケース', () => {
+  it('スコア100は規則的', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(100)).toBe('規則的');
+  });
+
+  it('スコア80は規則的', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(80)).toBe('規則的');
+  });
+
+  it('スコア79はやや不規則', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(79)).toBe('やや不規則');
+  });
+
+  it('スコア50はやや不規則', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(50)).toBe('やや不規則');
+  });
+
+  it('スコア49は不規則', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(49)).toBe('不規則');
+  });
+
+  it('スコア0は不規則', () => {
+    expect(HospitalEntity.getVisitRegularityScoreLabel(0)).toBe('不規則');
+  });
+});


### PR DESCRIPTION
## Summary
- getMeanSquaredError / getMeanSquaredErrorLabel のエッジケーステスト21件追加
- getVisitRegularityScore / getVisitRegularityScoreLabel のエッジケーステスト18件追加
- getGreetingIntensityScore / getGreetingIntensityScoreLabel のエッジケーステスト18件追加
- 合計57件のエッジケーステスト追加（総テスト数: 6526）

## Test plan
- [x] 全57件のエッジケーステストがパス
- [x] 既存テスト6469件に回帰なし