### PR TITLE
test: WinsorizedMean・MemberEngagementScore・AdherenceDecayRateのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceDecayRate.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceDecayRate.edge.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceTrendEntity } from '@/domain/entities/AdherenceTrend';
+
+describe('AdherenceTrendEntity.getAdherenceDecayRate - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([100])).toBe(0);
+  });
+
+  it('同値は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([80, 80, 80])).toBe(0);
+  });
+
+  it('完全減少は100', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([100, 0])).toBe(100);
+  });
+
+  it('半減は50', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([100, 50])).toBe(50);
+  });
+
+  it('改善は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([50, 80])).toBe(0);
+  });
+
+  it('初期0は0', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([0, 50])).toBe(0);
+  });
+
+  it('中間値は無視（最初と最後のみ）', () => {
+    // 100 -> 50: 50% decay
+    expect(AdherenceTrendEntity.getAdherenceDecayRate([100, 0, 50])).toBe(50);
+  });
+
+  it('大量データで減少', () => {
+    const data = Array.from({ length: 10 }, (_, i) => 100 - i * 10);
+    // 100 -> 10: 90% decay
+    expect(AdherenceTrendEntity.getAdherenceDecayRate(data)).toBe(90);
+  });
+
+  it('わずかな減少', () => {
+    const result = AdherenceTrendEntity.getAdherenceDecayRate([100, 95]);
+    expect(result).toBe(5);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceTrendEntity.getAdherenceDecayRate([90, 60]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('減少が大きいほど率が高い', () => {
+    const small = AdherenceTrendEntity.getAdherenceDecayRate([100, 90]);
+    const large = AdherenceTrendEntity.getAdherenceDecayRate([100, 20]);
+    expect(large).toBeGreaterThan(small);
+  });
+});
+
+describe('AdherenceTrendEntity.getAdherenceDecayRateLabel - エッジケース', () => {
+  it('100は急減', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(100)).toBe('急減');
+  });
+
+  it('60は急減', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(60)).toBe('急減');
+  });
+
+  it('59はやや減少', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(59)).toBe('やや減少');
+  });
+
+  it('20はやや減少', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(20)).toBe('やや減少');
+  });
+
+  it('19は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(19)).toBe('安定');
+  });
+
+  it('0は安定', () => {
+    expect(AdherenceTrendEntity.getAdherenceDecayRateLabel(0)).toBe('安定');
+  });
+});

--- a/src/__tests__/domain/entities/MemberEngagementScore.edge.test.ts
+++ b/src/__tests__/domain/entities/MemberEngagementScore.edge.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity.getMemberEngagementScore - エッジケース', () => {
+  it('全て0は0', () => {
+    expect(MemberEntity.getMemberEngagementScore(0, 0, 0)).toBe(0);
+  });
+
+  it('全て100は100', () => {
+    expect(MemberEntity.getMemberEngagementScore(100, 100, 100)).toBe(100);
+  });
+
+  it('ログインのみ100', () => {
+    expect(MemberEntity.getMemberEngagementScore(100, 0, 0)).toBe(30);
+  });
+
+  it('記録のみ100', () => {
+    expect(MemberEntity.getMemberEngagementScore(0, 100, 0)).toBe(40);
+  });
+
+  it('遵守のみ100', () => {
+    expect(MemberEntity.getMemberEngagementScore(0, 0, 100)).toBe(30);
+  });
+
+  it('負の値は0扱い', () => {
+    expect(MemberEntity.getMemberEngagementScore(-50, -50, -50)).toBe(0);
+  });
+
+  it('超過値は100扱い', () => {
+    expect(MemberEntity.getMemberEngagementScore(200, 200, 200)).toBe(100);
+  });
+
+  it('中程度の値', () => {
+    const result = MemberEntity.getMemberEngagementScore(50, 50, 50);
+    expect(result).toBe(50);
+  });
+
+  it('記録率が最も重い', () => {
+    const highRecord = MemberEntity.getMemberEngagementScore(50, 100, 50);
+    const highLogin = MemberEntity.getMemberEngagementScore(100, 50, 50);
+    expect(highRecord).toBeGreaterThan(highLogin);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MemberEntity.getMemberEngagementScore(60, 70, 40);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('各要素が高いほどスコアが高い', () => {
+    const low = MemberEntity.getMemberEngagementScore(20, 20, 20);
+    const high = MemberEntity.getMemberEngagementScore(80, 80, 80);
+    expect(high).toBeGreaterThan(low);
+  });
+});
+
+describe('MemberEntity.getMemberEngagementScoreLabel - エッジケース', () => {
+  it('100は積極的', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(100)).toBe('積極的');
+  });
+
+  it('80は積極的', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(80)).toBe('積極的');
+  });
+
+  it('79は普通', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(79)).toBe('普通');
+  });
+
+  it('50は普通', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(50)).toBe('普通');
+  });
+
+  it('49は消極的', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(49)).toBe('消極的');
+  });
+
+  it('0は消極的', () => {
+    expect(MemberEntity.getMemberEngagementScoreLabel(0)).toBe('消極的');
+  });
+});

--- a/src/__tests__/domain/entities/WinsorizedMean.edge.test.ts
+++ b/src/__tests__/domain/entities/WinsorizedMean.edge.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getWinsorizedMean - エッジケース', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getWinsorizedMean([], 0)).toBe(0);
+  });
+
+  it('空配列・高トリムは0', () => {
+    expect(MathHelper.getWinsorizedMean([], 50)).toBe(0);
+  });
+
+  it('1件はその値', () => {
+    expect(MathHelper.getWinsorizedMean([7], 20)).toBe(7);
+  });
+
+  it('2件同値は同じ', () => {
+    expect(MathHelper.getWinsorizedMean([5, 5], 0)).toBe(5);
+  });
+
+  it('2件異値・トリム0は平均', () => {
+    expect(MathHelper.getWinsorizedMean([10, 20], 0)).toBe(15);
+  });
+
+  it('全て同値はトリムに関わらず同じ', () => {
+    expect(MathHelper.getWinsorizedMean([10, 10, 10, 10], 25)).toBe(10);
+  });
+
+  it('トリム率が高すぎる場合は通常平均', () => {
+    expect(MathHelper.getWinsorizedMean([1, 2, 3], 50)).toBe(2);
+  });
+
+  it('外れ値を端に置換', () => {
+    const result = MathHelper.getWinsorizedMean([1, 10, 10, 10, 100], 20);
+    expect(result).toBe(10);
+  });
+
+  it('ソート順に関係なく同じ結果', () => {
+    const a = MathHelper.getWinsorizedMean([100, 1, 10, 10, 10], 20);
+    const b = MathHelper.getWinsorizedMean([1, 10, 10, 10, 100], 20);
+    expect(a).toBe(b);
+  });
+
+  it('大量データで均一', () => {
+    const data = Array(100).fill(50);
+    expect(MathHelper.getWinsorizedMean(data, 10)).toBe(50);
+  });
+
+  it('負の値を含む配列', () => {
+    const result = MathHelper.getWinsorizedMean([-10, 0, 10], 0);
+    expect(result).toBe(0);
+  });
+
+  it('トリムとウィンソライズの違い', () => {
+    const values = [1, 2, 3, 4, 100];
+    const trimmed = MathHelper.getTrimmedMean(values, 20);
+    const winsorized = MathHelper.getWinsorizedMean(values, 20);
+    // トリムは除外、ウィンソライズは置換なので結果が異なりうる
+    expect(typeof trimmed).toBe('number');
+    expect(typeof winsorized).toBe('number');
+  });
+});
+
+describe('MathHelper.getWinsorizedMeanLabel - エッジケース', () => {
+  it('100は高い', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(100)).toBe('高い');
+  });
+
+  it('70は高い', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(70)).toBe('高い');
+  });
+
+  it('69は中程度', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(69)).toBe('中程度');
+  });
+
+  it('30は中程度', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(30)).toBe('中程度');
+  });
+
+  it('29は低い', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(29)).toBe('低い');
+  });
+
+  it('0は低い', () => {
+    expect(MathHelper.getWinsorizedMeanLabel(0)).toBe('低い');
+  });
+});


### PR DESCRIPTION
## Summary
- MathHelper.getWinsorizedMean / getWinsorizedMeanLabel のエッジケーステスト追加（18件）
- MemberEntity.getMemberEngagementScore / getMemberEngagementScoreLabel のエッジケーステスト追加（17件）
- AdherenceTrendEntity.getAdherenceDecayRate / getAdherenceDecayRateLabel のエッジケーステスト追加（18件）

## Test plan
- [x] 53件のエッジケーステストが全て合格
- [x] 全7263テストが合格

closes #940