### PR TITLE
feat: 四分位偏差・薬剤1回あたりコスト・服薬一貫性指数を追加

### DIFF
--- a/src/__tests__/domain/entities/AdherenceConsistencyIndex.test.ts
+++ b/src/__tests__/domain/entities/AdherenceConsistencyIndex.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity.getAdherenceConsistencyIndex', () => {
+  it('空配列は0', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex([80])).toBe(100);
+  });
+
+  it('同値は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex([50, 50, 50])).toBe(100);
+  });
+
+  it('ばらつきが大きいと低い', () => {
+    const consistent = AdherenceStatsEntity.getAdherenceConsistencyIndex([80, 82, 78, 81]);
+    const inconsistent = AdherenceStatsEntity.getAdherenceConsistencyIndex([10, 90, 20, 80]);
+    expect(consistent).toBeGreaterThan(inconsistent);
+  });
+
+  it('全て0は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex([0, 0, 0])).toBe(100);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([30, 60, 90]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2件で大きな差', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([0, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('結果は整数', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([25, 75, 50]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('微小な差は高い一貫性', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([99, 100, 98, 100]);
+    expect(result).toBeGreaterThan(90);
+  });
+});
+
+describe('AdherenceStatsEntity.getAdherenceConsistencyIndexLabel', () => {
+  it('高い値は安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(85)).toBe('安定');
+  });
+
+  it('中程度はやや不安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(55)).toBe('やや不安定');
+  });
+
+  it('低い値は不安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(25)).toBe('不安定');
+  });
+});

--- a/src/__tests__/domain/entities/MedicationCostPerDose.test.ts
+++ b/src/__tests__/domain/entities/MedicationCostPerDose.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getMedicationCostPerDose', () => {
+  it('総額0は0', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(0, 30)).toBe(0);
+  });
+
+  it('回数0は0', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(3000, 0)).toBe(0);
+  });
+
+  it('両方0は0', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(0, 0)).toBe(0);
+  });
+
+  it('3000円/30回は100', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(3000, 30)).toBe(100);
+  });
+
+  it('回数が多いほど単価が下がる', () => {
+    const few = MedicationEntity.getMedicationCostPerDose(3000, 10);
+    const many = MedicationEntity.getMedicationCostPerDose(3000, 30);
+    expect(few).toBeGreaterThan(many);
+  });
+
+  it('結果は0以上', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(5000, 60);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('小数点以下2桁まで', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(1000, 3);
+    expect(result).toBe(Math.round((1000 / 3) * 100) / 100);
+  });
+
+  it('負の総額は0', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(-1000, 30)).toBe(0);
+  });
+
+  it('結果は数値', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(2500, 25);
+    expect(typeof result).toBe('number');
+  });
+});
+
+describe('MedicationEntity.getMedicationCostPerDoseLabel', () => {
+  it('高い値は高コスト', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(600)).toBe('高コスト');
+  });
+
+  it('中程度は標準', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(150)).toBe('標準');
+  });
+
+  it('低い値は低コスト', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(30)).toBe('低コスト');
+  });
+});

--- a/src/__tests__/domain/entities/QuartileDeviation.test.ts
+++ b/src/__tests__/domain/entities/QuartileDeviation.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getQuartileDeviation', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getQuartileDeviation([])).toBe(0);
+  });
+
+  it('1件は0', () => {
+    expect(MathHelper.getQuartileDeviation([42])).toBe(0);
+  });
+
+  it('2件は差の半分', () => {
+    expect(MathHelper.getQuartileDeviation([10, 20])).toBe(2.5);
+  });
+
+  it('同値は0', () => {
+    expect(MathHelper.getQuartileDeviation([5, 5, 5, 5])).toBe(0);
+  });
+
+  it('偏りが大きいほど値が大きい', () => {
+    const narrow = MathHelper.getQuartileDeviation([10, 11, 12, 13]);
+    const wide = MathHelper.getQuartileDeviation([1, 10, 50, 100]);
+    expect(wide).toBeGreaterThan(narrow);
+  });
+
+  it('4要素で正しい値', () => {
+    // [1, 2, 3, 4] -> Q1=1.75, Q3=3.25 -> QD=(3.25-1.75)/2=0.75
+    expect(MathHelper.getQuartileDeviation([1, 2, 3, 4])).toBe(0.75);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getQuartileDeviation([3, 7, 1, 9, 5]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('負の値を含む配列', () => {
+    const result = MathHelper.getQuartileDeviation([-10, -5, 0, 5, 10]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('結果は数値', () => {
+    const result = MathHelper.getQuartileDeviation([2, 4, 6, 8, 10]);
+    expect(typeof result).toBe('number');
+  });
+});
+
+describe('MathHelper.getQuartileDeviationLabel', () => {
+  it('小さい値は均一', () => {
+    expect(MathHelper.getQuartileDeviationLabel(3)).toBe('均一');
+  });
+
+  it('中程度はやや散布', () => {
+    expect(MathHelper.getQuartileDeviationLabel(12)).toBe('やや散布');
+  });
+
+  it('大きい値は散布', () => {
+    expect(MathHelper.getQuartileDeviationLabel(30)).toBe('散布');
+  });
+});

--- a/src/domain/entities/AdherenceStats.ts
+++ b/src/domain/entities/AdherenceStats.ts
@@ -337,6 +337,9 @@ export class AdherenceStatsEntity {
   private static readonly EFFICIENCY_STREAK_WEIGHT = 0.3;
   private static readonly EFFICIENCY_HIGH_THRESHOLD = 80;
   private static readonly EFFICIENCY_MODERATE_THRESHOLD = 50;
+  private static readonly CONSISTENCY_HIGH_THRESHOLD = 80;
+  private static readonly CONSISTENCY_MODERATE_THRESHOLD = 50;
+  private static readonly CONSISTENCY_MAX_STDDEV = 50;
 
   /**
    * 現在の連続日数から次のマイルストーンを取得する
@@ -434,5 +437,36 @@ export class AdherenceStatsEntity {
     if (score >= AdherenceStatsEntity.EFFICIENCY_HIGH_THRESHOLD) return '高効率';
     if (score >= AdherenceStatsEntity.EFFICIENCY_MODERATE_THRESHOLD) return '普通';
     return '低効率';
+  }
+
+  /**
+   * 服薬率の一貫性指数を算出する（0-100）
+   * 標準偏差が小さいほどスコアが高い
+   */
+  static getAdherenceConsistencyIndex(rates: number[]): number {
+    if (rates.length <= 1) return rates.length === 0 ? 0 : 100;
+    const avg = rates.reduce((a, b) => a + b, 0) / rates.length;
+    const variance =
+      rates.reduce((sum, v) => sum + (v - avg) ** 2, 0) / rates.length;
+    const stddev = Math.sqrt(variance);
+    return Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(
+          100 -
+            (stddev / AdherenceStatsEntity.CONSISTENCY_MAX_STDDEV) * 100
+        )
+      )
+    );
+  }
+
+  /**
+   * 一貫性指数に応じたラベルを返す
+   */
+  static getAdherenceConsistencyIndexLabel(score: number): string {
+    if (score >= AdherenceStatsEntity.CONSISTENCY_HIGH_THRESHOLD) return '安定';
+    if (score >= AdherenceStatsEntity.CONSISTENCY_MODERATE_THRESHOLD) return 'やや不安定';
+    return '不安定';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -65,6 +65,8 @@ export class MathHelper {
   private static readonly WINSORIZED_MODERATE_THRESHOLD = 30;
   private static readonly ENTROPY_NORM_HIGH_THRESHOLD = 80;
   private static readonly ENTROPY_NORM_MODERATE_THRESHOLD = 40;
+  private static readonly QD_UNIFORM_THRESHOLD = 5;
+  private static readonly QD_MODERATE_THRESHOLD = 20;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1078,5 +1080,33 @@ export class MathHelper {
     if (score >= MathHelper.ENTROPY_NORM_HIGH_THRESHOLD) return '均一';
     if (score >= MathHelper.ENTROPY_NORM_MODERATE_THRESHOLD) return 'やや偏り';
     return '偏り大';
+  }
+
+  /**
+   * 四分位偏差を算出する（(Q3-Q1)/2）
+   */
+  static getQuartileDeviation(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const sorted = [...values].sort((a, b) => a - b);
+    const q1Index = (sorted.length - 1) * 0.25;
+    const q3Index = (sorted.length - 1) * 0.75;
+    const q1 =
+      sorted[Math.floor(q1Index)] +
+      (sorted[Math.ceil(q1Index)] - sorted[Math.floor(q1Index)]) *
+        (q1Index - Math.floor(q1Index));
+    const q3 =
+      sorted[Math.floor(q3Index)] +
+      (sorted[Math.ceil(q3Index)] - sorted[Math.floor(q3Index)]) *
+        (q3Index - Math.floor(q3Index));
+    return Math.round(((q3 - q1) / 2) * 100) / 100;
+  }
+
+  /**
+   * 四分位偏差に応じたラベルを返す
+   */
+  static getQuartileDeviationLabel(qd: number): string {
+    if (qd <= MathHelper.QD_UNIFORM_THRESHOLD) return '均一';
+    if (qd <= MathHelper.QD_MODERATE_THRESHOLD) return 'やや散布';
+    return '散布';
   }
 }

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -105,6 +105,8 @@ export class MedicationEntity {
   private static readonly COMPLEXITY_MAX_TYPES = 5;
   private static readonly COMPLEXITY_HIGH_THRESHOLD = 70;
   private static readonly COMPLEXITY_MODERATE_THRESHOLD = 40;
+  private static readonly COST_PER_DOSE_HIGH_THRESHOLD = 500;
+  private static readonly COST_PER_DOSE_MODERATE_THRESHOLD = 100;
 
   private static readonly categoryLabels: Record<MedicationCategory, string> = {
     regular: '常用薬',
@@ -369,5 +371,22 @@ export class MedicationEntity {
     if (score >= MedicationEntity.COMPLEXITY_HIGH_THRESHOLD) return '複雑';
     if (score >= MedicationEntity.COMPLEXITY_MODERATE_THRESHOLD) return '普通';
     return 'シンプル';
+  }
+
+  /**
+   * 総額と回数から1回あたりのコストを算出する
+   */
+  static getMedicationCostPerDose(totalCost: number, doseCount: number): number {
+    if (totalCost <= 0 || doseCount <= 0) return 0;
+    return Math.round((totalCost / doseCount) * 100) / 100;
+  }
+
+  /**
+   * 1回あたりコストに応じたラベルを返す
+   */
+  static getMedicationCostPerDoseLabel(costPerDose: number): string {
+    if (costPerDose >= MedicationEntity.COST_PER_DOSE_HIGH_THRESHOLD) return '高コスト';
+    if (costPerDose >= MedicationEntity.COST_PER_DOSE_MODERATE_THRESHOLD) return '標準';
+    return '低コスト';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getQuartileDeviation / getQuartileDeviationLabel を追加
- MedicationEntity: getMedicationCostPerDose / getMedicationCostPerDoseLabel を追加
- AdherenceStatsEntity: getAdherenceConsistencyIndex / getAdherenceConsistencyIndexLabel を追加
- テスト36件追加（合計7383件）

## Test plan
- [x] 四分位偏差のテスト（12件）
- [x] 薬剤1回あたりコストのテスト（12件）
- [x] 服薬一貫性指数のテスト（12件）
- [x] 全テスト通過確認（7383件）

closes #946