### PR TITLE
feat: キャラクター語尾変更・服薬履歴の過去日付入力対応

### DIFF
--- a/src/__tests__/domain/entities/CalendarDateAttribute.test.ts
+++ b/src/__tests__/domain/entities/CalendarDateAttribute.test.ts
@@ -45,8 +45,6 @@ describe('CalendarEntity 日付選択ヘルパー', () => {
   });
 
   describe('getDateStatusLabel', () => {
-    const today = new Date('2025-06-15');
-
     it('todayは今日を返す', () => {
       expect(CalendarEntity.getDateStatusLabel('today')).toBe('今日');
     });

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -55,6 +55,7 @@ export async function POST(request: Request) {
         scheduleId: parsed.data.scheduleId,
         notes: parsed.data.notes,
         dosageAmount: parsed.data.dosageAmount,
+        ...(parsed.data.takenAt ? { takenAt: new Date(parsed.data.takenAt) } : {}),
       },
     });
     return created(record);

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Calendar, List } from 'lucide-react';
+import { Calendar, List, Plus } from 'lucide-react';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { MedicationHistoryList } from '@/components/history/MedicationHistoryList';
 import { MedicationCalendar } from '@/components/history/MedicationCalendar';
+import { AddPastRecordForm } from '@/components/history/AddPastRecordForm';
 import { MemberFilter } from '@/components/shared/MemberFilter';
 import { useMedicationHistory } from '@/presentation/hooks/useMedicationHistory';
 import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
@@ -16,12 +17,13 @@ type ViewMode = 'list' | 'calendar';
 
 export default function HistoryPage() {
   const { userId } = useAuth();
-  const { groups, isLoading, deleteRecord } = useMedicationHistory();
+  const { groups, isLoading, deleteRecord, createRecord } = useMedicationHistory();
   const { groups: healthLogGroups } = useHealthLogs();
   const { members } = useMembers(userId);
   const [viewMode, setViewMode] = useState<ViewMode>('calendar');
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
 
   const memberOptions = useMemo(
     () => members.map((m) => ({ id: m.id, name: m.name })),
@@ -106,14 +108,38 @@ export default function HistoryPage() {
             <MedicationCalendar
               records={allRecords}
               healthLogs={allHealthLogs}
-              onSelectDate={(dateKey) => setSelectedDate(dateKey === selectedDate ? null : dateKey)}
+              onSelectDate={(dateKey) => {
+                setSelectedDate(dateKey === selectedDate ? null : dateKey);
+                setShowAddForm(false);
+              }}
               selectedDate={selectedDate}
             />
             {selectedDate && (
               <div>
-                <h3 className="text-sm font-semibold text-gray-600 mb-2">
-                  {MedicationRecordEntity.formatDate(selectedDate)} の記録
-                </h3>
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-sm font-semibold text-gray-600">
+                    {MedicationRecordEntity.formatDate(selectedDate)} の記録
+                  </h3>
+                  {!showAddForm && (
+                    <button
+                      onClick={() => setShowAddForm(true)}
+                      className="flex items-center space-x-1 text-xs text-primary-600 hover:text-primary-700 font-medium"
+                    >
+                      <Plus size={14} />
+                      <span>記録を追加</span>
+                    </button>
+                  )}
+                </div>
+                {showAddForm && (
+                  <div className="mb-3">
+                    <AddPastRecordForm
+                      selectedDate={selectedDate}
+                      members={memberOptions}
+                      onSubmit={createRecord}
+                      onClose={() => setShowAddForm(false)}
+                    />
+                  </div>
+                )}
                 <MedicationHistoryList
                   groups={filteredGroups}
                   isLoading={isLoading}

--- a/src/components/dashboard/GreetingCard.tsx
+++ b/src/components/dashboard/GreetingCard.tsx
@@ -22,7 +22,7 @@ export const GreetingCard: React.FC<GreetingCardProps> = ({ displayName, weeklyR
         <p className="text-sm font-medium text-primary-800">
           {greeting}、{displayName}さん
         </p>
-        <p className="text-xs text-primary-600 mt-0.5">{summaryMessage}</p>
+        <p className="text-xs text-primary-600 mt-0.5">{summaryMessage}{config.suffix}</p>
         <p className="text-xs text-primary-400 mt-0.5">{config.name}より</p>
       </div>
     </div>

--- a/src/components/history/AddPastRecordForm.tsx
+++ b/src/components/history/AddPastRecordForm.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Plus, X } from 'lucide-react';
+import { apiClient } from '../../data/api/apiClient';
+
+interface Medication {
+  id: string;
+  name: string;
+  memberId: string;
+}
+
+interface Member {
+  id: string;
+  name: string;
+}
+
+interface AddPastRecordFormProps {
+  selectedDate: string;
+  members: Member[];
+  onSubmit: (input: {
+    memberId: string;
+    medicationId: string;
+    takenAt: string;
+    notes?: string;
+  }) => Promise<void>;
+  onClose: () => void;
+}
+
+export const AddPastRecordForm: React.FC<AddPastRecordFormProps> = ({
+  selectedDate,
+  members,
+  onSubmit,
+  onClose,
+}) => {
+  const [selectedMemberId, setSelectedMemberId] = useState('');
+  const [selectedMedicationId, setSelectedMedicationId] = useState('');
+  const [notes, setNotes] = useState('');
+  const [medications, setMedications] = useState<Medication[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedMemberId) {
+      setMedications([]);
+      setSelectedMedicationId('');
+      return;
+    }
+    apiClient.get<Medication[]>(`/medications/member/${selectedMemberId}`)
+      .then((data) => {
+        setMedications(data);
+        setSelectedMedicationId('');
+      })
+      .catch(() => {
+        setMedications([]);
+      });
+  }, [selectedMemberId]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedMemberId || !selectedMedicationId) return;
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const takenAt = new Date(`${selectedDate}T12:00:00`).toISOString();
+      await onSubmit({
+        memberId: selectedMemberId,
+        medicationId: selectedMedicationId,
+        takenAt,
+        notes: notes.trim() || undefined,
+      });
+      onClose();
+    } catch {
+      setError('記録の追加に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const formatDisplayDate = (dateKey: string) => {
+    const [y, m, d] = dateKey.split('-').map(Number);
+    return `${y}年${m}月${d}日`;
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-gray-700">
+          {formatDisplayDate(selectedDate)} の記録を追加
+        </h4>
+        <button
+          onClick={onClose}
+          className="p-1 text-gray-400 hover:text-gray-600"
+          aria-label="閉じる"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label htmlFor="past-record-member" className="block text-xs font-medium text-gray-600 mb-1">
+            メンバー
+          </label>
+          <select
+            id="past-record-member"
+            value={selectedMemberId}
+            onChange={(e) => setSelectedMemberId(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            required
+          >
+            <option value="">選択してください</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="past-record-medication" className="block text-xs font-medium text-gray-600 mb-1">
+            お薬
+          </label>
+          <select
+            id="past-record-medication"
+            value={selectedMedicationId}
+            onChange={(e) => setSelectedMedicationId(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            required
+            disabled={!selectedMemberId || medications.length === 0}
+          >
+            <option value="">
+              {!selectedMemberId
+                ? 'メンバーを先に選択'
+                : medications.length === 0
+                  ? '登録されたお薬がありません'
+                  : '選択してください'}
+            </option>
+            {medications.map((med) => (
+              <option key={med.id} value={med.id}>{med.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="past-record-notes" className="block text-xs font-medium text-gray-600 mb-1">
+            メモ（任意）
+          </label>
+          <input
+            id="past-record-notes"
+            type="text"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            placeholder="メモを入力"
+            maxLength={500}
+          />
+        </div>
+
+        {error && (
+          <p className="text-xs text-red-600">{error}</p>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting || !selectedMemberId || !selectedMedicationId}
+          className="w-full flex items-center justify-center space-x-1 bg-primary-600 text-white rounded-md py-2 text-sm font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Plus size={16} />
+          <span>{isSubmitting ? '追加中...' : '記録を追加'}</span>
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/data/api/recordApi.ts
+++ b/src/data/api/recordApi.ts
@@ -11,6 +11,7 @@ interface CreateRecordInput {
   scheduleId?: string;
   notes?: string;
   dosageAmount?: string;
+  takenAt?: string;
 }
 
 export const recordApi = {

--- a/src/domain/entities/Character.ts
+++ b/src/domain/entities/Character.ts
@@ -12,6 +12,7 @@ export type CharacterMood =
 export interface CharacterConfig {
   type: CharacterType;
   name: string;
+  suffix: string;
   sounds: {
     normal: string;
     medicationReminder: string;
@@ -148,6 +149,7 @@ export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {
   dog: {
     type: 'dog',
     name: 'いぬ',
+    suffix: 'ワン',
     sounds: {
       normal: '/sounds/dog/bark.mp3',
       medicationReminder: '/sounds/dog/reminder.mp3',
@@ -169,6 +171,7 @@ export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {
   cat: {
     type: 'cat',
     name: 'ねこ',
+    suffix: 'ニャ',
     sounds: {
       normal: '/sounds/cat/meow.mp3',
       medicationReminder: '/sounds/cat/reminder.mp3',
@@ -190,6 +193,7 @@ export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {
   rabbit: {
     type: 'rabbit',
     name: 'うさぎ',
+    suffix: 'ピョン',
     sounds: {
       normal: '/sounds/rabbit/squeak.mp3',
       medicationReminder: '/sounds/rabbit/reminder.mp3',
@@ -211,6 +215,7 @@ export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {
   bird: {
     type: 'bird',
     name: 'インコ',
+    suffix: 'ピィ',
     sounds: {
       normal: '/sounds/bird/chirp.mp3',
       medicationReminder: '/sounds/bird/reminder.mp3',

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -350,31 +350,6 @@ export class MathHelper {
   /**
    * 幾何平均に応じたラベルを返す
    */
-  /**
-   * トリム平均を算出する（上下指定%を除外した平均）
-   * @param values 数値配列
-   * @param trimPercent 上下から除外する割合(0-49)
-   */
-  static getTrimmedMean(values: number[], trimPercent: number): number {
-    if (values.length === 0) return 0;
-    if (values.length === 1) return values[0];
-    const sorted = [...values].sort((a, b) => a - b);
-    const trimCount = Math.floor(sorted.length * (trimPercent / 100));
-    const trimmed = sorted.slice(trimCount, sorted.length - trimCount);
-    if (trimmed.length === 0) return sorted[Math.floor(sorted.length / 2)];
-    const sum = trimmed.reduce((a, b) => a + b, 0);
-    return Math.round((sum / trimmed.length) * 10) / 10;
-  }
-
-  /**
-   * トリム平均値に応じたラベルを返す
-   */
-  static getTrimmedMeanLabel(mean: number): string {
-    if (mean >= MathHelper.GEOMETRIC_HIGH_THRESHOLD) return '高い';
-    if (mean >= MathHelper.GEOMETRIC_LOW_THRESHOLD) return '中程度';
-    return '低い';
-  }
-
   static getGeometricMeanLabel(mean: number): string {
     if (mean >= MathHelper.GEOMETRIC_HIGH_THRESHOLD) return '高い';
     if (mean >= MathHelper.GEOMETRIC_LOW_THRESHOLD) return '中程度';

--- a/src/domain/repositories/MedicationRecordRepository.ts
+++ b/src/domain/repositories/MedicationRecordRepository.ts
@@ -12,6 +12,7 @@ export interface CreateRecordInput {
   scheduleId?: string;
   notes?: string;
   dosageAmount?: string;
+  takenAt?: string;
 }
 
 export interface MedicationRecordRepository {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -92,6 +92,7 @@ export const createRecordSchema = z.object({
   scheduleId: optionalIdField,
   notes: z.string().trim().max(500).optional(),
   dosageAmount: z.string().trim().max(100).optional(),
+  takenAt: z.string().datetime().optional(),
 });
 
 // ===== Hospitals =====

--- a/src/presentation/hooks/useMedicationHistory.ts
+++ b/src/presentation/hooks/useMedicationHistory.ts
@@ -5,7 +5,8 @@
 
 import { useCallback, useMemo } from 'react';
 import { DailyRecordGroup } from '../../domain/entities/MedicationRecord';
-import { GetMedicationHistory, DeleteMedicationRecord } from '../../domain/usecases/ManageMedicationRecords';
+import { GetMedicationHistory, DeleteMedicationRecord, CreateMedicationRecord } from '../../domain/usecases/ManageMedicationRecords';
+import { CreateRecordInput } from '../../domain/repositories/MedicationRecordRepository';
 import { getDIContainer } from '../../infrastructure/DIContainer';
 import { useFetcher } from './useFetcher';
 
@@ -14,6 +15,7 @@ export interface UseMedicationHistoryResult {
   isLoading: boolean;
   error: Error | null;
   deleteRecord: (recordId: string) => Promise<void>;
+  createRecord: (input: CreateRecordInput) => Promise<void>;
   refetch: () => Promise<void>;
 }
 
@@ -23,6 +25,7 @@ export const useMedicationHistory = (): UseMedicationHistoryResult => {
     return {
       getHistory: new GetMedicationHistory(medicationRecordRepository),
       deleteRecord: new DeleteMedicationRecord(medicationRecordRepository),
+      createRecord: new CreateMedicationRecord(medicationRecordRepository),
     };
   }, []);
 
@@ -38,11 +41,17 @@ export const useMedicationHistory = (): UseMedicationHistoryResult => {
     await refetch();
   }, [useCases, refetch]);
 
+  const handleCreateRecord = useCallback(async (input: CreateRecordInput) => {
+    await useCases.createRecord.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
   return {
     groups,
     isLoading,
     error,
     deleteRecord: handleDeleteRecord,
+    createRecord: handleCreateRecord,
     refetch,
   };
 };


### PR DESCRIPTION
## Summary
- キャラクターの語尾を追加（いぬ:ワン、ねこ:ニャ、うさぎ:ピョン、インコ:ピィ）
- GreetingCardのメッセージ末尾にキャラクター語尾を表示
- 服薬履歴の過去日付入力に対応（カレンダーで日付選択後「記録を追加」ボタンから追加可能）
- AddPastRecordFormコンポーネント新規作成（メンバー・薬選択 → 過去日付で記録作成）
- MathHelperの重複getTrimmedMean定義を修正

## Test plan
- [x] 全テスト通過確認（7436件）
- [x] ビルド成功確認
- [ ] デプロイ後にキャラクター語尾が表示されることを確認
- [ ] 履歴ページで過去日付の記録追加が動作することを確認

closes #950