### PR TITLE
feat: ジニ係数・服薬負担スコア・体調回復速度メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/ConditionRecoverySpeed.test.ts
+++ b/src/__tests__/domain/entities/ConditionRecoverySpeed.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getConditionRecoverySpeed', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getConditionRecoverySpeed([])).toBe(0);
+  });
+
+  it('1要素は0', () => {
+    expect(HealthLogEntity.getConditionRecoverySpeed([3])).toBe(0);
+  });
+
+  it('常に同じ値は0（変動なし）', () => {
+    expect(HealthLogEntity.getConditionRecoverySpeed([3, 3, 3, 3])).toBe(0);
+  });
+
+  it('低下後に即回復は高スコア', () => {
+    const result = HealthLogEntity.getConditionRecoverySpeed([5, 1, 5]);
+    expect(result).toBeGreaterThan(70);
+  });
+
+  it('低下後に回復しないは低スコア', () => {
+    const result = HealthLogEntity.getConditionRecoverySpeed([5, 1, 1, 1]);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('結果は0-100', () => {
+    const result = HealthLogEntity.getConditionRecoverySpeed([3, 1, 2, 4, 3]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = HealthLogEntity.getConditionRecoverySpeed([4, 2, 3, 5]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('徐々に回復は低〜中程度', () => {
+    const result = HealthLogEntity.getConditionRecoverySpeed([5, 1, 2, 3, 4, 5]);
+    expect(result).toBeGreaterThan(20);
+    expect(result).toBeLessThan(90);
+  });
+
+  it('低下のみは0', () => {
+    expect(HealthLogEntity.getConditionRecoverySpeed([5, 4, 3, 2, 1])).toBe(0);
+  });
+
+  it('複数回の低下と回復', () => {
+    const result = HealthLogEntity.getConditionRecoverySpeed([5, 1, 5, 1, 5]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('緩やかな低下後に急回復', () => {
+    const result = HealthLogEntity.getConditionRecoverySpeed([5, 4, 3, 2, 5]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('HealthLogEntity.getConditionRecoverySpeedLabel', () => {
+  it('70以上は回復早い', () => {
+    expect(HealthLogEntity.getConditionRecoverySpeedLabel(80)).toBe('回復早い');
+  });
+
+  it('40以上は普通', () => {
+    expect(HealthLogEntity.getConditionRecoverySpeedLabel(50)).toBe('普通');
+  });
+
+  it('40未満は回復遅い', () => {
+    expect(HealthLogEntity.getConditionRecoverySpeedLabel(20)).toBe('回復遅い');
+  });
+});

--- a/src/__tests__/domain/entities/GiniCoefficient.test.ts
+++ b/src/__tests__/domain/entities/GiniCoefficient.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getGiniCoefficient', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getGiniCoefficient([])).toBe(0);
+  });
+
+  it('1要素は0', () => {
+    expect(MathHelper.getGiniCoefficient([100])).toBe(0);
+  });
+
+  it('全て同じ値は0（完全平等）', () => {
+    expect(MathHelper.getGiniCoefficient([10, 10, 10, 10])).toBe(0);
+  });
+
+  it('1つだけ正で他が0なら最大に近い', () => {
+    const result = MathHelper.getGiniCoefficient([0, 0, 0, 100]);
+    expect(result).toBeGreaterThan(0.7);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('2つの値で差が大きい場合', () => {
+    const result = MathHelper.getGiniCoefficient([1, 99]);
+    expect(result).toBeGreaterThan(0.4);
+  });
+
+  it('均等に近い分布は低い値', () => {
+    const result = MathHelper.getGiniCoefficient([10, 11, 12, 13]);
+    expect(result).toBeLessThan(0.1);
+  });
+
+  it('結果は0以上1以下', () => {
+    const result = MathHelper.getGiniCoefficient([5, 10, 20, 50, 100]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('小数第2位まで丸められる', () => {
+    const result = MathHelper.getGiniCoefficient([1, 2, 3, 4, 5]);
+    const decimals = result.toString().split('.')[1];
+    expect(!decimals || decimals.length <= 2).toBe(true);
+  });
+
+  it('全て0は0', () => {
+    expect(MathHelper.getGiniCoefficient([0, 0, 0])).toBe(0);
+  });
+
+  it('不均等な分布は高い値', () => {
+    const result = MathHelper.getGiniCoefficient([1, 1, 1, 1, 100]);
+    expect(result).toBeGreaterThan(0.5);
+  });
+});
+
+describe('MathHelper.getGiniCoefficientLabel', () => {
+  it('0.2以下は均等', () => {
+    expect(MathHelper.getGiniCoefficientLabel(0.15)).toBe('均等');
+  });
+
+  it('0.5以下はやや偏り', () => {
+    expect(MathHelper.getGiniCoefficientLabel(0.35)).toBe('やや偏り');
+  });
+
+  it('0.5超は偏り大', () => {
+    expect(MathHelper.getGiniCoefficientLabel(0.7)).toBe('偏り大');
+  });
+});

--- a/src/__tests__/domain/entities/MedicationBurdenScore.test.ts
+++ b/src/__tests__/domain/entities/MedicationBurdenScore.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getMedicationBurdenScore', () => {
+  it('0回は0', () => {
+    expect(MedicationEntity.getMedicationBurdenScore(0)).toBe(0);
+  });
+
+  it('負の回数は0', () => {
+    expect(MedicationEntity.getMedicationBurdenScore(-3)).toBe(0);
+  });
+
+  it('1日1回は低いスコア', () => {
+    const result = MedicationEntity.getMedicationBurdenScore(1);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('1日3回は中程度', () => {
+    const result = MedicationEntity.getMedicationBurdenScore(3);
+    expect(result).toBeGreaterThan(20);
+    expect(result).toBeLessThan(60);
+  });
+
+  it('1日6回は高いスコア', () => {
+    const result = MedicationEntity.getMedicationBurdenScore(6);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('1日10回以上は100', () => {
+    expect(MedicationEntity.getMedicationBurdenScore(10)).toBe(100);
+    expect(MedicationEntity.getMedicationBurdenScore(15)).toBe(100);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationEntity.getMedicationBurdenScore(5);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MedicationEntity.getMedicationBurdenScore(4);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('回数が増えるとスコアも増える', () => {
+    const score1 = MedicationEntity.getMedicationBurdenScore(2);
+    const score2 = MedicationEntity.getMedicationBurdenScore(5);
+    expect(score2).toBeGreaterThan(score1);
+  });
+
+  it('1日8回は高スコア', () => {
+    const result = MedicationEntity.getMedicationBurdenScore(8);
+    expect(result).toBeGreaterThan(70);
+  });
+});
+
+describe('MedicationEntity.getMedicationBurdenScoreLabel', () => {
+  it('70以上は負担大', () => {
+    expect(MedicationEntity.getMedicationBurdenScoreLabel(80)).toBe('負担大');
+  });
+
+  it('40以上は普通', () => {
+    expect(MedicationEntity.getMedicationBurdenScoreLabel(50)).toBe('普通');
+  });
+
+  it('40未満は負担小', () => {
+    expect(MedicationEntity.getMedicationBurdenScoreLabel(20)).toBe('負担小');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -92,6 +92,8 @@ export class HealthLogEntity {
   private static readonly HEALTH_TREND_MAX_LEVEL = 5;
   private static readonly HEALTH_TREND_GOOD_THRESHOLD = 80;
   private static readonly HEALTH_TREND_MODERATE_THRESHOLD = 50;
+  private static readonly RECOVERY_SPEED_FAST_THRESHOLD = 70;
+  private static readonly RECOVERY_SPEED_MODERATE_THRESHOLD = 40;
 
   private static readonly CONDITION_LABELS: Record<ConditionLevel, string> = {
     1: 'とても悪い',
@@ -1052,5 +1054,52 @@ export class HealthLogEntity {
     if (score >= HealthLogEntity.HEALTH_TREND_GOOD_THRESHOLD) return '良好';
     if (score >= HealthLogEntity.HEALTH_TREND_MODERATE_THRESHOLD) return '普通';
     return '注意';
+  }
+
+  /**
+   * 体調レベル配列から回復速度スコア(0-100)を算出する
+   * 低下後に回復するまでの速さを評価する
+   */
+  static getConditionRecoverySpeed(levels: number[]): number {
+    if (levels.length <= 1) return 0;
+    const recoveries: number[] = [];
+    let i = 0;
+    while (i < levels.length - 1) {
+      if (levels[i + 1] < levels[i]) {
+        const dipStart = levels[i];
+        const dipValue = levels[i + 1];
+        const drop = dipStart - dipValue;
+        let recoverySteps = 0;
+        let recovered = false;
+        for (let j = i + 2; j < levels.length; j++) {
+          recoverySteps++;
+          if (levels[j] >= dipStart) {
+            recovered = true;
+            break;
+          }
+        }
+        if (recovered && drop > 0) {
+          recoveries.push(drop / recoverySteps);
+        } else if (!recovered && drop > 0) {
+          recoveries.push(0);
+        }
+        i++;
+      } else {
+        i++;
+      }
+    }
+    if (recoveries.length === 0) return 0;
+    const maxSpeed = HealthLogEntity.HEALTH_TREND_MAX_LEVEL - 1;
+    const avgSpeed = recoveries.reduce((a, b) => a + b, 0) / recoveries.length;
+    return Math.min(100, Math.round((avgSpeed / maxSpeed) * 100));
+  }
+
+  /**
+   * 体調回復速度に応じたラベルを返す
+   */
+  static getConditionRecoverySpeedLabel(score: number): string {
+    if (score >= HealthLogEntity.RECOVERY_SPEED_FAST_THRESHOLD) return '回復早い';
+    if (score >= HealthLogEntity.RECOVERY_SPEED_MODERATE_THRESHOLD) return '普通';
+    return '回復遅い';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -69,6 +69,8 @@ export class MathHelper {
   private static readonly QD_MODERATE_THRESHOLD = 20;
   private static readonly MAPE_HIGH_THRESHOLD = 10;
   private static readonly MAPE_MODERATE_THRESHOLD = 25;
+  private static readonly GINI_EQUAL_THRESHOLD = 0.2;
+  private static readonly GINI_MODERATE_THRESHOLD = 0.5;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1111,5 +1113,32 @@ export class MathHelper {
     if (mape <= MathHelper.MAPE_HIGH_THRESHOLD) return '精度高';
     if (mape <= MathHelper.MAPE_MODERATE_THRESHOLD) return 'やや誤差';
     return '誤差大';
+  }
+
+  /**
+   * ジニ係数を算出する（0=完全平等、1=完全不平等）
+   */
+  static getGiniCoefficient(values: number[]): number {
+    if (values.length <= 1) return 0;
+    const total = values.reduce((a, b) => a + b, 0);
+    if (total === 0) return 0;
+    const n = values.length;
+    let sumAbsDiff = 0;
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        sumAbsDiff += Math.abs(values[i] - values[j]);
+      }
+    }
+    const gini = sumAbsDiff / (2 * n * n * (total / n));
+    return Math.round(Math.min(1, Math.max(0, gini)) * 100) / 100;
+  }
+
+  /**
+   * ジニ係数に応じたラベルを返す
+   */
+  static getGiniCoefficientLabel(gini: number): string {
+    if (gini <= MathHelper.GINI_EQUAL_THRESHOLD) return '均等';
+    if (gini <= MathHelper.GINI_MODERATE_THRESHOLD) return 'やや偏り';
+    return '偏り大';
   }
 }

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -107,6 +107,9 @@ export class MedicationEntity {
   private static readonly COMPLEXITY_MODERATE_THRESHOLD = 40;
   private static readonly COST_PER_DOSE_HIGH_THRESHOLD = 500;
   private static readonly COST_PER_DOSE_MODERATE_THRESHOLD = 100;
+  private static readonly BURDEN_MAX_DAILY_DOSES = 10;
+  private static readonly BURDEN_HIGH_THRESHOLD = 70;
+  private static readonly BURDEN_MODERATE_THRESHOLD = 40;
 
   private static readonly categoryLabels: Record<MedicationCategory, string> = {
     regular: '常用薬',
@@ -388,5 +391,22 @@ export class MedicationEntity {
     if (costPerDose >= MedicationEntity.COST_PER_DOSE_HIGH_THRESHOLD) return '高コスト';
     if (costPerDose >= MedicationEntity.COST_PER_DOSE_MODERATE_THRESHOLD) return '標準';
     return '低コスト';
+  }
+
+  /**
+   * 1日の服薬回数から負担スコア(0-100)を算出する
+   */
+  static getMedicationBurdenScore(dailyDoses: number): number {
+    if (dailyDoses <= 0) return 0;
+    return Math.min(100, Math.round((dailyDoses / MedicationEntity.BURDEN_MAX_DAILY_DOSES) * 100));
+  }
+
+  /**
+   * 服薬負担スコアに応じたラベルを返す
+   */
+  static getMedicationBurdenScoreLabel(score: number): string {
+    if (score >= MedicationEntity.BURDEN_HIGH_THRESHOLD) return '負担大';
+    if (score >= MedicationEntity.BURDEN_MODERATE_THRESHOLD) return '普通';
+    return '負担小';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getGiniCoefficient: 分布の不平等度をジニ係数(0〜1)で算出
- MedicationEntity.getMedicationBurdenScore: 1日の服薬回数から負担スコア(0-100)を算出
- HealthLogEntity.getConditionRecoverySpeed: 体調低下後の回復速度スコア(0-100)を算出
- 各メソッドにラベル関数も追加

closes #956

## Test plan
- [x] GiniCoefficient: 13テスト通過
- [x] MedicationBurdenScore: 13テスト通過
- [x] ConditionRecoverySpeed: 14テスト通過
- [x] 全7564テスト通過
- [x] ビルド成功