### PR TITLE
単純線形回帰・在庫一貫性スコア・服薬タイミングスコアの追加

### DIFF
--- a/src/__tests__/domain/entities/DoseTimingScore.test.ts
+++ b/src/__tests__/domain/entities/DoseTimingScore.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseTimingScore', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([])).toBe(0);
+  });
+
+  it('ずれなしは100', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([0, 0, 0])).toBe(100);
+  });
+
+  it('1件ずれなしは100', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([0])).toBe(100);
+  });
+
+  it('大きなずれはスコアが低い', () => {
+    const result = MedicationRecordEntity.getDoseTimingScore([60, 60, 60]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('小さなずれはスコアが高い', () => {
+    const result = MedicationRecordEntity.getDoseTimingScore([5, 5, 5]);
+    expect(result).toBeGreaterThan(80);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MedicationRecordEntity.getDoseTimingScore([10, 20, 30]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('ずれが少ないほどスコアが高い', () => {
+    const accurate = MedicationRecordEntity.getDoseTimingScore([5, 5, 5]);
+    const inaccurate = MedicationRecordEntity.getDoseTimingScore([30, 30, 30]);
+    expect(accurate).toBeGreaterThan(inaccurate);
+  });
+
+  it('負のずれは絶対値で扱う', () => {
+    const pos = MedicationRecordEntity.getDoseTimingScore([10]);
+    const neg = MedicationRecordEntity.getDoseTimingScore([-10]);
+    expect(pos).toBe(neg);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseTimingScoreLabel', () => {
+  it('スコア高は正確', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(85)).toBe('正確');
+  });
+
+  it('スコア中はやや遅れ', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(55)).toBe('やや遅れ');
+  });
+
+  it('スコア低は遅れがち', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(25)).toBe('遅れがち');
+  });
+});

--- a/src/__tests__/domain/entities/SimpleLinearRegression.test.ts
+++ b/src/__tests__/domain/entities/SimpleLinearRegression.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getSimpleLinearRegression', () => {
+  it('空配列は傾き0・切片0', () => {
+    const result = MathHelper.getSimpleLinearRegression([]);
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(0);
+  });
+
+  it('1件は傾き0', () => {
+    const result = MathHelper.getSimpleLinearRegression([5]);
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(5);
+  });
+
+  it('上昇傾向', () => {
+    const result = MathHelper.getSimpleLinearRegression([1, 2, 3, 4, 5]);
+    expect(result.slope).toBe(1);
+  });
+
+  it('下降傾向', () => {
+    const result = MathHelper.getSimpleLinearRegression([5, 4, 3, 2, 1]);
+    expect(result.slope).toBe(-1);
+  });
+
+  it('横ばい', () => {
+    const result = MathHelper.getSimpleLinearRegression([3, 3, 3]);
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(3);
+  });
+
+  it('2件', () => {
+    const result = MathHelper.getSimpleLinearRegression([0, 10]);
+    expect(result.slope).toBe(10);
+    expect(result.intercept).toBe(0);
+  });
+
+  it('傾きの正負で傾向がわかる', () => {
+    const up = MathHelper.getSimpleLinearRegression([1, 3, 5, 7]);
+    const down = MathHelper.getSimpleLinearRegression([7, 5, 3, 1]);
+    expect(up.slope).toBeGreaterThan(0);
+    expect(down.slope).toBeLessThan(0);
+  });
+
+  it('結果は数値', () => {
+    const result = MathHelper.getSimpleLinearRegression([10, 20, 15, 25]);
+    expect(typeof result.slope).toBe('number');
+    expect(typeof result.intercept).toBe('number');
+  });
+});
+
+describe('MathHelper.getSimpleLinearRegressionLabel', () => {
+  it('正の傾きは上昇', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(2)).toBe('上昇');
+  });
+
+  it('負の傾きは下降', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(-2)).toBe('下降');
+  });
+
+  it('0付近は横ばい', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(0)).toBe('横ばい');
+  });
+
+  it('微小な正の傾きは横ばい', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(0.05)).toBe('横ばい');
+  });
+});

--- a/src/__tests__/domain/entities/StockConsistencyScore.test.ts
+++ b/src/__tests__/domain/entities/StockConsistencyScore.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockConsistencyScore', () => {
+  it('空配列は0', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([50])).toBe(100);
+  });
+
+  it('全て同じは100', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([10, 10, 10])).toBe(100);
+  });
+
+  it('ばらつきがあるとスコアが下がる', () => {
+    const result = StockAlertEntity.getStockConsistencyScore([10, 50, 90]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('大きなばらつき', () => {
+    const result = StockAlertEntity.getStockConsistencyScore([0, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = StockAlertEntity.getStockConsistencyScore([20, 40, 60, 80]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('均一なほどスコアが高い', () => {
+    const regular = StockAlertEntity.getStockConsistencyScore([50, 50, 50]);
+    const irregular = StockAlertEntity.getStockConsistencyScore([10, 50, 90]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('2件で同値は100', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([30, 30])).toBe(100);
+  });
+});
+
+describe('StockAlertEntity.getStockConsistencyScoreLabel', () => {
+  it('スコア高は安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(85)).toBe('安定');
+  });
+
+  it('スコア中はやや不安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(60)).toBe('やや不安定');
+  });
+
+  it('スコア低は不安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(30)).toBe('不安定');
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -49,6 +49,7 @@ export class MathHelper {
   private static readonly MSE_MODERATE_THRESHOLD = 25;
   private static readonly JACCARD_HIGH_THRESHOLD = 70;
   private static readonly JACCARD_MODERATE_THRESHOLD = 40;
+  private static readonly LR_SLOPE_THRESHOLD = 0.1;
 
   /**
    * パーセントを算出(0-100%)
@@ -827,5 +828,37 @@ export class MathHelper {
     if (similarity >= MathHelper.JACCARD_HIGH_THRESHOLD) return '類似';
     if (similarity >= MathHelper.JACCARD_MODERATE_THRESHOLD) return 'やや類似';
     return '異なる';
+  }
+
+  /**
+   * 単純線形回帰の傾きと切片を算出する
+   * x軸はインデックス（0, 1, 2, ...）
+   */
+  static getSimpleLinearRegression(values: number[]): {
+    slope: number;
+    intercept: number;
+  } {
+    if (values.length === 0) return { slope: 0, intercept: 0 };
+    if (values.length === 1) return { slope: 0, intercept: values[0] };
+    const n = values.length;
+    const sumX = (n * (n - 1)) / 2;
+    const sumY = values.reduce((a, b) => a + b, 0);
+    const sumXY = values.reduce((sum, y, x) => sum + x * y, 0);
+    const sumX2 = (n * (n - 1) * (2 * n - 1)) / 6;
+    const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+    const intercept = (sumY - slope * sumX) / n;
+    return {
+      slope: Math.round(slope * 100) / 100,
+      intercept: Math.round(intercept * 100) / 100,
+    };
+  }
+
+  /**
+   * 線形回帰の傾きに応じたラベルを返す
+   */
+  static getSimpleLinearRegressionLabel(slope: number): string {
+    if (slope > MathHelper.LR_SLOPE_THRESHOLD) return '上昇';
+    if (slope < -MathHelper.LR_SLOPE_THRESHOLD) return '下降';
+    return '横ばい';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -60,6 +60,9 @@ export class MedicationRecordEntity {
   private static readonly DOSE_CONSECUTIVE_GOOD_THRESHOLD = 50;
   private static readonly DOSE_COMPLETION_PERFECT_THRESHOLD = 90;
   private static readonly DOSE_COMPLETION_GOOD_THRESHOLD = 70;
+  private static readonly DOSE_TIMING_MAX_DELAY = 60;
+  private static readonly DOSE_TIMING_ACCURATE_THRESHOLD = 80;
+  private static readonly DOSE_TIMING_MODERATE_THRESHOLD = 50;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -884,5 +887,33 @@ export class MedicationRecordEntity {
     if (rate >= MedicationRecordEntity.DOSE_COMPLETION_PERFECT_THRESHOLD) return '完璧';
     if (rate >= MedicationRecordEntity.DOSE_COMPLETION_GOOD_THRESHOLD) return '良好';
     return '要改善';
+  }
+
+  /**
+   * 服薬タイミングのずれ（分）からスコアを算出する（0-100）
+   * ずれが小さいほどスコアが高い
+   */
+  static getDoseTimingScore(delayMinutes: number[]): number {
+    if (delayMinutes.length === 0) return 0;
+    const avgDelay =
+      delayMinutes.reduce((sum, d) => sum + Math.abs(d), 0) / delayMinutes.length;
+    return Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(
+          100 - (avgDelay / MedicationRecordEntity.DOSE_TIMING_MAX_DELAY) * 100
+        )
+      )
+    );
+  }
+
+  /**
+   * 服薬タイミングスコアに応じたラベルを返す
+   */
+  static getDoseTimingScoreLabel(score: number): string {
+    if (score >= MedicationRecordEntity.DOSE_TIMING_ACCURATE_THRESHOLD) return '正確';
+    if (score >= MedicationRecordEntity.DOSE_TIMING_MODERATE_THRESHOLD) return 'やや遅れ';
+    return '遅れがち';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -49,6 +49,9 @@ export class StockAlertEntity {
   private static readonly SAFETY_MARGIN_MAX_DAYS = 30;
   private static readonly SAFETY_MARGIN_SAFE_THRESHOLD = 70;
   private static readonly SAFETY_MARGIN_CAUTION_THRESHOLD = 30;
+  private static readonly CONSISTENCY_MAX_STDDEV = 50;
+  private static readonly CONSISTENCY_HIGH_THRESHOLD = 80;
+  private static readonly CONSISTENCY_MODERATE_THRESHOLD = 50;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -657,5 +660,34 @@ export class StockAlertEntity {
     if (score >= StockAlertEntity.SAFETY_MARGIN_SAFE_THRESHOLD) return '安全';
     if (score >= StockAlertEntity.SAFETY_MARGIN_CAUTION_THRESHOLD) return '注意';
     return '危険';
+  }
+
+  /**
+   * 在庫レベルの一貫性スコアを算出する（0-100）
+   * 標準偏差が小さいほどスコアが高い
+   */
+  static getStockConsistencyScore(stockLevels: number[]): number {
+    if (stockLevels.length <= 1) return stockLevels.length === 0 ? 0 : 100;
+    const avg = stockLevels.reduce((a, b) => a + b, 0) / stockLevels.length;
+    if (avg === 0) return 0;
+    const variance =
+      stockLevels.reduce((sum, v) => sum + (v - avg) ** 2, 0) / stockLevels.length;
+    const stdDev = Math.sqrt(variance);
+    return Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(100 - (stdDev / StockAlertEntity.CONSISTENCY_MAX_STDDEV) * 100)
+      )
+    );
+  }
+
+  /**
+   * 在庫一貫性スコアに応じたラベルを返す
+   */
+  static getStockConsistencyScoreLabel(score: number): string {
+    if (score >= StockAlertEntity.CONSISTENCY_HIGH_THRESHOLD) return '安定';
+    if (score >= StockAlertEntity.CONSISTENCY_MODERATE_THRESHOLD) return 'やや不安定';
+    return '不安定';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getSimpleLinearRegression / getSimpleLinearRegressionLabel（単純線形回帰）追加
- StockAlertEntity: getStockConsistencyScore / getStockConsistencyScoreLabel（在庫一貫性スコア）追加
- MedicationRecordEntity: getDoseTimingScore / getDoseTimingScoreLabel（服薬タイミングスコア）追加
- 34件のユニットテスト追加（総テスト数: 6654）

## Test plan
- [x] 全34件の新規テストがパス
- [x] 既存テスト6620件に回帰なし