### PR TITLE
feat: ペット向け症状項目を追加

### DIFF
--- a/src/domain/entities/HealthLog.ts
+++ b/src/domain/entities/HealthLog.ts
@@ -20,6 +20,13 @@ export const SYMPTOM_OPTIONS = [
   'joint_pain',
   'insomnia',
   'menstrual_pain',
+  'vomiting',
+  'diarrhea',
+  'bloody_urine',
+  'bleeding',
+  'eye_discharge',
+  'loss_of_appetite',
+  'lethargy',
 ] as const;
 export type SymptomType = (typeof SYMPTOM_OPTIONS)[number];
 
@@ -35,6 +42,13 @@ export const SYMPTOM_LABELS: Record<SymptomType, string> = {
   joint_pain: '関節痛',
   insomnia: '不眠',
   menstrual_pain: '生理痛',
+  vomiting: '嘔吐',
+  diarrhea: '下痢',
+  bloody_urine: '血尿',
+  bleeding: '出血',
+  eye_discharge: '目ヤニ',
+  loss_of_appetite: '食欲不振',
+  lethargy: '元気がない',
 };
 
 export interface HealthLog {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -142,7 +142,7 @@ export const updateAppointmentSchema = z.object({
 export const createHealthLogSchema = z.object({
   memberId: idField,
   conditionLevel: z.number().int().min(1, '体調レベルは1以上を指定してください').max(5, '体調レベルは5以下を指定してください'),
-  symptoms: z.array(z.enum(['headache', 'fever', 'fatigue', 'nausea', 'stomachache', 'dizziness', 'cough', 'runny_nose', 'joint_pain', 'insomnia', 'menstrual_pain'])).max(10).optional(),
+  symptoms: z.array(z.enum(['headache', 'fever', 'fatigue', 'nausea', 'stomachache', 'dizziness', 'cough', 'runny_nose', 'joint_pain', 'insomnia', 'menstrual_pain', 'vomiting', 'diarrhea', 'bloody_urine', 'bleeding', 'eye_discharge', 'loss_of_appetite', 'lethargy'])).max(10).optional(),
   notes: z.string().trim().max(500).optional(),
 });
 


### PR DESCRIPTION
## Summary
- 体調記録の症状選択に7項目追加: 嘔吐、下痢、血尿、出血、目ヤニ、食欲不振、元気がない
- SYMPTOM_OPTIONS、SYMPTOM_LABELS、Zodバリデーションスキーマを更新

## Test plan
- [ ] 体調記録画面で新しい症状項目が表示されること
- [ ] 新しい症状を選択して記録できること