### PR TITLE
test: MovingRange・DateRegularityScore・AdherenceEfficiencyScoreのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceEfficiencyScore.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceEfficiencyScore.edge.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity.getAdherenceEfficiencyScore - エッジケース', () => {
+  it('両方0は0', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(0, 0)).toBe(0);
+  });
+
+  it('率100・ストリーク0', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(100, 0)).toBe(70);
+  });
+
+  it('率0・ストリーク30', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(0, 30)).toBe(30);
+  });
+
+  it('率100・ストリーク30は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(100, 30)).toBe(100);
+  });
+
+  it('率50・ストリーク15は50', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(50, 15)).toBe(50);
+  });
+
+  it('負の率は0扱い', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(-20, 10)).toBe(10);
+  });
+
+  it('超過率は100扱い', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(150, 0)).toBe(70);
+  });
+
+  it('超過ストリークは30扱い', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScore(100, 60)).toBe(100);
+  });
+
+  it('率が高いほどスコアが高い', () => {
+    const low = AdherenceStatsEntity.getAdherenceEfficiencyScore(20, 10);
+    const high = AdherenceStatsEntity.getAdherenceEfficiencyScore(80, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('ストリークが長いほどスコアが高い', () => {
+    const low = AdherenceStatsEntity.getAdherenceEfficiencyScore(50, 1);
+    const high = AdherenceStatsEntity.getAdherenceEfficiencyScore(50, 25);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceStatsEntity.getAdherenceEfficiencyScore(60, 12);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel - エッジケース', () => {
+  it('100は高効率', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(100)).toBe('高効率');
+  });
+
+  it('80は高効率', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(80)).toBe('高効率');
+  });
+
+  it('79は普通', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(79)).toBe('普通');
+  });
+
+  it('50は普通', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(50)).toBe('普通');
+  });
+
+  it('49は低効率', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(49)).toBe('低効率');
+  });
+
+  it('0は低効率', () => {
+    expect(AdherenceStatsEntity.getAdherenceEfficiencyScoreLabel(0)).toBe('低効率');
+  });
+});

--- a/src/__tests__/domain/entities/DateRegularityScore.edge.test.ts
+++ b/src/__tests__/domain/entities/DateRegularityScore.edge.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateRegularityScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(DateRangeHelper.getDateRegularityScore([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(DateRangeHelper.getDateRegularityScore([14])).toBe(100);
+  });
+
+  it('全て同じは100', () => {
+    expect(DateRangeHelper.getDateRegularityScore([7, 7, 7, 7])).toBe(100);
+  });
+
+  it('2件同値は100', () => {
+    expect(DateRangeHelper.getDateRegularityScore([30, 30])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(DateRangeHelper.getDateRegularityScore([0, 0, 0])).toBe(0);
+  });
+
+  it('わずかなばらつき', () => {
+    const result = DateRangeHelper.getDateRegularityScore([6, 7, 8]);
+    expect(result).toBeGreaterThan(85);
+  });
+
+  it('大きなばらつき', () => {
+    const result = DateRangeHelper.getDateRegularityScore([1, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('均一なほどスコアが高い', () => {
+    const regular = DateRangeHelper.getDateRegularityScore([10, 10, 10]);
+    const irregular = DateRangeHelper.getDateRegularityScore([1, 10, 50]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = DateRangeHelper.getDateRegularityScore([3, 7, 14, 21]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(50).fill(7);
+    expect(DateRangeHelper.getDateRegularityScore(data)).toBe(100);
+  });
+});
+
+describe('DateRangeHelper.getDateRegularityScoreLabel - エッジケース', () => {
+  it('100は規則的', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(100)).toBe('規則的');
+  });
+
+  it('80は規則的', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(80)).toBe('規則的');
+  });
+
+  it('79はやや不規則', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(79)).toBe('やや不規則');
+  });
+
+  it('50はやや不規則', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(50)).toBe('やや不規則');
+  });
+
+  it('49は不規則', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(49)).toBe('不規則');
+  });
+
+  it('0は不規則', () => {
+    expect(DateRangeHelper.getDateRegularityScoreLabel(0)).toBe('不規則');
+  });
+});

--- a/src/__tests__/domain/entities/MovingRange.edge.test.ts
+++ b/src/__tests__/domain/entities/MovingRange.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMovingRange - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getMovingRange([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getMovingRange([42])).toBe(0);
+  });
+
+  it('2件同値は0', () => {
+    expect(MathHelper.getMovingRange([5, 5])).toBe(0);
+  });
+
+  it('全て同じは0', () => {
+    expect(MathHelper.getMovingRange([10, 10, 10, 10])).toBe(0);
+  });
+
+  it('2件の差', () => {
+    expect(MathHelper.getMovingRange([0, 100])).toBe(100);
+  });
+
+  it('均等な増加', () => {
+    expect(MathHelper.getMovingRange([0, 5, 10, 15])).toBe(5);
+  });
+
+  it('均等な減少', () => {
+    expect(MathHelper.getMovingRange([15, 10, 5, 0])).toBe(5);
+  });
+
+  it('交互変動', () => {
+    expect(MathHelper.getMovingRange([0, 10, 0, 10])).toBe(10);
+  });
+
+  it('負の値', () => {
+    expect(MathHelper.getMovingRange([-10, 10])).toBe(20);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getMovingRange([0.1, 0.3, 0.5]);
+    expect(result).toBeCloseTo(0.2, 1);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(100).fill(50);
+    expect(MathHelper.getMovingRange(data)).toBe(0);
+  });
+
+  it('結果は常に0以上', () => {
+    const result = MathHelper.getMovingRange([100, 1, 50, 25]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('変動が大きいほどMRが大きい', () => {
+    const stable = MathHelper.getMovingRange([10, 11, 12, 13]);
+    const volatile = MathHelper.getMovingRange([10, 50, 5, 80]);
+    expect(volatile).toBeGreaterThan(stable);
+  });
+});
+
+describe('MathHelper.getMovingRangeLabel - エッジケース', () => {
+  it('0は安定', () => {
+    expect(MathHelper.getMovingRangeLabel(0)).toBe('安定');
+  });
+
+  it('5は安定', () => {
+    expect(MathHelper.getMovingRangeLabel(5)).toBe('安定');
+  });
+
+  it('6はやや変動', () => {
+    expect(MathHelper.getMovingRangeLabel(6)).toBe('やや変動');
+  });
+
+  it('20はやや変動', () => {
+    expect(MathHelper.getMovingRangeLabel(20)).toBe('やや変動');
+  });
+
+  it('21は変動大', () => {
+    expect(MathHelper.getMovingRangeLabel(21)).toBe('変動大');
+  });
+
+  it('100は変動大', () => {
+    expect(MathHelper.getMovingRangeLabel(100)).toBe('変動大');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getMovingRange / getMovingRangeLabel のエッジケーステスト追加（19件）
- DateRangeHelper.getDateRegularityScore / getDateRegularityScoreLabel のエッジケーステスト追加（16件）
- AdherenceStatsEntity.getAdherenceEfficiencyScore / getAdherenceEfficiencyScoreLabel のエッジケーステスト追加（17件）

## Test plan
- [x] 52件のエッジケーステストが全て合格
- [x] 全6956テストが合格

closes #924