### PR TITLE
test: GeometricStdDev・CalendarDensity・StockDepletionRateのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/CalendarDensity.edge.test.ts
+++ b/src/__tests__/domain/entities/CalendarDensity.edge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { CalendarEntity } from '@/domain/entities/Calendar';
+
+describe('CalendarEntity.getCalendarDensity - エッジケース', () => {
+  it('記録0・日数0は0', () => {
+    expect(CalendarEntity.getCalendarDensity(0, 0)).toBe(0);
+  });
+
+  it('記録0・日数30は0', () => {
+    expect(CalendarEntity.getCalendarDensity(0, 30)).toBe(0);
+  });
+
+  it('記録10・日数0は0', () => {
+    expect(CalendarEntity.getCalendarDensity(10, 0)).toBe(0);
+  });
+
+  it('記録30・日数30は100', () => {
+    expect(CalendarEntity.getCalendarDensity(30, 30)).toBe(100);
+  });
+
+  it('記録1・日数1は100', () => {
+    expect(CalendarEntity.getCalendarDensity(1, 1)).toBe(100);
+  });
+
+  it('超過しても100以下', () => {
+    expect(CalendarEntity.getCalendarDensity(50, 30)).toBeLessThanOrEqual(100);
+  });
+
+  it('半分は50', () => {
+    expect(CalendarEntity.getCalendarDensity(15, 30)).toBe(50);
+  });
+
+  it('1/3は33', () => {
+    expect(CalendarEntity.getCalendarDensity(10, 30)).toBe(33);
+  });
+
+  it('記録が多いほどスコアが高い', () => {
+    const low = CalendarEntity.getCalendarDensity(5, 30);
+    const high = CalendarEntity.getCalendarDensity(25, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('日数が多いほどスコアが低い', () => {
+    const low = CalendarEntity.getCalendarDensity(10, 30);
+    const high = CalendarEntity.getCalendarDensity(10, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = CalendarEntity.getCalendarDensity(12, 30);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('負の日数は0', () => {
+    expect(CalendarEntity.getCalendarDensity(5, -10)).toBe(0);
+  });
+});
+
+describe('CalendarEntity.getCalendarDensityLabel - エッジケース', () => {
+  it('100は高密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(100)).toBe('高密度');
+  });
+
+  it('80は高密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(80)).toBe('高密度');
+  });
+
+  it('79は中密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(79)).toBe('中密度');
+  });
+
+  it('50は中密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(50)).toBe('中密度');
+  });
+
+  it('49は低密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(49)).toBe('低密度');
+  });
+
+  it('0は低密度', () => {
+    expect(CalendarEntity.getCalendarDensityLabel(0)).toBe('低密度');
+  });
+});

--- a/src/__tests__/domain/entities/GeometricStdDev.edge.test.ts
+++ b/src/__tests__/domain/entities/GeometricStdDev.edge.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getGeometricStandardDeviation - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([42])).toBe(0);
+  });
+
+  it('2件同値は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([10, 10])).toBe(0);
+  });
+
+  it('全て同値は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([5, 5, 5, 5])).toBe(0);
+  });
+
+  it('0を含む場合は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([0, 5, 10])).toBe(0);
+  });
+
+  it('負の値は0', () => {
+    expect(MathHelper.getGeometricStandardDeviation([-1, 5])).toBe(0);
+  });
+
+  it('わずかなばらつき', () => {
+    const result = MathHelper.getGeometricStandardDeviation([9, 10, 11]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(1);
+  });
+
+  it('大きなばらつき', () => {
+    const result = MathHelper.getGeometricStandardDeviation([1, 100, 10000]);
+    expect(result).toBeGreaterThan(1);
+  });
+
+  it('ばらつきが大きいほど値が大きい', () => {
+    const small = MathHelper.getGeometricStandardDeviation([10, 11, 12]);
+    const large = MathHelper.getGeometricStandardDeviation([1, 50, 1000]);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(100).fill(7);
+    expect(MathHelper.getGeometricStandardDeviation(data)).toBe(0);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getGeometricStandardDeviation([2, 4, 8]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('2件の差', () => {
+    const result = MathHelper.getGeometricStandardDeviation([1, 100]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getGeometricStandardDeviationLabel - エッジケース', () => {
+  it('0は均一', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(0)).toBe('均一');
+  });
+
+  it('0.5は均一', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(0.5)).toBe('均一');
+  });
+
+  it('0.51はやや散布', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(0.51)).toBe('やや散布');
+  });
+
+  it('2はやや散布', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(2)).toBe('やや散布');
+  });
+
+  it('2.01は散布', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(2.01)).toBe('散布');
+  });
+
+  it('10は散布', () => {
+    expect(MathHelper.getGeometricStandardDeviationLabel(10)).toBe('散布');
+  });
+});

--- a/src/__tests__/domain/entities/StockDepletionRate.edge.test.ts
+++ b/src/__tests__/domain/entities/StockDepletionRate.edge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { StockAlertEntity } from '@/domain/entities/StockAlert';
+
+describe('StockAlertEntity.getStockDepletionRate - エッジケース', () => {
+  it('初期0・残0は0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(0, 0)).toBe(0);
+  });
+
+  it('初期0・残10は0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(0, 10)).toBe(0);
+  });
+
+  it('初期100・残0は100', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 0)).toBe(100);
+  });
+
+  it('初期100・残100は0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 100)).toBe(0);
+  });
+
+  it('残りが初期より多い場合は0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(50, 80)).toBe(0);
+  });
+
+  it('半分使用は50', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 50)).toBe(50);
+  });
+
+  it('1/4使用は25', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 75)).toBe(25);
+  });
+
+  it('3/4使用は75', () => {
+    expect(StockAlertEntity.getStockDepletionRate(100, 25)).toBe(75);
+  });
+
+  it('初期1・残0は100', () => {
+    expect(StockAlertEntity.getStockDepletionRate(1, 0)).toBe(100);
+  });
+
+  it('使用が多いほど率が高い', () => {
+    const low = StockAlertEntity.getStockDepletionRate(100, 90);
+    const high = StockAlertEntity.getStockDepletionRate(100, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = StockAlertEntity.getStockDepletionRate(80, 30);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('負の初期在庫は0', () => {
+    expect(StockAlertEntity.getStockDepletionRate(-10, 5)).toBe(0);
+  });
+});
+
+describe('StockAlertEntity.getStockDepletionRateLabel - エッジケース', () => {
+  it('100は急速消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(100)).toBe('急速消費');
+  });
+
+  it('70は急速消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(70)).toBe('急速消費');
+  });
+
+  it('69は通常消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(69)).toBe('通常消費');
+  });
+
+  it('40は通常消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(40)).toBe('通常消費');
+  });
+
+  it('39は低消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(39)).toBe('低消費');
+  });
+
+  it('0は低消費', () => {
+    expect(StockAlertEntity.getStockDepletionRateLabel(0)).toBe('低消費');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getGeometricStandardDeviation / getGeometricStandardDeviationLabel のエッジケーステスト追加（18件）
- CalendarEntity.getCalendarDensity / getCalendarDensityLabel のエッジケーステスト追加（18件）
- StockAlertEntity.getStockDepletionRate / getStockDepletionRateLabel のエッジケーステスト追加（18件）

## Test plan
- [x] 54件のエッジケーステストが全て合格
- [x] 全7177テストが合格

closes #936