### PR TITLE
指数減衰・薬の複雑さスコア・症状負担スコアの追加

### DIFF
--- a/src/__tests__/domain/entities/ExponentialDecay.test.ts
+++ b/src/__tests__/domain/entities/ExponentialDecay.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getExponentialDecay', () => {
+  it('時間0は初期値そのまま', () => {
+    expect(MathHelper.getExponentialDecay(100, 0, 0.1)).toBe(100);
+  });
+
+  it('時間が増えると値が減る', () => {
+    const early = MathHelper.getExponentialDecay(100, 1, 0.1);
+    const late = MathHelper.getExponentialDecay(100, 10, 0.1);
+    expect(late).toBeLessThan(early);
+  });
+
+  it('初期値0は常に0', () => {
+    expect(MathHelper.getExponentialDecay(0, 5, 0.1)).toBe(0);
+  });
+
+  it('減衰率0は初期値のまま', () => {
+    expect(MathHelper.getExponentialDecay(100, 10, 0)).toBe(100);
+  });
+
+  it('大きな減衰率で急速減衰', () => {
+    const result = MathHelper.getExponentialDecay(100, 10, 1);
+    expect(result).toBeLessThan(1);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getExponentialDecay(100, 100, 0.5);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('結果は初期値以下', () => {
+    const result = MathHelper.getExponentialDecay(50, 5, 0.2);
+    expect(result).toBeLessThanOrEqual(50);
+  });
+
+  it('半減期の確認', () => {
+    const result = MathHelper.getExponentialDecay(100, 1, Math.LN2);
+    expect(result).toBeCloseTo(50, 0);
+  });
+});
+
+describe('MathHelper.getExponentialDecayLabel', () => {
+  it('値高は有効', () => {
+    expect(MathHelper.getExponentialDecayLabel(80)).toBe('有効');
+  });
+
+  it('値中はやや減衰', () => {
+    expect(MathHelper.getExponentialDecayLabel(40)).toBe('やや減衰');
+  });
+
+  it('値低は減衰大', () => {
+    expect(MathHelper.getExponentialDecayLabel(15)).toBe('減衰大');
+  });
+});

--- a/src/__tests__/domain/entities/MedicationComplexityScore.test.ts
+++ b/src/__tests__/domain/entities/MedicationComplexityScore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getMedicationComplexityScore', () => {
+  it('全て0は0', () => {
+    expect(MedicationEntity.getMedicationComplexityScore(0, 0, 0)).toBe(0);
+  });
+
+  it('薬1種・1回・1回量は低い', () => {
+    const result = MedicationEntity.getMedicationComplexityScore(1, 1, 1);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('薬が多いほどスコアが高い', () => {
+    const low = MedicationEntity.getMedicationComplexityScore(1, 2, 1);
+    const high = MedicationEntity.getMedicationComplexityScore(5, 2, 1);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('回数が多いほどスコアが高い', () => {
+    const low = MedicationEntity.getMedicationComplexityScore(3, 1, 1);
+    const high = MedicationEntity.getMedicationComplexityScore(3, 4, 1);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('種類数が多いほどスコアが高い', () => {
+    const low = MedicationEntity.getMedicationComplexityScore(3, 2, 1);
+    const high = MedicationEntity.getMedicationComplexityScore(3, 2, 3);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('最大100', () => {
+    expect(MedicationEntity.getMedicationComplexityScore(20, 10, 10)).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MedicationEntity.getMedicationComplexityScore(3, 3, 2);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MedicationEntity.getMedicationComplexityScoreLabel', () => {
+  it('スコア高は複雑', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(80)).toBe('複雑');
+  });
+
+  it('スコア中は普通', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(50)).toBe('普通');
+  });
+
+  it('スコア低はシンプル', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(20)).toBe('シンプル');
+  });
+});

--- a/src/__tests__/domain/entities/SymptomBurdenScore.test.ts
+++ b/src/__tests__/domain/entities/SymptomBurdenScore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getSymptomBurdenScore', () => {
+  it('両方0は0', () => {
+    expect(HealthLogEntity.getSymptomBurdenScore(0, 0)).toBe(0);
+  });
+
+  it('症状数多い・体調悪いはスコアが高い', () => {
+    const result = HealthLogEntity.getSymptomBurdenScore(5, 1);
+    expect(result).toBeGreaterThan(70);
+  });
+
+  it('症状なし・体調良いは0', () => {
+    expect(HealthLogEntity.getSymptomBurdenScore(0, 5)).toBe(0);
+  });
+
+  it('症状が多いほどスコアが高い', () => {
+    const low = HealthLogEntity.getSymptomBurdenScore(1, 3);
+    const high = HealthLogEntity.getSymptomBurdenScore(5, 3);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('体調が悪いほどスコアが高い', () => {
+    const low = HealthLogEntity.getSymptomBurdenScore(3, 5);
+    const high = HealthLogEntity.getSymptomBurdenScore(3, 1);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HealthLogEntity.getSymptomBurdenScore(3, 3);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('最大100', () => {
+    expect(HealthLogEntity.getSymptomBurdenScore(10, 1)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('HealthLogEntity.getSymptomBurdenScoreLabel', () => {
+  it('スコア高は重い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(80)).toBe('重い');
+  });
+
+  it('スコア中はやや重い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(50)).toBe('やや重い');
+  });
+
+  it('スコア低は軽い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(20)).toBe('軽い');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -85,6 +85,10 @@ export class HealthLogEntity {
   private static readonly IMPROVEMENT_IMPROVED_THRESHOLD = 70;
   private static readonly IMPROVEMENT_DECLINED_THRESHOLD = 30;
   private static readonly IMPROVEMENT_MAX_DIFF = 4;
+  private static readonly BURDEN_MAX_SYMPTOMS = 5;
+  private static readonly BURDEN_MAX_CONDITION = 5;
+  private static readonly BURDEN_HEAVY_THRESHOLD = 70;
+  private static readonly BURDEN_MODERATE_THRESHOLD = 40;
 
   private static readonly CONDITION_LABELS: Record<ConditionLevel, string> = {
     1: 'とても悪い',
@@ -992,5 +996,37 @@ export class HealthLogEntity {
     if (score >= HealthLogEntity.IMPROVEMENT_IMPROVED_THRESHOLD) return '改善';
     if (score >= HealthLogEntity.IMPROVEMENT_DECLINED_THRESHOLD) return '横ばい';
     return '悪化';
+  }
+
+  /**
+   * 症状負担スコアを算出する（0-100）
+   * 症状数と体調レベル（1-5、1が最悪）から算出
+   */
+  static getSymptomBurdenScore(
+    symptomCount: number,
+    conditionLevel: number
+  ): number {
+    if (symptomCount <= 0) return 0;
+    const symptomNorm = Math.min(
+      symptomCount / HealthLogEntity.BURDEN_MAX_SYMPTOMS,
+      1
+    );
+    const conditionPenalty =
+      1 -
+      Math.min(conditionLevel, HealthLogEntity.BURDEN_MAX_CONDITION) /
+        HealthLogEntity.BURDEN_MAX_CONDITION;
+    return Math.min(
+      100,
+      Math.round(((symptomNorm + conditionPenalty) / 2) * 100)
+    );
+  }
+
+  /**
+   * 症状負担スコアに応じたラベルを返す
+   */
+  static getSymptomBurdenScoreLabel(score: number): string {
+    if (score >= HealthLogEntity.BURDEN_HEAVY_THRESHOLD) return '重い';
+    if (score >= HealthLogEntity.BURDEN_MODERATE_THRESHOLD) return 'やや重い';
+    return '軽い';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -51,6 +51,8 @@ export class MathHelper {
   private static readonly JACCARD_MODERATE_THRESHOLD = 40;
   private static readonly LR_SLOPE_THRESHOLD = 0.1;
   private static readonly SPEARMAN_STRONG_THRESHOLD = 0.6;
+  private static readonly DECAY_HIGH_THRESHOLD = 60;
+  private static readonly DECAY_MODERATE_THRESHOLD = 30;
 
   /**
    * パーセントを算出(0-100%)
@@ -888,5 +890,27 @@ export class MathHelper {
     if (rho >= MathHelper.SPEARMAN_STRONG_THRESHOLD) return '正相関';
     if (rho <= -MathHelper.SPEARMAN_STRONG_THRESHOLD) return '逆相関';
     return '無相関';
+  }
+
+  /**
+   * 指数減衰を算出する
+   * initialValue * e^(-decayRate * time)
+   */
+  static getExponentialDecay(
+    initialValue: number,
+    time: number,
+    decayRate: number
+  ): number {
+    if (initialValue === 0) return 0;
+    return Math.round(initialValue * Math.exp(-decayRate * time) * 100) / 100;
+  }
+
+  /**
+   * 減衰後の値に応じたラベルを返す
+   */
+  static getExponentialDecayLabel(value: number): string {
+    if (value >= MathHelper.DECAY_HIGH_THRESHOLD) return '有効';
+    if (value >= MathHelper.DECAY_MODERATE_THRESHOLD) return 'やや減衰';
+    return '減衰大';
   }
 }

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -100,6 +100,11 @@ export class MedicationEntity {
 
   private static readonly LOW_STOCK_THRESHOLD = 5;
   private static readonly MEDIUM_STOCK_THRESHOLD = 10;
+  private static readonly COMPLEXITY_MAX_MEDS = 10;
+  private static readonly COMPLEXITY_MAX_TIMES = 6;
+  private static readonly COMPLEXITY_MAX_TYPES = 5;
+  private static readonly COMPLEXITY_HIGH_THRESHOLD = 70;
+  private static readonly COMPLEXITY_MODERATE_THRESHOLD = 40;
 
   private static readonly categoryLabels: Record<MedicationCategory, string> = {
     regular: '常用薬',
@@ -339,5 +344,30 @@ export class MedicationEntity {
     if (MedicationEntity.isIntervalSafe(hoursSinceLastDose, timesPerDay)) return null;
     const minInterval = MedicationEntity.getMinimumInterval(timesPerDay);
     return `前回の服用から十分な時間が経っていません。最低${minInterval}時間の間隔をあけてください`;
+  }
+
+  /**
+   * 薬の複雑さスコアを算出する（0-100）
+   * 薬数・服用回数・種類数から算出
+   */
+  static getMedicationComplexityScore(
+    medicationCount: number,
+    timesPerDay: number,
+    typeCount: number
+  ): number {
+    if (medicationCount <= 0 && timesPerDay <= 0 && typeCount <= 0) return 0;
+    const medNorm = Math.min(medicationCount / MedicationEntity.COMPLEXITY_MAX_MEDS, 1);
+    const timesNorm = Math.min(timesPerDay / MedicationEntity.COMPLEXITY_MAX_TIMES, 1);
+    const typeNorm = Math.min(typeCount / MedicationEntity.COMPLEXITY_MAX_TYPES, 1);
+    return Math.min(100, Math.round(((medNorm + timesNorm + typeNorm) / 3) * 100));
+  }
+
+  /**
+   * 薬の複雑さスコアに応じたラベルを返す
+   */
+  static getMedicationComplexityScoreLabel(score: number): string {
+    if (score >= MedicationEntity.COMPLEXITY_HIGH_THRESHOLD) return '複雑';
+    if (score >= MedicationEntity.COMPLEXITY_MODERATE_THRESHOLD) return '普通';
+    return 'シンプル';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getExponentialDecay / getExponentialDecayLabel（指数減衰）追加
- MedicationEntity: getMedicationComplexityScore / getMedicationComplexityScoreLabel（薬の複雑さスコア）追加
- HealthLogEntity: getSymptomBurdenScore / getSymptomBurdenScoreLabel（症状負担スコア）追加
- 31件のユニットテスト追加（総テスト数: 6823）

## Test plan
- [x] 全31件の新規テストがパス
- [x] 既存テスト6792件に回帰なし