### PR TITLE
feat: 在庫アラートを達成率の前に移動し曜日ラベルを下揃えに修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,11 +67,11 @@ export default function Dashboard() {
           onMarkCompleted={markAsCompleted}
         />
 
+        <StockAlertList alerts={alerts} isLoading={alertsLoading} />
+
         <AdherenceStatsCard stats={stats} isLoading={statsLoading} />
 
         <AdherenceTrendCard trend={trend} isLoading={trendLoading} />
-
-        <StockAlertList alerts={alerts} isLoading={alertsLoading} />
 
         <UpcomingAppointments
           appointments={appointments}

--- a/src/components/dashboard/AdherenceTrendCard.tsx
+++ b/src/components/dashboard/AdherenceTrendCard.tsx
@@ -32,7 +32,7 @@ export const AdherenceTrendCard: React.FC<AdherenceTrendCardProps> = ({ trend, i
         </div>
       </div>
 
-      <div className="flex justify-between mb-2">
+      <div className="flex justify-between items-end mb-2">
         {trend.dayOfWeekStats.map((stat) => (
           <div key={stat.day} className="flex flex-col items-center">
             <div


### PR DESCRIPTION
## Summary
- ダッシュボードで在庫アラートをお薬の達成率の前に表示するよう順序変更
- 週間達成率チャートの曜日ラベル(日,月,火...)をバーの高さに関わらず下揃えに修正

## Test plan
- [ ] 在庫アラートが達成率カードより上に表示されること
- [ ] 週間チャートの曜日ラベルが下揃えで表示されること