### PR TITLE
feat: 移動相関係数・スケジュール遵守スコア・エンゲージメント傾向メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MemberEngagementTrend.test.ts
+++ b/src/__tests__/domain/entities/MemberEngagementTrend.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { MemberEntity } from '@/domain/entities/Member';
+
+describe('MemberEntity.getMemberEngagementTrend', () => {
+  it('空配列は0', () => {
+    expect(MemberEntity.getMemberEngagementTrend([])).toBe(0);
+  });
+
+  it('1要素は0', () => {
+    expect(MemberEntity.getMemberEngagementTrend([5])).toBe(0);
+  });
+
+  it('増加傾向は正の値', () => {
+    const result = MemberEntity.getMemberEngagementTrend([1, 2, 3, 4, 5, 6]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('減少傾向は負の値', () => {
+    const result = MemberEntity.getMemberEngagementTrend([6, 5, 4, 3, 2, 1]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('一定は0', () => {
+    expect(MemberEntity.getMemberEngagementTrend([5, 5, 5, 5])).toBe(0);
+  });
+
+  it('結果は-100から100の範囲', () => {
+    const result = MemberEntity.getMemberEngagementTrend([10, 1, 8, 3, 7, 2]);
+    expect(result).toBeGreaterThanOrEqual(-100);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MemberEntity.getMemberEngagementTrend([3, 5, 2, 7, 1, 8]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('前半0で後半に記録は正', () => {
+    const result = MemberEntity.getMemberEngagementTrend([0, 0, 5, 5]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('前半に記録で後半0は負', () => {
+    const result = MemberEntity.getMemberEngagementTrend([5, 5, 0, 0]);
+    expect(result).toBeLessThan(0);
+  });
+
+  it('急増は高い正の値', () => {
+    const result = MemberEntity.getMemberEngagementTrend([1, 1, 10, 10]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('2要素で増加', () => {
+    const result = MemberEntity.getMemberEngagementTrend([1, 5]);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MemberEntity.getMemberEngagementTrendLabel', () => {
+  it('正の値は上昇', () => {
+    expect(MemberEntity.getMemberEngagementTrendLabel(30)).toBe('上昇');
+  });
+
+  it('0は横ばい', () => {
+    expect(MemberEntity.getMemberEngagementTrendLabel(0)).toBe('横ばい');
+  });
+
+  it('負の値は下降', () => {
+    expect(MemberEntity.getMemberEngagementTrendLabel(-20)).toBe('下降');
+  });
+});

--- a/src/__tests__/domain/entities/MovingCorrelation.test.ts
+++ b/src/__tests__/domain/entities/MovingCorrelation.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getMovingCorrelation', () => {
+  it('空配列は空配列', () => {
+    expect(MathHelper.getMovingCorrelation([], [], 3)).toEqual([]);
+  });
+
+  it('ウィンドウより短い配列は空', () => {
+    expect(MathHelper.getMovingCorrelation([1, 2], [3, 4], 3)).toEqual([]);
+  });
+
+  it('配列長不一致は空', () => {
+    expect(MathHelper.getMovingCorrelation([1, 2, 3], [1, 2], 2)).toEqual([]);
+  });
+
+  it('完全正相関は1に近い', () => {
+    const result = MathHelper.getMovingCorrelation([1, 2, 3, 4, 5], [2, 4, 6, 8, 10], 3);
+    expect(result.length).toBe(3);
+    result.forEach((r) => expect(r).toBeCloseTo(1, 1));
+  });
+
+  it('完全負相関は-1に近い', () => {
+    const result = MathHelper.getMovingCorrelation([1, 2, 3, 4, 5], [10, 8, 6, 4, 2], 3);
+    expect(result.length).toBe(3);
+    result.forEach((r) => expect(r).toBeCloseTo(-1, 1));
+  });
+
+  it('無相関は0に近い', () => {
+    const result = MathHelper.getMovingCorrelation([1, 2, 3], [3, 1, 2], 3);
+    expect(result.length).toBe(1);
+    expect(Math.abs(result[0])).toBeLessThan(0.8);
+  });
+
+  it('ウィンドウサイズと同じ長さは1要素', () => {
+    const result = MathHelper.getMovingCorrelation([1, 2, 3], [2, 4, 6], 3);
+    expect(result.length).toBe(1);
+  });
+
+  it('結果は-1から1の範囲', () => {
+    const result = MathHelper.getMovingCorrelation([5, 3, 8, 1, 9, 2], [2, 7, 1, 8, 3, 6], 3);
+    result.forEach((r) => {
+      expect(r).toBeGreaterThanOrEqual(-1);
+      expect(r).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('ウィンドウ0以下は空', () => {
+    expect(MathHelper.getMovingCorrelation([1, 2, 3], [4, 5, 6], 0)).toEqual([]);
+  });
+
+  it('定数系列は0', () => {
+    const result = MathHelper.getMovingCorrelation([5, 5, 5, 5], [1, 2, 3, 4], 3);
+    result.forEach((r) => expect(r).toBe(0));
+  });
+
+  it('小数第2位まで丸められる', () => {
+    const result = MathHelper.getMovingCorrelation([1, 3, 2, 5, 4], [2, 4, 1, 6, 3], 3);
+    result.forEach((r) => {
+      const str = r.toString();
+      const decimals = str.split('.')[1];
+      expect(!decimals || decimals.length <= 2).toBe(true);
+    });
+  });
+});
+
+describe('MathHelper.getMovingCorrelationLabel', () => {
+  it('0.6以上は強い正相関', () => {
+    expect(MathHelper.getMovingCorrelationLabel(0.8)).toBe('強い正相関');
+  });
+
+  it('0.3以上はやや正相関', () => {
+    expect(MathHelper.getMovingCorrelationLabel(0.4)).toBe('やや正相関');
+  });
+
+  it('-0.3以上は無相関', () => {
+    expect(MathHelper.getMovingCorrelationLabel(0.1)).toBe('無相関');
+  });
+
+  it('-0.6以上はやや負相関', () => {
+    expect(MathHelper.getMovingCorrelationLabel(-0.5)).toBe('やや負相関');
+  });
+
+  it('-0.6未満は強い負相関', () => {
+    expect(MathHelper.getMovingCorrelationLabel(-0.8)).toBe('強い負相関');
+  });
+});

--- a/src/__tests__/domain/entities/SchedulePunctualityScore.test.ts
+++ b/src/__tests__/domain/entities/SchedulePunctualityScore.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { ScheduleEntity } from '@/domain/entities/Schedule';
+
+describe('ScheduleEntity.getSchedulePunctualityScore', () => {
+  it('空配列は0', () => {
+    expect(ScheduleEntity.getSchedulePunctualityScore([])).toBe(0);
+  });
+
+  it('全てぴったりは100', () => {
+    expect(ScheduleEntity.getSchedulePunctualityScore([0, 0, 0])).toBe(100);
+  });
+
+  it('全て大幅遅延は0', () => {
+    expect(ScheduleEntity.getSchedulePunctualityScore([60, 60, 60])).toBe(0);
+  });
+
+  it('小さな遅延は高スコア', () => {
+    const result = ScheduleEntity.getSchedulePunctualityScore([5, 5, 5]);
+    expect(result).toBeGreaterThan(80);
+  });
+
+  it('中程度の遅延は中スコア', () => {
+    const result = ScheduleEntity.getSchedulePunctualityScore([30, 30, 30]);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(70);
+  });
+
+  it('結果は0-100', () => {
+    const result = ScheduleEntity.getSchedulePunctualityScore([10, 20, 30, 40]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = ScheduleEntity.getSchedulePunctualityScore([7, 15, 22]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('負の値（早い場合）も絶対値で計算', () => {
+    const result = ScheduleEntity.getSchedulePunctualityScore([-10, -10, -10]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('1要素', () => {
+    const result = ScheduleEntity.getSchedulePunctualityScore([15]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(100);
+  });
+
+  it('遅延が大きいほどスコア低い', () => {
+    const score1 = ScheduleEntity.getSchedulePunctualityScore([5]);
+    const score2 = ScheduleEntity.getSchedulePunctualityScore([30]);
+    expect(score1).toBeGreaterThan(score2);
+  });
+});
+
+describe('ScheduleEntity.getSchedulePunctualityScoreLabel', () => {
+  it('80以上は正確', () => {
+    expect(ScheduleEntity.getSchedulePunctualityScoreLabel(90)).toBe('正確');
+  });
+
+  it('50以上はやや遅延', () => {
+    expect(ScheduleEntity.getSchedulePunctualityScoreLabel(60)).toBe('やや遅延');
+  });
+
+  it('50未満は遅延多い', () => {
+    expect(ScheduleEntity.getSchedulePunctualityScoreLabel(30)).toBe('遅延多い');
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -71,6 +71,8 @@ export class MathHelper {
   private static readonly MAPE_MODERATE_THRESHOLD = 25;
   private static readonly GINI_EQUAL_THRESHOLD = 0.2;
   private static readonly GINI_MODERATE_THRESHOLD = 0.5;
+  private static readonly MCORR_STRONG_THRESHOLD = 0.6;
+  private static readonly MCORR_WEAK_THRESHOLD = 0.3;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1140,5 +1142,48 @@ export class MathHelper {
     if (gini <= MathHelper.GINI_EQUAL_THRESHOLD) return '均等';
     if (gini <= MathHelper.GINI_MODERATE_THRESHOLD) return 'やや偏り';
     return '偏り大';
+  }
+
+  /**
+   * 2つの系列の移動相関係数を算出する
+   * ウィンドウサイズごとにピアソン相関係数を計算
+   */
+  static getMovingCorrelation(xs: number[], ys: number[], windowSize: number): number[] {
+    if (xs.length !== ys.length || xs.length < windowSize || windowSize <= 0) return [];
+    const results: number[] = [];
+    for (let i = 0; i <= xs.length - windowSize; i++) {
+      const wx = xs.slice(i, i + windowSize);
+      const wy = ys.slice(i, i + windowSize);
+      const avgX = wx.reduce((a, b) => a + b, 0) / windowSize;
+      const avgY = wy.reduce((a, b) => a + b, 0) / windowSize;
+      let sumXY = 0;
+      let sumX2 = 0;
+      let sumY2 = 0;
+      for (let j = 0; j < windowSize; j++) {
+        const dx = wx[j] - avgX;
+        const dy = wy[j] - avgY;
+        sumXY += dx * dy;
+        sumX2 += dx * dx;
+        sumY2 += dy * dy;
+      }
+      if (sumX2 === 0 || sumY2 === 0) {
+        results.push(0);
+      } else {
+        const corr = sumXY / Math.sqrt(sumX2 * sumY2);
+        results.push(Math.round(Math.max(-1, Math.min(1, corr)) * 100) / 100);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * 移動相関係数に応じたラベルを返す
+   */
+  static getMovingCorrelationLabel(corr: number): string {
+    if (corr >= MathHelper.MCORR_STRONG_THRESHOLD) return '強い正相関';
+    if (corr >= MathHelper.MCORR_WEAK_THRESHOLD) return 'やや正相関';
+    if (corr >= -MathHelper.MCORR_WEAK_THRESHOLD) return '無相関';
+    if (corr >= -MathHelper.MCORR_STRONG_THRESHOLD) return 'やや負相関';
+    return '強い負相関';
   }
 }

--- a/src/domain/entities/Member.ts
+++ b/src/domain/entities/Member.ts
@@ -162,6 +162,7 @@ export class MemberEntity {
   private static readonly ENGAGEMENT_ADHERENCE_WEIGHT = 0.3;
   private static readonly ENGAGEMENT_HIGH_THRESHOLD = 80;
   private static readonly ENGAGEMENT_MODERATE_THRESHOLD = 50;
+  private static readonly ENGAGEMENT_TREND_THRESHOLD = 0;
 
   private static readonly memberTypeLabels: Record<MemberType, string> = {
     human: '家族',
@@ -576,5 +577,31 @@ export class MemberEntity {
     if (score >= MemberEntity.ENGAGEMENT_HIGH_THRESHOLD) return '積極的';
     if (score >= MemberEntity.ENGAGEMENT_MODERATE_THRESHOLD) return '普通';
     return '消極的';
+  }
+
+  /**
+   * 記録数の配列から前半/後半の変化率でエンゲージメント傾向(-100〜100)を算出する
+   * 正は増加傾向、負は減少傾向
+   */
+  static getMemberEngagementTrend(recordCounts: number[]): number {
+    if (recordCounts.length <= 1) return 0;
+    const mid = Math.floor(recordCounts.length / 2);
+    const firstHalf = recordCounts.slice(0, mid);
+    const secondHalf = recordCounts.slice(mid);
+    const avgFirst = firstHalf.reduce((a, b) => a + b, 0) / firstHalf.length;
+    const avgSecond = secondHalf.reduce((a, b) => a + b, 0) / secondHalf.length;
+    if (avgFirst === 0 && avgSecond === 0) return 0;
+    const maxAvg = Math.max(avgFirst, avgSecond, 1);
+    const diff = avgSecond - avgFirst;
+    return Math.max(-100, Math.min(100, Math.round((diff / maxAvg) * 100)));
+  }
+
+  /**
+   * エンゲージメント傾向に応じたラベルを返す
+   */
+  static getMemberEngagementTrendLabel(trend: number): string {
+    if (trend > MemberEntity.ENGAGEMENT_TREND_THRESHOLD) return '上昇';
+    if (trend < MemberEntity.ENGAGEMENT_TREND_THRESHOLD) return '下降';
+    return '横ばい';
   }
 }

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -41,6 +41,9 @@ export class ScheduleEntity {
   private static readonly PROXIMITY_NEAR_MINUTES = 60;
   private static readonly STREAK_MONTH_THRESHOLD = 30;
   private static readonly STREAK_WEEK_THRESHOLD = 7;
+  private static readonly SCHED_PUNCTUALITY_MAX_DELAY = 60;
+  private static readonly SCHED_PUNCTUALITY_HIGH_THRESHOLD = 80;
+  private static readonly SCHED_PUNCTUALITY_MODERATE_THRESHOLD = 50;
 
   constructor(private readonly schedule: Schedule) {}
 
@@ -1110,5 +1113,33 @@ export class ScheduleEntity {
     if (score >= ScheduleEntity.LOAD_BALANCE_HIGH_THRESHOLD) return '均等';
     if (score >= ScheduleEntity.LOAD_BALANCE_MODERATE_THRESHOLD) return 'やや偏り';
     return '偏り大';
+  }
+
+  /**
+   * 遅延分数の配列からスケジュール遵守スコア(0-100)を算出する
+   * 遅延が小さいほど高スコア
+   */
+  static getSchedulePunctualityScore(delayMinutes: number[]): number {
+    if (delayMinutes.length === 0) return 0;
+    const avgDelay =
+      delayMinutes.reduce((sum, d) => sum + Math.abs(d), 0) / delayMinutes.length;
+    return Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(
+          100 - (avgDelay / ScheduleEntity.SCHED_PUNCTUALITY_MAX_DELAY) * 100,
+        ),
+      ),
+    );
+  }
+
+  /**
+   * スケジュール遵守スコアに応じたラベルを返す
+   */
+  static getSchedulePunctualityScoreLabel(score: number): string {
+    if (score >= ScheduleEntity.SCHED_PUNCTUALITY_HIGH_THRESHOLD) return '正確';
+    if (score >= ScheduleEntity.SCHED_PUNCTUALITY_MODERATE_THRESHOLD) return 'やや遅延';
+    return '遅延多い';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getMovingCorrelation: 2つの数値系列のウィンドウごとの移動相関係数を算出
- ScheduleEntity.getSchedulePunctualityScore: 遅延分数からスケジュール遵守スコア(0-100)を算出
- MemberEntity.getMemberEngagementTrend: 記録数の前半/後半比較でエンゲージメント傾向(-100〜100)を算出
- 各メソッドにラベル関数も追加

closes #960

## Test plan
- [x] MovingCorrelation: 16テスト通過
- [x] SchedulePunctualityScore: 13テスト通過
- [x] MemberEngagementTrend: 14テスト通過
- [x] 全7671テスト通過
- [x] ビルド成功