### PR TITLE
fix: 薬作成時にデフォルトスケジュールを自動作成

### DIFF
--- a/src/__tests__/components/schedules/ScheduleForm.test.tsx
+++ b/src/__tests__/components/schedules/ScheduleForm.test.tsx
@@ -17,8 +17,14 @@ describe('ScheduleForm', () => {
     expect(screen.getByText('スケジュールを追加')).toBeInTheDocument();
   });
 
-  it('曜日ボタンが全て表示される', () => {
+  it('毎日ボタンがデフォルトで選択されている', () => {
     render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    expect(screen.getByLabelText('毎日')).toBeChecked();
+  });
+
+  it('毎日を解除すると曜日ボタンが表示される', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByLabelText('毎日'));
     expect(screen.getByLabelText('月')).toBeInTheDocument();
     expect(screen.getByLabelText('火')).toBeInTheDocument();
     expect(screen.getByLabelText('水')).toBeInTheDocument();
@@ -28,14 +34,26 @@ describe('ScheduleForm', () => {
     expect(screen.getByLabelText('日')).toBeInTheDocument();
   });
 
+  it('毎日選択時に送信すると空のdaysOfWeekで呼ばれる', () => {
+    render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByText('スケジュールを追加'));
+    expect(mockOnSubmit).toHaveBeenCalledWith({
+      scheduledTime: '08:00',
+      daysOfWeek: [],
+      reminderMinutesBefore: 10,
+    });
+  });
+
   it('曜日を選択せずに送信するとonSubmitが呼ばれない', () => {
     render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByLabelText('毎日'));
     fireEvent.click(screen.getByText('スケジュールを追加'));
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 
   it('曜日を選択して送信するとonSubmitが正しいデータで呼ばれる', () => {
     render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByLabelText('毎日'));
     fireEvent.click(screen.getByLabelText('月'));
     fireEvent.click(screen.getByLabelText('水'));
     fireEvent.click(screen.getByText('スケジュールを追加'));
@@ -48,6 +66,7 @@ describe('ScheduleForm', () => {
 
   it('曜日のトグルが正しく動作する', () => {
     render(<ScheduleForm onSubmit={mockOnSubmit} />);
+    fireEvent.click(screen.getByLabelText('毎日'));
     const mondayCheckbox = screen.getByLabelText('月');
     fireEvent.click(mondayCheckbox);
     expect(mondayCheckbox).toBeChecked();
@@ -65,8 +84,7 @@ describe('ScheduleForm', () => {
 
   it('送信後にフォームがリセットされる', () => {
     render(<ScheduleForm onSubmit={mockOnSubmit} />);
-    fireEvent.click(screen.getByLabelText('金'));
     fireEvent.click(screen.getByText('スケジュールを追加'));
-    expect(screen.getByLabelText('金')).not.toBeChecked();
+    expect(screen.getByLabelText('毎日')).toBeChecked();
   });
 });

--- a/src/app/api/medications/route.ts
+++ b/src/app/api/medications/route.ts
@@ -40,6 +40,19 @@ export async function POST(request: Request) {
         isActive: true,
       },
     });
+
+    await prisma.schedule.create({
+      data: {
+        userId,
+        medicationId: medication.id,
+        memberId: parsed.data.memberId,
+        scheduledTime: '08:00',
+        daysOfWeek: [],
+        isEnabled: true,
+        reminderMinutesBefore: 5,
+      },
+    });
+
     return created(medication);
   })();
 }

--- a/src/components/schedules/ScheduleForm.tsx
+++ b/src/components/schedules/ScheduleForm.tsx
@@ -24,6 +24,7 @@ const DAY_OPTIONS: { value: DayOfWeek; label: string }[] = [
 export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
   const [scheduledTime, setScheduledTime] = useState('08:00');
   const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
+  const [isEveryDay, setIsEveryDay] = useState(true);
   const [reminderMinutes, setReminderMinutes] = useState('10');
 
   const toggleDay = (day: DayOfWeek) => {
@@ -32,19 +33,30 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
     );
   };
 
+  const toggleEveryDay = () => {
+    if (isEveryDay) {
+      setIsEveryDay(false);
+      setSelectedDays([]);
+    } else {
+      setIsEveryDay(true);
+      setSelectedDays([]);
+    }
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (selectedDays.length === 0) return;
+    if (!isEveryDay && selectedDays.length === 0) return;
 
     onSubmit({
       scheduledTime,
-      daysOfWeek: selectedDays,
+      daysOfWeek: isEveryDay ? [] : selectedDays,
       reminderMinutesBefore: parseInt(reminderMinutes, 10) || 0,
     });
 
     setScheduledTime('08:00');
     setSelectedDays([]);
+    setIsEveryDay(true);
     setReminderMinutes('10');
   };
 
@@ -65,27 +77,50 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
 
       <div>
         <span className="block text-sm font-medium text-gray-700 mb-2">曜日</span>
-        <div className="flex flex-wrap gap-2">
-          {DAY_OPTIONS.map(({ value, label }) => (
-            <label
-              key={value}
-              className={`flex items-center justify-center w-10 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
-                selectedDays.includes(value)
-                  ? 'bg-blue-600 text-white border-blue-600'
-                  : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
-              }`}
-            >
-              <input
-                type="checkbox"
-                checked={selectedDays.includes(value)}
-                onChange={() => toggleDay(value)}
-                className="sr-only"
-                aria-label={label}
-              />
-              {label}
-            </label>
-          ))}
+        <div className="flex flex-wrap gap-2 mb-2">
+          <label
+            className={`flex items-center justify-center px-3 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
+              isEveryDay
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+            }`}
+          >
+            <input
+              type="checkbox"
+              checked={isEveryDay}
+              onChange={toggleEveryDay}
+              className="sr-only"
+              aria-label="毎日"
+            />
+            毎日
+          </label>
         </div>
+        {!isEveryDay && (
+          <div className="flex flex-wrap gap-2">
+            {DAY_OPTIONS.map(({ value, label }) => (
+              <label
+                key={value}
+                className={`flex items-center justify-center w-10 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
+                  selectedDays.includes(value)
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedDays.includes(value)}
+                  onChange={() => toggleDay(value)}
+                  className="sr-only"
+                  aria-label={label}
+                />
+                {label}
+              </label>
+            ))}
+            {!isEveryDay && selectedDays.length === 0 && (
+              <p className="w-full text-sm text-red-500 mt-1">曜日を選択してください</p>
+            )}
+          </div>
+        )}
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- 薬を作成した際にデフォルトスケジュール（毎日08:00）を自動作成するように変更
- ScheduleFormに「毎日」トグルボタンを追加（デフォルトで選択済み）
- 毎日を解除すると個別の曜日選択UIが表示される
- 曜日未選択時にバリデーションメッセージを表示
- 既存のスケジュール未設定の薬に対してデフォルトスケジュールをDBに作成済み

## 原因
薬の作成とスケジュールの作成が別ステップだったため、薬を追加してもスケジュールを作成しないとダッシュボードの「今日の予定」に表示されなかった。

## Test plan
- [x] ScheduleFormのテスト更新・全パス（9テスト）
- [x] 全テスト8055件パス
- [x] TypeScriptチェックパス
- [x] ビルド成功