### PR TITLE
スピアマン順位相関・服薬連続ボーナス・スケジュール稼働率のエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceStreakBonus.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceStreakBonus.edge.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceStreakBonus - エッジケース', () => {
+  it('0日は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(0)).toBe(0);
+  });
+
+  it('負の値は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(-10)).toBe(0);
+  });
+
+  it('1日', () => {
+    const result = AdherenceTrendEntity.getAdherenceStreakBonus(1);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(10);
+  });
+
+  it('15日は50', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(15)).toBe(50);
+  });
+
+  it('30日は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(30)).toBe(100);
+  });
+
+  it('超過しても100', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonus(60)).toBe(100);
+  });
+
+  it('日数が多いほどボーナスが高い', () => {
+    const low = AdherenceTrendEntity.getAdherenceStreakBonus(5);
+    const high = AdherenceTrendEntity.getAdherenceStreakBonus(25);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceTrendEntity.getAdherenceStreakBonus(10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('7日', () => {
+    const result = AdherenceTrendEntity.getAdherenceStreakBonus(7);
+    expect(result).toBe(23);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceStreakBonusLabel - エッジケース', () => {
+  it('100はボーナス大', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(100)).toBe('ボーナス大');
+  });
+
+  it('70はボーナス大', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(70)).toBe('ボーナス大');
+  });
+
+  it('69はボーナス中', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(69)).toBe('ボーナス中');
+  });
+
+  it('30はボーナス中', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(30)).toBe('ボーナス中');
+  });
+
+  it('29はボーナス小', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(29)).toBe('ボーナス小');
+  });
+
+  it('0はボーナス小', () => {
+    expect(AdherenceTrendEntity.getAdherenceStreakBonusLabel(0)).toBe('ボーナス小');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleUtilizationRate.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleUtilizationRate.edge.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleUtilizationRate - エッジケース', () => {
+  it('両方0は0', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(0, 0)).toBe(0);
+  });
+
+  it('完了0・予定ありは0', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(0, 10)).toBe(0);
+  });
+
+  it('完了あり・予定0は0', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(5, 0)).toBe(0);
+  });
+
+  it('全完了は100', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(10, 10)).toBe(100);
+  });
+
+  it('1件中1件は100', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(1, 1)).toBe(100);
+  });
+
+  it('超過は100', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(20, 10)).toBe(100);
+  });
+
+  it('半分は50', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(5, 10)).toBe(50);
+  });
+
+  it('1/3', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(1, 3)).toBe(33);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = ScheduleEntity.getScheduleUtilizationRate(7, 20);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('完了が多いほどスコアが高い', () => {
+    const low = ScheduleEntity.getScheduleUtilizationRate(2, 10);
+    const high = ScheduleEntity.getScheduleUtilizationRate(8, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('大きな値', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRate(100, 100)).toBe(100);
+  });
+});
+
+describe('ScheduleEntity.getScheduleUtilizationRateLabel - エッジケース', () => {
+  it('率100は高稼働', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(100)).toBe('高稼働');
+  });
+
+  it('率80は高稼働', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(80)).toBe('高稼働');
+  });
+
+  it('率79は普通', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(79)).toBe('普通');
+  });
+
+  it('率50は普通', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(50)).toBe('普通');
+  });
+
+  it('率49は低稼働', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(49)).toBe('低稼働');
+  });
+
+  it('率0は低稼働', () => {
+    expect(ScheduleEntity.getScheduleUtilizationRateLabel(0)).toBe('低稼働');
+  });
+});

--- a/src/__tests__/domain/entities/SpearmanRankCorrelation.edge.test.ts
+++ b/src/__tests__/domain/entities/SpearmanRankCorrelation.edge.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getSpearmanRankCorrelation - エッジケース', () => {
+  it('両方空は0', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([], [])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([5], [10])).toBe(0);
+  });
+
+  it('2件で完全正相関は1', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([1, 2], [10, 20])).toBe(1);
+  });
+
+  it('2件で完全逆相関は-1', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([1, 2], [20, 10])).toBe(-1);
+  });
+
+  it('完全正相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([1, 2, 3, 4, 5], [2, 4, 6, 8, 10])).toBe(1);
+  });
+
+  it('完全逆相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelation([1, 2, 3, 4, 5], [10, 8, 6, 4, 2])).toBe(-1);
+  });
+
+  it('配列長が異なる場合', () => {
+    const result = MathHelper.getSpearmanRankCorrelation([1, 2, 3], [10, 20]);
+    expect(result).toBe(1);
+  });
+
+  it('全て同値', () => {
+    const result = MathHelper.getSpearmanRankCorrelation([5, 5, 5], [10, 10, 10]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('結果は-1から1の範囲', () => {
+    const result = MathHelper.getSpearmanRankCorrelation([3, 1, 4, 1, 5], [9, 2, 6, 5, 3]);
+    expect(result).toBeGreaterThanOrEqual(-1);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('大量データ', () => {
+    const x = Array.from({ length: 50 }, (_, i) => i);
+    const y = Array.from({ length: 50 }, (_, i) => i * 2);
+    expect(MathHelper.getSpearmanRankCorrelation(x, y)).toBe(1);
+  });
+
+  it('対称性', () => {
+    const ab = MathHelper.getSpearmanRankCorrelation([1, 2, 3], [3, 1, 2]);
+    const ba = MathHelper.getSpearmanRankCorrelation([3, 1, 2], [1, 2, 3]);
+    expect(ab).toBe(ba);
+  });
+});
+
+describe('MathHelper.getSpearmanRankCorrelationLabel - エッジケース', () => {
+  it('1は正相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(1)).toBe('正相関');
+  });
+
+  it('0.6は正相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(0.6)).toBe('正相関');
+  });
+
+  it('0.59は無相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(0.59)).toBe('無相関');
+  });
+
+  it('0は無相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(0)).toBe('無相関');
+  });
+
+  it('-0.59は無相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(-0.59)).toBe('無相関');
+  });
+
+  it('-0.6は逆相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(-0.6)).toBe('逆相関');
+  });
+
+  it('-1は逆相関', () => {
+    expect(MathHelper.getSpearmanRankCorrelationLabel(-1)).toBe('逆相関');
+  });
+});


### PR DESCRIPTION
## Summary
- getSpearmanRankCorrelation / getSpearmanRankCorrelationLabel のエッジケーステスト18件追加
- getAdherenceStreakBonus / getAdherenceStreakBonusLabel のエッジケーステスト15件追加
- getScheduleUtilizationRate / getScheduleUtilizationRateLabel のエッジケーステスト17件追加
- 合計50件のエッジケーステスト追加（総テスト数: 6792）

## Test plan
- [x] 全50件のエッジケーステストがパス
- [x] 既存テスト6742件に回帰なし