### PR TITLE
スピアマン順位相関・服薬連続ボーナス・スケジュール稼働率の追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceStreakBonus.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStreakBonus.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceStreakBonus', () => {
+  it('0日は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(0)).toBe(0);
+  });
+
+  it('1日は低いスコア', () => {
+    const result = AdherenceTrendEntity.getAdherenceStreakBonus(1);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(20);
+  });
+
+  it('7日は中程度', () => {
+    const result = AdherenceTrendEntity.getAdherenceStreakBonus(7);
+    expect(result).toBeGreaterThan(10);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('30日は高い', () => {
+    const result = AdherenceTrendEntity.getAdherenceStreakBonus(30);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('日数が多いほどボーナスが高い', () => {
+    const low = AdherenceTrendEntity.getAdherenceStreakBonus(3);
+    const high = AdherenceTrendEntity.getAdherenceStreakBonus(20);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('最大100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(100)).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceTrendEntity.getAdherenceStreakBonus(14);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('負の値は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(-5)).toBe(0);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceStreakBonusLabel', () => {
+  it('ボーナス高はボーナス大', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(80)).toBe('ボーナス大');
+  });
+
+  it('ボーナス中はボーナス中', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(50)).toBe('ボーナス中');
+  });
+
+  it('ボーナス低はボーナス小', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(15)).toBe('ボーナス小');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleUtilizationRate.test.ts
+++ b/src/__tests__/domain/entities/ScheduleUtilizationRate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleUtilizationRate', () => {
+  it('両方0は0', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(0, 0)).toBe(0);
+  });
+
+  it('完了0は0', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(0, 10)).toBe(0);
+  });
+
+  it('予定0は0', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(5, 0)).toBe(0);
+  });
+
+  it('全完了は100', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(10, 10)).toBe(100);
+  });
+
+  it('半分は50', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(5, 10)).toBe(50);
+  });
+
+  it('超過も100', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(15, 10)).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = ScheduleEntity.getScheduleUtilizationRate(7, 20);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('完了が多いほどスコアが高い', () => {
+    const low = ScheduleEntity.getScheduleUtilizationRate(2, 10);
+    const high = ScheduleEntity.getScheduleUtilizationRate(8, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('1件中1件完了は100', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(1, 1)).toBe(100);
+  });
+});
+
+describe('ScheduleEntity.getScheduleUtilizationRateLabel', () => {
+  it('率高は高稼働', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(85)).toBe('高稼働');
+  });
+
+  it('率中は普通', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(60)).toBe('普通');
+  });
+
+  it('率低は低稼働', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(30)).toBe('低稼働');
+  });
+});

--- a/src/__tests__/domain/entities/SpearmanRankCorrelation.test.ts
+++ b/src/__tests__/domain/entities/SpearmanRankCorrelation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getSpearmanRankCorrelation', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([], [])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([1], [1])).toBe(0);
+  });
+
+  it('完全正相関は1', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([1, 2, 3, 4, 5], [10, 20, 30, 40, 50])).toBe(1);
+  });
+
+  it('完全逆相関は-1', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([1, 2, 3, 4, 5], [50, 40, 30, 20, 10])).toBe(-1);
+  });
+
+  it('無相関は0付近', () => {
+    const result = MathHelper.getSpearmanRankCorrelation([1, 2, 3, 4], [3, 1, 4, 2]);
+    expect(Math.abs(result)).toBeLessThan(0.5);
+  });
+
+  it('配列長が異なる場合は短い方に合わせる', () => {
+    const result = MathHelper.getSpearmanRankCorrelation([1, 2, 3], [1, 2, 3, 4, 5]);
+    expect(result).toBe(1);
+  });
+
+  it('結果は-1から1の範囲', () => {
+    const result = MathHelper.getSpearmanRankCorrelation([5, 3, 1, 2, 4], [2, 4, 5, 1, 3]);
+    expect(result).toBeGreaterThanOrEqual(-1);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('同順位でも計算できる', () => {
+    const result = MathHelper.getSpearmanRankCorrelation([1, 1, 2, 3], [1, 2, 3, 4]);
+    expect(typeof result).toBe('number');
+  });
+});
+
+describe('MathHelper.getSpearmanRankCorrelationLabel', () => {
+  it('正の強い相関は正相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(0.8)).toBe('正相関');
+  });
+
+  it('負の強い相関は逆相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(-0.8)).toBe('逆相関');
+  });
+
+  it('弱い相関は無相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(0.2)).toBe('無相関');
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -45,6 +45,9 @@ export class AdherenceTrendEntity {
   private static readonly STABILITY_MAX_STDDEV = 30;
   private static readonly STABILITY_HIGH_THRESHOLD = 80;
   private static readonly STABILITY_MODERATE_THRESHOLD = 50;
+  private static readonly STREAK_BONUS_MAX_DAYS = 30;
+  private static readonly STREAK_BONUS_HIGH_THRESHOLD = 70;
+  private static readonly STREAK_BONUS_MODERATE_THRESHOLD = 30;
 
   constructor(private readonly trend: AdherenceTrend) {}
 
@@ -519,5 +522,29 @@ export class AdherenceTrendEntity {
     if (score >= AdherenceTrendEntity.STABILITY_HIGH_THRESHOLD) return '安定';
     if (score >= AdherenceTrendEntity.STABILITY_MODERATE_THRESHOLD) return 'やや不安定';
     return '不安定';
+  }
+
+  /**
+   * 連続服薬日数からボーナススコアを算出する（0-100）
+   */
+  static getAdherenceStreakBonus(streakDays: number): number {
+    if (streakDays <= 0) return 0;
+    return Math.min(
+      100,
+      Math.round(
+        (Math.min(streakDays, AdherenceTrendEntity.STREAK_BONUS_MAX_DAYS) /
+          AdherenceTrendEntity.STREAK_BONUS_MAX_DAYS) *
+          100
+      )
+    );
+  }
+
+  /**
+   * 連続ボーナススコアに応じたラベルを返す
+   */
+  static getAdherenceStreakBonusLabel(bonus: number): string {
+    if (bonus >= AdherenceTrendEntity.STREAK_BONUS_HIGH_THRESHOLD) return 'ボーナス大';
+    if (bonus >= AdherenceTrendEntity.STREAK_BONUS_MODERATE_THRESHOLD) return 'ボーナス中';
+    return 'ボーナス小';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -50,6 +50,7 @@ export class MathHelper {
   private static readonly JACCARD_HIGH_THRESHOLD = 70;
   private static readonly JACCARD_MODERATE_THRESHOLD = 40;
   private static readonly LR_SLOPE_THRESHOLD = 0.1;
+  private static readonly SPEARMAN_STRONG_THRESHOLD = 0.6;
 
   /**
    * パーセントを算出(0-100%)
@@ -860,5 +861,32 @@ export class MathHelper {
     if (slope > MathHelper.LR_SLOPE_THRESHOLD) return '上昇';
     if (slope < -MathHelper.LR_SLOPE_THRESHOLD) return '下降';
     return '横ばい';
+  }
+
+  /**
+   * スピアマン順位相関係数を算出する（-1〜1）
+   * 配列長が異なる場合は短い方に合わせる
+   */
+  static getSpearmanRankCorrelation(x: number[], y: number[]): number {
+    const n = Math.min(x.length, y.length);
+    if (n <= 1) return 0;
+    const rank = (arr: number[]): number[] => {
+      const sorted = [...arr].sort((a, b) => a - b);
+      return arr.map((v) => sorted.indexOf(v) + 1);
+    };
+    const rx = rank(x.slice(0, n));
+    const ry = rank(y.slice(0, n));
+    const d2 = rx.reduce((sum, r, i) => sum + (r - ry[i]) ** 2, 0);
+    const rho = 1 - (6 * d2) / (n * (n * n - 1));
+    return Math.round(rho * 100) / 100;
+  }
+
+  /**
+   * スピアマン順位相関係数に応じたラベルを返す
+   */
+  static getSpearmanRankCorrelationLabel(rho: number): string {
+    if (rho >= MathHelper.SPEARMAN_STRONG_THRESHOLD) return '正相関';
+    if (rho <= -MathHelper.SPEARMAN_STRONG_THRESHOLD) return '逆相関';
+    return '無相関';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -801,6 +801,8 @@ export class ScheduleEntity {
   private static readonly LOAD_MAX_PER_HOUR = 1;
   private static readonly LOAD_HIGH_THRESHOLD = 70;
   private static readonly LOAD_MODERATE_THRESHOLD = 30;
+  private static readonly UTILIZATION_HIGH_THRESHOLD = 80;
+  private static readonly UTILIZATION_MODERATE_THRESHOLD = 50;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -1052,5 +1054,26 @@ export class ScheduleEntity {
     if (score >= ScheduleEntity.LOAD_HIGH_THRESHOLD) return '過密';
     if (score >= ScheduleEntity.LOAD_MODERATE_THRESHOLD) return '適度';
     return '余裕';
+  }
+
+  /**
+   * スケジュール稼働率を算出する（0-100）
+   * 完了数 / 予定数
+   */
+  static getScheduleUtilizationRate(
+    completed: number,
+    scheduled: number
+  ): number {
+    if (scheduled <= 0) return 0;
+    return Math.min(100, Math.round((completed / scheduled) * 100));
+  }
+
+  /**
+   * 稼働率に応じたラベルを返す
+   */
+  static getScheduleUtilizationRateLabel(rate: number): string {
+    if (rate >= ScheduleEntity.UTILIZATION_HIGH_THRESHOLD) return '高稼働';
+    if (rate >= ScheduleEntity.UTILIZATION_MODERATE_THRESHOLD) return '普通';
+    return '低稼働';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getSpearmanRankCorrelation / getSpearmanRankCorrelationLabel（スピアマン順位相関係数）追加
- AdherenceTrendEntity: getAdherenceStreakBonus / getAdherenceStreakBonusLabel（服薬連続ボーナススコア）追加
- ScheduleEntity: getScheduleUtilizationRate / getScheduleUtilizationRateLabel（スケジュール稼働率）追加
- 34件のユニットテスト追加（総テスト数: 6742）

## Test plan
- [x] 全34件の新規テストがパス
- [x] 既存テスト6708件に回帰なし