### PR TITLE
指数減衰・薬の複雑さスコア・症状負担スコアのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/ExponentialDecay.edge.test.ts
+++ b/src/__tests__/domain/entities/ExponentialDecay.edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getExponentialDecay - エッジケース', () => {
+  it('初期値0は常に0', () => {
+    expect(MathHelper.getExponentialDecay(0, 10, 0.5)).toBe(0);
+  });
+
+  it('時間0は初期値', () => {
+    expect(MathHelper.getExponentialDecay(100, 0, 0.5)).toBe(100);
+  });
+
+  it('減衰率0は初期値', () => {
+    expect(MathHelper.getExponentialDecay(100, 100, 0)).toBe(100);
+  });
+
+  it('時間1・減衰率1', () => {
+    const result = MathHelper.getExponentialDecay(100, 1, 1);
+    expect(result).toBeCloseTo(36.79, 0);
+  });
+
+  it('大きな時間で0に近づく', () => {
+    const result = MathHelper.getExponentialDecay(100, 100, 1);
+    expect(result).toBeLessThan(0.01);
+  });
+
+  it('小さな減衰率では緩やかに減少', () => {
+    const result = MathHelper.getExponentialDecay(100, 1, 0.01);
+    expect(result).toBeGreaterThanOrEqual(99);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getExponentialDecay(50, 50, 0.5);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('結果は初期値以下', () => {
+    const result = MathHelper.getExponentialDecay(80, 5, 0.3);
+    expect(result).toBeLessThanOrEqual(80);
+  });
+
+  it('初期値が大きいほど結果も大きい', () => {
+    const small = MathHelper.getExponentialDecay(50, 5, 0.1);
+    const large = MathHelper.getExponentialDecay(100, 5, 0.1);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('減衰率が大きいほど結果が小さい', () => {
+    const slow = MathHelper.getExponentialDecay(100, 5, 0.1);
+    const fast = MathHelper.getExponentialDecay(100, 5, 1);
+    expect(fast).toBeLessThan(slow);
+  });
+
+  it('半減期の確認', () => {
+    const result = MathHelper.getExponentialDecay(100, 1, Math.LN2);
+    expect(result).toBeCloseTo(50, 0);
+  });
+});
+
+describe('MathHelper.getExponentialDecayLabel - エッジケース', () => {
+  it('100は有効', () => {
+    expect(MathHelper.getExponentialDecayLabel(100)).toBe('有効');
+  });
+
+  it('60は有効', () => {
+    expect(MathHelper.getExponentialDecayLabel(60)).toBe('有効');
+  });
+
+  it('59はやや減衰', () => {
+    expect(MathHelper.getExponentialDecayLabel(59)).toBe('やや減衰');
+  });
+
+  it('30はやや減衰', () => {
+    expect(MathHelper.getExponentialDecayLabel(30)).toBe('やや減衰');
+  });
+
+  it('29は減衰大', () => {
+    expect(MathHelper.getExponentialDecayLabel(29)).toBe('減衰大');
+  });
+
+  it('0は減衰大', () => {
+    expect(MathHelper.getExponentialDecayLabel(0)).toBe('減衰大');
+  });
+});

--- a/src/__tests__/domain/entities/MedicationComplexityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationComplexityScore.edge.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getMedicationComplexityScore - エッジケース', () => {
+  it('全て0は0', () => {
+    expect(MedicationEntity.getMedicationComplexityScore(0, 0, 0)).toBe(0);
+  });
+
+  it('薬1・回1・種1', () => {
+    const result = MedicationEntity.getMedicationComplexityScore(1, 1, 1);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('最大値全て', () => {
+    expect(MedicationEntity.getMedicationComplexityScore(10, 6, 5)).toBe(100);
+  });
+
+  it('超過しても100', () => {
+    expect(MedicationEntity.getMedicationComplexityScore(20, 12, 10)).toBe(100);
+  });
+
+  it('薬のみ', () => {
+    const result = MedicationEntity.getMedicationComplexityScore(5, 0, 0);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('回数のみ', () => {
+    const result = MedicationEntity.getMedicationComplexityScore(0, 3, 0);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('種類のみ', () => {
+    const result = MedicationEntity.getMedicationComplexityScore(0, 0, 3);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('薬が多いほどスコアが高い', () => {
+    const low = MedicationEntity.getMedicationComplexityScore(1, 2, 1);
+    const high = MedicationEntity.getMedicationComplexityScore(8, 2, 1);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MedicationEntity.getMedicationComplexityScore(3, 2, 2);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MedicationEntity.getMedicationComplexityScoreLabel - エッジケース', () => {
+  it('100は複雑', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(100)).toBe('複雑');
+  });
+
+  it('70は複雑', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(70)).toBe('複雑');
+  });
+
+  it('69は普通', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(69)).toBe('普通');
+  });
+
+  it('40は普通', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(40)).toBe('普通');
+  });
+
+  it('39はシンプル', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(39)).toBe('シンプル');
+  });
+
+  it('0はシンプル', () => {
+    expect(MedicationEntity.getMedicationComplexityScoreLabel(0)).toBe('シンプル');
+  });
+});

--- a/src/__tests__/domain/entities/SymptomBurdenScore.edge.test.ts
+++ b/src/__tests__/domain/entities/SymptomBurdenScore.edge.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getSymptomBurdenScore - エッジケース', () => {
+  it('症状0は常に0', () => {
+    expect(HealthLogEntity.getSymptomBurdenScore(0, 3)).toBe(0);
+  });
+
+  it('症状0・体調0も0', () => {
+    expect(HealthLogEntity.getSymptomBurdenScore(0, 0)).toBe(0);
+  });
+
+  it('症状最大・体調最悪', () => {
+    const result = HealthLogEntity.getSymptomBurdenScore(5, 1);
+    expect(result).toBeGreaterThan(70);
+  });
+
+  it('症状最大・体調最良', () => {
+    const result = HealthLogEntity.getSymptomBurdenScore(5, 5);
+    expect(result).toBe(50);
+  });
+
+  it('症状1・体調最悪', () => {
+    const result = HealthLogEntity.getSymptomBurdenScore(1, 1);
+    expect(result).toBeGreaterThan(30);
+  });
+
+  it('症状1・体調最良', () => {
+    const result = HealthLogEntity.getSymptomBurdenScore(1, 5);
+    expect(result).toBe(10);
+  });
+
+  it('症状が多いほどスコアが高い', () => {
+    const low = HealthLogEntity.getSymptomBurdenScore(1, 3);
+    const high = HealthLogEntity.getSymptomBurdenScore(5, 3);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('体調が悪いほどスコアが高い', () => {
+    const low = HealthLogEntity.getSymptomBurdenScore(3, 5);
+    const high = HealthLogEntity.getSymptomBurdenScore(3, 1);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HealthLogEntity.getSymptomBurdenScore(3, 3);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('超過しても100以下', () => {
+    expect(HealthLogEntity.getSymptomBurdenScore(100, 0)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('HealthLogEntity.getSymptomBurdenScoreLabel - エッジケース', () => {
+  it('100は重い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(100)).toBe('重い');
+  });
+
+  it('70は重い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(70)).toBe('重い');
+  });
+
+  it('69はやや重い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(69)).toBe('やや重い');
+  });
+
+  it('40はやや重い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(40)).toBe('やや重い');
+  });
+
+  it('39は軽い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(39)).toBe('軽い');
+  });
+
+  it('0は軽い', () => {
+    expect(HealthLogEntity.getSymptomBurdenScoreLabel(0)).toBe('軽い');
+  });
+});


### PR DESCRIPTION
## Summary
- getExponentialDecay / getExponentialDecayLabel のエッジケーステスト17件追加
- getMedicationComplexityScore / getMedicationComplexityScoreLabel のエッジケーステスト15件追加
- getSymptomBurdenScore / getSymptomBurdenScoreLabel のエッジケーステスト16件追加
- 合計48件のエッジケーステスト追加（総テスト数: 6871）

## Test plan
- [x] 全48件のエッジケーステストがパス
- [x] 既存テスト6823件に回帰なし