### PR TITLE
test: 正規化エントロピー・挨拶多様性スコア・通院費用スコアのエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/EntropyNormalized.edge.test.ts
+++ b/src/__tests__/domain/entities/EntropyNormalized.edge.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getEntropyNormalized エッジケース', () => {
+  it('負の値を含む配列', () => {
+    const result = MathHelper.getEntropyNormalized([-10, 20, 30]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('非常に大きな値の配列', () => {
+    const result = MathHelper.getEntropyNormalized([1000000, 1000000, 1000000]);
+    expect(result).toBe(100);
+  });
+
+  it('小数値の配列', () => {
+    const result = MathHelper.getEntropyNormalized([0.1, 0.2, 0.3, 0.4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2要素で均等', () => {
+    expect(MathHelper.getEntropyNormalized([50, 50])).toBe(100);
+  });
+
+  it('2要素で極端な偏り', () => {
+    const result = MathHelper.getEntropyNormalized([99, 1]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('多数の要素で均等', () => {
+    const result = MathHelper.getEntropyNormalized([10, 10, 10, 10, 10, 10, 10, 10, 10, 10]);
+    expect(result).toBe(100);
+  });
+
+  it('多数の要素で1つだけ非ゼロ', () => {
+    expect(MathHelper.getEntropyNormalized([0, 0, 0, 0, 100])).toBe(0);
+  });
+
+  it('3要素で1つだけゼロ', () => {
+    const result = MathHelper.getEntropyNormalized([50, 50, 0]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('整数に丸められる', () => {
+    const result = MathHelper.getEntropyNormalized([30, 30, 40]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('要素数が1000でも動作する', () => {
+    const values = Array.from({ length: 1000 }, () => 1);
+    const result = MathHelper.getEntropyNormalized(values);
+    expect(result).toBe(100);
+  });
+
+  it('合計が非常に小さい正の値', () => {
+    const result = MathHelper.getEntropyNormalized([0.001, 0.001]);
+    expect(result).toBe(100);
+  });
+
+  it('ほぼ均等な分布', () => {
+    const result = MathHelper.getEntropyNormalized([25, 25, 25, 26]);
+    expect(result).toBeGreaterThan(95);
+  });
+});
+
+describe('MathHelper.getEntropyNormalizedLabel エッジケース', () => {
+  it('境界値80は均一', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(80)).toBe('均一');
+  });
+
+  it('境界値40はやや偏り', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(40)).toBe('やや偏り');
+  });
+
+  it('境界値79はやや偏り', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(79)).toBe('やや偏り');
+  });
+
+  it('境界値39は偏り大', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(39)).toBe('偏り大');
+  });
+
+  it('0は偏り大', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(0)).toBe('偏り大');
+  });
+
+  it('100は均一', () => {
+    expect(MathHelper.getEntropyNormalizedLabel(100)).toBe('均一');
+  });
+});

--- a/src/__tests__/domain/entities/GreetingVarietyScore.edge.test.ts
+++ b/src/__tests__/domain/entities/GreetingVarietyScore.edge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { GreetingMessageEntity } from '@/domain/entities/GreetingMessage';
+
+describe('GreetingMessageEntity.getGreetingVarietyScore エッジケース', () => {
+  it('負の使用種類数は0', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(-5, 10)).toBe(0);
+  });
+
+  it('負の全種類数は0', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(5, -10)).toBe(0);
+  });
+
+  it('両方負は0', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(-1, -1)).toBe(0);
+  });
+
+  it('1種類中1使用は100', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(1, 1)).toBe(100);
+  });
+
+  it('使用数が全数を超えても100以下', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(200, 10)).toBeLessThanOrEqual(100);
+  });
+
+  it('大きな数値でも動作する', () => {
+    const result = GreetingMessageEntity.getGreetingVarietyScore(500, 1000);
+    expect(result).toBe(50);
+  });
+
+  it('小数の使用数', () => {
+    const result = GreetingMessageEntity.getGreetingVarietyScore(2.5, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = GreetingMessageEntity.getGreetingVarietyScore(3, 7);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('3/4は75', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(3, 4)).toBe(75);
+  });
+
+  it('1/3は33', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(1, 3)).toBe(33);
+  });
+
+  it('全種類数0で使用数正は0', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(5, 0)).toBe(0);
+  });
+
+  it('9/10は90', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScore(9, 10)).toBe(90);
+  });
+});
+
+describe('GreetingMessageEntity.getGreetingVarietyScoreLabel エッジケース', () => {
+  it('境界値80は豊富', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(80)).toBe('豊富');
+  });
+
+  it('境界値40は普通', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(40)).toBe('普通');
+  });
+
+  it('境界値79は普通', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(79)).toBe('普通');
+  });
+
+  it('境界値39は少ない', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(39)).toBe('少ない');
+  });
+
+  it('0は少ない', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(0)).toBe('少ない');
+  });
+
+  it('100は豊富', () => {
+    expect(GreetingMessageEntity.getGreetingVarietyScoreLabel(100)).toBe('豊富');
+  });
+});

--- a/src/__tests__/domain/entities/HospitalVisitCostScore.edge.test.ts
+++ b/src/__tests__/domain/entities/HospitalVisitCostScore.edge.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { HospitalEntity } from '@/domain/entities/Hospital';
+
+describe('HospitalEntity.getHospitalVisitCostScore エッジケース', () => {
+  it('負の費用は0', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(-5000)).toBe(0);
+  });
+
+  it('1円は0に近い', () => {
+    const result = HospitalEntity.getHospitalVisitCostScore(1);
+    expect(result).toBe(0);
+  });
+
+  it('100000円は100', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(100000)).toBe(100);
+  });
+
+  it('100000円超でも100以下', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(500000)).toBeLessThanOrEqual(100);
+  });
+
+  it('10000円は10', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(10000)).toBe(10);
+  });
+
+  it('小数の費用', () => {
+    const result = HospitalEntity.getHospitalVisitCostScore(1234.56);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = HospitalEntity.getHospitalVisitCostScore(33333);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('費用が増えるとスコアが増える', () => {
+    const low = HospitalEntity.getHospitalVisitCostScore(5000);
+    const mid = HospitalEntity.getHospitalVisitCostScore(25000);
+    const high = HospitalEntity.getHospitalVisitCostScore(75000);
+    expect(mid).toBeGreaterThan(low);
+    expect(high).toBeGreaterThan(mid);
+  });
+
+  it('50000円は50', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(50000)).toBe(50);
+  });
+
+  it('非常に大きな費用は100', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(10000000)).toBe(100);
+  });
+
+  it('0.5円は0', () => {
+    expect(HospitalEntity.getHospitalVisitCostScore(0.5)).toBe(0);
+  });
+
+  it('99999円は100未満', () => {
+    const result = HospitalEntity.getHospitalVisitCostScore(99999);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('HospitalEntity.getHospitalVisitCostScoreLabel エッジケース', () => {
+  it('境界値70は高額', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(70)).toBe('高額');
+  });
+
+  it('境界値40は標準', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(40)).toBe('標準');
+  });
+
+  it('境界値69は標準', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(69)).toBe('標準');
+  });
+
+  it('境界値39は安価', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(39)).toBe('安価');
+  });
+
+  it('0は安価', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(0)).toBe('安価');
+  });
+
+  it('100は高額', () => {
+    expect(HospitalEntity.getHospitalVisitCostScoreLabel(100)).toBe('高額');
+  });
+});


### PR DESCRIPTION
## Summary
- getEntropyNormalized のエッジケーステスト18件
- getGreetingVarietyScore のエッジケーステスト18件
- getHospitalVisitCostScore のエッジケーステスト18件
- テスト54件追加（合計7347件）

## Test plan
- [x] 境界値テスト
- [x] 負の値テスト
- [x] 大きな値テスト
- [x] 小数値テスト
- [x] 全テスト通過確認（7347件）

closes #944