### PR TITLE
ジャッカード類似度・メンバーケアスコア・週間記録率の追加

### DIFF
--- a/src/__tests__/domain/entities/JaccardSimilarity.test.ts
+++ b/src/__tests__/domain/entities/JaccardSimilarity.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getJaccardSimilarity', () => {
+  it('両方空は0', () => {
+    expect(MathHelper.getJaccardSimilarity([], [])).toBe(0);
+  });
+
+  it('完全一致は100', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2, 3], [1, 2, 3])).toBe(100);
+  });
+
+  it('共通なしは0', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2], [3, 4])).toBe(0);
+  });
+
+  it('部分一致', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2, 3], [2, 3, 4])).toBe(50);
+  });
+
+  it('片方空は0', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2], [])).toBe(0);
+  });
+
+  it('1件同じは100', () => {
+    expect(MathHelper.getJaccardSimilarity([5], [5])).toBe(100);
+  });
+
+  it('重複要素は無視', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 1, 2], [1, 2, 2])).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MathHelper.getJaccardSimilarity([1, 2, 3, 4], [3, 4, 5, 6]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('共通が多いほどスコアが高い', () => {
+    const low = MathHelper.getJaccardSimilarity([1, 2, 3, 4, 5], [6, 7, 8, 9, 10]);
+    const high = MathHelper.getJaccardSimilarity([1, 2, 3, 4, 5], [1, 2, 3, 4, 5]);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('包含関係', () => {
+    const result = MathHelper.getJaccardSimilarity([1, 2], [1, 2, 3, 4]);
+    expect(result).toBe(50);
+  });
+});
+
+describe('MathHelper.getJaccardSimilarityLabel', () => {
+  it('類似度高は類似', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(80)).toBe('類似');
+  });
+
+  it('類似度中はやや類似', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(50)).toBe('やや類似');
+  });
+
+  it('類似度低は異なる', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(20)).toBe('異なる');
+  });
+});

--- a/src/__tests__/domain/entities/MemberCareScore.test.ts
+++ b/src/__tests__/domain/entities/MemberCareScore.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity.getMemberCareScore', () => {
+  it('両方0は0', () => {
+    expect(MemberEntity.getMemberCareScore(0, 0)).toBe(0);
+  });
+
+  it('両方100は100', () => {
+    expect(MemberEntity.getMemberCareScore(100, 100)).toBe(100);
+  });
+
+  it('服薬率のみ高い', () => {
+    const result = MemberEntity.getMemberCareScore(100, 0);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('記録率のみ高い', () => {
+    const result = MemberEntity.getMemberCareScore(0, 100);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('中程度の値', () => {
+    const result = MemberEntity.getMemberCareScore(50, 50);
+    expect(result).toBe(50);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MemberEntity.getMemberCareScore(70, 80);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('服薬率が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberCareScore(20, 50);
+    const high = MemberEntity.getMemberCareScore(80, 50);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('記録率が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberCareScore(50, 20);
+    const high = MemberEntity.getMemberCareScore(50, 80);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('100超えは100', () => {
+    expect(MemberEntity.getMemberCareScore(150, 150)).toBe(100);
+  });
+});
+
+describe('MemberEntity.getMemberCareScoreLabel', () => {
+  it('スコア高は良好', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(85)).toBe('良好');
+  });
+
+  it('スコア中は普通', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(60)).toBe('普通');
+  });
+
+  it('スコア低は要注意', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(30)).toBe('要注意');
+  });
+});

--- a/src/__tests__/domain/entities/WeeklyRecordRate.test.ts
+++ b/src/__tests__/domain/entities/WeeklyRecordRate.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getWeeklyRecordRate', () => {
+  it('空配列は0', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([])).toBe(0);
+  });
+
+  it('全て記録ありは100', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([1, 1, 1, 1, 1, 1, 1])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([0, 0, 0, 0, 0, 0, 0])).toBe(0);
+  });
+
+  it('半分記録あり', () => {
+    const result = CalendarEntity.getWeeklyRecordRate([1, 0, 1, 0, 1, 0, 0]);
+    expect(result).toBe(43);
+  });
+
+  it('1日だけ記録あり', () => {
+    const result = CalendarEntity.getWeeklyRecordRate([0, 0, 0, 1, 0, 0, 0]);
+    expect(result).toBe(14);
+  });
+
+  it('7日以上でも対応', () => {
+    const result = CalendarEntity.getWeeklyRecordRate([1, 1, 1, 0, 0, 0, 0, 1, 1, 1]);
+    expect(result).toBe(60);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = CalendarEntity.getWeeklyRecordRate([1, 0, 1, 1, 0]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('記録数が多いほどスコアが高い', () => {
+    const low = CalendarEntity.getWeeklyRecordRate([1, 0, 0, 0, 0, 0, 0]);
+    const high = CalendarEntity.getWeeklyRecordRate([1, 1, 1, 1, 1, 0, 0]);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('複数回の記録も1日として数える', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([3, 2, 0, 0, 0, 0, 0])).toBe(29);
+  });
+});
+
+describe('CalendarEntity.getWeeklyRecordRateLabel', () => {
+  it('率高は毎日記録', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(90)).toBe('毎日記録');
+  });
+
+  it('率中はまずまず', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(60)).toBe('まずまず');
+  });
+
+  it('率低は記録不足', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(30)).toBe('記録不足');
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -20,6 +20,8 @@ export interface CalendarMonth {
 }
 
 export class CalendarEntity {
+  private static readonly WEEKLY_RECORD_DAILY_THRESHOLD = 80;
+  private static readonly WEEKLY_RECORD_MODERATE_THRESHOLD = 50;
   private static readonly RECORD_COUNT_LOW_THRESHOLD = 2;
   private static readonly RECORD_COUNT_MEDIUM_THRESHOLD = 5;
   private static readonly CONDITION_GOOD_THRESHOLD = 4;
@@ -649,5 +651,24 @@ export class CalendarEntity {
     if (score >= CalendarEntity.RECORD_GAP_SCORE_GOOD_THRESHOLD) return '良好';
     if (score >= CalendarEntity.RECORD_GAP_SCORE_FAIR_THRESHOLD) return 'まずまず';
     return '空白多い';
+  }
+
+  /**
+   * 日別記録数配列から週間記録率を算出する（0-100）
+   * 記録がある日の割合
+   */
+  static getWeeklyRecordRate(dailyCounts: number[]): number {
+    if (dailyCounts.length === 0) return 0;
+    const recordDays = dailyCounts.filter((c) => c > 0).length;
+    return Math.round((recordDays / dailyCounts.length) * 100);
+  }
+
+  /**
+   * 週間記録率に応じたラベルを返す
+   */
+  static getWeeklyRecordRateLabel(rate: number): string {
+    if (rate >= CalendarEntity.WEEKLY_RECORD_DAILY_THRESHOLD) return '毎日記録';
+    if (rate >= CalendarEntity.WEEKLY_RECORD_MODERATE_THRESHOLD) return 'まずまず';
+    return '記録不足';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -47,6 +47,8 @@ export class MathHelper {
   private static readonly PMEAN_MEDIUM_THRESHOLD = 30;
   private static readonly MSE_LOW_THRESHOLD = 5;
   private static readonly MSE_MODERATE_THRESHOLD = 25;
+  private static readonly JACCARD_HIGH_THRESHOLD = 70;
+  private static readonly JACCARD_MODERATE_THRESHOLD = 40;
 
   /**
    * パーセントを算出(0-100%)
@@ -803,5 +805,27 @@ export class MathHelper {
     if (mse <= MathHelper.MSE_LOW_THRESHOLD) return '正確';
     if (mse <= MathHelper.MSE_MODERATE_THRESHOLD) return 'やや乖離';
     return '乖離大';
+  }
+
+  /**
+   * ジャッカード類似度を算出する（0-100）
+   * 2つの集合の共通要素数 / 和集合要素数
+   */
+  static getJaccardSimilarity(a: number[], b: number[]): number {
+    const setA = new Set(a);
+    const setB = new Set(b);
+    if (setA.size === 0 && setB.size === 0) return 0;
+    const intersection = [...setA].filter((v) => setB.has(v)).length;
+    const union = new Set([...setA, ...setB]).size;
+    return Math.round((intersection / union) * 100);
+  }
+
+  /**
+   * ジャッカード類似度に応じたラベルを返す
+   */
+  static getJaccardSimilarityLabel(similarity: number): string {
+    if (similarity >= MathHelper.JACCARD_HIGH_THRESHOLD) return '類似';
+    if (similarity >= MathHelper.JACCARD_MODERATE_THRESHOLD) return 'やや類似';
+    return '異なる';
   }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -153,6 +153,10 @@ export class MemberEntity {
   private static readonly ACTIVITY_HIGH_THRESHOLD = 80;
   private static readonly ACTIVITY_NORMAL_THRESHOLD = 50;
   private static readonly ACTIVITY_LOW_THRESHOLD = 20;
+  private static readonly CARE_SCORE_GOOD_THRESHOLD = 80;
+  private static readonly CARE_SCORE_MODERATE_THRESHOLD = 50;
+  private static readonly CARE_SCORE_ADHERENCE_WEIGHT = 0.6;
+  private static readonly CARE_SCORE_RECORD_WEIGHT = 0.4;
 
   private static readonly memberTypeLabels: Record<MemberType, string> = {
     human: '家族',
@@ -512,5 +516,29 @@ export class MemberEntity {
     if (score >= MemberEntity.ACTIVITY_NORMAL_THRESHOLD) return '普通';
     if (score >= MemberEntity.ACTIVITY_LOW_THRESHOLD) return '低調';
     return '非活動';
+  }
+
+  /**
+   * 服薬率と記録率からケアスコアを算出する（0-100）
+   */
+  static getMemberCareScore(adherenceRate: number, recordRate: number): number {
+    const clampedAdherence = Math.max(0, Math.min(100, adherenceRate));
+    const clampedRecord = Math.max(0, Math.min(100, recordRate));
+    return Math.min(
+      100,
+      Math.round(
+        clampedAdherence * MemberEntity.CARE_SCORE_ADHERENCE_WEIGHT +
+          clampedRecord * MemberEntity.CARE_SCORE_RECORD_WEIGHT
+      )
+    );
+  }
+
+  /**
+   * ケアスコアに応じたラベルを返す
+   */
+  static getMemberCareScoreLabel(score: number): string {
+    if (score >= MemberEntity.CARE_SCORE_GOOD_THRESHOLD) return '良好';
+    if (score >= MemberEntity.CARE_SCORE_MODERATE_THRESHOLD) return '普通';
+    return '要注意';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getJaccardSimilarity / getJaccardSimilarityLabel（ジャッカード類似度）追加
- MemberEntity: getMemberCareScore / getMemberCareScoreLabel（メンバーケアスコア）追加
- CalendarEntity: getWeeklyRecordRate / getWeeklyRecordRateLabel（週間記録率）追加
- 37件のユニットテスト追加（総テスト数: 6563）

## Test plan
- [x] 全37件の新規テストがパス
- [x] 既存テスト6526件に回帰なし