### PR TITLE
feat: WinsorizedMean・MemberEngagementScore・AdherenceDecayRate追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceDecayRate.test.ts
+++ b/src/__tests__/domain/entities/AdherenceDecayRate.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceDecayRate', () => {
+  it('空配列は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([80])).toBe(0);
+  });
+
+  it('同値は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([50, 50, 50])).toBe(0);
+  });
+
+  it('完全減少は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([100, 0])).toBe(100);
+  });
+
+  it('改善は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([50, 80])).toBe(0);
+  });
+
+  it('部分的な減少', () => {
+    const result = AdherenceTrendEntity.getAdherenceDecayRate([100, 80, 60]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceTrendEntity.getAdherenceDecayRate([90, 70, 60]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('減少率が大きいほどスコアが高い', () => {
+    const small = AdherenceTrendEntity.getAdherenceDecayRate([100, 95]);
+    const large = AdherenceTrendEntity.getAdherenceDecayRate([100, 30]);
+    expect(large).toBeGreaterThan(small);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceDecayRateLabel', () => {
+  it('率高は急減', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(75)).toBe('急減');
+  });
+
+  it('率中はやや減少', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(40)).toBe('やや減少');
+  });
+
+  it('率低は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(10)).toBe('安定');
+  });
+});

--- a/src/__tests__/domain/entities/MemberEngagementScore.test.ts
+++ b/src/__tests__/domain/entities/MemberEngagementScore.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity.getMemberEngagementScore', () => {
+  it('全て0は0', () => {
+    expect(MemberEntity.getMemberEngagementScore(0, 0, 0)).toBe(0);
+  });
+
+  it('全て100は100', () => {
+    expect(MemberEntity.getMemberEngagementScore(100, 100, 100)).toBe(100);
+  });
+
+  it('ログイン率のみ高い', () => {
+    const result = MemberEntity.getMemberEngagementScore(100, 0, 0);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(60);
+  });
+
+  it('ログイン率が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberEngagementScore(20, 50, 50);
+    const high = MemberEntity.getMemberEngagementScore(80, 50, 50);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('記録率が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberEngagementScore(50, 20, 50);
+    const high = MemberEntity.getMemberEngagementScore(50, 80, 50);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('遵守率が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberEngagementScore(50, 50, 20);
+    const high = MemberEntity.getMemberEngagementScore(50, 50, 80);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MemberEntity.getMemberEngagementScore(60, 70, 50);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('超過しても100以下', () => {
+    expect(MemberEntity.getMemberEngagementScore(150, 150, 150)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('MemberEntity.getMemberEngagementScoreLabel', () => {
+  it('スコア高は積極的', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(85)).toBe('積極的');
+  });
+
+  it('スコア中は普通', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(55)).toBe('普通');
+  });
+
+  it('スコア低は消極的', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(25)).toBe('消極的');
+  });
+});

--- a/src/__tests__/domain/entities/WinsorizedMean.test.ts
+++ b/src/__tests__/domain/entities/WinsorizedMean.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getWinsorizedMean', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getWinsorizedMean([], 10)).toBe(0);
+  });
+
+  it('1件はその値', () => {
+    expect(MathHelper.getWinsorizedMean([42], 10)).toBe(42);
+  });
+
+  it('同値は同じ', () => {
+    expect(MathHelper.getWinsorizedMean([5, 5, 5], 20)).toBe(5);
+  });
+
+  it('外れ値を端に置換', () => {
+    // [1, 2, 3, 4, 100] 20%置換 -> [2, 2, 3, 4, 4] -> 平均3
+    expect(MathHelper.getWinsorizedMean([1, 2, 3, 4, 100], 20)).toBe(3);
+  });
+
+  it('トリム0は通常の平均', () => {
+    expect(MathHelper.getWinsorizedMean([10, 20, 30], 0)).toBe(20);
+  });
+
+  it('外れ値の影響が軽減される', () => {
+    const withOutlier = [1, 2, 3, 4, 5, 100];
+    const winsorized = MathHelper.getWinsorizedMean(withOutlier, 20);
+    const regular = withOutlier.reduce((a, b) => a + b, 0) / withOutlier.length;
+    expect(winsorized).toBeLessThan(regular);
+  });
+
+  it('2件は通常平均', () => {
+    expect(MathHelper.getWinsorizedMean([10, 20], 10)).toBe(15);
+  });
+
+  it('結果は数値', () => {
+    const result = MathHelper.getWinsorizedMean([3, 6, 9, 12], 10);
+    expect(typeof result).toBe('number');
+  });
+});
+
+describe('MathHelper.getWinsorizedMeanLabel', () => {
+  it('高い値は高い', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(75)).toBe('高い');
+  });
+
+  it('中程度は中程度', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(50)).toBe('中程度');
+  });
+
+  it('低い値は低い', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(20)).toBe('低い');
+  });
+});

--- a/src/domain/entities/AdherenceTrend.ts
+++ b/src/domain/entities/AdherenceTrend.ts
@@ -48,6 +48,8 @@ export class AdherenceTrendEntity {
   private static readonly STREAK_BONUS_MAX_DAYS = 30;
   private static readonly STREAK_BONUS_HIGH_THRESHOLD = 70;
   private static readonly STREAK_BONUS_MODERATE_THRESHOLD = 30;
+  private static readonly DECAY_RAPID_THRESHOLD = 60;
+  private static readonly DECAY_MODERATE_THRESHOLD = 20;
 
   constructor(private readonly trend: AdherenceTrend) {}
 
@@ -546,5 +548,28 @@ export class AdherenceTrendEntity {
     if (bonus >= AdherenceTrendEntity.STREAK_BONUS_HIGH_THRESHOLD) return 'ボーナス大';
     if (bonus >= AdherenceTrendEntity.STREAK_BONUS_MODERATE_THRESHOLD) return 'ボーナス中';
     return 'ボーナス小';
+  }
+
+  /**
+   * 服薬遵守度の減衰率(0-100)を算出する
+   * 最初の値から最後の値への減少割合
+   */
+  static getAdherenceDecayRate(rates: number[]): number {
+    if (rates.length <= 1) return 0;
+    const first = rates[0];
+    const last = rates[rates.length - 1];
+    if (first <= 0) return 0;
+    const decay = first - last;
+    if (decay <= 0) return 0;
+    return Math.min(100, Math.round((decay / first) * 100));
+  }
+
+  /**
+   * 減衰率に応じたラベルを返す
+   */
+  static getAdherenceDecayRateLabel(rate: number): string {
+    if (rate >= AdherenceTrendEntity.DECAY_RAPID_THRESHOLD) return '急減';
+    if (rate >= AdherenceTrendEntity.DECAY_MODERATE_THRESHOLD) return 'やや減少';
+    return '安定';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -61,6 +61,8 @@ export class MathHelper {
   private static readonly WHMEAN_MODERATE_THRESHOLD = 30;
   private static readonly GSD_UNIFORM_THRESHOLD = 0.5;
   private static readonly GSD_MODERATE_THRESHOLD = 2;
+  private static readonly WINSORIZED_HIGH_THRESHOLD = 70;
+  private static readonly WINSORIZED_MODERATE_THRESHOLD = 30;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1015,5 +1017,36 @@ export class MathHelper {
     if (gsd <= MathHelper.GSD_UNIFORM_THRESHOLD) return '均一';
     if (gsd <= MathHelper.GSD_MODERATE_THRESHOLD) return 'やや散布';
     return '散布';
+  }
+
+  /**
+   * ウィンソライズド平均を算出する
+   * 上下winsorPercent%のデータを端の値に置換して平均を取る
+   */
+  static getWinsorizedMean(values: number[], winsorPercent: number): number {
+    if (values.length === 0) return 0;
+    if (values.length === 1) return values[0];
+    const sorted = [...values].sort((a, b) => a - b);
+    const count = Math.floor(sorted.length * (winsorPercent / 100));
+    if (count * 2 >= sorted.length) {
+      const sum = sorted.reduce((a, b) => a + b, 0);
+      return Math.round((sum / sorted.length) * 100) / 100;
+    }
+    const winsorized = sorted.map((v, i) => {
+      if (i < count) return sorted[count];
+      if (i >= sorted.length - count) return sorted[sorted.length - 1 - count];
+      return v;
+    });
+    const sum = winsorized.reduce((a, b) => a + b, 0);
+    return Math.round((sum / winsorized.length) * 100) / 100;
+  }
+
+  /**
+   * ウィンソライズド平均に応じたラベルを返す
+   */
+  static getWinsorizedMeanLabel(value: number): string {
+    if (value >= MathHelper.WINSORIZED_HIGH_THRESHOLD) return '高い';
+    if (value >= MathHelper.WINSORIZED_MODERATE_THRESHOLD) return '中程度';
+    return '低い';
   }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -157,6 +157,11 @@ export class MemberEntity {
   private static readonly CARE_SCORE_MODERATE_THRESHOLD = 50;
   private static readonly CARE_SCORE_ADHERENCE_WEIGHT = 0.6;
   private static readonly CARE_SCORE_RECORD_WEIGHT = 0.4;
+  private static readonly ENGAGEMENT_LOGIN_WEIGHT = 0.3;
+  private static readonly ENGAGEMENT_RECORD_WEIGHT = 0.4;
+  private static readonly ENGAGEMENT_ADHERENCE_WEIGHT = 0.3;
+  private static readonly ENGAGEMENT_HIGH_THRESHOLD = 80;
+  private static readonly ENGAGEMENT_MODERATE_THRESHOLD = 50;
 
   private static readonly memberTypeLabels: Record<MemberType, string> = {
     human: '家族',
@@ -540,5 +545,36 @@ export class MemberEntity {
     if (score >= MemberEntity.CARE_SCORE_GOOD_THRESHOLD) return '良好';
     if (score >= MemberEntity.CARE_SCORE_MODERATE_THRESHOLD) return '普通';
     return '要注意';
+  }
+
+  /**
+   * メンバー関与度スコア(0-100)を算出する
+   * ログイン率・記録率・遵守率の加重平均
+   */
+  static getMemberEngagementScore(
+    loginRate: number,
+    recordRate: number,
+    adherenceRate: number,
+  ): number {
+    const clampedLogin = Math.max(0, Math.min(100, loginRate));
+    const clampedRecord = Math.max(0, Math.min(100, recordRate));
+    const clampedAdherence = Math.max(0, Math.min(100, adherenceRate));
+    return Math.min(
+      100,
+      Math.round(
+        clampedLogin * MemberEntity.ENGAGEMENT_LOGIN_WEIGHT +
+          clampedRecord * MemberEntity.ENGAGEMENT_RECORD_WEIGHT +
+          clampedAdherence * MemberEntity.ENGAGEMENT_ADHERENCE_WEIGHT,
+      ),
+    );
+  }
+
+  /**
+   * 関与度スコアに応じたラベルを返す
+   */
+  static getMemberEngagementScoreLabel(score: number): string {
+    if (score >= MemberEntity.ENGAGEMENT_HIGH_THRESHOLD) return '積極的';
+    if (score >= MemberEntity.ENGAGEMENT_MODERATE_THRESHOLD) return '普通';
+    return '消極的';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getWinsorizedMean / getWinsorizedMeanLabel 追加（ウィンソライズド平均の算出）
- MemberEntity.getMemberEngagementScore / getMemberEngagementScoreLabel 追加（メンバー関与度スコアの算出）
- AdherenceTrendEntity.getAdherenceDecayRate / getAdherenceDecayRateLabel 追加（遵守度減衰率の算出）

## Test plan
- [x] 33件の新規テストが全て合格
- [x] 全7210テストが合格

closes #938