### PR TITLE
test: WeightedHarmonicMean・HealthTrendScore・ScheduleLoadBalanceのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/HealthTrendScore.edge.test.ts
+++ b/src/__tests__/domain/entities/HealthTrendScore.edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getHealthTrendScore - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getHealthTrendScore([])).toBe(0);
+  });
+
+  it('1件・レベル1は20', () => {
+    expect(HealthLogEntity.getHealthTrendScore([1])).toBe(20);
+  });
+
+  it('1件・レベル5は100', () => {
+    expect(HealthLogEntity.getHealthTrendScore([5])).toBe(100);
+  });
+
+  it('全て最低は20', () => {
+    expect(HealthLogEntity.getHealthTrendScore([1, 1, 1, 1])).toBe(20);
+  });
+
+  it('全て最高は100', () => {
+    expect(HealthLogEntity.getHealthTrendScore([5, 5, 5, 5])).toBe(100);
+  });
+
+  it('中央値は60', () => {
+    expect(HealthLogEntity.getHealthTrendScore([3, 3, 3])).toBe(60);
+  });
+
+  it('レベル2は40', () => {
+    expect(HealthLogEntity.getHealthTrendScore([2])).toBe(40);
+  });
+
+  it('レベル4は80', () => {
+    expect(HealthLogEntity.getHealthTrendScore([4])).toBe(80);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(100).fill(3);
+    expect(HealthLogEntity.getHealthTrendScore(data)).toBe(60);
+  });
+
+  it('体調が良いほどスコアが高い', () => {
+    const low = HealthLogEntity.getHealthTrendScore([1, 2]);
+    const high = HealthLogEntity.getHealthTrendScore([4, 5]);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HealthLogEntity.getHealthTrendScore([2, 3, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('混合値', () => {
+    // (1+5)/2 = 3 -> 3/5*100 = 60
+    expect(HealthLogEntity.getHealthTrendScore([1, 5])).toBe(60);
+  });
+});
+
+describe('HealthLogEntity.getHealthTrendScoreLabel - エッジケース', () => {
+  it('100は良好', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(100)).toBe('良好');
+  });
+
+  it('80は良好', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(80)).toBe('良好');
+  });
+
+  it('79は普通', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(79)).toBe('普通');
+  });
+
+  it('50は普通', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(50)).toBe('普通');
+  });
+
+  it('49は注意', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(49)).toBe('注意');
+  });
+
+  it('0は注意', () => {
+    expect(HealthLogEntity.getHealthTrendScoreLabel(0)).toBe('注意');
+  });
+});

--- a/src/__tests__/domain/entities/ScheduleLoadBalance.edge.test.ts
+++ b/src/__tests__/domain/entities/ScheduleLoadBalance.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getScheduleLoadBalance - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([])).toBe(0);
+  });
+
+  it('1件・値0は0', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([0])).toBe(0);
+  });
+
+  it('1件・正値は100', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([5])).toBe(100);
+  });
+
+  it('2件均等は100', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([5, 5])).toBe(100);
+  });
+
+  it('全て0は0', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([0, 0, 0])).toBe(0);
+  });
+
+  it('全て同値は100', () => {
+    expect(ScheduleEntity.getScheduleLoadBalance([3, 3, 3, 3])).toBe(100);
+  });
+
+  it('極端な偏りは低スコア', () => {
+    const result = ScheduleEntity.getScheduleLoadBalance([0, 0, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('均等なほどスコアが高い', () => {
+    const balanced = ScheduleEntity.getScheduleLoadBalance([5, 5, 5, 5]);
+    const unbalanced = ScheduleEntity.getScheduleLoadBalance([1, 1, 1, 20]);
+    expect(balanced).toBeGreaterThan(unbalanced);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(50).fill(10);
+    expect(ScheduleEntity.getScheduleLoadBalance(data)).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = ScheduleEntity.getScheduleLoadBalance([2, 5, 8]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('やや偏り', () => {
+    const result = ScheduleEntity.getScheduleLoadBalance([3, 5, 7]);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('2件で大差', () => {
+    const result = ScheduleEntity.getScheduleLoadBalance([1, 100]);
+    expect(result).toBeLessThan(50);
+  });
+});
+
+describe('ScheduleEntity.getScheduleLoadBalanceLabel - エッジケース', () => {
+  it('100は均等', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(100)).toBe('均等');
+  });
+
+  it('80は均等', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(80)).toBe('均等');
+  });
+
+  it('79はやや偏り', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(79)).toBe('やや偏り');
+  });
+
+  it('50はやや偏り', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(50)).toBe('やや偏り');
+  });
+
+  it('49は偏り大', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(49)).toBe('偏り大');
+  });
+
+  it('0は偏り大', () => {
+    expect(ScheduleEntity.getScheduleLoadBalanceLabel(0)).toBe('偏り大');
+  });
+});

--- a/src/__tests__/domain/entities/WeightedHarmonicMean.edge.test.ts
+++ b/src/__tests__/domain/entities/WeightedHarmonicMean.edge.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getWeightedHarmonicMean - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([], [])).toBe(0);
+  });
+
+  it('1件はその値', () => {
+    expect(MathHelper.getWeightedHarmonicMean([42], [1])).toBe(42);
+  });
+
+  it('1件・重み大はその値', () => {
+    expect(MathHelper.getWeightedHarmonicMean([42], [100])).toBe(42);
+  });
+
+  it('同値は重みに関わらず同じ', () => {
+    expect(MathHelper.getWeightedHarmonicMean([10, 10, 10], [1, 2, 3])).toBe(10);
+  });
+
+  it('0を含む値は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([0, 10], [1, 1])).toBe(0);
+  });
+
+  it('負の値は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([-5, 10], [1, 1])).toBe(0);
+  });
+
+  it('配列長不一致は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([10, 20, 30], [1, 2])).toBe(0);
+  });
+
+  it('重み合計0は0', () => {
+    expect(MathHelper.getWeightedHarmonicMean([10, 20], [0, 0])).toBe(0);
+  });
+
+  it('等重みは通常の調和平均', () => {
+    const weighted = MathHelper.getWeightedHarmonicMean([40, 60], [1, 1]);
+    const harmonic = MathHelper.getHarmonicMean([40, 60]);
+    expect(weighted).toBe(harmonic);
+  });
+
+  it('重みで偏る', () => {
+    const heavyFirst = MathHelper.getWeightedHarmonicMean([10, 100], [10, 1]);
+    const heavySecond = MathHelper.getWeightedHarmonicMean([10, 100], [1, 10]);
+    expect(heavyFirst).toBeLessThan(heavySecond);
+  });
+
+  it('大量データで均一', () => {
+    const values = Array(50).fill(20);
+    const weights = Array(50).fill(1);
+    expect(MathHelper.getWeightedHarmonicMean(values, weights)).toBe(20);
+  });
+
+  it('結果は正の値', () => {
+    const result = MathHelper.getWeightedHarmonicMean([5, 10, 15], [1, 2, 3]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('算術平均以下', () => {
+    const values = [2, 8];
+    const result = MathHelper.getWeightedHarmonicMean(values, [1, 1]);
+    const am = (2 + 8) / 2;
+    expect(result).toBeLessThanOrEqual(am);
+  });
+});
+
+describe('MathHelper.getWeightedHarmonicMeanLabel - エッジケース', () => {
+  it('100は高い', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(100)).toBe('高い');
+  });
+
+  it('70は高い', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(70)).toBe('高い');
+  });
+
+  it('69は中程度', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(69)).toBe('中程度');
+  });
+
+  it('30は中程度', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(30)).toBe('中程度');
+  });
+
+  it('29は低い', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(29)).toBe('低い');
+  });
+
+  it('0は低い', () => {
+    expect(MathHelper.getWeightedHarmonicMeanLabel(0)).toBe('低い');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getWeightedHarmonicMean / getWeightedHarmonicMeanLabel のエッジケーステスト追加（19件）
- HealthLogEntity.getHealthTrendScore / getHealthTrendScoreLabel のエッジケーステスト追加（18件）
- ScheduleEntity.getScheduleLoadBalance / getScheduleLoadBalanceLabel のエッジケーステスト追加（18件）

## Test plan
- [x] 55件のエッジケーステストが全て合格
- [x] 全7092テストが合格

closes #932