### PR TITLE
feat: GeometricStdDev・CalendarDensity・StockDepletionRate追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarDensity.test.ts
+++ b/src/__tests__/domain/entities/CalendarDensity.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getCalendarDensity', () => {
+  it('全て0は0', () => {
+    expect(CalendarEntity.getCalendarDensity(0, 30)).toBe(0);
+  });
+
+  it('全日記録は100', () => {
+    expect(CalendarEntity.getCalendarDensity(30, 30)).toBe(100);
+  });
+
+  it('日数0は0', () => {
+    expect(CalendarEntity.getCalendarDensity(10, 0)).toBe(0);
+  });
+
+  it('半分は50', () => {
+    expect(CalendarEntity.getCalendarDensity(15, 30)).toBe(50);
+  });
+
+  it('記録日が多いほどスコアが高い', () => {
+    const low = CalendarEntity.getCalendarDensity(5, 30);
+    const high = CalendarEntity.getCalendarDensity(25, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = CalendarEntity.getCalendarDensity(10, 30);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('超過しても100以下', () => {
+    expect(CalendarEntity.getCalendarDensity(40, 30)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('CalendarEntity.getCalendarDensityLabel', () => {
+  it('スコア高は高密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(85)).toBe('高密度');
+  });
+
+  it('スコア中は中密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(55)).toBe('中密度');
+  });
+
+  it('スコア低は低密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(25)).toBe('低密度');
+  });
+});

--- a/src/__tests__/domain/entities/GeometricStdDev.test.ts
+++ b/src/__tests__/domain/entities/GeometricStdDev.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getGeometricStandardDeviation', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([10])).toBe(0);
+  });
+
+  it('同値は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([5, 5, 5])).toBe(0);
+  });
+
+  it('0を含む場合は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([0, 10, 20])).toBe(0);
+  });
+
+  it('負の値は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([-5, 10])).toBe(0);
+  });
+
+  it('ばらつきがある場合は正の値', () => {
+    const result = MathHelper.getGeometricStandardDeviation([2, 8, 32]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('ばらつきが大きいほど値が大きい', () => {
+    const small = MathHelper.getGeometricStandardDeviation([9, 10, 11]);
+    const large = MathHelper.getGeometricStandardDeviation([1, 10, 100]);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getGeometricStandardDeviation([3, 6, 9]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('MathHelper.getGeometricStandardDeviationLabel', () => {
+  it('低い値は均一', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(0.3)).toBe('均一');
+  });
+
+  it('中程度はやや散布', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(1.5)).toBe('やや散布');
+  });
+
+  it('高い値は散布', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(3)).toBe('散布');
+  });
+});

--- a/src/__tests__/domain/entities/StockDepletionRate.test.ts
+++ b/src/__tests__/domain/entities/StockDepletionRate.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockDepletionRate', () => {
+  it('初期在庫0は0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(0, 0)).toBe(0);
+  });
+
+  it('全て使用は100', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 0)).toBe(100);
+  });
+
+  it('使用なしは0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 100)).toBe(0);
+  });
+
+  it('半分使用は50', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 50)).toBe(50);
+  });
+
+  it('使用が多いほど率が高い', () => {
+    const low = StockAlertEntity.getStockDepletionRate(100, 80);
+    const high = StockAlertEntity.getStockDepletionRate(100, 20);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = StockAlertEntity.getStockDepletionRate(50, 20);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('残りが初期より多い場合は0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(50, 80)).toBe(0);
+  });
+});
+
+describe('StockAlertEntity.getStockDepletionRateLabel', () => {
+  it('率高は急速消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(85)).toBe('急速消費');
+  });
+
+  it('率中は通常消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(55)).toBe('通常消費');
+  });
+
+  it('率低は低消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(25)).toBe('低消費');
+  });
+});

--- a/src/domain/entities/Calendar.ts
+++ b/src/domain/entities/Calendar.ts
@@ -22,6 +22,8 @@ export interface CalendarMonth {
 export class CalendarEntity {
   private static readonly WEEKLY_RECORD_DAILY_THRESHOLD = 80;
   private static readonly WEEKLY_RECORD_MODERATE_THRESHOLD = 50;
+  private static readonly DENSITY_HIGH_THRESHOLD = 80;
+  private static readonly DENSITY_MODERATE_THRESHOLD = 50;
   private static readonly RECORD_COUNT_LOW_THRESHOLD = 2;
   private static readonly RECORD_COUNT_MEDIUM_THRESHOLD = 5;
   private static readonly CONDITION_GOOD_THRESHOLD = 4;
@@ -670,5 +672,23 @@ export class CalendarEntity {
     if (rate >= CalendarEntity.WEEKLY_RECORD_DAILY_THRESHOLD) return '毎日記録';
     if (rate >= CalendarEntity.WEEKLY_RECORD_MODERATE_THRESHOLD) return 'まずまず';
     return '記録不足';
+  }
+
+  /**
+   * カレンダー密度(0-100)を算出する
+   * 記録日数/全日数の割合
+   */
+  static getCalendarDensity(recordDays: number, totalDays: number): number {
+    if (totalDays <= 0) return 0;
+    return Math.min(100, Math.round((recordDays / totalDays) * 100));
+  }
+
+  /**
+   * カレンダー密度に応じたラベルを返す
+   */
+  static getCalendarDensityLabel(density: number): string {
+    if (density >= CalendarEntity.DENSITY_HIGH_THRESHOLD) return '高密度';
+    if (density >= CalendarEntity.DENSITY_MODERATE_THRESHOLD) return '中密度';
+    return '低密度';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -59,6 +59,8 @@ export class MathHelper {
   private static readonly TRIMMED_MODERATE_THRESHOLD = 30;
   private static readonly WHMEAN_HIGH_THRESHOLD = 70;
   private static readonly WHMEAN_MODERATE_THRESHOLD = 30;
+  private static readonly GSD_UNIFORM_THRESHOLD = 0.5;
+  private static readonly GSD_MODERATE_THRESHOLD = 2;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -990,5 +992,28 @@ export class MathHelper {
     if (value >= MathHelper.WHMEAN_HIGH_THRESHOLD) return '高い';
     if (value >= MathHelper.WHMEAN_MODERATE_THRESHOLD) return '中程度';
     return '低い';
+  }
+
+  /**
+   * 幾何標準偏差を算出する
+   * 0以下の値を含む場合は0を返す
+   */
+  static getGeometricStandardDeviation(values: number[]): number {
+    if (values.length <= 1) return 0;
+    if (values.some((v) => v <= 0)) return 0;
+    const logValues = values.map((v) => Math.log(v));
+    const avg = logValues.reduce((a, b) => a + b, 0) / logValues.length;
+    const variance =
+      logValues.reduce((sum, v) => sum + (v - avg) ** 2, 0) / logValues.length;
+    return Math.round(Math.sqrt(variance) * 100) / 100;
+  }
+
+  /**
+   * 幾何標準偏差に応じたラベルを返す
+   */
+  static getGeometricStandardDeviationLabel(gsd: number): string {
+    if (gsd <= MathHelper.GSD_UNIFORM_THRESHOLD) return '均一';
+    if (gsd <= MathHelper.GSD_MODERATE_THRESHOLD) return 'やや散布';
+    return '散布';
   }
 }

--- a/src/domain/entities/StockAlert.ts
+++ b/src/domain/entities/StockAlert.ts
@@ -52,6 +52,8 @@ export class StockAlertEntity {
   private static readonly CONSISTENCY_MAX_STDDEV = 50;
   private static readonly CONSISTENCY_HIGH_THRESHOLD = 80;
   private static readonly CONSISTENCY_MODERATE_THRESHOLD = 50;
+  private static readonly DEPLETION_RATE_HIGH_THRESHOLD = 70;
+  private static readonly DEPLETION_RATE_MODERATE_THRESHOLD = 40;
 
   constructor(private readonly alert: StockAlert) {}
 
@@ -689,5 +691,28 @@ export class StockAlertEntity {
     if (score >= StockAlertEntity.CONSISTENCY_HIGH_THRESHOLD) return '安定';
     if (score >= StockAlertEntity.CONSISTENCY_MODERATE_THRESHOLD) return 'やや不安定';
     return '不安定';
+  }
+
+  /**
+   * 在庫減少率(0-100)を算出する
+   * (初期在庫 - 残在庫) / 初期在庫
+   */
+  static getStockDepletionRate(
+    initialStock: number,
+    currentStock: number,
+  ): number {
+    if (initialStock <= 0) return 0;
+    const depleted = initialStock - currentStock;
+    if (depleted <= 0) return 0;
+    return Math.min(100, Math.round((depleted / initialStock) * 100));
+  }
+
+  /**
+   * 在庫減少率に応じたラベルを返す
+   */
+  static getStockDepletionRateLabel(rate: number): string {
+    if (rate >= StockAlertEntity.DEPLETION_RATE_HIGH_THRESHOLD) return '急速消費';
+    if (rate >= StockAlertEntity.DEPLETION_RATE_MODERATE_THRESHOLD) return '通常消費';
+    return '低消費';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getGeometricStandardDeviation / getGeometricStandardDeviationLabel 追加（幾何標準偏差の算出）
- CalendarEntity.getCalendarDensity / getCalendarDensityLabel 追加（カレンダー密度の算出）
- StockAlertEntity.getStockDepletionRate / getStockDepletionRateLabel 追加（在庫減少率の算出）

## Test plan
- [x] 31件の新規テストが全て合格
- [x] 全7123テストが合格

closes #934