### PR TITLE
ジャッカード類似度・メンバーケアスコア・週間記録率のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/JaccardSimilarity.edge.test.ts
+++ b/src/__tests__/domain/entities/JaccardSimilarity.edge.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getJaccardSimilarity - エッジケース', () => {
+  it('両方空は0', () => {
+    expect(MathHelper.getJaccardSimilarity([], [])).toBe(0);
+  });
+
+  it('片方空（左）は0', () => {
+    expect(MathHelper.getJaccardSimilarity([], [1, 2])).toBe(0);
+  });
+
+  it('片方空（右）は0', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2], [])).toBe(0);
+  });
+
+  it('1件同値は100', () => {
+    expect(MathHelper.getJaccardSimilarity([1], [1])).toBe(100);
+  });
+
+  it('1件異値は0', () => {
+    expect(MathHelper.getJaccardSimilarity([1], [2])).toBe(0);
+  });
+
+  it('完全一致は100', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2, 3, 4, 5], [1, 2, 3, 4, 5])).toBe(100);
+  });
+
+  it('完全不一致は0', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2, 3], [4, 5, 6])).toBe(0);
+  });
+
+  it('部分一致50%', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 2, 3], [2, 3, 4])).toBe(50);
+  });
+
+  it('包含関係（小さい方が部分集合）', () => {
+    expect(MathHelper.getJaccardSimilarity([1], [1, 2, 3])).toBe(33);
+  });
+
+  it('重複要素は無視される', () => {
+    expect(MathHelper.getJaccardSimilarity([1, 1, 1], [1])).toBe(100);
+  });
+
+  it('順序に依存しない', () => {
+    const a = MathHelper.getJaccardSimilarity([3, 1, 2], [2, 3, 1]);
+    expect(a).toBe(100);
+  });
+
+  it('対称性', () => {
+    const ab = MathHelper.getJaccardSimilarity([1, 2], [2, 3]);
+    const ba = MathHelper.getJaccardSimilarity([2, 3], [1, 2]);
+    expect(ab).toBe(ba);
+  });
+
+  it('大量データ', () => {
+    const a = Array.from({ length: 100 }, (_, i) => i);
+    const b = Array.from({ length: 100 }, (_, i) => i);
+    expect(MathHelper.getJaccardSimilarity(a, b)).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MathHelper.getJaccardSimilarity([1, 2, 3, 4], [3, 4, 5, 6]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MathHelper.getJaccardSimilarityLabel - エッジケース', () => {
+  it('100は類似', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(100)).toBe('類似');
+  });
+
+  it('70は類似', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(70)).toBe('類似');
+  });
+
+  it('69はやや類似', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(69)).toBe('やや類似');
+  });
+
+  it('40はやや類似', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(40)).toBe('やや類似');
+  });
+
+  it('39は異なる', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(39)).toBe('異なる');
+  });
+
+  it('0は異なる', () => {
+    expect(MathHelper.getJaccardSimilarityLabel(0)).toBe('異なる');
+  });
+});

--- a/src/__tests__/domain/entities/MemberCareScore.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberCareScore.edge.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity.getMemberCareScore - エッジケース', () => {
+  it('両方0は0', () => {
+    expect(MemberEntity.getMemberCareScore(0, 0)).toBe(0);
+  });
+
+  it('両方100は100', () => {
+    expect(MemberEntity.getMemberCareScore(100, 100)).toBe(100);
+  });
+
+  it('服薬率100・記録率0', () => {
+    expect(MemberEntity.getMemberCareScore(100, 0)).toBe(60);
+  });
+
+  it('服薬率0・記録率100', () => {
+    expect(MemberEntity.getMemberCareScore(0, 100)).toBe(40);
+  });
+
+  it('両方50は50', () => {
+    expect(MemberEntity.getMemberCareScore(50, 50)).toBe(50);
+  });
+
+  it('負の服薬率は0扱い', () => {
+    expect(MemberEntity.getMemberCareScore(-10, 50)).toBe(20);
+  });
+
+  it('負の記録率は0扱い', () => {
+    expect(MemberEntity.getMemberCareScore(50, -10)).toBe(30);
+  });
+
+  it('100超えの服薬率は100扱い', () => {
+    expect(MemberEntity.getMemberCareScore(150, 50)).toBe(80);
+  });
+
+  it('100超えの記録率は100扱い', () => {
+    expect(MemberEntity.getMemberCareScore(50, 150)).toBe(70);
+  });
+
+  it('両方100超えは100', () => {
+    expect(MemberEntity.getMemberCareScore(200, 200)).toBe(100);
+  });
+
+  it('服薬率が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberCareScore(20, 50);
+    const high = MemberEntity.getMemberCareScore(80, 50);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('記録率が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberCareScore(50, 20);
+    const high = MemberEntity.getMemberCareScore(50, 80);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MemberEntity.getMemberCareScore(70, 60);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MemberEntity.getMemberCareScoreLabel - エッジケース', () => {
+  it('スコア100は良好', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(100)).toBe('良好');
+  });
+
+  it('スコア80は良好', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(80)).toBe('良好');
+  });
+
+  it('スコア79は普通', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(79)).toBe('普通');
+  });
+
+  it('スコア50は普通', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(50)).toBe('普通');
+  });
+
+  it('スコア49は要注意', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(49)).toBe('要注意');
+  });
+
+  it('スコア0は要注意', () => {
+    expect(MemberEntity.getMemberCareScoreLabel(0)).toBe('要注意');
+  });
+});

--- a/src/__tests__/domain/entities/WeeklyRecordRate.edge.test.ts
+++ b/src/__tests__/domain/entities/WeeklyRecordRate.edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getWeeklyRecordRate - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([])).toBe(0);
+  });
+
+  it('1日のみ記録ありは100', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([1])).toBe(100);
+  });
+
+  it('1日のみ記録なしは0', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([0])).toBe(0);
+  });
+
+  it('全て記録ありは100', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([1, 2, 3, 1, 1, 1, 1])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([0, 0, 0, 0, 0, 0, 0])).toBe(0);
+  });
+
+  it('1日だけ記録あり(7日中)', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([0, 0, 0, 0, 0, 0, 1])).toBe(14);
+  });
+
+  it('6日記録あり(7日中)', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([1, 1, 1, 1, 1, 1, 0])).toBe(86);
+  });
+
+  it('複数回の記録も1日として数える', () => {
+    expect(CalendarEntity.getWeeklyRecordRate([5, 0])).toBe(50);
+  });
+
+  it('大量データ', () => {
+    const data = Array(100).fill(1);
+    expect(CalendarEntity.getWeeklyRecordRate(data)).toBe(100);
+  });
+
+  it('大量データ半分0', () => {
+    const data = Array(100).fill(0).map((_, i) => (i % 2 === 0 ? 1 : 0));
+    expect(CalendarEntity.getWeeklyRecordRate(data)).toBe(50);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = CalendarEntity.getWeeklyRecordRate([1, 0, 1, 0, 1]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('記録数が多いほどスコアが高い', () => {
+    const low = CalendarEntity.getWeeklyRecordRate([1, 0, 0, 0, 0, 0, 0]);
+    const high = CalendarEntity.getWeeklyRecordRate([1, 1, 1, 1, 1, 0, 0]);
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
+describe('CalendarEntity.getWeeklyRecordRateLabel - エッジケース', () => {
+  it('率100は毎日記録', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(100)).toBe('毎日記録');
+  });
+
+  it('率80は毎日記録', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(80)).toBe('毎日記録');
+  });
+
+  it('率79はまずまず', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(79)).toBe('まずまず');
+  });
+
+  it('率50はまずまず', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(50)).toBe('まずまず');
+  });
+
+  it('率49は記録不足', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(49)).toBe('記録不足');
+  });
+
+  it('率0は記録不足', () => {
+    expect(CalendarEntity.getWeeklyRecordRateLabel(0)).toBe('記録不足');
+  });
+});


### PR DESCRIPTION
## Summary
- getJaccardSimilarity / getJaccardSimilarityLabel のエッジケーステスト20件追加
- getMemberCareScore / getMemberCareScoreLabel のエッジケーステスト19件追加
- getWeeklyRecordRate / getWeeklyRecordRateLabel のエッジケーステスト18件追加
- 合計57件のエッジケーステスト追加（総テスト数: 6620）

## Test plan
- [x] 全57件のエッジケーステストがパス
- [x] 既存テスト6563件に回帰なし