### PR TITLE
病院管理に診療科・担当医フィールドを追加しラベルを変更

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Hospital {
   address      String?
   phoneNumber  String?
   department   String?
+  doctorName   String?
   notes        String?
   createdAt    DateTime @default(now())
 

--- a/src/app/api/hospitals/[hospitalId]/route.ts
+++ b/src/app/api/hospitals/[hospitalId]/route.ts
@@ -34,6 +34,8 @@ export async function PUT(request: Request, { params }: { params: Promise<{ hosp
             hospitalType: parsed.data.type,
             address: parsed.data.address,
             phoneNumber: parsed.data.phone,
+            department: parsed.data.department,
+            doctorName: parsed.data.doctorName,
             notes: parsed.data.notes,
           },
         });

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -33,6 +33,8 @@ export async function POST(request: Request) {
         hospitalType: parsed.data.type,
         address: parsed.data.address,
         phoneNumber: parsed.data.phone,
+        department: parsed.data.department,
+        doctorName: parsed.data.doctorName,
         notes: parsed.data.notes,
       },
     });

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -151,7 +151,7 @@ export default function AppointmentsPage() {
           >
             <div className="flex items-center space-x-3">
               <MapPin size={18} className="text-primary-600" />
-              <span className="text-sm font-medium text-gray-700">病院管理</span>
+              <span className="text-sm font-medium text-gray-700">かかりつけ医(病院)</span>
             </div>
             <span className="text-xs text-gray-400">{hospitals.length}件</span>
           </Link>

--- a/src/app/hospitals/page.tsx
+++ b/src/app/hospitals/page.tsx
@@ -34,7 +34,7 @@ export default function HospitalsPage() {
             >
               <ArrowLeft size={20} />
             </button>
-            <h1 className="text-xl font-bold text-primary-600">病院管理</h1>
+            <h1 className="text-xl font-bold text-primary-600">かかりつけ医(病院)</h1>
           </div>
           <button
             onClick={() => setShowForm(!showForm)}

--- a/src/components/hospitals/HospitalForm.tsx
+++ b/src/components/hospitals/HospitalForm.tsx
@@ -6,6 +6,8 @@ export interface HospitalFormData {
   name: string;
   address?: string;
   phone?: string;
+  department?: string;
+  doctorName?: string;
   notes?: string;
 }
 
@@ -17,6 +19,8 @@ export const HospitalForm: React.FC<HospitalFormProps> = ({ onSubmit }) => {
   const [name, setName] = useState('');
   const [address, setAddress] = useState('');
   const [phone, setPhone] = useState('');
+  const [department, setDepartment] = useState('');
+  const [doctorName, setDoctorName] = useState('');
   const [notes, setNotes] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -27,12 +31,16 @@ export const HospitalForm: React.FC<HospitalFormProps> = ({ onSubmit }) => {
       name: name.trim(),
       address: address.trim() || undefined,
       phone: phone.trim() || undefined,
+      department: department.trim() || undefined,
+      doctorName: doctorName.trim() || undefined,
       notes: notes.trim() || undefined,
     });
 
     setName('');
     setAddress('');
     setPhone('');
+    setDepartment('');
+    setDoctorName('');
     setNotes('');
   };
 
@@ -78,6 +86,34 @@ export const HospitalForm: React.FC<HospitalFormProps> = ({ onSubmit }) => {
           onChange={(e) => setPhone(e.target.value)}
           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           placeholder="電話番号を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="hosp-department" className="block text-sm font-medium text-gray-700 mb-1">
+          診療科（任意）
+        </label>
+        <input
+          id="hosp-department"
+          type="text"
+          value={department}
+          onChange={(e) => setDepartment(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="例: 内科、外科、小児科"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="hosp-doctorName" className="block text-sm font-medium text-gray-700 mb-1">
+          担当医（任意）
+        </label>
+        <input
+          id="hosp-doctorName"
+          type="text"
+          value={doctorName}
+          onChange={(e) => setDoctorName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="担当医の名前を入力"
         />
       </div>
 

--- a/src/components/hospitals/HospitalList.tsx
+++ b/src/components/hospitals/HospitalList.tsx
@@ -49,6 +49,8 @@ const HospitalCard: React.FC<HospitalCardProps> = React.memo(({ hospital, onUpda
   const [editName, setEditName] = useState(hospital.name);
   const [editAddress, setEditAddress] = useState(hospital.address || '');
   const [editPhone, setEditPhone] = useState(hospital.phoneNumber || '');
+  const [editDepartment, setEditDepartment] = useState(hospital.department || '');
+  const [editDoctorName, setEditDoctorName] = useState(hospital.doctorName || '');
   const [editNotes, setEditNotes] = useState(hospital.notes || '');
 
   const handleSave = async () => {
@@ -57,6 +59,8 @@ const HospitalCard: React.FC<HospitalCardProps> = React.memo(({ hospital, onUpda
       name: editName.trim(),
       address: editAddress.trim() || undefined,
       phone: editPhone.trim() || undefined,
+      department: editDepartment.trim() || undefined,
+      doctorName: editDoctorName.trim() || undefined,
       notes: editNotes.trim() || undefined,
     });
     setIsEditing(false);
@@ -66,6 +70,8 @@ const HospitalCard: React.FC<HospitalCardProps> = React.memo(({ hospital, onUpda
     setEditName(hospital.name);
     setEditAddress(hospital.address || '');
     setEditPhone(hospital.phoneNumber || '');
+    setEditDepartment(hospital.department || '');
+    setEditDoctorName(hospital.doctorName || '');
     setEditNotes(hospital.notes || '');
     setIsEditing(false);
   };
@@ -101,6 +107,26 @@ const HospitalCard: React.FC<HospitalCardProps> = React.memo(({ hospital, onUpda
             onChange={(e) => setEditPhone(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
             placeholder="電話番号を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">診療科</label>
+          <input
+            type="text"
+            value={editDepartment}
+            onChange={(e) => setEditDepartment(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            placeholder="例: 内科、外科、小児科"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">担当医</label>
+          <input
+            type="text"
+            value={editDoctorName}
+            onChange={(e) => setEditDoctorName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            placeholder="担当医の名前を入力"
           />
         </div>
         <div>
@@ -151,6 +177,8 @@ const HospitalCard: React.FC<HospitalCardProps> = React.memo(({ hospital, onUpda
                   <span>{hospital.phoneNumber}</span>
                 </p>
               )}
+              {hospital.department && <p>{hospital.department}</p>}
+              {hospital.doctorName && <p>担当医: {hospital.doctorName}</p>}
               {hospital.notes && <p className="text-gray-400">{hospital.notes}</p>}
             </div>
           </div>

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -69,6 +69,8 @@ export function toHospital(b: BackendHospital): Hospital {
     hospitalType: b.hospitalType,
     address: b.address,
     phoneNumber: b.phoneNumber,
+    department: b.department,
+    doctorName: b.doctorName,
     notes: b.notes,
     createdAt: new Date(b.createdAt),
   };

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -45,6 +45,8 @@ export interface BackendHospital {
   hospitalType?: string;
   address?: string;
   phoneNumber?: string;
+  department?: string;
+  doctorName?: string;
   notes?: string;
   createdAt: string;
 }

--- a/src/domain/entities/Hospital.ts
+++ b/src/domain/entities/Hospital.ts
@@ -11,6 +11,8 @@ export interface Hospital {
   readonly hospitalType?: string;
   readonly address?: string;
   readonly phoneNumber?: string;
+  readonly department?: string;
+  readonly doctorName?: string;
   readonly notes?: string;
   readonly createdAt: Date;
 }

--- a/src/domain/repositories/HospitalRepository.ts
+++ b/src/domain/repositories/HospitalRepository.ts
@@ -9,6 +9,8 @@ export interface CreateHospitalInput {
   type?: string;
   address?: string;
   phone?: string;
+  department?: string;
+  doctorName?: string;
   notes?: string;
 }
 
@@ -17,6 +19,8 @@ export interface UpdateHospitalInput {
   type?: string;
   address?: string;
   phone?: string;
+  department?: string;
+  doctorName?: string;
   notes?: string;
 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -101,6 +101,8 @@ export const createHospitalSchema = z.object({
   address: z.string().trim().max(500).optional(),
   phone: z.string().trim().max(20).optional(),
   type: z.string().trim().max(100).optional(),
+  department: z.string().trim().max(100).optional(),
+  doctorName: z.string().trim().max(100).optional(),
   notes: z.string().trim().max(1000).optional(),
   memberId: optionalIdField,
 });
@@ -110,6 +112,8 @@ export const updateHospitalSchema = z.object({
   address: z.string().trim().max(500).optional(),
   phone: z.string().trim().max(20).optional(),
   type: z.string().trim().max(100).optional(),
+  department: z.string().trim().max(100).optional(),
+  doctorName: z.string().trim().max(100).optional(),
   notes: z.string().trim().max(1000).optional(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',


### PR DESCRIPTION
## Summary
- 病院登録・編集フォームに「診療科」「担当医」の入力欄を追加（任意項目）
- 「病院管理」のラベルを「かかりつけ医(病院)」に変更（通院ページ・病院ページ両方）
- 全レイヤー対応: Prisma/Entity/Repository/API/Zod Schema/UI

closes #985

## Test plan
- [x] 全テスト通過（663ファイル、8055テスト）
- [x] ビルド成功
- [ ] 病院追加フォームで診療科・担当医が入力できること
- [ ] 病院編集で診療科・担当医が保存・表示されること
- [ ] 通院ページ・病院ページのラベルが「かかりつけ医(病院)」になっていること