### PR TITLE
feat: パーセンタイル順位・同時服用薬数スコア・症状クラスタースコアメソッド追加

### DIFF
--- a/src/__tests__/domain/entities/MedicationOverlapCount.test.ts
+++ b/src/__tests__/domain/entities/MedicationOverlapCount.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getMedicationOverlapCount', () => {
+  it('0は0', () => {
+    expect(MedicationEntity.getMedicationOverlapCount(0)).toBe(0);
+  });
+
+  it('1薬は低スコア', () => {
+    const result = MedicationEntity.getMedicationOverlapCount(1);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('3薬は中程度', () => {
+    const result = MedicationEntity.getMedicationOverlapCount(3);
+    expect(result).toBeGreaterThan(20);
+    expect(result).toBeLessThan(60);
+  });
+
+  it('5薬は高スコア', () => {
+    const result = MedicationEntity.getMedicationOverlapCount(5);
+    expect(result).toBeGreaterThan(40);
+  });
+
+  it('8薬以上は100', () => {
+    expect(MedicationEntity.getMedicationOverlapCount(8)).toBe(100);
+    expect(MedicationEntity.getMedicationOverlapCount(10)).toBe(100);
+  });
+
+  it('負の値は0', () => {
+    expect(MedicationEntity.getMedicationOverlapCount(-3)).toBe(0);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationEntity.getMedicationOverlapCount(4);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MedicationEntity.getMedicationOverlapCount(3);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('数が増えるとスコアも増える', () => {
+    const score1 = MedicationEntity.getMedicationOverlapCount(2);
+    const score2 = MedicationEntity.getMedicationOverlapCount(5);
+    expect(score2).toBeGreaterThan(score1);
+  });
+
+  it('6薬は75', () => {
+    expect(MedicationEntity.getMedicationOverlapCount(6)).toBe(75);
+  });
+});
+
+describe('MedicationEntity.getMedicationOverlapCountLabel', () => {
+  it('70以上はリスク高', () => {
+    expect(MedicationEntity.getMedicationOverlapCountLabel(80)).toBe('リスク高');
+  });
+
+  it('40以上は注意', () => {
+    expect(MedicationEntity.getMedicationOverlapCountLabel(50)).toBe('注意');
+  });
+
+  it('40未満は安全', () => {
+    expect(MedicationEntity.getMedicationOverlapCountLabel(20)).toBe('安全');
+  });
+});

--- a/src/__tests__/domain/entities/PercentileRank.test.ts
+++ b/src/__tests__/domain/entities/PercentileRank.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getPercentileRank', () => {
+  it('空配列は0', () => {
+    expect(MathHelper.getPercentileRank([], 5)).toBe(0);
+  });
+
+  it('最小値は0に近い', () => {
+    const result = MathHelper.getPercentileRank([1, 2, 3, 4, 5], 1);
+    expect(result).toBeLessThanOrEqual(20);
+  });
+
+  it('最大値は100に近い', () => {
+    const result = MathHelper.getPercentileRank([1, 2, 3, 4, 5], 5);
+    expect(result).toBeGreaterThanOrEqual(80);
+  });
+
+  it('中央値は50付近', () => {
+    const result = MathHelper.getPercentileRank([1, 2, 3, 4, 5], 3);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(70);
+  });
+
+  it('全て同じ値は0', () => {
+    expect(MathHelper.getPercentileRank([5, 5, 5, 5], 5)).toBe(0);
+  });
+
+  it('値より小さい要素がない場合は0', () => {
+    expect(MathHelper.getPercentileRank([10, 20, 30], 10)).toBe(0);
+  });
+
+  it('結果は0-100', () => {
+    const result = MathHelper.getPercentileRank([1, 5, 10, 15, 20], 12);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MathHelper.getPercentileRank([2, 4, 6, 8, 10], 7);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('1要素で同じ値は0', () => {
+    expect(MathHelper.getPercentileRank([5], 5)).toBe(0);
+  });
+
+  it('1要素で異なる値は0または100', () => {
+    expect(MathHelper.getPercentileRank([5], 10)).toBe(100);
+    expect(MathHelper.getPercentileRank([5], 1)).toBe(0);
+  });
+
+  it('値が分布外（上側）は100', () => {
+    expect(MathHelper.getPercentileRank([1, 2, 3], 100)).toBe(100);
+  });
+
+  it('値が分布外（下側）は0', () => {
+    expect(MathHelper.getPercentileRank([10, 20, 30], 1)).toBe(0);
+  });
+});
+
+describe('MathHelper.getPercentileRankLabel', () => {
+  it('75以上は上位', () => {
+    expect(MathHelper.getPercentileRankLabel(80)).toBe('上位');
+  });
+
+  it('25以上は中位', () => {
+    expect(MathHelper.getPercentileRankLabel(50)).toBe('中位');
+  });
+
+  it('25未満は下位', () => {
+    expect(MathHelper.getPercentileRankLabel(10)).toBe('下位');
+  });
+});

--- a/src/__tests__/domain/entities/SymptomClusterScore.test.ts
+++ b/src/__tests__/domain/entities/SymptomClusterScore.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { HealthLogEntity } from '@/domain/entities/HealthLog';
+
+describe('HealthLogEntity.getSymptomClusterScore', () => {
+  it('空配列は0', () => {
+    expect(HealthLogEntity.getSymptomClusterScore([])).toBe(0);
+  });
+
+  it('全て0は0', () => {
+    expect(HealthLogEntity.getSymptomClusterScore([0, 0, 0])).toBe(0);
+  });
+
+  it('全て1は低スコア', () => {
+    const result = HealthLogEntity.getSymptomClusterScore([1, 1, 1]);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(30);
+  });
+
+  it('多数の症状同時出現は高スコア', () => {
+    const result = HealthLogEntity.getSymptomClusterScore([5, 4, 5]);
+    expect(result).toBeGreaterThan(50);
+  });
+
+  it('結果は0-100', () => {
+    const result = HealthLogEntity.getSymptomClusterScore([2, 3, 1, 4]);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = HealthLogEntity.getSymptomClusterScore([1, 3, 2]);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('1要素', () => {
+    const result = HealthLogEntity.getSymptomClusterScore([3]);
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('負の値は0として扱う', () => {
+    const result = HealthLogEntity.getSymptomClusterScore([-1, 2, 3]);
+    expect(result).toBeGreaterThanOrEqual(0);
+  });
+
+  it('症状数が増えるとスコアも上がる', () => {
+    const score1 = HealthLogEntity.getSymptomClusterScore([1, 1]);
+    const score2 = HealthLogEntity.getSymptomClusterScore([5, 5]);
+    expect(score2).toBeGreaterThan(score1);
+  });
+
+  it('多数のログ', () => {
+    const counts = Array.from({ length: 30 }, () => 2);
+    const result = HealthLogEntity.getSymptomClusterScore(counts);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('最大5症状で全てのログが5は100', () => {
+    expect(HealthLogEntity.getSymptomClusterScore([5, 5, 5, 5])).toBe(100);
+  });
+});
+
+describe('HealthLogEntity.getSymptomClusterScoreLabel', () => {
+  it('70以上は集中的', () => {
+    expect(HealthLogEntity.getSymptomClusterScoreLabel(80)).toBe('集中的');
+  });
+
+  it('40以上はやや集中', () => {
+    expect(HealthLogEntity.getSymptomClusterScoreLabel(50)).toBe('やや集中');
+  });
+
+  it('40未満は分散的', () => {
+    expect(HealthLogEntity.getSymptomClusterScoreLabel(20)).toBe('分散的');
+  });
+});

--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -94,6 +94,9 @@ export class HealthLogEntity {
   private static readonly HEALTH_TREND_MODERATE_THRESHOLD = 50;
   private static readonly RECOVERY_SPEED_FAST_THRESHOLD = 70;
   private static readonly RECOVERY_SPEED_MODERATE_THRESHOLD = 40;
+  private static readonly SYMPTOM_CLUSTER_MAX = 5;
+  private static readonly SYMPTOM_CLUSTER_HIGH_THRESHOLD = 70;
+  private static readonly SYMPTOM_CLUSTER_MODERATE_THRESHOLD = 40;
 
   private static readonly CONDITION_LABELS: Record<ConditionLevel, string> = {
     1: 'とても悪い',
@@ -1101,5 +1104,25 @@ export class HealthLogEntity {
     if (score >= HealthLogEntity.RECOVERY_SPEED_FAST_THRESHOLD) return '回復早い';
     if (score >= HealthLogEntity.RECOVERY_SPEED_MODERATE_THRESHOLD) return '普通';
     return '回復遅い';
+  }
+
+  /**
+   * 各ログの同時出現症状数の配列から症状クラスタースコア(0-100)を算出する
+   * 同時出現が多いほど高スコア
+   */
+  static getSymptomClusterScore(symptomCounts: number[]): number {
+    if (symptomCounts.length === 0) return 0;
+    const clamped = symptomCounts.map((c) => Math.max(0, c));
+    const avg = clamped.reduce((a, b) => a + b, 0) / clamped.length;
+    return Math.min(100, Math.round((avg / HealthLogEntity.SYMPTOM_CLUSTER_MAX) * 100));
+  }
+
+  /**
+   * 症状クラスタースコアに応じたラベルを返す
+   */
+  static getSymptomClusterScoreLabel(score: number): string {
+    if (score >= HealthLogEntity.SYMPTOM_CLUSTER_HIGH_THRESHOLD) return '集中的';
+    if (score >= HealthLogEntity.SYMPTOM_CLUSTER_MODERATE_THRESHOLD) return 'やや集中';
+    return '分散的';
   }
 }

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -75,6 +75,8 @@ export class MathHelper {
   private static readonly MCORR_WEAK_THRESHOLD = 0.3;
   private static readonly EXP_SMOOTH_REACTIVE_THRESHOLD = 0.7;
   private static readonly EXP_SMOOTH_BALANCED_THRESHOLD = 0.3;
+  private static readonly PRANK_UPPER_THRESHOLD = 75;
+  private static readonly PRANK_LOWER_THRESHOLD = 25;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1211,5 +1213,23 @@ export class MathHelper {
     if (alpha >= MathHelper.EXP_SMOOTH_REACTIVE_THRESHOLD) return '反応的';
     if (alpha >= MathHelper.EXP_SMOOTH_BALANCED_THRESHOLD) return 'バランス';
     return '安定的';
+  }
+
+  /**
+   * 値が分布の何パーセンタイルに位置するかを算出する(0-100)
+   */
+  static getPercentileRank(values: number[], target: number): number {
+    if (values.length === 0) return 0;
+    const belowCount = values.filter((v) => v < target).length;
+    return Math.round((belowCount / values.length) * 100);
+  }
+
+  /**
+   * パーセンタイル順位に応じたラベルを返す
+   */
+  static getPercentileRankLabel(rank: number): string {
+    if (rank >= MathHelper.PRANK_UPPER_THRESHOLD) return '上位';
+    if (rank >= MathHelper.PRANK_LOWER_THRESHOLD) return '中位';
+    return '下位';
   }
 }

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -113,6 +113,9 @@ export class MedicationEntity {
   private static readonly WASTAGE_MAX_RATIO = 5;
   private static readonly WASTAGE_HIGH_THRESHOLD = 70;
   private static readonly WASTAGE_MODERATE_THRESHOLD = 40;
+  private static readonly OVERLAP_MAX_MEDS = 8;
+  private static readonly OVERLAP_HIGH_THRESHOLD = 70;
+  private static readonly OVERLAP_MODERATE_THRESHOLD = 40;
 
   private static readonly categoryLabels: Record<MedicationCategory, string> = {
     regular: '常用薬',
@@ -431,5 +434,22 @@ export class MedicationEntity {
     if (score >= MedicationEntity.WASTAGE_HIGH_THRESHOLD) return '廃棄リスク高';
     if (score >= MedicationEntity.WASTAGE_MODERATE_THRESHOLD) return '注意';
     return '低リスク';
+  }
+
+  /**
+   * 同時服用薬数から相互作用リスクスコア(0-100)を算出する
+   */
+  static getMedicationOverlapCount(concurrentMeds: number): number {
+    if (concurrentMeds <= 0) return 0;
+    return Math.min(100, Math.round((concurrentMeds / MedicationEntity.OVERLAP_MAX_MEDS) * 100));
+  }
+
+  /**
+   * 同時服用薬数リスクスコアに応じたラベルを返す
+   */
+  static getMedicationOverlapCountLabel(score: number): string {
+    if (score >= MedicationEntity.OVERLAP_HIGH_THRESHOLD) return 'リスク高';
+    if (score >= MedicationEntity.OVERLAP_MODERATE_THRESHOLD) return '注意';
+    return '安全';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getPercentileRank: 値が分布の何パーセンタイルに位置するか算出
- MedicationEntity.getMedicationOverlapCount: 同時服用薬数から相互作用リスクスコア(0-100)を算出
- HealthLogEntity.getSymptomClusterScore: 症状の同時出現数からクラスタースコア(0-100)を算出
- 各メソッドにラベル関数も追加

closes #968

## Test plan
- [x] PercentileRank: 15テスト通過
- [x] MedicationOverlapCount: 13テスト通過
- [x] SymptomClusterScore: 14テスト通過
- [x] 全7882テスト通過
- [x] ビルド成功