### PR TITLE
feat: 線形補間・投薬効率スコア・期間別記録密度メソッド追加

### DIFF
--- a/src/__tests__/domain/entities/DosageEfficiency.test.ts
+++ b/src/__tests__/domain/entities/DosageEfficiency.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationEntity } from '@/domain/entities/Medication';
+
+describe('MedicationEntity.getDosageEfficiency', () => {
+  it('処方量0は0', () => {
+    expect(MedicationEntity.getDosageEfficiency(5, 0)).toBe(0);
+  });
+
+  it('実際量0は0', () => {
+    expect(MedicationEntity.getDosageEfficiency(0, 10)).toBe(0);
+  });
+
+  it('同量は100', () => {
+    expect(MedicationEntity.getDosageEfficiency(10, 10)).toBe(100);
+  });
+
+  it('半分は50', () => {
+    expect(MedicationEntity.getDosageEfficiency(5, 10)).toBe(50);
+  });
+
+  it('処方以上は100にクランプ', () => {
+    expect(MedicationEntity.getDosageEfficiency(15, 10)).toBe(100);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationEntity.getDosageEfficiency(7, 10);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MedicationEntity.getDosageEfficiency(3, 7);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('負の実際量は0', () => {
+    expect(MedicationEntity.getDosageEfficiency(-5, 10)).toBe(0);
+  });
+
+  it('負の処方量は0', () => {
+    expect(MedicationEntity.getDosageEfficiency(5, -10)).toBe(0);
+  });
+
+  it('小数値', () => {
+    const result = MedicationEntity.getDosageEfficiency(2.5, 5);
+    expect(result).toBe(50);
+  });
+
+  it('実際量が増えるとスコアも上がる', () => {
+    const score1 = MedicationEntity.getDosageEfficiency(3, 10);
+    const score2 = MedicationEntity.getDosageEfficiency(7, 10);
+    expect(score2).toBeGreaterThan(score1);
+  });
+});
+
+describe('MedicationEntity.getDosageEfficiencyLabel', () => {
+  it('80以上は良好', () => {
+    expect(MedicationEntity.getDosageEfficiencyLabel(90)).toBe('良好');
+  });
+
+  it('50以上は普通', () => {
+    expect(MedicationEntity.getDosageEfficiencyLabel(60)).toBe('普通');
+  });
+
+  it('50未満は不足', () => {
+    expect(MedicationEntity.getDosageEfficiencyLabel(30)).toBe('不足');
+  });
+});

--- a/src/__tests__/domain/entities/LinearInterpolation.test.ts
+++ b/src/__tests__/domain/entities/LinearInterpolation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { MathHelper } from '@/domain/entities/MathHelper';
+
+describe('MathHelper.getLinearInterpolation', () => {
+  it('t=0はy1', () => {
+    expect(MathHelper.getLinearInterpolation(10, 20, 0)).toBe(10);
+  });
+
+  it('t=1はy2', () => {
+    expect(MathHelper.getLinearInterpolation(10, 20, 1)).toBe(20);
+  });
+
+  it('t=0.5は中間値', () => {
+    expect(MathHelper.getLinearInterpolation(0, 100, 0.5)).toBe(50);
+  });
+
+  it('t=0.25は1/4の位置', () => {
+    expect(MathHelper.getLinearInterpolation(0, 100, 0.25)).toBe(25);
+  });
+
+  it('同じ値の場合は常にその値', () => {
+    expect(MathHelper.getLinearInterpolation(5, 5, 0.3)).toBe(5);
+    expect(MathHelper.getLinearInterpolation(5, 5, 0.7)).toBe(5);
+  });
+
+  it('負の値でも動作', () => {
+    expect(MathHelper.getLinearInterpolation(-10, 10, 0.5)).toBe(0);
+  });
+
+  it('t<0はy1にクランプ', () => {
+    expect(MathHelper.getLinearInterpolation(10, 20, -0.5)).toBe(10);
+  });
+
+  it('t>1はy2にクランプ', () => {
+    expect(MathHelper.getLinearInterpolation(10, 20, 1.5)).toBe(20);
+  });
+
+  it('小数第2位まで丸められる', () => {
+    const result = MathHelper.getLinearInterpolation(1, 3, 0.33);
+    const str = result.toString();
+    const decimals = str.split('.')[1];
+    expect(!decimals || decimals.length <= 2).toBe(true);
+  });
+
+  it('y1 > y2でも動作', () => {
+    expect(MathHelper.getLinearInterpolation(100, 0, 0.5)).toBe(50);
+  });
+
+  it('大きな値', () => {
+    expect(MathHelper.getLinearInterpolation(0, 1000000, 0.5)).toBe(500000);
+  });
+});
+
+describe('MathHelper.getLinearInterpolationLabel', () => {
+  it('0.7以上は上位', () => {
+    expect(MathHelper.getLinearInterpolationLabel(0.8)).toBe('上位');
+  });
+
+  it('0.3以上は中位', () => {
+    expect(MathHelper.getLinearInterpolationLabel(0.5)).toBe('中位');
+  });
+
+  it('0.3未満は下位', () => {
+    expect(MathHelper.getLinearInterpolationLabel(0.1)).toBe('下位');
+  });
+});

--- a/src/__tests__/domain/entities/RecordDensityByPeriod.test.ts
+++ b/src/__tests__/domain/entities/RecordDensityByPeriod.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+
+describe('MedicationRecordEntity.getRecordDensityByPeriod', () => {
+  it('記録0件は0', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriod(0, 30)).toBe(0);
+  });
+
+  it('日数0は0', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriod(10, 0)).toBe(0);
+  });
+
+  it('両方0は0', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriod(0, 0)).toBe(0);
+  });
+
+  it('1日1件は低スコア', () => {
+    const result = MedicationRecordEntity.getRecordDensityByPeriod(30, 30);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThan(50);
+  });
+
+  it('1日3件は中程度', () => {
+    const result = MedicationRecordEntity.getRecordDensityByPeriod(90, 30);
+    expect(result).toBeGreaterThan(30);
+    expect(result).toBeLessThan(80);
+  });
+
+  it('1日5件以上は100', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriod(150, 30)).toBe(100);
+  });
+
+  it('結果は0-100', () => {
+    const result = MedicationRecordEntity.getRecordDensityByPeriod(60, 30);
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it('結果は整数', () => {
+    const result = MedicationRecordEntity.getRecordDensityByPeriod(45, 30);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('負の記録数は0', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriod(-10, 30)).toBe(0);
+  });
+
+  it('記録が増えるとスコアも増える', () => {
+    const score1 = MedicationRecordEntity.getRecordDensityByPeriod(10, 30);
+    const score2 = MedicationRecordEntity.getRecordDensityByPeriod(50, 30);
+    expect(score2).toBeGreaterThan(score1);
+  });
+
+  it('1日分', () => {
+    const result = MedicationRecordEntity.getRecordDensityByPeriod(3, 1);
+    expect(result).toBeGreaterThan(0);
+  });
+});
+
+describe('MedicationRecordEntity.getRecordDensityByPeriodLabel', () => {
+  it('70以上は高密度', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriodLabel(80)).toBe('高密度');
+  });
+
+  it('40以上は標準', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriodLabel(50)).toBe('標準');
+  });
+
+  it('40未満は低密度', () => {
+    expect(MedicationRecordEntity.getRecordDensityByPeriodLabel(20)).toBe('低密度');
+  });
+});

--- a/src/domain/entities/MathHelper.ts
+++ b/src/domain/entities/MathHelper.ts
@@ -77,6 +77,8 @@ export class MathHelper {
   private static readonly EXP_SMOOTH_BALANCED_THRESHOLD = 0.3;
   private static readonly PRANK_UPPER_THRESHOLD = 75;
   private static readonly PRANK_LOWER_THRESHOLD = 25;
+  private static readonly LERP_UPPER_THRESHOLD = 0.7;
+  private static readonly LERP_LOWER_THRESHOLD = 0.3;
   /**
    * パーセントを算出(0-100%)
    * @param numerator 分子
@@ -1230,6 +1232,25 @@ export class MathHelper {
   static getPercentileRankLabel(rank: number): string {
     if (rank >= MathHelper.PRANK_UPPER_THRESHOLD) return '上位';
     if (rank >= MathHelper.PRANK_LOWER_THRESHOLD) return '中位';
+    return '下位';
+  }
+
+  /**
+   * 2点間の線形補間値を算出する
+   * t: 補間パラメータ(0-1)、0ならy1、1ならy2
+   */
+  static getLinearInterpolation(y1: number, y2: number, t: number): number {
+    const clampedT = Math.max(0, Math.min(1, t));
+    const result = y1 + (y2 - y1) * clampedT;
+    return Math.round(result * 100) / 100;
+  }
+
+  /**
+   * 補間パラメータに応じたラベルを返す
+   */
+  static getLinearInterpolationLabel(t: number): string {
+    if (t >= MathHelper.LERP_UPPER_THRESHOLD) return '上位';
+    if (t >= MathHelper.LERP_LOWER_THRESHOLD) return '中位';
     return '下位';
   }
 }

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -116,6 +116,8 @@ export class MedicationEntity {
   private static readonly OVERLAP_MAX_MEDS = 8;
   private static readonly OVERLAP_HIGH_THRESHOLD = 70;
   private static readonly OVERLAP_MODERATE_THRESHOLD = 40;
+  private static readonly DOSAGE_EFF_GOOD_THRESHOLD = 80;
+  private static readonly DOSAGE_EFF_MODERATE_THRESHOLD = 50;
 
   private static readonly categoryLabels: Record<MedicationCategory, string> = {
     regular: '常用薬',
@@ -451,5 +453,22 @@ export class MedicationEntity {
     if (score >= MedicationEntity.OVERLAP_HIGH_THRESHOLD) return 'リスク高';
     if (score >= MedicationEntity.OVERLAP_MODERATE_THRESHOLD) return '注意';
     return '安全';
+  }
+
+  /**
+   * 実際の服薬量と処方量の比率から投薬効率(0-100)を算出する
+   */
+  static getDosageEfficiency(actualDose: number, prescribedDose: number): number {
+    if (actualDose <= 0 || prescribedDose <= 0) return 0;
+    return Math.min(100, Math.round((actualDose / prescribedDose) * 100));
+  }
+
+  /**
+   * 投薬効率に応じたラベルを返す
+   */
+  static getDosageEfficiencyLabel(efficiency: number): string {
+    if (efficiency >= MedicationEntity.DOSAGE_EFF_GOOD_THRESHOLD) return '良好';
+    if (efficiency >= MedicationEntity.DOSAGE_EFF_MODERATE_THRESHOLD) return '普通';
+    return '不足';
   }
 }

--- a/src/domain/entities/MedicationRecord.ts
+++ b/src/domain/entities/MedicationRecord.ts
@@ -65,6 +65,9 @@ export class MedicationRecordEntity {
   private static readonly DOSE_TIMING_MODERATE_THRESHOLD = 50;
   private static readonly RECORD_CONSECUTIVE_EXCELLENT_THRESHOLD = 80;
   private static readonly RECORD_CONSECUTIVE_GOOD_THRESHOLD = 50;
+  private static readonly DENSITY_MAX_PER_DAY = 5;
+  private static readonly DENSITY_HIGH_THRESHOLD = 70;
+  private static readonly DENSITY_MODERATE_THRESHOLD = 40;
 
   /**
    * 記録を日付ごとにグループ化（新しい順）
@@ -936,5 +939,23 @@ export class MedicationRecordEntity {
     if (rate >= MedicationRecordEntity.RECORD_CONSECUTIVE_EXCELLENT_THRESHOLD) return '優秀';
     if (rate >= MedicationRecordEntity.RECORD_CONSECUTIVE_GOOD_THRESHOLD) return '良好';
     return '要改善';
+  }
+
+  /**
+   * 期間あたりの記録件数から記録密度スコア(0-100)を算出する
+   */
+  static getRecordDensityByPeriod(recordCount: number, days: number): number {
+    if (recordCount <= 0 || days <= 0) return 0;
+    const dailyRate = recordCount / days;
+    return Math.min(100, Math.round((dailyRate / MedicationRecordEntity.DENSITY_MAX_PER_DAY) * 100));
+  }
+
+  /**
+   * 記録密度スコアに応じたラベルを返す
+   */
+  static getRecordDensityByPeriodLabel(score: number): string {
+    if (score >= MedicationRecordEntity.DENSITY_HIGH_THRESHOLD) return '高密度';
+    if (score >= MedicationRecordEntity.DENSITY_MODERATE_THRESHOLD) return '標準';
+    return '低密度';
   }
 }


### PR DESCRIPTION
## Summary
- MathHelper.getLinearInterpolation: 2点間の線形補間値を算出
- MedicationEntity.getDosageEfficiency: 実際量と処方量の比率から投薬効率(0-100)を算出
- MedicationRecordEntity.getRecordDensityByPeriod: 期間あたりの記録密度スコア(0-100)を算出
- 各メソッドにラベル関数も追加

closes #972

## Test plan
- [x] LinearInterpolation: 14テスト通過
- [x] DosageEfficiency: 14テスト通過
- [x] RecordDensityByPeriod: 14テスト通過
- [x] 全7987テスト通過
- [x] ビルド成功