### PR TITLE
単純線形回帰・在庫一貫性スコア・服薬タイミングスコアのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/DoseTimingScore.edge.test.ts
+++ b/src/__tests__/domain/entities/DoseTimingScore.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getDoseTimingScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([])).toBe(0);
+  });
+
+  it('ずれ0は100', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([0])).toBe(100);
+  });
+
+  it('全てずれ0は100', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([0, 0, 0, 0])).toBe(100);
+  });
+
+  it('ずれ60分は0', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([60])).toBe(0);
+  });
+
+  it('ずれ30分は50', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([30])).toBe(50);
+  });
+
+  it('超過ずれは0', () => {
+    expect(MedicationRecordEntity.getDoseTimingScore([120])).toBe(0);
+  });
+
+  it('負のずれは絶対値で扱う', () => {
+    const pos = MedicationRecordEntity.getDoseTimingScore([15]);
+    const neg = MedicationRecordEntity.getDoseTimingScore([-15]);
+    expect(pos).toBe(neg);
+  });
+
+  it('ずれが少ないほどスコアが高い', () => {
+    const accurate = MedicationRecordEntity.getDoseTimingScore([5, 5]);
+    const inaccurate = MedicationRecordEntity.getDoseTimingScore([40, 40]);
+    expect(accurate).toBeGreaterThan(inaccurate);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MedicationRecordEntity.getDoseTimingScore([10, 20, 30]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('混在するずれ', () => {
+    const result = MedicationRecordEntity.getDoseTimingScore([0, 60]);
+    expect(result).toBe(50);
+  });
+
+  it('大量データ', () => {
+    const data = Array(100).fill(0);
+    expect(MedicationRecordEntity.getDoseTimingScore(data)).toBe(100);
+  });
+
+  it('小さなずれは高スコア', () => {
+    const result = MedicationRecordEntity.getDoseTimingScore([3, 2, 1]);
+    expect(result).toBeGreaterThan(90);
+  });
+});
+
+describe('MedicationRecordEntity.getDoseTimingScoreLabel - エッジケース', () => {
+  it('スコア100は正確', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(100)).toBe('正確');
+  });
+
+  it('スコア80は正確', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(80)).toBe('正確');
+  });
+
+  it('スコア79はやや遅れ', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(79)).toBe('やや遅れ');
+  });
+
+  it('スコア50はやや遅れ', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(50)).toBe('やや遅れ');
+  });
+
+  it('スコア49は遅れがち', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(49)).toBe('遅れがち');
+  });
+
+  it('スコア0は遅れがち', () => {
+    expect(MedicationRecordEntity.getDoseTimingScoreLabel(0)).toBe('遅れがち');
+  });
+});

--- a/src/__tests__/domain/entities/SimpleLinearRegression.edge.test.ts
+++ b/src/__tests__/domain/entities/SimpleLinearRegression.edge.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getSimpleLinearRegression - エッジケース', () => {
+  it('空配列は傾き0・切片0', () => {
+    const result = MathHelper.getSimpleLinearRegression([]);
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(0);
+  });
+
+  it('1件は傾き0・切片が値', () => {
+    const result = MathHelper.getSimpleLinearRegression([42]);
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(42);
+  });
+
+  it('2件で上昇', () => {
+    const result = MathHelper.getSimpleLinearRegression([0, 10]);
+    expect(result.slope).toBe(10);
+    expect(result.intercept).toBe(0);
+  });
+
+  it('2件で下降', () => {
+    const result = MathHelper.getSimpleLinearRegression([10, 0]);
+    expect(result.slope).toBe(-10);
+    expect(result.intercept).toBe(10);
+  });
+
+  it('全て同じは傾き0', () => {
+    const result = MathHelper.getSimpleLinearRegression([5, 5, 5, 5]);
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(5);
+  });
+
+  it('完全な線形増加', () => {
+    const result = MathHelper.getSimpleLinearRegression([0, 2, 4, 6, 8]);
+    expect(result.slope).toBe(2);
+    expect(result.intercept).toBe(0);
+  });
+
+  it('完全な線形減少', () => {
+    const result = MathHelper.getSimpleLinearRegression([8, 6, 4, 2, 0]);
+    expect(result.slope).toBe(-2);
+    expect(result.intercept).toBe(8);
+  });
+
+  it('ノイズがある場合', () => {
+    const result = MathHelper.getSimpleLinearRegression([1, 3, 2, 4, 3, 5]);
+    expect(result.slope).toBeGreaterThan(0);
+  });
+
+  it('全て0は傾き0・切片0', () => {
+    const result = MathHelper.getSimpleLinearRegression([0, 0, 0]);
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(0);
+  });
+
+  it('負の値', () => {
+    const result = MathHelper.getSimpleLinearRegression([-10, -5, 0, 5, 10]);
+    expect(result.slope).toBe(5);
+    expect(result.intercept).toBe(-10);
+  });
+
+  it('大量データ', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i);
+    const result = MathHelper.getSimpleLinearRegression(data);
+    expect(result.slope).toBe(1);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getSimpleLinearRegression([0.5, 1.0, 1.5]);
+    expect(result.slope).toBeCloseTo(0.5, 1);
+  });
+});
+
+describe('MathHelper.getSimpleLinearRegressionLabel - エッジケース', () => {
+  it('傾き1は上昇', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(1)).toBe('上昇');
+  });
+
+  it('傾き0.11は上昇', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(0.11)).toBe('上昇');
+  });
+
+  it('傾き0.1は横ばい', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(0.1)).toBe('横ばい');
+  });
+
+  it('傾き0は横ばい', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(0)).toBe('横ばい');
+  });
+
+  it('傾き-0.1は横ばい', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(-0.1)).toBe('横ばい');
+  });
+
+  it('傾き-0.11は下降', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(-0.11)).toBe('下降');
+  });
+
+  it('傾き-5は下降', () => {
+    expect(MathHelper.getSimpleLinearRegressionLabel(-5)).toBe('下降');
+  });
+});

--- a/src/__tests__/domain/entities/StockConsistencyScore.edge.test.ts
+++ b/src/__tests__/domain/entities/StockConsistencyScore.edge.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockConsistencyScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([50])).toBe(100);
+  });
+
+  it('全て同じは100', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([30, 30, 30, 30])).toBe(100);
+  });
+
+  it('2件同値は100', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([20, 20])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([0, 0, 0])).toBe(0);
+  });
+
+  it('わずかなばらつき', () => {
+    const result = StockAlertEntity.getStockConsistencyScore([49, 50, 51]);
+    expect(result).toBeGreaterThan(95);
+  });
+
+  it('大きなばらつき', () => {
+    const result = StockAlertEntity.getStockConsistencyScore([0, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('均一なほどスコアが高い', () => {
+    const regular = StockAlertEntity.getStockConsistencyScore([50, 50, 50]);
+    const irregular = StockAlertEntity.getStockConsistencyScore([10, 50, 90]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = StockAlertEntity.getStockConsistencyScore([5, 15, 25, 35]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(50).fill(20);
+    expect(StockAlertEntity.getStockConsistencyScore(data)).toBe(100);
+  });
+
+  it('大きな値', () => {
+    expect(StockAlertEntity.getStockConsistencyScore([1000, 1000])).toBe(100);
+  });
+});
+
+describe('StockAlertEntity.getStockConsistencyScoreLabel - エッジケース', () => {
+  it('スコア100は安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(100)).toBe('安定');
+  });
+
+  it('スコア80は安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(80)).toBe('安定');
+  });
+
+  it('スコア79はやや不安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(79)).toBe('やや不安定');
+  });
+
+  it('スコア50はやや不安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(50)).toBe('やや不安定');
+  });
+
+  it('スコア49は不安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(49)).toBe('不安定');
+  });
+
+  it('スコア0は不安定', () => {
+    expect(StockAlertEntity.getStockConsistencyScoreLabel(0)).toBe('不安定');
+  });
+});


### PR DESCRIPTION
## Summary
- getSimpleLinearRegression / getSimpleLinearRegressionLabel のエッジケーステスト19件追加
- getStockConsistencyScore / getStockConsistencyScoreLabel のエッジケーステスト17件追加
- getDoseTimingScore / getDoseTimingScoreLabel のエッジケーステスト18件追加
- 合計54件のエッジケーステスト追加（総テスト数: 6708）

## Test plan
- [x] 全54件のエッジケーステストがパス
- [x] 既存テスト6654件に回帰なし