### PR TITLE
test: 指数平滑化・在庫廃棄リスクスコア・予約リードタイムのエッジケーステスト追加

### DIFF
--- a/src/__tests__/domain/entities/AppointmentLeadTime.edge.test.ts
+++ b/src/__tests__/domain/entities/AppointmentLeadTime.edge.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { AppointmentEntity } from '@/domain/entities/Appointment';
+
+describe('AppointmentEntity.getAppointmentLeadTime エッジケース', () => {
+  it('全て0は0', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([0, 0, 0])).toBe(0);
+  });
+
+  it('全て同じ値はその値', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([7, 7, 7])).toBe(7);
+  });
+
+  it('負の値は0にクランプ', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([-10])).toBe(0);
+  });
+
+  it('全て負は0', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([-5, -10, -15])).toBe(0);
+  });
+
+  it('混在する正負の値', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([-5, 10, 20]);
+    expect(result).toBe(10);
+  });
+
+  it('非常に大きな値', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([365])).toBe(365);
+  });
+
+  it('小数の日数は丸められる', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([7, 8, 9]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('多数の要素', () => {
+    const days = Array.from({ length: 100 }, () => 14);
+    expect(AppointmentEntity.getAppointmentLeadTime(days)).toBe(14);
+  });
+
+  it('2要素の平均', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([10, 20])).toBe(15);
+  });
+
+  it('3要素の平均で丸め', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([1, 2, 3]);
+    expect(result).toBe(2);
+  });
+
+  it('1日は1', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([1])).toBe(1);
+  });
+
+  it('値が大きいほどリードタイムも大きい', () => {
+    const short = AppointmentEntity.getAppointmentLeadTime([3]);
+    const long = AppointmentEntity.getAppointmentLeadTime([30]);
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it('ばらつきのある値', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([1, 30, 7, 14, 60]);
+    expect(result).toBeGreaterThan(0);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('0と大きな値の混在', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([0, 28]);
+    expect(result).toBe(14);
+  });
+
+  it('3要素の不均等', () => {
+    const result = AppointmentEntity.getAppointmentLeadTime([1, 1, 100]);
+    expect(result).toBe(34);
+  });
+
+  it('100日は100', () => {
+    expect(AppointmentEntity.getAppointmentLeadTime([100])).toBe(100);
+  });
+});
+
+describe('AppointmentEntity.getAppointmentLeadTimeLabel エッジケース', () => {
+  it('境界値14は余裕あり', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(14)).toBe('余裕あり');
+  });
+
+  it('境界値7は適切', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(7)).toBe('適切');
+  });
+
+  it('境界値13は適切', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(13)).toBe('適切');
+  });
+
+  it('境界値6は直前', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(6)).toBe('直前');
+  });
+
+  it('0は直前', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(0)).toBe('直前');
+  });
+
+  it('30は余裕あり', () => {
+    expect(AppointmentEntity.getAppointmentLeadTimeLabel(30)).toBe('余裕あり');
+  });
+});

--- a/src/__tests__/domain/entities/ExponentialSmoothing.edge.test.ts
+++ b/src/__tests__/domain/entities/ExponentialSmoothing.edge.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getExponentialSmoothing エッジケース', () => {
+  it('alpha=0.1は非常に安定した平滑化', () => {
+    const result = MathHelper.getExponentialSmoothing([10, 100, 10, 100], 0.1);
+    expect(result[3]).toBeLessThan(50);
+  });
+
+  it('alpha=0.9は元の値に近い', () => {
+    const result = MathHelper.getExponentialSmoothing([10, 100, 10, 100], 0.9);
+    expect(result[3]).toBeGreaterThan(80);
+  });
+
+  it('負の値を含む系列', () => {
+    const result = MathHelper.getExponentialSmoothing([-10, 10, -10, 10], 0.5);
+    expect(result.length).toBe(4);
+    expect(result[0]).toBe(-10);
+  });
+
+  it('全て0の系列', () => {
+    const result = MathHelper.getExponentialSmoothing([0, 0, 0, 0], 0.5);
+    result.forEach((v) => expect(v).toBe(0));
+  });
+
+  it('非常に大きな値', () => {
+    const result = MathHelper.getExponentialSmoothing([1000000, 2000000], 0.5);
+    expect(result[1]).toBe(1500000);
+  });
+
+  it('非常に小さな値', () => {
+    const result = MathHelper.getExponentialSmoothing([0.001, 0.002], 0.5);
+    expect(result.length).toBe(2);
+  });
+
+  it('2要素でalpha=0.5', () => {
+    const result = MathHelper.getExponentialSmoothing([0, 10], 0.5);
+    expect(result[0]).toBe(0);
+    expect(result[1]).toBe(5);
+  });
+
+  it('多数の要素', () => {
+    const values = Array.from({ length: 100 }, (_, i) => Math.sin(i) * 10);
+    const result = MathHelper.getExponentialSmoothing(values, 0.3);
+    expect(result.length).toBe(100);
+  });
+
+  it('最初の値は常に元のまま', () => {
+    expect(MathHelper.getExponentialSmoothing([42, 100, 200], 0.5)[0]).toBe(42);
+    expect(MathHelper.getExponentialSmoothing([42, 100, 200], 0.1)[0]).toBe(42);
+    expect(MathHelper.getExponentialSmoothing([42, 100, 200], 0.9)[0]).toBe(42);
+  });
+
+  it('alpha=-1は0にクランプ', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 10, 20], -1);
+    expect(result).toEqual([1, 1, 1]);
+  });
+
+  it('alpha=2は1にクランプ', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 10, 20], 2);
+    expect(result).toEqual([1, 10, 20]);
+  });
+
+  it('急激な変化の平滑化', () => {
+    const result = MathHelper.getExponentialSmoothing([0, 0, 0, 100, 100, 100], 0.5);
+    expect(result[3]).toBeLessThan(100);
+    expect(result[5]).toBeGreaterThan(result[3]);
+  });
+
+  it('小数第2位まで丸められる', () => {
+    const result = MathHelper.getExponentialSmoothing([1, 3, 7, 2], 0.3);
+    result.forEach((v) => {
+      const str = v.toString();
+      const decimals = str.split('.')[1];
+      expect(!decimals || decimals.length <= 2).toBe(true);
+    });
+  });
+});
+
+describe('MathHelper.getExponentialSmoothingLabel エッジケース', () => {
+  it('境界値0.7は反応的', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0.7)).toBe('反応的');
+  });
+
+  it('境界値0.3はバランス', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0.3)).toBe('バランス');
+  });
+
+  it('境界値0.69はバランス', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0.69)).toBe('バランス');
+  });
+
+  it('境界値0.29は安定的', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0.29)).toBe('安定的');
+  });
+
+  it('0は安定的', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(0)).toBe('安定的');
+  });
+
+  it('1は反応的', () => {
+    expect(MathHelper.getExponentialSmoothingLabel(1)).toBe('反応的');
+  });
+});

--- a/src/__tests__/domain/entities/StockWastageScore.edge.test.ts
+++ b/src/__tests__/domain/entities/StockWastageScore.edge.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getStockWastageScore エッジケース', () => {
+  it('在庫1で残30日は低スコア', () => {
+    const result = MedicationEntity.getStockWastageScore(1, 30);
+    expect(result).toBeLessThan(10);
+  });
+
+  it('在庫100で残1日は高スコア', () => {
+    const result = MedicationEntity.getStockWastageScore(100, 1);
+    expect(result).toBe(100);
+  });
+
+  it('在庫5で残1日は100', () => {
+    expect(MedicationEntity.getStockWastageScore(5, 1)).toBe(100);
+  });
+
+  it('在庫1で残1日は20', () => {
+    expect(MedicationEntity.getStockWastageScore(1, 1)).toBe(20);
+  });
+
+  it('在庫0は常に0', () => {
+    expect(MedicationEntity.getStockWastageScore(0, 1)).toBe(0);
+    expect(MedicationEntity.getStockWastageScore(0, 100)).toBe(0);
+  });
+
+  it('残日数0は常に100（在庫ある場合）', () => {
+    expect(MedicationEntity.getStockWastageScore(1, 0)).toBe(100);
+    expect(MedicationEntity.getStockWastageScore(100, 0)).toBe(100);
+  });
+
+  it('非常に大きな在庫', () => {
+    const result = MedicationEntity.getStockWastageScore(10000, 30);
+    expect(result).toBe(100);
+  });
+
+  it('非常に大きな残日数', () => {
+    const result = MedicationEntity.getStockWastageScore(10, 1000);
+    expect(result).toBeLessThan(5);
+  });
+
+  it('小数の在庫', () => {
+    const result = MedicationEntity.getStockWastageScore(0.5, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MedicationEntity.getStockWastageScore(33, 47);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('在庫増で残日数同じならスコア上がる', () => {
+    const score1 = MedicationEntity.getStockWastageScore(10, 30);
+    const score2 = MedicationEntity.getStockWastageScore(50, 30);
+    expect(score2).toBeGreaterThanOrEqual(score1);
+  });
+
+  it('残日数増で在庫同じならスコア下がる', () => {
+    const score1 = MedicationEntity.getStockWastageScore(50, 10);
+    const score2 = MedicationEntity.getStockWastageScore(50, 60);
+    expect(score1).toBeGreaterThan(score2);
+  });
+
+  it('負の在庫は0', () => {
+    expect(MedicationEntity.getStockWastageScore(-50, 30)).toBe(0);
+  });
+
+  it('負の残日数は100', () => {
+    expect(MedicationEntity.getStockWastageScore(50, -10)).toBe(100);
+  });
+
+  it('在庫5で残日数10', () => {
+    expect(MedicationEntity.getStockWastageScore(5, 10)).toBe(10);
+  });
+});
+
+describe('MedicationEntity.getStockWastageScoreLabel エッジケース', () => {
+  it('境界値70は廃棄リスク高', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(70)).toBe('廃棄リスク高');
+  });
+
+  it('境界値40は注意', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(40)).toBe('注意');
+  });
+
+  it('境界値69は注意', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(69)).toBe('注意');
+  });
+
+  it('境界値39は低リスク', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(39)).toBe('低リスク');
+  });
+
+  it('0は低リスク', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(0)).toBe('低リスク');
+  });
+
+  it('100は廃棄リスク高', () => {
+    expect(MedicationEntity.getStockWastageScoreLabel(100)).toBe('廃棄リスク高');
+  });
+});


### PR DESCRIPTION
## Summary
- ExponentialSmoothing: 各alphaパターン・境界値テスト19件追加
- StockWastageScore: 各在庫/残日数パターン・境界値テスト21件追加
- AppointmentLeadTime: 各リードタイムパターン・境界値テスト22件追加

closes #966

## Test plan
- [x] エッジケーステスト62件全通過
- [x] 全7840テスト通過