### PR TITLE
feat: 平均絶対パーセント誤差・キャラクター忠誠度スコア・日付規則性指数を追加

### DIFF
--- a/src/__tests__/domain/entities/CharacterLoyaltyScore.test.ts
+++ b/src/__tests__/domain/entities/CharacterLoyaltyScore.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { CharacterEntity } from '@/domain/entities/Character';
+
+describe('CharacterEntity.getCharacterLoyaltyScore', () => {
+  it('使用日数0は0', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(0, 30)).toBe(0);
+  });
+
+  it('全日使用は100', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(30, 30)).toBe(100);
+  });
+
+  it('総日数0は0', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(0, 0)).toBe(0);
+  });
+
+  it('半分は50', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(15, 30)).toBe(50);
+  });
+
+  it('使用日数が多いほどスコアが高い', () => {
+    const low = CharacterEntity.getCharacterLoyaltyScore(5, 30);
+    const high = CharacterEntity.getCharacterLoyaltyScore(25, 30);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = CharacterEntity.getCharacterLoyaltyScore(10, 30);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('超過しても100以下', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(50, 30)).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = CharacterEntity.getCharacterLoyaltyScore(7, 30);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('1日中1日使用は100', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(1, 1)).toBe(100);
+  });
+});
+
+describe('CharacterEntity.getCharacterLoyaltyScoreLabel', () => {
+  it('高スコアは忠実', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(85)).toBe('忠実');
+  });
+
+  it('中スコアは普通', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(55)).toBe('普通');
+  });
+
+  it('低スコアは浮気性', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(25)).toBe('浮気性');
+  });
+});

--- a/src/__tests__/domain/entities/DateRegularityIndex.test.ts
+++ b/src/__tests__/domain/entities/DateRegularityIndex.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateRegularityIndex', () => {
+  it('空配列は0', () => {
+    expect(DateRangeHelper.getDateRegularityIndex([])).toBe(0);
+  });
+
+  it('1件は100', () => {
+    expect(DateRangeHelper.getDateRegularityIndex([7])).toBe(100);
+  });
+
+  it('均等間隔は100', () => {
+    expect(DateRangeHelper.getDateRegularityIndex([7, 7, 7, 7])).toBe(100);
+  });
+
+  it('ばらつきが大きいと低い', () => {
+    const regular = DateRangeHelper.getDateRegularityIndex([7, 7, 7]);
+    const irregular = DateRangeHelper.getDateRegularityIndex([1, 14, 3]);
+    expect(regular).toBeGreaterThan(irregular);
+  });
+
+  it('結果は0-100の範囲', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([3, 5, 7, 10]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('2件で同値は100', () => {
+    expect(DateRangeHelper.getDateRegularityIndex([10, 10])).toBe(100);
+  });
+
+  it('2件で異なる値は100未満', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([1, 30]);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('結果は整数', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([5, 8, 3]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+});
+
+describe('DateRangeHelper.getDateRegularityIndexLabel', () => {
+  it('高い値は規則的', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(85)).toBe('規則的');
+  });
+
+  it('中程度はやや不規則', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(55)).toBe('やや不規則');
+  });
+
+  it('低い値は不規則', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(25)).toBe('不規則');
+  });
+});

--- a/src/__tests__/domain/entities/MeanAbsolutePercentageError.test.ts
+++ b/src/__tests__/domain/entities/MeanAbsolutePercentageError.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMeanAbsolutePercentageError', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getMeanAbsolutePercentageError([], [])).toBe(0);
+  });
+
+  it('配列長不一致は0', () => {
+    expect(MathHelper.getMeanAbsolutePercentageError([1, 2], [1])).toBe(0);
+  });
+
+  it('同値は0', () => {
+    expect(MathHelper.getMeanAbsolutePercentageError([10, 20, 30], [10, 20, 30])).toBe(0);
+  });
+
+  it('実測値に0を含む場合はスキップ', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([0, 10], [5, 10]);
+    expect(result).toBe(0);
+  });
+
+  it('差が大きいほど値が大きい', () => {
+    const small = MathHelper.getMeanAbsolutePercentageError([100, 100], [90, 110]);
+    const large = MathHelper.getMeanAbsolutePercentageError([100, 100], [50, 150]);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it('結果は0以上', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([10, 20], [12, 18]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('予測が全て2倍なら100', () => {
+    expect(MathHelper.getMeanAbsolutePercentageError([10, 20], [20, 40])).toBe(100);
+  });
+
+  it('結果は数値', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([5, 10, 15], [6, 11, 14]);
+    expect(typeof result).toBe('number');
+  });
+
+  it('1件でも計算可能', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([50], [60]);
+    expect(result).toBe(20);
+  });
+});
+
+describe('MathHelper.getMeanAbsolutePercentageErrorLabel', () => {
+  it('低い値は精度高', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(5)).toBe('精度高');
+  });
+
+  it('中程度はやや誤差', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(15)).toBe('やや誤差');
+  });
+
+  it('高い値は誤差大', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(35)).toBe('誤差大');
+  });
+});

--- a/src/domain/entities/Character.ts
+++ b/src/domain/entities/Character.ts
@@ -35,6 +35,9 @@ export interface CharacterConfig {
 const VALID_TYPES: CharacterType[] = ['dog', 'cat', 'rabbit', 'bird'];
 
 export class CharacterEntity {
+  private static readonly LOYALTY_HIGH_THRESHOLD = 80;
+  private static readonly LOYALTY_MODERATE_THRESHOLD = 40;
+
   /**
    * 文字列がCharacterTypeか検証する
    */
@@ -142,6 +145,23 @@ export class CharacterEntity {
     const greeting = CharacterEntity.getTimeBasedGreeting(hour);
     const context = CharacterEntity.getGreetingContext(info);
     return `${greeting}、${info.memberName}さん。${context}`;
+  }
+
+  /**
+   * キャラクター使用日数から忠誠度スコアを算出する（0-100）
+   */
+  static getCharacterLoyaltyScore(usageDays: number, totalDays: number): number {
+    if (totalDays <= 0 || usageDays <= 0) return 0;
+    return Math.min(100, Math.round((usageDays / totalDays) * 100));
+  }
+
+  /**
+   * 忠誠度スコアに応じたラベルを返す
+   */
+  static getCharacterLoyaltyScoreLabel(score: number): string {
+    if (score >= CharacterEntity.LOYALTY_HIGH_THRESHOLD) return '忠実';
+    if (score >= CharacterEntity.LOYALTY_MODERATE_THRESHOLD) return '普通';
+    return '浮気性';
   }
 }
 

--- a/src/domain/entities/DateRange.ts
+++ b/src/domain/entities/DateRange.ts
@@ -115,6 +115,9 @@ export class DateRangeHelper {
   private static readonly DATE_REGULARITY_MAX_CV = 100;
   private static readonly DATE_REGULARITY_HIGH_THRESHOLD = 80;
   private static readonly DATE_REGULARITY_MODERATE_THRESHOLD = 50;
+  private static readonly REGULARITY_INDEX_MAX_CV = 100;
+  private static readonly REGULARITY_INDEX_HIGH_THRESHOLD = 80;
+  private static readonly REGULARITY_INDEX_MODERATE_THRESHOLD = 50;
 
   static getDayOfWeekLabel(date: Date): string {
     return DateRangeHelper.DAY_LABELS[date.getDay()];
@@ -487,6 +490,35 @@ export class DateRangeHelper {
   static getDateRegularityScoreLabel(score: number): string {
     if (score >= DateRangeHelper.DATE_REGULARITY_HIGH_THRESHOLD) return '規則的';
     if (score >= DateRangeHelper.DATE_REGULARITY_MODERATE_THRESHOLD) return 'やや不規則';
+    return '不規則';
+  }
+
+  /**
+   * 間隔日数配列から規則性指数を算出する（0-100）
+   * 変動係数(CV)が小さいほどスコアが高い
+   */
+  static getDateRegularityIndex(intervals: number[]): number {
+    if (intervals.length <= 1) return intervals.length === 0 ? 0 : 100;
+    const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+    if (avg === 0) return 0;
+    const variance =
+      intervals.reduce((sum, v) => sum + (v - avg) ** 2, 0) / intervals.length;
+    const cv = (Math.sqrt(variance) / avg) * 100;
+    return Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(100 - (cv / DateRangeHelper.REGULARITY_INDEX_MAX_CV) * 100)
+      )
+    );
+  }
+
+  /**
+   * 規則性指数に応じたラベルを返す
+   */
+  static getDateRegularityIndexLabel(score: number): string {
+    if (score >= DateRangeHelper.REGULARITY_INDEX_HIGH_THRESHOLD) return '規則的';
+    if (score >= DateRangeHelper.REGULARITY_INDEX_MODERATE_THRESHOLD) return 'やや不規則';
     return '不規則';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -67,6 +67,8 @@ export class MathHelper {
   private static readonly ENTROPY_NORM_MODERATE_THRESHOLD = 40;
   private static readonly QD_UNIFORM_THRESHOLD = 5;
   private static readonly QD_MODERATE_THRESHOLD = 20;
+  private static readonly MAPE_HIGH_THRESHOLD = 10;
+  private static readonly MAPE_MODERATE_THRESHOLD = 25;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1083,5 +1085,31 @@ export class MathHelper {
     if (qd <= MathHelper.QD_UNIFORM_THRESHOLD) return '均一';
     if (qd <= MathHelper.QD_MODERATE_THRESHOLD) return 'やや散布';
     return '散布';
+  }
+
+  /**
+   * 平均絶対パーセント誤差（MAPE）を算出する
+   * 実測値が0の要素はスキップする
+   */
+  static getMeanAbsolutePercentageError(actual: number[], predicted: number[]): number {
+    if (actual.length === 0 || actual.length !== predicted.length) return 0;
+    const validPairs = actual
+      .map((a, i) => ({ a, p: predicted[i] }))
+      .filter(({ a }) => a !== 0);
+    if (validPairs.length === 0) return 0;
+    const sum = validPairs.reduce(
+      (acc, { a, p }) => acc + Math.abs((a - p) / a),
+      0,
+    );
+    return Math.round((sum / validPairs.length) * 100 * 100) / 100;
+  }
+
+  /**
+   * MAPEに応じたラベルを返す
+   */
+  static getMeanAbsolutePercentageErrorLabel(mape: number): string {
+    if (mape <= MathHelper.MAPE_HIGH_THRESHOLD) return '精度高';
+    if (mape <= MathHelper.MAPE_MODERATE_THRESHOLD) return 'やや誤差';
+    return '誤差大';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper: getMeanAbsolutePercentageError / getMeanAbsolutePercentageErrorLabel を追加
- CharacterEntity: getCharacterLoyaltyScore / getCharacterLoyaltyScoreLabel を追加
- DateRangeHelper: getDateRegularityIndex / getDateRegularityIndexLabel を追加
- テスト35件追加（合計7471件）

## Test plan
- [x] MAPEのテスト（12件）
- [x] 忠誠度スコアのテスト（12件）
- [x] 日付規則性指数のテスト（11件）
- [x] 全テスト通過確認（7471件）

closes #952