### PR TITLE
test: 四分位偏差・薬剤1回あたりコスト・服薬一貫性指数のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/AdherenceConsistencyIndex.edge.test.ts
+++ b/src/__tests__/domain/entities/AdherenceConsistencyIndex.edge.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { AdherenceStatsEntity } from '@/domain/entities/AdherenceStats';
+
+describe('AdherenceStatsEntity.getAdherenceConsistencyIndex エッジケース', () => {
+  it('全て100は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex([100, 100, 100])).toBe(100);
+  });
+
+  it('0と100の交互', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([0, 100, 0, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('徐々に増加するデータ', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([20, 40, 60, 80, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('徐々に減少するデータ', () => {
+    const increasing = AdherenceStatsEntity.getAdherenceConsistencyIndex([20, 40, 60, 80, 100]);
+    const decreasing = AdherenceStatsEntity.getAdherenceConsistencyIndex([100, 80, 60, 40, 20]);
+    expect(increasing).toBe(decreasing);
+  });
+
+  it('大量のデータ', () => {
+    const values = Array.from({ length: 365 }, () => 80);
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex(values)).toBe(100);
+  });
+
+  it('2件で同値は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex([75, 75])).toBe(100);
+  });
+
+  it('負の値を含む場合', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([-10, 50, 80]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('100を超える値を含む場合', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([120, 90, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('小数値のデータ', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([75.5, 76.2, 74.8]);
+    expect(result).toBeGreaterThan(90);
+  });
+
+  it('全て50は100', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndex([50, 50, 50, 50])).toBe(100);
+  });
+
+  it('結果は整数', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([30, 60, 45, 55]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('3件でばらつき大', () => {
+    const result = AdherenceStatsEntity.getAdherenceConsistencyIndex([0, 50, 100]);
+    expect(result).toBeLessThan(50);
+  });
+});
+
+describe('AdherenceStatsEntity.getAdherenceConsistencyIndexLabel エッジケース', () => {
+  it('境界値80は安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(80)).toBe('安定');
+  });
+
+  it('境界値50はやや不安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(50)).toBe('やや不安定');
+  });
+
+  it('境界値79はやや不安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(79)).toBe('やや不安定');
+  });
+
+  it('境界値49は不安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(49)).toBe('不安定');
+  });
+
+  it('0は不安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(0)).toBe('不安定');
+  });
+
+  it('100は安定', () => {
+    expect(AdherenceStatsEntity.getAdherenceConsistencyIndexLabel(100)).toBe('安定');
+  });
+});

--- a/src/__tests__/domain/entities/MedicationCostPerDose.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationCostPerDose.edge.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getMedicationCostPerDose エッジケース', () => {
+  it('負の回数は0', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(3000, -5)).toBe(0);
+  });
+
+  it('両方負は0', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(-1000, -10)).toBe(0);
+  });
+
+  it('1回あたり1円', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(1, 1)).toBe(1);
+  });
+
+  it('非常に大きな金額', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(1000000, 100);
+    expect(result).toBe(10000);
+  });
+
+  it('小数点の金額', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(100.5, 3);
+    expect(result).toBe(Math.round((100.5 / 3) * 100) / 100);
+  });
+
+  it('回数1は総額そのまま', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(5000, 1)).toBe(5000);
+  });
+
+  it('大きな回数で小さな単価', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(100, 1000);
+    expect(result).toBe(0.1);
+  });
+
+  it('同額同数は1', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(50, 50)).toBe(1);
+  });
+
+  it('結果は小数点以下2桁まで', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(1000, 7);
+    const decimalPlaces = (result.toString().split('.')[1] || '').length;
+    expect(decimalPlaces).toBeLessThanOrEqual(2);
+  });
+
+  it('非常に小さな金額', () => {
+    const result = MedicationEntity.getMedicationCostPerDose(0.01, 1);
+    expect(result).toBe(0.01);
+  });
+
+  it('金額0で回数正は0', () => {
+    expect(MedicationEntity.getMedicationCostPerDose(0, 100)).toBe(0);
+  });
+});
+
+describe('MedicationEntity.getMedicationCostPerDoseLabel エッジケース', () => {
+  it('境界値500は高コスト', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(500)).toBe('高コスト');
+  });
+
+  it('境界値100は標準', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(100)).toBe('標準');
+  });
+
+  it('境界値499は標準', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(499)).toBe('標準');
+  });
+
+  it('境界値99は低コスト', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(99)).toBe('低コスト');
+  });
+
+  it('0は低コスト', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(0)).toBe('低コスト');
+  });
+
+  it('10000は高コスト', () => {
+    expect(MedicationEntity.getMedicationCostPerDoseLabel(10000)).toBe('高コスト');
+  });
+});

--- a/src/__tests__/domain/entities/QuartileDeviation.edge.test.ts
+++ b/src/__tests__/domain/entities/QuartileDeviation.edge.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getQuartileDeviation エッジケース', () => {
+  it('3件で均等', () => {
+    expect(MathHelper.getQuartileDeviation([5, 5, 5])).toBe(0);
+  });
+
+  it('3件で異なる値', () => {
+    const result = MathHelper.getQuartileDeviation([1, 5, 10]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('非常に大きな値', () => {
+    const result = MathHelper.getQuartileDeviation([1000000, 2000000, 3000000]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getQuartileDeviation([0.1, 0.2, 0.3, 0.4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('負の値のみ', () => {
+    const result = MathHelper.getQuartileDeviation([-10, -5, -3, -1]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('要素数が多い場合', () => {
+    const values = Array.from({ length: 100 }, (_, i) => i + 1);
+    const result = MathHelper.getQuartileDeviation(values);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('全て同じ大きな値', () => {
+    expect(MathHelper.getQuartileDeviation([999, 999, 999, 999])).toBe(0);
+  });
+
+  it('2件で同値は0', () => {
+    expect(MathHelper.getQuartileDeviation([7, 7])).toBe(0);
+  });
+
+  it('外れ値がある場合', () => {
+    const withoutOutlier = MathHelper.getQuartileDeviation([10, 11, 12, 13]);
+    const withOutlier = MathHelper.getQuartileDeviation([10, 11, 12, 1000]);
+    expect(withOutlier).toBeGreaterThan(withoutOutlier);
+  });
+
+  it('5件で正しく計算', () => {
+    const result = MathHelper.getQuartileDeviation([2, 4, 6, 8, 10]);
+    expect(result).toBeGreaterThan(0);
+    expect(typeof result).toBe('number');
+  });
+
+  it('結果は数値', () => {
+    const result = MathHelper.getQuartileDeviation([1, 3, 5, 7, 9, 11]);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it('ソートされていない入力でも正しい', () => {
+    const sorted = MathHelper.getQuartileDeviation([1, 2, 3, 4, 5]);
+    const unsorted = MathHelper.getQuartileDeviation([3, 1, 5, 2, 4]);
+    expect(sorted).toBe(unsorted);
+  });
+});
+
+describe('MathHelper.getQuartileDeviationLabel エッジケース', () => {
+  it('境界値5は均一', () => {
+    expect(MathHelper.getQuartileDeviationLabel(5)).toBe('均一');
+  });
+
+  it('境界値20はやや散布', () => {
+    expect(MathHelper.getQuartileDeviationLabel(20)).toBe('やや散布');
+  });
+
+  it('境界値5.01はやや散布', () => {
+    expect(MathHelper.getQuartileDeviationLabel(5.01)).toBe('やや散布');
+  });
+
+  it('境界値20.01は散布', () => {
+    expect(MathHelper.getQuartileDeviationLabel(20.01)).toBe('散布');
+  });
+
+  it('0は均一', () => {
+    expect(MathHelper.getQuartileDeviationLabel(0)).toBe('均一');
+  });
+
+  it('100は散布', () => {
+    expect(MathHelper.getQuartileDeviationLabel(100)).toBe('散布');
+  });
+});


### PR DESCRIPTION
## Summary
- getQuartileDeviation のエッジケーステスト18件
- getMedicationCostPerDose のエッジケーステスト17件
- getAdherenceConsistencyIndex のエッジケーステスト18件
- テスト53件追加（合計7436件）

## Test plan
- [x] 境界値テスト
- [x] 負の値テスト
- [x] 大きな値テスト
- [x] 小数値テスト
- [x] 全テスト通過確認（7436件）

closes #948