### PR TITLE
feat: 薬編集の自動スクロール・カテゴリ追加・ワクチン記録改善

### DIFF
--- a/src/__tests__/domain/entities/MedicationEntity.edge.test.ts
+++ b/src/__tests__/domain/entities/MedicationEntity.edge.test.ts
@@ -131,9 +131,9 @@ describe('MedicationEntity エッジケーステスト', () => {
   });
 
   describe('getAllCategories', () => {
-    it('6カテゴリ分のデータを返す', () => {
+    it('9カテゴリ分のデータを返す', () => {
       const categories = MedicationEntity.getAllCategories();
-      expect(categories).toHaveLength(6);
+      expect(categories).toHaveLength(9);
     });
 
     it('各カテゴリにidとlabelが含まれる', () => {

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useMedications } from '@/presentation/hooks/useMedications';
@@ -21,6 +21,13 @@ function MemberMedications({ member, categoryFilter }: { member: Member; categor
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
   const [editingMed, setEditingMed] = useState<Medication | null>(null);
+  const editFormRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (editingMed && editFormRef.current) {
+      editFormRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [editingMed]);
 
   const filteredMedications = useMemo(
     () => categoryFilter ? medications.filter((m) => m.medication.category === categoryFilter) : medications,
@@ -74,7 +81,7 @@ function MemberMedications({ member, categoryFilter }: { member: Member; categor
       </div>
 
       {editingMed && (
-        <div className="mb-3 bg-white rounded-lg shadow-md p-4 border border-primary-200">
+        <div ref={editFormRef} className="mb-3 bg-white rounded-lg shadow-md p-4 border border-primary-200">
           <h3 className="text-sm font-semibold text-gray-700 mb-3">薬の編集</h3>
           <MedicationForm
             onSubmit={handleUpdate}

--- a/src/components/appointments/AppointmentForm.tsx
+++ b/src/components/appointments/AppointmentForm.tsx
@@ -143,7 +143,7 @@ export const AppointmentForm: React.FC<AppointmentFormProps> = ({ members, hospi
 
       <div>
         <label htmlFor="apt-notes" className="block text-sm font-medium text-gray-700 mb-1">
-          メモ（任意）
+          {type === 'vaccination' ? 'ワクチン名' : 'メモ'}（任意）
         </label>
         <textarea
           id="apt-notes"
@@ -151,7 +151,7 @@ export const AppointmentForm: React.FC<AppointmentFormProps> = ({ members, hospi
           onChange={(e) => setNotes(e.target.value)}
           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           rows={2}
-          placeholder="メモを入力"
+          placeholder={type === 'vaccination' ? '例: 混合ワクチン, 狂犬病ワクチン' : 'メモを入力'}
         />
       </div>
 

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -89,6 +89,9 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
           <option value="supplement">サプリメント</option>
           <option value="prn">頓服薬</option>
           <option value="inhaler">吸入薬</option>
+          <option value="eye_drops">目薬</option>
+          <option value="patch">湿布</option>
+          <option value="topical">塗り薬</option>
           <option value="flea_tick">ノミ・ダニ薬</option>
           <option value="heartworm">フィラリア薬</option>
         </select>

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -10,7 +10,7 @@ import { BackendAppointment, BackendHealthLog, BackendHospital, BackendMember, B
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
 const VALID_MEMBER_TYPES: readonly string[] = ['human', 'pet'];
-const VALID_MEDICATION_CATEGORIES: readonly string[] = ['regular', 'supplement', 'prn', 'inhaler', 'flea_tick', 'heartworm'];
+const VALID_MEDICATION_CATEGORIES: readonly string[] = ['regular', 'supplement', 'prn', 'inhaler', 'eye_drops', 'patch', 'topical', 'flea_tick', 'heartworm'];
 const VALID_DAYS_OF_WEEK: readonly string[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 const VALID_PET_TYPES: readonly string[] = ['dog', 'cat', 'rabbit', 'bird', 'other'];
 

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -9,6 +9,9 @@ export type MedicationCategory =
   | 'supplement'
   | 'prn'
   | 'inhaler'
+  | 'eye_drops'
+  | 'patch'
+  | 'topical'
   | 'flea_tick'
   | 'heartworm';
 
@@ -124,6 +127,9 @@ export class MedicationEntity {
     supplement: 'サプリメント',
     prn: '頓服薬',
     inhaler: '吸入薬',
+    eye_drops: '目薬',
+    patch: '湿布',
+    topical: '塗り薬',
     flea_tick: 'ノミ・ダニ薬',
     heartworm: 'フィラリア薬',
   };


### PR DESCRIPTION
## Summary
- 薬の編集ペンマーク押下時に編集フォームまで自動スクロールするように改善
- お薬カテゴリに目薬・湿布・塗り薬の3種類を追加
- 通院フォームで種別「予防接種」選択時にメモ欄のラベルを「ワクチン名」に変更しプレースホルダーを追加

## Test plan
- [x] 全テスト8055件パス
- [x] TypeScriptチェックパス
- [x] ビルド成功