### PR TITLE
移動範囲・日付規則性スコア・服薬効率スコアの追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceEfficiencyScore.test.ts
+++ b/src/__tests__/domain/entities/AdherenceEfficiencyScore.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity.getAdherenceEfficiencyScore', () => {
+  it('両方0は0', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(0, 0)).toBe(0);
+  });
+
+  it('率100・ストリーク高は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(100, 30)).toBe(100);
+  });
+
+  it('率0は低い', () => {
+    const result = AdherenceStatsEntity.getAdherenceEfficiencyScore(0, 10);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('率が高いほどスコアが高い', () => {
+    const low = AdherenceStatsEntity.getAdherenceEfficiencyScore(30, 5);
+    const high = AdherenceStatsEntity.getAdherenceEfficiencyScore(90, 5);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('ストリークが長いほどスコアが高い', () => {
+    const low = AdherenceStatsEntity.getAdherenceEfficiencyScore(80, 1);
+    const high = AdherenceStatsEntity.getAdherenceEfficiencyScore(80, 20);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceStatsEntity.getAdherenceEfficiencyScore(70, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('中程度の値', () => {
+    const result = AdherenceStatsEntity.getAdherenceEfficiencyScore(50, 15);
+    expect(result).toBeGreaterThan(20);
+    expect(result).toBeLessThan(80);
+  });
+
+  it('超過しても100', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(150, 60)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel', () => {
+  it('スコア高は高効率', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(85)).toBe('高効率');
+  });
+
+  it('スコア中は普通', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(55)).toBe('普通');
+  });
+
+  it('スコア低は低効率', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(25)).toBe('低効率');
+  });
+});

--- a/src/__tests__/domain/entities/DateRegularityScore.test.ts
+++ b/src/__tests__/domain/entities/DateRegularityScore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateRegularityScore', () => {
+  it('空配列は0', () => {
+    expect(DateRangeHelper.getDateRegularityScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(DateRangeHelper.getDateRegularityScore([7])).toBe(100);
+  });
+
+  it('全て同じ間隔は100', () => {
+    expect(DateRangeHelper.getDateRegularityScore([7, 7, 7])).toBe(100);
+  });
+
+  it('ばらつきがあるとスコアが下がる', () => {
+    const result = DateRangeHelper.getDateRegularityScore([3, 10, 20]);
+    expect(result).toBeLessThan(100);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('均一なほどスコアが高い', () => {
+    const regular = DateRangeHelper.getDateRegularityScore([7, 7, 7]);
+    const irregular = DateRangeHelper.getDateRegularityScore([1, 7, 20]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = DateRangeHelper.getDateRegularityScore([5, 10, 15]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2件で同値は100', () => {
+    expect(DateRangeHelper.getDateRegularityScore([14, 14])).toBe(100);
+  });
+});
+
+describe('DateRangeHelper.getDateRegularityScoreLabel', () => {
+  it('スコア高は規則的', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(85)).toBe('規則的');
+  });
+
+  it('スコア中はやや不規則', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(55)).toBe('やや不規則');
+  });
+
+  it('スコア低は不規則', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(25)).toBe('不規則');
+  });
+});

--- a/src/__tests__/domain/entities/MovingRange.test.ts
+++ b/src/__tests__/domain/entities/MovingRange.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMovingRange', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getMovingRange([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getMovingRange([5])).toBe(0);
+  });
+
+  it('全て同じは0', () => {
+    expect(MathHelper.getMovingRange([3, 3, 3])).toBe(0);
+  });
+
+  it('2件の差', () => {
+    expect(MathHelper.getMovingRange([10, 20])).toBe(10);
+  });
+
+  it('上昇系列', () => {
+    expect(MathHelper.getMovingRange([1, 2, 3, 4])).toBe(1);
+  });
+
+  it('不規則な系列', () => {
+    const result = MathHelper.getMovingRange([10, 5, 20, 15]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('差が大きいほどMRが大きい', () => {
+    const stable = MathHelper.getMovingRange([10, 11, 12]);
+    const volatile = MathHelper.getMovingRange([10, 30, 5]);
+    expect(volatile).toBeGreaterThan(stable);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getMovingRange([100, 50, 75, 25]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('負の値', () => {
+    expect(MathHelper.getMovingRange([-5, 5])).toBe(10);
+  });
+});
+
+describe('MathHelper.getMovingRangeLabel', () => {
+  it('MR低は安定', () => {
+    expect(MathHelper.getMovingRangeLabel(3)).toBe('安定');
+  });
+
+  it('MR中はやや変動', () => {
+    expect(MathHelper.getMovingRangeLabel(12)).toBe('やや変動');
+  });
+
+  it('MR高は変動大', () => {
+    expect(MathHelper.getMovingRangeLabel(25)).toBe('変動大');
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -332,6 +332,11 @@ export class AdherenceStatsEntity {
   }
 
   private static readonly MILESTONES = [7, 14, 30, 60, 90, 100, 180, 365];
+  private static readonly EFFICIENCY_MAX_STREAK = 30;
+  private static readonly EFFICIENCY_RATE_WEIGHT = 0.7;
+  private static readonly EFFICIENCY_STREAK_WEIGHT = 0.3;
+  private static readonly EFFICIENCY_HIGH_THRESHOLD = 80;
+  private static readonly EFFICIENCY_MODERATE_THRESHOLD = 50;
 
   /**
    * 現在の連続日数から次のマイルストーンを取得する
@@ -399,5 +404,35 @@ export class AdherenceStatsEntity {
     if (rate >= 70) return 'あと少しで目標達成です';
     if (rate >= 50) return '服薬を習慣化していきましょう';
     return 'リマインダーを活用してみましょう';
+  }
+
+  /**
+   * 服薬効率スコアを算出する（0-100）
+   * 達成率とストリークから加重平均
+   */
+  static getAdherenceEfficiencyScore(
+    rate: number,
+    streakDays: number
+  ): number {
+    const clampedRate = Math.max(0, Math.min(100, rate));
+    const streakNorm =
+      Math.min(streakDays, AdherenceStatsEntity.EFFICIENCY_MAX_STREAK) /
+      AdherenceStatsEntity.EFFICIENCY_MAX_STREAK;
+    return Math.min(
+      100,
+      Math.round(
+        clampedRate * AdherenceStatsEntity.EFFICIENCY_RATE_WEIGHT +
+          streakNorm * 100 * AdherenceStatsEntity.EFFICIENCY_STREAK_WEIGHT
+      )
+    );
+  }
+
+  /**
+   * 服薬効率スコアに応じたラベルを返す
+   */
+  static getAdherenceEfficiencyScoreLabel(score: number): string {
+    if (score >= AdherenceStatsEntity.EFFICIENCY_HIGH_THRESHOLD) return '高効率';
+    if (score >= AdherenceStatsEntity.EFFICIENCY_MODERATE_THRESHOLD) return '普通';
+    return '低効率';
   }
 }

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -112,6 +112,9 @@ export class DateRangeHelper {
   private static readonly WEEKEND_RATIO_LOW_THRESHOLD = 20;
   private static readonly DATE_SPAN_SUFFICIENT_THRESHOLD = 80;
   private static readonly DATE_SPAN_MODERATE_THRESHOLD = 50;
+  private static readonly DATE_REGULARITY_MAX_CV = 100;
+  private static readonly DATE_REGULARITY_HIGH_THRESHOLD = 80;
+  private static readonly DATE_REGULARITY_MODERATE_THRESHOLD = 50;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -459,5 +462,31 @@ export class DateRangeHelper {
     if (score >= DateRangeHelper.DATE_SPAN_SUFFICIENT_THRESHOLD) return '十分';
     if (score >= DateRangeHelper.DATE_SPAN_MODERATE_THRESHOLD) return 'やや不足';
     return '不足';
+  }
+
+  /**
+   * 日付間隔の規則性スコアを算出する（0-100）
+   * 変動係数(CV)が小さいほどスコアが高い
+   */
+  static getDateRegularityScore(intervals: number[]): number {
+    if (intervals.length <= 1) return intervals.length === 0 ? 0 : 100;
+    const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+    if (avg === 0) return 0;
+    const variance =
+      intervals.reduce((sum, v) => sum + (v - avg) ** 2, 0) / intervals.length;
+    const cv = (Math.sqrt(variance) / avg) * 100;
+    return Math.max(
+      0,
+      Math.min(100, Math.round(100 - (cv / DateRangeHelper.DATE_REGULARITY_MAX_CV) * 100))
+    );
+  }
+
+  /**
+   * 日付規則性スコアに応じたラベルを返す
+   */
+  static getDateRegularityScoreLabel(score: number): string {
+    if (score >= DateRangeHelper.DATE_REGULARITY_HIGH_THRESHOLD) return '規則的';
+    if (score >= DateRangeHelper.DATE_REGULARITY_MODERATE_THRESHOLD) return 'やや不規則';
+    return '不規則';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -53,6 +53,8 @@ export class MathHelper {
   private static readonly SPEARMAN_STRONG_THRESHOLD = 0.6;
   private static readonly DECAY_HIGH_THRESHOLD = 60;
   private static readonly DECAY_MODERATE_THRESHOLD = 30;
+  private static readonly MR_STABLE_THRESHOLD = 5;
+  private static readonly MR_MODERATE_THRESHOLD = 20;
 
   /**
    * パーセントを算出(0-100%)
@@ -912,5 +914,26 @@ export class MathHelper {
     if (value >= MathHelper.DECAY_HIGH_THRESHOLD) return '有効';
     if (value >= MathHelper.DECAY_MODERATE_THRESHOLD) return 'やや減衰';
     return '減衰大';
+  }
+
+  /**
+   * 移動範囲（連続値の差の絶対値の平均）を算出する
+   */
+  static getMovingRange(values: number[]): number {
+    if (values.length <= 1) return 0;
+    let totalDiff = 0;
+    for (let i = 1; i < values.length; i++) {
+      totalDiff += Math.abs(values[i] - values[i - 1]);
+    }
+    return Math.round((totalDiff / (values.length - 1)) * 100) / 100;
+  }
+
+  /**
+   * 移動範囲に応じたラベルを返す
+   */
+  static getMovingRangeLabel(mr: number): string {
+    if (mr <= MathHelper.MR_STABLE_THRESHOLD) return '安定';
+    if (mr <= MathHelper.MR_MODERATE_THRESHOLD) return 'やや変動';
+    return '変動大';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getMovingRange / getMovingRangeLabel（移動範囲）追加
- DateRangeHelper: getDateRegularityScore / getDateRegularityScoreLabel（日付規則性スコア）追加
- AdherenceStatsEntity: getAdherenceEfficiencyScore / getAdherenceEfficiencyScoreLabel（服薬効率スコア）追加
- 33件のユニットテスト追加（総テスト数: 6904）

## Test plan
- [x] 全33件の新規テストがパス
- [x] 既存テスト6871件に回帰なし