### PR TITLE
feat: 指数平滑化・在庫廃棄リスクスコア・予約リードタイムメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentLeadTime.test.ts
+++ b/src/__tests__/domain/entities/AppointmentLeadTime.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentLeadTime', () => {
+  it('空配列は0', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([])).toBe(0);
+  });
+
+  it('1要素はその値', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([14])).toBe(14);
+  });
+
+  it('複数の値は平均', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([7, 14, 21])).toBe(14);
+  });
+
+  it('全て同じ値', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([10, 10, 10])).toBe(10);
+  });
+
+  it('全て0は0', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([0, 0, 0])).toBe(0);
+  });
+
+  it('負の値は0としてクランプ', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([-5, 10])).toBe(5);
+  });
+
+  it('結果は整数', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([3, 5, 7]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('大きな値', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([90, 90])).toBe(90);
+  });
+
+  it('小数の日数は丸められる', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([7, 8]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('値が増えるとリードタイムも増える', () => {
+    const short = AppointmentEntity.getAppointmentLeadTime([3, 3, 3]);
+    const long = AppointmentEntity.getAppointmentLeadTime([30, 30, 30]);
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it('多数の要素', () => {
+    const days = Array.from({ length: 50 }, () => 14);
+    expect(AppointmentEntity.getAppointmentLeadTime(days)).toBe(14);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentLeadTimeLabel', () => {
+  it('14日以上は余裕あり', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(20)).toBe('余裕あり');
+  });
+
+  it('7日以上は適切', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(10)).toBe('適切');
+  });
+
+  it('7日未満は直前', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(3)).toBe('直前');
+  });
+});

--- a/src/__tests__/domain/entities/ExponentialSmoothing.test.ts
+++ b/src/__tests__/domain/entities/ExponentialSmoothing.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getExponentialSmoothing', () => {
+  it('空配列は空', () => {
+    expect(MathHelper.getExponentialSmoothing([], 0.5)).toEqual([]);
+  });
+
+  it('1要素はそのまま', () => {
+    expect(MathHelper.getExponentialSmoothing([10], 0.5)).toEqual([10]);
+  });
+
+  it('alpha=1は元の系列と同じ', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 2, 3, 4, 5], 1);
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('alpha=0は最初の値で固定', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 10, 20, 30], 0);
+    expect(result).toEqual([1, 1, 1, 1]);
+  });
+
+  it('alpha=0.5で平滑化される', () => {
+    const result = MathHelper.getExponentialSmoothing([10, 20, 30], 0.5);
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe(10);
+    expect(result[1]).toBe(15);
+  });
+
+  it('結果の要素数は入力と同じ', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 2, 3, 4, 5], 0.3);
+    expect(result.length).toBe(5);
+  });
+
+  it('小数第2位まで丸められる', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 5, 3, 7], 0.3);
+    result.forEach((v) => {
+      const str = v.toString();
+      const decimals = str.split('.')[1];
+      expect(!decimals || decimals.length <= 2).toBe(true);
+    });
+  });
+
+  it('定数系列は変わらない', () => {
+    const result = MathHelper.getExponentialSmoothing([5, 5, 5, 5], 0.5);
+    result.forEach((v) => expect(v).toBe(5));
+  });
+
+  it('alpha範囲外は0にクランプ', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 10], -0.5);
+    expect(result).toEqual([1, 1]);
+  });
+
+  it('alpha>1は1にクランプ', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 10], 1.5);
+    expect(result).toEqual([1, 10]);
+  });
+
+  it('増加系列は遅れて追従', () => {
+    const result = MathHelper.getExponentialSmoothing([0, 10, 20, 30], 0.5);
+    expect(result[1]).toBeLessThan(10);
+    expect(result[3]).toBeLessThan(30);
+  });
+});
+
+describe('MathHelper.getExponentialSmoothingLabel', () => {
+  it('alpha高は反応的', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0.8)).toBe('反応的');
+  });
+
+  it('alpha中はバランス', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0.5)).toBe('バランス');
+  });
+
+  it('alpha低は安定的', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0.2)).toBe('安定的');
+  });
+});

--- a/src/__tests__/domain/entities/StockWastageScore.test.ts
+++ b/src/__tests__/domain/entities/StockWastageScore.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getStockWastageScore', () => {
+  it('在庫0は0', () => {
+    expect(MedicationEntity.getStockWastageScore(0, 30)).toBe(0);
+  });
+
+  it('残日数0は100', () => {
+    expect(MedicationEntity.getStockWastageScore(100, 0)).toBe(100);
+  });
+
+  it('両方0は0', () => {
+    expect(MedicationEntity.getStockWastageScore(0, 0)).toBe(0);
+  });
+
+  it('在庫多くて残日数少ないは高スコア', () => {
+    const result = MedicationEntity.getStockWastageScore(100, 5);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('在庫少なくて残日数多いは低スコア', () => {
+    const result = MedicationEntity.getStockWastageScore(5, 90);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationEntity.getStockWastageScore(50, 30);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MedicationEntity.getStockWastageScore(30, 45);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('負の在庫は0', () => {
+    expect(MedicationEntity.getStockWastageScore(-10, 30)).toBe(0);
+  });
+
+  it('負の残日数は高スコア', () => {
+    const result = MedicationEntity.getStockWastageScore(50, -5);
+    expect(result).toBe(100);
+  });
+
+  it('在庫多いほどスコア高い（残日数同じ場合）', () => {
+    const score1 = MedicationEntity.getStockWastageScore(10, 30);
+    const score2 = MedicationEntity.getStockWastageScore(50, 30);
+    expect(score2).toBeGreaterThanOrEqual(score1);
+  });
+
+  it('残日数が多いほどスコア低い（在庫同じ場合）', () => {
+    const score1 = MedicationEntity.getStockWastageScore(50, 10);
+    const score2 = MedicationEntity.getStockWastageScore(50, 60);
+    expect(score1).toBeGreaterThan(score2);
+  });
+});
+
+describe('MedicationEntity.getStockWastageScoreLabel', () => {
+  it('70以上は廃棄リスク高', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(80)).toBe('廃棄リスク高');
+  });
+
+  it('40以上は注意', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(50)).toBe('注意');
+  });
+
+  it('40未満は低リスク', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(20)).toBe('低リスク');
+  });
+});

--- a/src/domain/entities/Appointment.ts
+++ b/src/domain/entities/Appointment.ts
@@ -45,6 +45,8 @@ export class AppointmentEntity {
   private static readonly COMPLIANCE_REGULARITY_WEIGHT = 0.2;
   private static readonly COMPLIANCE_HIGH_THRESHOLD = 80;
   private static readonly COMPLIANCE_MODERATE_THRESHOLD = 50;
+  private static readonly LEAD_TIME_LONG_THRESHOLD = 14;
+  private static readonly LEAD_TIME_SHORT_THRESHOLD = 7;
 
   constructor(private readonly appointment: Appointment) {}
 
@@ -707,5 +709,25 @@ export class AppointmentEntity {
     if (score >= AppointmentEntity.COMPLIANCE_HIGH_THRESHOLD) return '良好';
     if (score >= AppointmentEntity.COMPLIANCE_MODERATE_THRESHOLD) return '普通';
     return '要改善';
+  }
+
+  /**
+   * 予約リードタイム日数の配列から平均リードタイムを算出する
+   * 負の値は0としてクランプ
+   */
+  static getAppointmentLeadTime(leadDays: number[]): number {
+    if (leadDays.length === 0) return 0;
+    const clamped = leadDays.map((d) => Math.max(0, d));
+    const avg = clamped.reduce((a, b) => a + b, 0) / clamped.length;
+    return Math.round(avg);
+  }
+
+  /**
+   * 平均リードタイムに応じたラベルを返す
+   */
+  static getAppointmentLeadTimeLabel(days: number): string {
+    if (days >= AppointmentEntity.LEAD_TIME_LONG_THRESHOLD) return '余裕あり';
+    if (days >= AppointmentEntity.LEAD_TIME_SHORT_THRESHOLD) return '適切';
+    return '直前';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -73,6 +73,8 @@ export class MathHelper {
   private static readonly GINI_MODERATE_THRESHOLD = 0.5;
   private static readonly MCORR_STRONG_THRESHOLD = 0.6;
   private static readonly MCORR_WEAK_THRESHOLD = 0.3;
+  private static readonly EXP_SMOOTH_REACTIVE_THRESHOLD = 0.7;
+  private static readonly EXP_SMOOTH_BALANCED_THRESHOLD = 0.3;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1185,5 +1187,29 @@ export class MathHelper {
     if (corr >= -MathHelper.MCORR_WEAK_THRESHOLD) return '無相関';
     if (corr >= -MathHelper.MCORR_STRONG_THRESHOLD) return 'やや負相関';
     return '強い負相関';
+  }
+
+  /**
+   * 指数平滑化を算出する
+   * alpha: 平滑化係数(0-1)、大きいほど直近の値を重視
+   */
+  static getExponentialSmoothing(values: number[], alpha: number): number[] {
+    if (values.length === 0) return [];
+    const a = Math.max(0, Math.min(1, alpha));
+    const result: number[] = [values[0]];
+    for (let i = 1; i < values.length; i++) {
+      const smoothed = a * values[i] + (1 - a) * result[i - 1];
+      result.push(Math.round(smoothed * 100) / 100);
+    }
+    return result;
+  }
+
+  /**
+   * 平滑化係数に応じたラベルを返す
+   */
+  static getExponentialSmoothingLabel(alpha: number): string {
+    if (alpha >= MathHelper.EXP_SMOOTH_REACTIVE_THRESHOLD) return '反応的';
+    if (alpha >= MathHelper.EXP_SMOOTH_BALANCED_THRESHOLD) return 'バランス';
+    return '安定的';
   }
 }

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -110,6 +110,9 @@ export class MedicationEntity {
   private static readonly BURDEN_MAX_DAILY_DOSES = 10;
   private static readonly BURDEN_HIGH_THRESHOLD = 70;
   private static readonly BURDEN_MODERATE_THRESHOLD = 40;
+  private static readonly WASTAGE_MAX_RATIO = 5;
+  private static readonly WASTAGE_HIGH_THRESHOLD = 70;
+  private static readonly WASTAGE_MODERATE_THRESHOLD = 40;
 
   private static readonly categoryLabels: Record<MedicationCategory, string> = {
     regular: '常用薬',
@@ -408,5 +411,25 @@ export class MedicationEntity {
     if (score >= MedicationEntity.BURDEN_HIGH_THRESHOLD) return '負担大';
     if (score >= MedicationEntity.BURDEN_MODERATE_THRESHOLD) return '普通';
     return '負担小';
+  }
+
+  /**
+   * 在庫数と残日数から在庫廃棄リスクスコア(0-100)を算出する
+   * 在庫が多く残日数が少ないほど高スコア（廃棄リスクが高い）
+   */
+  static getStockWastageScore(stockQuantity: number, remainingDays: number): number {
+    if (stockQuantity <= 0) return 0;
+    if (remainingDays <= 0) return 100;
+    const ratio = stockQuantity / remainingDays;
+    return Math.min(100, Math.round((ratio / MedicationEntity.WASTAGE_MAX_RATIO) * 100));
+  }
+
+  /**
+   * 在庫廃棄リスクスコアに応じたラベルを返す
+   */
+  static getStockWastageScoreLabel(score: number): string {
+    if (score >= MedicationEntity.WASTAGE_HIGH_THRESHOLD) return '廃棄リスク高';
+    if (score >= MedicationEntity.WASTAGE_MODERATE_THRESHOLD) return '注意';
+    return '低リスク';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getExponentialSmoothing: 時系列データの指数平滑化を算出
- MedicationEntity.getStockWastageScore: 在庫数と残日数から廃棄リスクスコア(0-100)を算出
- AppointmentEntity.getAppointmentLeadTime: 予約から受診までの平均リードタイム日数を算出
- 各メソッドにラベル関数も追加

closes #964

## Test plan
- [x] ExponentialSmoothing: 14テスト通過
- [x] StockWastageScore: 14テスト通過
- [x] AppointmentLeadTime: 14テスト通過
- [x] 全7778テスト通過
- [x] ビルド成功