### PR TITLE
test: 平均絶対パーセント誤差・キャラクター忠誠度スコア・日付規則性指数のエッジケーステスト

### DIFF
--- a/src/__tests__/domain/entities/CharacterLoyaltyScore.edge.test.ts
+++ b/src/__tests__/domain/entities/CharacterLoyaltyScore.edge.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { CharacterEntity } from '@/domain/entities/Character';
+
+describe('CharacterEntity.getCharacterLoyaltyScore エッジケース', () => {
+  it('負の使用日数は0', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(-5, 30)).toBe(0);
+  });
+
+  it('負の総日数は0', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(10, -30)).toBe(0);
+  });
+
+  it('両方負は0', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(-1, -1)).toBe(0);
+  });
+
+  it('大量の使用日数でも100以下', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(1000, 30)).toBeLessThanOrEqual(100);
+  });
+
+  it('365日中365日使用は100', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(365, 365)).toBe(100);
+  });
+
+  it('小数の使用日数', () => {
+    const result = CharacterEntity.getCharacterLoyaltyScore(2.5, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = CharacterEntity.getCharacterLoyaltyScore(7, 30);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('1/3は33', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(1, 3)).toBe(33);
+  });
+
+  it('2/3は67', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(2, 3)).toBe(67);
+  });
+
+  it('非常に大きな数値', () => {
+    const result = CharacterEntity.getCharacterLoyaltyScore(50000, 100000);
+    expect(result).toBe(50);
+  });
+
+  it('総日数0で使用日数正は0', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(5, 0)).toBe(0);
+  });
+
+  it('90%は90', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScore(9, 10)).toBe(90);
+  });
+});
+
+describe('CharacterEntity.getCharacterLoyaltyScoreLabel エッジケース', () => {
+  it('境界値80は忠実', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(80)).toBe('忠実');
+  });
+
+  it('境界値40は普通', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(40)).toBe('普通');
+  });
+
+  it('境界値79は普通', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(79)).toBe('普通');
+  });
+
+  it('境界値39は浮気性', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(39)).toBe('浮気性');
+  });
+
+  it('0は浮気性', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(0)).toBe('浮気性');
+  });
+
+  it('100は忠実', () => {
+    expect(CharacterEntity.getCharacterLoyaltyScoreLabel(100)).toBe('忠実');
+  });
+});

--- a/src/__tests__/domain/entities/DateRegularityIndex.edge.test.ts
+++ b/src/__tests__/domain/entities/DateRegularityIndex.edge.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
+
+describe('DateRangeHelper.getDateRegularityIndex エッジケース', () => {
+  it('全て0の間隔は0', () => {
+    expect(DateRangeHelper.getDateRegularityIndex([0, 0, 0])).toBe(0);
+  });
+
+  it('負の間隔を含む場合', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([-1, 7, 7]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('非常に大きな間隔', () => {
+    expect(DateRangeHelper.getDateRegularityIndex([365, 365, 365])).toBe(100);
+  });
+
+  it('小数の間隔', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([7.5, 7.5, 7.5]);
+    expect(result).toBe(100);
+  });
+
+  it('多数の要素', () => {
+    const intervals = Array.from({ length: 52 }, () => 7);
+    expect(DateRangeHelper.getDateRegularityIndex(intervals)).toBe(100);
+  });
+
+  it('交互に異なる間隔', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([1, 14, 1, 14, 1, 14]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('徐々に増加する間隔', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([1, 2, 3, 4, 5]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('1つだけ外れ値', () => {
+    const regular = DateRangeHelper.getDateRegularityIndex([7, 7, 7, 7]);
+    const withOutlier = DateRangeHelper.getDateRegularityIndex([7, 7, 7, 100]);
+    expect(regular).toBeGreaterThan(withOutlier);
+  });
+
+  it('2件で大きな差', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([1, 100]);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('結果は整数', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([3, 5, 7]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('3件で均等は100', () => {
+    expect(DateRangeHelper.getDateRegularityIndex([14, 14, 14])).toBe(100);
+  });
+
+  it('ほぼ均等な間隔は高スコア', () => {
+    const result = DateRangeHelper.getDateRegularityIndex([7, 7, 7, 8]);
+    expect(result).toBeGreaterThan(90);
+  });
+});
+
+describe('DateRangeHelper.getDateRegularityIndexLabel エッジケース', () => {
+  it('境界値80は規則的', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(80)).toBe('規則的');
+  });
+
+  it('境界値50はやや不規則', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(50)).toBe('やや不規則');
+  });
+
+  it('境界値79はやや不規則', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(79)).toBe('やや不規則');
+  });
+
+  it('境界値49は不規則', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(49)).toBe('不規則');
+  });
+
+  it('0は不規則', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(0)).toBe('不規則');
+  });
+
+  it('100は規則的', () => {
+    expect(DateRangeHelper.getDateRegularityIndexLabel(100)).toBe('規則的');
+  });
+});

--- a/src/__tests__/domain/entities/MeanAbsolutePercentageError.edge.test.ts
+++ b/src/__tests__/domain/entities/MeanAbsolutePercentageError.edge.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMeanAbsolutePercentageError エッジケース', () => {
+  it('全て0の実測値は0', () => {
+    expect(MathHelper.getMeanAbsolutePercentageError([0, 0, 0], [1, 2, 3])).toBe(0);
+  });
+
+  it('負の実測値でも計算可能', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([-10, -20], [-15, -25]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('非常に大きな値', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([1000000], [1000001]);
+    expect(result).toBeLessThan(1);
+  });
+
+  it('小数値', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([0.1, 0.2], [0.15, 0.25]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('予測が0で実測が非ゼロ', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([10], [0]);
+    expect(result).toBe(100);
+  });
+
+  it('部分的に実測が0', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([0, 10, 0, 20], [5, 10, 5, 20]);
+    expect(result).toBe(0);
+  });
+
+  it('多数の要素', () => {
+    const actual = Array.from({ length: 100 }, (_, i) => i + 1);
+    const predicted = actual.map((v) => v * 1.1);
+    const result = MathHelper.getMeanAbsolutePercentageError(actual, predicted);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(20);
+  });
+
+  it('予測が半分なら50', () => {
+    expect(MathHelper.getMeanAbsolutePercentageError([100], [50])).toBe(50);
+  });
+
+  it('予測がゼロで実測もゼロは0', () => {
+    expect(MathHelper.getMeanAbsolutePercentageError([0], [0])).toBe(0);
+  });
+
+  it('結果は数値', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([5, 10], [6, 9]);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it('実測と予測が逆でも正の値', () => {
+    const result = MathHelper.getMeanAbsolutePercentageError([10, 20], [20, 10]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MathHelper.getMeanAbsolutePercentageErrorLabel エッジケース', () => {
+  it('境界値10は精度高', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(10)).toBe('精度高');
+  });
+
+  it('境界値25はやや誤差', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(25)).toBe('やや誤差');
+  });
+
+  it('境界値10.01はやや誤差', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(10.01)).toBe('やや誤差');
+  });
+
+  it('境界値25.01は誤差大', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(25.01)).toBe('誤差大');
+  });
+
+  it('0は精度高', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(0)).toBe('精度高');
+  });
+
+  it('100は誤差大', () => {
+    expect(MathHelper.getMeanAbsolutePercentageErrorLabel(100)).toBe('誤差大');
+  });
+});


### PR DESCRIPTION
## Summary
- getMeanAbsolutePercentageError のエッジケーステスト17件
- getCharacterLoyaltyScore のエッジケーステスト18件
- getDateRegularityIndex のエッジケーステスト18件
- テスト53件追加（合計7524件）

## Test plan
- [x] 境界値テスト
- [x] 負の値テスト
- [x] 大きな値テスト
- [x] 全テスト通過確認（7524件）

closes #954