### PR TITLE
feat: 正規化エントロピー・挨拶多様性スコア・通院費用スコアを追加

### DIFF
--- a/src/__tests__/domain/entities/EntropyNormalized.test.ts
+++ b/src/__tests__/domain/entities/EntropyNormalized.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getEntropyNormalized', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getEntropyNormalized([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getEntropyNormalized([100])).toBe(0);
+  });
+
+  it('全て同値は100', () => {
+    expect(MathHelper.getEntropyNormalized([25, 25, 25, 25])).toBe(100);
+  });
+
+  it('1つだけ正は0', () => {
+    expect(MathHelper.getEntropyNormalized([100, 0, 0])).toBe(0);
+  });
+
+  it('2つ均等は100', () => {
+    expect(MathHelper.getEntropyNormalized([50, 50])).toBe(100);
+  });
+
+  it('偏りが大きいほど低い', () => {
+    const balanced = MathHelper.getEntropyNormalized([25, 25, 25, 25]);
+    const skewed = MathHelper.getEntropyNormalized([90, 5, 3, 2]);
+    expect(balanced).toBeGreaterThan(skewed);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = MathHelper.getEntropyNormalized([40, 30, 20, 10]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('全て0は0', () => {
+    expect(MathHelper.getEntropyNormalized([0, 0, 0])).toBe(0);
+  });
+});
+
+describe('MathHelper.getEntropyNormalizedLabel', () => {
+  it('高い値は均一', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(85)).toBe('均一');
+  });
+
+  it('中程度はやや偏り', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(55)).toBe('やや偏り');
+  });
+
+  it('低い値は偏り大', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(25)).toBe('偏り大');
+  });
+});

--- a/src/__tests__/domain/entities/GreetingVarietyScore.test.ts
+++ b/src/__tests__/domain/entities/GreetingVarietyScore.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity.getGreetingVarietyScore', () => {
+  it('0種類は0', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(0, 10)).toBe(0);
+  });
+
+  it('使用種類=全種類は100', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(10, 10)).toBe(100);
+  });
+
+  it('全種類0は0', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(0, 0)).toBe(0);
+  });
+
+  it('半分は50', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(5, 10)).toBe(50);
+  });
+
+  it('使用が多いほどスコアが高い', () => {
+    const low = GreetingMessageEntity.getGreetingVarietyScore(2, 10);
+    const high = GreetingMessageEntity.getGreetingVarietyScore(8, 10);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = GreetingMessageEntity.getGreetingVarietyScore(3, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('超過しても100以下', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(20, 10)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('GreetingMessageEntity.getGreetingVarietyScoreLabel', () => {
+  it('スコア高は豊富', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(85)).toBe('豊富');
+  });
+
+  it('スコア中は普通', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(55)).toBe('普通');
+  });
+
+  it('スコア低は少ない', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(25)).toBe('少ない');
+  });
+});

--- a/src/__tests__/domain/entities/HospitalVisitCostScore.test.ts
+++ b/src/__tests__/domain/entities/HospitalVisitCostScore.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity.getHospitalVisitCostScore', () => {
+  it('費用0は0', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(0)).toBe(0);
+  });
+
+  it('低費用は低スコア', () => {
+    const result = HospitalEntity.getHospitalVisitCostScore(1000);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('高費用は高スコア', () => {
+    const result = HospitalEntity.getHospitalVisitCostScore(60000);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('費用が高いほどスコアが高い', () => {
+    const low = HospitalEntity.getHospitalVisitCostScore(3000);
+    const high = HospitalEntity.getHospitalVisitCostScore(30000);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = HospitalEntity.getHospitalVisitCostScore(10000);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('超過しても100以下', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(1000000)).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('HospitalEntity.getHospitalVisitCostScoreLabel', () => {
+  it('スコア高は高額', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(85)).toBe('高額');
+  });
+
+  it('スコア中は標準', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(55)).toBe('標準');
+  });
+
+  it('スコア低は安価', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(25)).toBe('安価');
+  });
+});

--- a/src/domain/entities/GreetingMessage.ts
+++ b/src/domain/entities/GreetingMessage.ts
@@ -5,6 +5,8 @@
 export class GreetingMessageEntity {
   private static readonly GREETING_INTENSITY_HIGH_THRESHOLD = 70;
   private static readonly GREETING_INTENSITY_MODERATE_THRESHOLD = 40;
+  private static readonly VARIETY_HIGH_THRESHOLD = 80;
+  private static readonly VARIETY_MODERATE_THRESHOLD = 40;
   private static readonly GREETING_INTENSITY_MAX_HOURS = 72;
   private static readonly GREETING_INTENSITY_MAX_STREAK = 30;
   private static readonly GREETING_INTENSITY_HOURS_WEIGHT = 0.6;
@@ -102,5 +104,22 @@ export class GreetingMessageEntity {
     if (score >= GreetingMessageEntity.GREETING_INTENSITY_HIGH_THRESHOLD) return '熱烈';
     if (score >= GreetingMessageEntity.GREETING_INTENSITY_MODERATE_THRESHOLD) return '普通';
     return '軽め';
+  }
+
+  /**
+   * 使用した挨拶種類数から多様性スコアを算出する（0-100）
+   */
+  static getGreetingVarietyScore(usedTypes: number, totalTypes: number): number {
+    if (totalTypes <= 0 || usedTypes <= 0) return 0;
+    return Math.min(100, Math.round((usedTypes / totalTypes) * 100));
+  }
+
+  /**
+   * 挨拶多様性スコアに応じたラベルを返す
+   */
+  static getGreetingVarietyScoreLabel(score: number): string {
+    if (score >= GreetingMessageEntity.VARIETY_HIGH_THRESHOLD) return '豊富';
+    if (score >= GreetingMessageEntity.VARIETY_MODERATE_THRESHOLD) return '普通';
+    return '少ない';
   }
 }

--- a/src/domain/entities/Hospital.ts
+++ b/src/domain/entities/Hospital.ts
@@ -22,6 +22,9 @@ export class HospitalEntity {
   private static readonly VISIT_REGULARITY_HIGH_THRESHOLD = 80;
   private static readonly VISIT_REGULARITY_MODERATE_THRESHOLD = 50;
   private static readonly VISIT_REGULARITY_MAX_CV = 100;
+  private static readonly VISIT_COST_MAX = 100000;
+  private static readonly VISIT_COST_HIGH_THRESHOLD = 70;
+  private static readonly VISIT_COST_MODERATE_THRESHOLD = 40;
 
   private static readonly typeLabels: Record<string, string> = {
     general: '総合病院',
@@ -204,5 +207,22 @@ export class HospitalEntity {
     if (score >= HospitalEntity.VISIT_REGULARITY_HIGH_THRESHOLD) return '規則的';
     if (score >= HospitalEntity.VISIT_REGULARITY_MODERATE_THRESHOLD) return 'やや不規則';
     return '不規則';
+  }
+
+  /**
+   * 通院費用から費用負担スコアを算出する（0-100）
+   */
+  static getHospitalVisitCostScore(cost: number): number {
+    if (cost <= 0) return 0;
+    return Math.min(100, Math.round((cost / HospitalEntity.VISIT_COST_MAX) * 100));
+  }
+
+  /**
+   * 費用負担スコアに応じたラベルを返す
+   */
+  static getHospitalVisitCostScoreLabel(score: number): string {
+    if (score >= HospitalEntity.VISIT_COST_HIGH_THRESHOLD) return '高額';
+    if (score >= HospitalEntity.VISIT_COST_MODERATE_THRESHOLD) return '標準';
+    return '安価';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -63,6 +63,8 @@ export class MathHelper {
   private static readonly GSD_MODERATE_THRESHOLD = 2;
   private static readonly WINSORIZED_HIGH_THRESHOLD = 70;
   private static readonly WINSORIZED_MODERATE_THRESHOLD = 30;
+  private static readonly ENTROPY_NORM_HIGH_THRESHOLD = 80;
+  private static readonly ENTROPY_NORM_MODERATE_THRESHOLD = 40;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1048,5 +1050,33 @@ export class MathHelper {
     if (value >= MathHelper.WINSORIZED_HIGH_THRESHOLD) return '高い';
     if (value >= MathHelper.WINSORIZED_MODERATE_THRESHOLD) return '中程度';
     return '低い';
+  }
+
+  /**
+   * 正規化エントロピー(0-100)を算出する
+   * 分布の均一性を評価（均一なら100、偏っていれば0に近い）
+   */
+  static getEntropyNormalized(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const total = values.reduce((a, b) => a + b, 0);
+    if (total === 0) return 0;
+    const probs = values.map((v) => v / total);
+    const nonZeroProbs = probs.filter((p) => p > 0);
+    if (nonZeroProbs.length <= 1) return 0;
+    const entropy = -nonZeroProbs.reduce(
+      (sum, p) => sum + p * Math.log2(p),
+      0,
+    );
+    const maxEntropy = Math.log2(values.length);
+    return Math.round((entropy / maxEntropy) * 100);
+  }
+
+  /**
+   * 正規化エントロピーに応じたラベルを返す
+   */
+  static getEntropyNormalizedLabel(score: number): string {
+    if (score >= MathHelper.ENTROPY_NORM_HIGH_THRESHOLD) return '均一';
+    if (score >= MathHelper.ENTROPY_NORM_MODERATE_THRESHOLD) return 'やや偏り';
+    return '偏り大';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getEntropyNormalized / getEntropyNormalizedLabel を追加
- GreetingMessageEntity: getGreetingVarietyScore / getGreetingVarietyScoreLabel を追加
- HospitalEntity: getHospitalVisitCostScore / getHospitalVisitCostScoreLabel を追加
- テスト30件追加（合計7293件）

## Test plan
- [x] 正規化エントロピーのテスト（11件）
- [x] 挨拶多様性スコアのテスト（10件）
- [x] 通院費用スコアのテスト（9件）
- [x] 全テスト通過確認（7293件）

closes #942