### PR TITLE
feat: WeightedHarmonicMean・HealthTrendScore・ScheduleLoadBalance追加

### DIFF
--- a/src/__tests__/domain/entities/HealthTrendScore.test.ts
+++ b/src/__tests__/domain/entities/HealthTrendScore.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getHealthTrendScore', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getHealthTrendScore([])).toBe(0);
+  });
+
+  it('全て最高は100', () => {
+    expect(HealthLogEntity.getHealthTrendScore([5, 5, 5])).toBe(100);
+  });
+
+  it('全て最低は20', () => {
+    expect(HealthLogEntity.getHealthTrendScore([1, 1, 1])).toBe(20);
+  });
+
+  it('体調が良いほどスコアが高い', () => {
+    const low = HealthLogEntity.getHealthTrendScore([1, 2, 1]);
+    const high = HealthLogEntity.getHealthTrendScore([4, 5, 4]);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('1件は単純変換', () => {
+    expect(HealthLogEntity.getHealthTrendScore([3])).toBe(60);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HealthLogEntity.getHealthTrendScore([2, 3, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('中程度の値', () => {
+    const result = HealthLogEntity.getHealthTrendScore([3, 3, 3]);
+    expect(result).toBe(60);
+  });
+});
+
+describe('HealthLogEntity.getHealthTrendScoreLabel', () => {
+  it('スコア高は良好', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(85)).toBe('良好');
+  });
+
+  it('スコア中は普通', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(55)).toBe('普通');
+  });
+
+  it('スコア低は注意', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(25)).toBe('注意');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleLoadBalance.test.ts
+++ b/src/__tests__/domain/entities/ScheduleLoadBalance.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleLoadBalance', () => {
+  it('空配列は0', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([5])).toBe(100);
+  });
+
+  it('均等は100', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([3, 3, 3])).toBe(100);
+  });
+
+  it('偏りが大きいほどスコアが低い', () => {
+    const balanced = ScheduleEntity.getScheduleLoadBalance([5, 5, 5]);
+    const unbalanced = ScheduleEntity.getScheduleLoadBalance([1, 1, 10]);
+    expect(balanced).toBeGreaterThan(unbalanced);
+  });
+
+  it('全て0は0', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([0, 0, 0])).toBe(0);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = ScheduleEntity.getScheduleLoadBalance([2, 5, 3]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2件均等は100', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([10, 10])).toBe(100);
+  });
+});
+
+describe('ScheduleEntity.getScheduleLoadBalanceLabel', () => {
+  it('スコア高は均等', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(85)).toBe('均等');
+  });
+
+  it('スコア中はやや偏り', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(55)).toBe('やや偏り');
+  });
+
+  it('スコア低は偏り大', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(25)).toBe('偏り大');
+  });
+});

--- a/src/__tests__/domain/entities/WeightedHarmonicMean.test.ts
+++ b/src/__tests__/domain/entities/WeightedHarmonicMean.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getWeightedHarmonicMean', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([], [])).toBe(0);
+  });
+
+  it('1件はその値', () => {
+    expect(MathHelper.getWeightedHarmonicMean([10], [1])).toBe(10);
+  });
+
+  it('同値・同重みは同じ値', () => {
+    expect(MathHelper.getWeightedHarmonicMean([5, 5, 5], [1, 1, 1])).toBe(5);
+  });
+
+  it('2件・等重みは調和平均', () => {
+    // 等重みの調和平均: 2/(1/40 + 1/60) = 48
+    expect(MathHelper.getWeightedHarmonicMean([40, 60], [1, 1])).toBe(48);
+  });
+
+  it('重みで加重される', () => {
+    // 重み[3,1]で40と60: (3+1)/(3/40 + 1/60) = 4/(0.075+0.0167) = 4/0.0917 = 43.64
+    const result = MathHelper.getWeightedHarmonicMean([40, 60], [3, 1]);
+    expect(result).toBeGreaterThan(40);
+    expect(result).toBeLessThan(48);
+  });
+
+  it('0を含む値は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([10, 0, 20], [1, 1, 1])).toBe(0);
+  });
+
+  it('配列長不一致は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([10, 20], [1])).toBe(0);
+  });
+
+  it('重み合計0は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([10, 20], [0, 0])).toBe(0);
+  });
+
+  it('負の値は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([-5, 10], [1, 1])).toBe(0);
+  });
+
+  it('結果は正の値', () => {
+    const result = MathHelper.getWeightedHarmonicMean([3, 6, 9], [1, 2, 3]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getWeightedHarmonicMeanLabel', () => {
+  it('高い値は高い', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(75)).toBe('高い');
+  });
+
+  it('中程度は中程度', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(50)).toBe('中程度');
+  });
+
+  it('低い値は低い', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(20)).toBe('低い');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -89,6 +89,9 @@ export class HealthLogEntity {
   private static readonly BURDEN_MAX_CONDITION = 5;
   private static readonly BURDEN_HEAVY_THRESHOLD = 70;
   private static readonly BURDEN_MODERATE_THRESHOLD = 40;
+  private static readonly HEALTH_TREND_MAX_LEVEL = 5;
+  private static readonly HEALTH_TREND_GOOD_THRESHOLD = 80;
+  private static readonly HEALTH_TREND_MODERATE_THRESHOLD = 50;
 
   private static readonly CONDITION_LABELS: Record<ConditionLevel, string> = {
     1: 'とても悪い',
@@ -1028,5 +1031,26 @@ export class HealthLogEntity {
     if (score >= HealthLogEntity.BURDEN_HEAVY_THRESHOLD) return '重い';
     if (score >= HealthLogEntity.BURDEN_MODERATE_THRESHOLD) return 'やや重い';
     return '軽い';
+  }
+
+  /**
+   * 体調レベル配列から健康トレンドスコア(0-100)を算出する
+   * 体調レベル(1-5)の平均を0-100にスケーリング
+   */
+  static getHealthTrendScore(levels: number[]): number {
+    if (levels.length === 0) return 0;
+    const avg = levels.reduce((a, b) => a + b, 0) / levels.length;
+    return Math.round(
+      (avg / HealthLogEntity.HEALTH_TREND_MAX_LEVEL) * 100,
+    );
+  }
+
+  /**
+   * 健康トレンドスコアに応じたラベルを返す
+   */
+  static getHealthTrendScoreLabel(score: number): string {
+    if (score >= HealthLogEntity.HEALTH_TREND_GOOD_THRESHOLD) return '良好';
+    if (score >= HealthLogEntity.HEALTH_TREND_MODERATE_THRESHOLD) return '普通';
+    return '注意';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -57,6 +57,8 @@ export class MathHelper {
   private static readonly MR_MODERATE_THRESHOLD = 20;
   private static readonly TRIMMED_HIGH_THRESHOLD = 70;
   private static readonly TRIMMED_MODERATE_THRESHOLD = 30;
+  private static readonly WHMEAN_HIGH_THRESHOLD = 70;
+  private static readonly WHMEAN_MODERATE_THRESHOLD = 30;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -962,6 +964,31 @@ export class MathHelper {
   static getTrimmedMeanLabel(value: number): string {
     if (value >= MathHelper.TRIMMED_HIGH_THRESHOLD) return '高い';
     if (value >= MathHelper.TRIMMED_MODERATE_THRESHOLD) return '中程度';
+    return '低い';
+  }
+
+  /**
+   * 加重調和平均を算出する
+   * 0以下の値を含む場合や配列長不一致の場合は0を返す
+   */
+  static getWeightedHarmonicMean(values: number[], weights: number[]): number {
+    if (values.length === 0 || values.length !== weights.length) return 0;
+    if (values.some((v) => v <= 0)) return 0;
+    const totalWeight = weights.reduce((a, b) => a + b, 0);
+    if (totalWeight === 0) return 0;
+    const weightedReciprocalSum = values.reduce(
+      (sum, v, i) => sum + weights[i] / v,
+      0,
+    );
+    return Math.round((totalWeight / weightedReciprocalSum) * 100) / 100;
+  }
+
+  /**
+   * 加重調和平均に応じたラベルを返す
+   */
+  static getWeightedHarmonicMeanLabel(value: number): string {
+    if (value >= MathHelper.WHMEAN_HIGH_THRESHOLD) return '高い';
+    if (value >= MathHelper.WHMEAN_MODERATE_THRESHOLD) return '中程度';
     return '低い';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -803,6 +803,9 @@ export class ScheduleEntity {
   private static readonly LOAD_MODERATE_THRESHOLD = 30;
   private static readonly UTILIZATION_HIGH_THRESHOLD = 80;
   private static readonly UTILIZATION_MODERATE_THRESHOLD = 50;
+  private static readonly LOAD_BALANCE_MAX_CV = 100;
+  private static readonly LOAD_BALANCE_HIGH_THRESHOLD = 80;
+  private static readonly LOAD_BALANCE_MODERATE_THRESHOLD = 50;
 
   /**
    * 遅延分数配列からスケジュール効率(0-100)を算出する
@@ -1075,5 +1078,37 @@ export class ScheduleEntity {
     if (rate >= ScheduleEntity.UTILIZATION_HIGH_THRESHOLD) return '高稼働';
     if (rate >= ScheduleEntity.UTILIZATION_MODERATE_THRESHOLD) return '普通';
     return '低稼働';
+  }
+
+  /**
+   * 時間帯別スケジュール件数から負荷分散スコア(0-100)を算出する
+   * 変動係数が小さいほど均等で高スコア
+   */
+  static getScheduleLoadBalance(countsPerPeriod: number[]): number {
+    if (countsPerPeriod.length <= 1) {
+      return countsPerPeriod.length === 0 ? 0 : (countsPerPeriod[0] > 0 ? 100 : 0);
+    }
+    const avg = countsPerPeriod.reduce((a, b) => a + b, 0) / countsPerPeriod.length;
+    if (avg === 0) return 0;
+    const variance =
+      countsPerPeriod.reduce((sum, v) => sum + (v - avg) ** 2, 0) /
+      countsPerPeriod.length;
+    const cv = (Math.sqrt(variance) / avg) * 100;
+    return Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(100 - (cv / ScheduleEntity.LOAD_BALANCE_MAX_CV) * 100),
+      ),
+    );
+  }
+
+  /**
+   * 負荷分散スコアに応じたラベルを返す
+   */
+  static getScheduleLoadBalanceLabel(score: number): string {
+    if (score >= ScheduleEntity.LOAD_BALANCE_HIGH_THRESHOLD) return '均等';
+    if (score >= ScheduleEntity.LOAD_BALANCE_MODERATE_THRESHOLD) return 'やや偏り';
+    return '偏り大';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getWeightedHarmonicMean / getWeightedHarmonicMeanLabel 追加（加重調和平均の算出）
- HealthLogEntity.getHealthTrendScore / getHealthTrendScoreLabel 追加（健康トレンドスコアの算出）
- ScheduleEntity.getScheduleLoadBalance / getScheduleLoadBalanceLabel 追加（負荷分散スコアの算出）

## Test plan
- [x] 33件の新規テストが全て合格
- [x] 全7037テストが合格

closes #930