### PR TITLE
通院ページにワクチンスケジュール管理機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   hospitals    Hospital[]
   appointments Appointment[]
   healthLogs   HealthLog[]
+  vaccinations Vaccination[]
 }
 
 model Member {
@@ -49,6 +50,7 @@ model Member {
   records      MedicationRecord[]
   appointments Appointment[]
   healthLogs   HealthLog[]
+  vaccinations Vaccination[]
 
   @@index([userId])
 }
@@ -160,6 +162,22 @@ model Appointment {
   reminderEnabled    Boolean   @default(true)
   reminderDaysBefore Int       @default(1)
   createdAt          DateTime  @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+}
+
+model Vaccination {
+  id                String    @id @default(cuid())
+  userId            String
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId          String
+  member            Member    @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  vaccineName       String
+  vaccinatedAt      DateTime
+  nextScheduledDate DateTime?
+  notes             String?
+  createdAt         DateTime  @default(now())
 
   @@index([userId])
   @@index([memberId])

--- a/src/app/api/vaccinations/[vaccinationId]/route.ts
+++ b/src/app/api/vaccinations/[vaccinationId]/route.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/prisma';
+import { updateVaccinationSchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const findVaccination = (id: string) => prisma.vaccination.findUnique({ where: { id } });
+
+export async function PUT(request: Request, { params }: { params: Promise<{ vaccinationId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`vaccinations-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { vaccinationId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: vaccinationId,
+      finder: findVaccination,
+      resourceName: 'ワクチン記録',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updateVaccinationSchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const updated = await prisma.vaccination.update({
+          where: { id: vaccinationId },
+          data: {
+            vaccineName: parsed.data.vaccineName,
+            vaccinatedAt: parsed.data.vaccinatedAt ? new Date(parsed.data.vaccinatedAt) : undefined,
+            nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : parsed.data.nextScheduledDate === null ? null : undefined,
+            notes: parsed.data.notes,
+          },
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ vaccinationId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`vaccinations-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const { vaccinationId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: vaccinationId,
+      finder: findVaccination,
+      resourceName: 'ワクチン記録',
+      handler: async () => {
+        await prisma.vaccination.delete({ where: { id: vaccinationId } });
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/vaccinations/route.ts
+++ b/src/app/api/vaccinations/route.ts
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+import { createVaccinationSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`vaccinations-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const vaccinations = await prisma.vaccination.findMany({
+    where: { userId },
+    orderBy: { vaccinatedAt: 'desc' },
+    take: QUERY_LIMITS.DEFAULT,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = vaccinations.map((v) =>
+    flattenRelations(v, { member: 'memberName' }),
+  );
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`vaccinations-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createVaccinationSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const vaccination = await prisma.vaccination.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        vaccineName: parsed.data.vaccineName,
+        vaccinatedAt: new Date(parsed.data.vaccinatedAt),
+        nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : undefined,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(vaccination);
+  })();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -5,21 +5,26 @@ import { useAuth } from '@/hooks/useAuth';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
 import { useHospitals } from '@/presentation/hooks/useHospitals';
+import { useVaccinations } from '@/presentation/hooks/useVaccinations';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { AppointmentList, AppointmentFilter, getAppointmentCounts } from '@/components/appointments/AppointmentList';
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
+import { VaccinationForm, VaccinationFormData } from '@/components/vaccinations/VaccinationForm';
+import { VaccinationList } from '@/components/vaccinations/VaccinationList';
 import { TabSwitch } from '@/components/shared/TabSwitch';
 import { Appointment } from '@/domain/entities/Appointment';
 import { MiniCalendar } from '@/components/appointments/MiniCalendar';
 import Link from 'next/link';
-import { Plus, X, MapPin } from 'lucide-react';
+import { Plus, X, MapPin, Syringe } from 'lucide-react';
 
 export default function AppointmentsPage() {
   const { userId } = useAuth();
   const { members, isLoading: membersLoading } = useMembers(userId);
   const { appointments, isLoading, createAppointment, updateAppointment, deleteAppointment } = useAppointments();
   const { hospitals } = useHospitals();
+  const { vaccinations, isLoading: vaccinationsLoading, createVaccination, updateVaccination, deleteVaccination } = useVaccinations();
   const [showForm, setShowForm] = useState(false);
+  const [showVaccinationForm, setShowVaccinationForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
   const [updateError, setUpdateError] = useState<string | null>(null);
@@ -71,6 +76,16 @@ export default function AppointmentsPage() {
   const handleDelete = async (appointmentId: string) => {
     if (!window.confirm('この予約を削除しますか？')) return;
     await deleteAppointment(appointmentId);
+  };
+
+  const handleCreateVaccination = async (data: VaccinationFormData) => {
+    await createVaccination(data);
+    setShowVaccinationForm(false);
+  };
+
+  const handleDeleteVaccination = async (id: string) => {
+    if (!window.confirm('このワクチン記録を削除しますか？')) return;
+    await deleteVaccination(id);
   };
 
   const handleToggleForm = () => {
@@ -143,6 +158,46 @@ export default function AppointmentsPage() {
           onEdit={handleEdit}
           onDelete={handleDelete}
         />
+
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <Syringe size={18} className="text-primary-600" />
+              <h2 className="text-base font-bold text-gray-800">ワクチンスケジュール</h2>
+            </div>
+            <button
+              onClick={() => setShowVaccinationForm(!showVaccinationForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showVaccinationForm ? '閉じる' : 'ワクチン記録を追加'}
+            >
+              {showVaccinationForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showVaccinationForm && !membersLoading && members.length > 0 && (
+            <div className="mb-4 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">ワクチン記録の追加</h3>
+              <VaccinationForm
+                members={members}
+                onSubmit={handleCreateVaccination}
+                onCancel={() => setShowVaccinationForm(false)}
+              />
+            </div>
+          )}
+
+          {showVaccinationForm && !membersLoading && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先にメンバーを登録してください。
+            </div>
+          )}
+
+          <VaccinationList
+            vaccinations={vaccinations}
+            isLoading={vaccinationsLoading}
+            onUpdate={updateVaccination}
+            onDelete={handleDeleteVaccination}
+          />
+        </div>
 
         <div className="mt-6">
           <Link

--- a/src/components/vaccinations/VaccinationForm.tsx
+++ b/src/components/vaccinations/VaccinationForm.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member } from '../../domain/entities/Member';
+
+export interface VaccinationFormData {
+  memberId: string;
+  vaccineName: string;
+  vaccinatedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+}
+
+interface VaccinationFormProps {
+  members: Member[];
+  onSubmit: (data: VaccinationFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    vaccineName: string;
+    vaccinatedAt: Date;
+    nextScheduledDate?: Date;
+    notes?: string;
+  };
+}
+
+export const VaccinationForm: React.FC<VaccinationFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ''));
+  const [vaccineName, setVaccineName] = useState(initialData?.vaccineName || '');
+  const [vaccinatedAt, setVaccinatedAt] = useState(
+    initialData?.vaccinatedAt ? initialData.vaccinatedAt.toISOString().split('T')[0] : new Date().toISOString().split('T')[0],
+  );
+  const [nextScheduledDate, setNextScheduledDate] = useState(
+    initialData?.nextScheduledDate ? initialData.nextScheduledDate.toISOString().split('T')[0] : '',
+  );
+  const [notes, setNotes] = useState(initialData?.notes || '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !vaccineName.trim() || !vaccinatedAt) return;
+
+    onSubmit({
+      memberId,
+      vaccineName: vaccineName.trim(),
+      vaccinatedAt: new Date(vaccinatedAt).toISOString(),
+      nextScheduledDate: nextScheduledDate ? new Date(nextScheduledDate).toISOString() : undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setVaccineName('');
+      setVaccinatedAt(new Date().toISOString().split('T')[0]);
+      setNextScheduledDate('');
+      setNotes('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="vacc-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="vacc-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="vacc-name" className="block text-sm font-medium text-gray-700 mb-1">
+          ワクチンの種類
+        </label>
+        <input
+          id="vacc-name"
+          type="text"
+          value={vaccineName}
+          onChange={(e) => setVaccineName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+          placeholder="例: インフルエンザ、混合ワクチン"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vacc-date" className="block text-sm font-medium text-gray-700 mb-1">
+          ワクチン接種日
+        </label>
+        <input
+          id="vacc-date"
+          type="date"
+          value={vaccinatedAt}
+          onChange={(e) => setVaccinatedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vacc-next" className="block text-sm font-medium text-gray-700 mb-1">
+          次回ワクチン予定日（任意）
+        </label>
+        <input
+          id="vacc-next"
+          type="date"
+          value={nextScheduledDate}
+          onChange={(e) => setNextScheduledDate(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vacc-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="vacc-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="メモを入力"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {initialData ? '更新する' : '登録する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/components/vaccinations/VaccinationList.tsx
+++ b/src/components/vaccinations/VaccinationList.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Pencil, Trash2, Check, X, Calendar } from 'lucide-react';
+import { Vaccination } from '../../domain/entities/Vaccination';
+import { UpdateVaccinationInput } from '../../domain/repositories/VaccinationRepository';
+
+interface VaccinationListProps {
+  vaccinations: Vaccination[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateVaccinationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const VaccinationList: React.FC<VaccinationListProps> = ({ vaccinations, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (vaccinations.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-8">
+        <p className="text-gray-500 text-sm">ワクチン記録がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {vaccinations.map((vaccination) => (
+        <VaccinationCard key={vaccination.id} vaccination={vaccination} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface VaccinationCardProps {
+  vaccination: Vaccination;
+  onUpdate: (id: string, input: UpdateVaccinationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const formatDate = (date: Date) => {
+  return date.toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' });
+};
+
+const VaccinationCard: React.FC<VaccinationCardProps> = React.memo(({ vaccination, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(vaccination.vaccineName);
+  const [editDate, setEditDate] = useState(vaccination.vaccinatedAt.toISOString().split('T')[0]);
+  const [editNextDate, setEditNextDate] = useState(
+    vaccination.nextScheduledDate ? vaccination.nextScheduledDate.toISOString().split('T')[0] : '',
+  );
+  const [editNotes, setEditNotes] = useState(vaccination.notes || '');
+
+  const handleSave = async () => {
+    if (!editName.trim() || !editDate) return;
+    await onUpdate(vaccination.id, {
+      vaccineName: editName.trim(),
+      vaccinatedAt: new Date(editDate).toISOString(),
+      nextScheduledDate: editNextDate ? new Date(editNextDate).toISOString() : null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(vaccination.vaccineName);
+    setEditDate(vaccination.vaccinatedAt.toISOString().split('T')[0]);
+    setEditNextDate(vaccination.nextScheduledDate ? vaccination.nextScheduledDate.toISOString().split('T')[0] : '');
+    setEditNotes(vaccination.notes || '');
+    setIsEditing(false);
+  };
+
+  const isNextDateUpcoming = vaccination.nextScheduledDate && vaccination.nextScheduledDate > new Date();
+  const isNextDatePast = vaccination.nextScheduledDate && vaccination.nextScheduledDate <= new Date();
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-blue-200 space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">ワクチンの種類</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">接種日</label>
+          <input
+            type="date"
+            value={editDate}
+            onChange={(e) => setEditDate(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">次回予定日</label>
+          <input
+            type="date"
+            value={editNextDate}
+            onChange={(e) => setEditNextDate(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim() || !editDate}
+            className="flex-1 flex items-center justify-center space-x-1 bg-blue-600 text-white py-1.5 rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-gray-200 text-gray-700 py-1.5 rounded-lg text-sm hover:bg-gray-300 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2">
+            <p className="font-medium text-gray-800 text-sm">{vaccination.vaccineName}</p>
+            {vaccination.memberName && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{vaccination.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-gray-500 mt-1 space-y-0.5">
+            <p className="flex items-center space-x-1">
+              <Calendar size={10} />
+              <span>接種日: {formatDate(vaccination.vaccinatedAt)}</span>
+            </p>
+            {vaccination.nextScheduledDate && (
+              <p className={`flex items-center space-x-1 ${isNextDatePast ? 'text-red-500 font-medium' : isNextDateUpcoming ? 'text-blue-500' : ''}`}>
+                <Calendar size={10} />
+                <span>次回予定: {formatDate(vaccination.nextScheduledDate)}</span>
+                {isNextDatePast && <span>(期限切れ)</span>}
+              </p>
+            )}
+            {vaccination.notes && <p className="text-gray-400">{vaccination.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-gray-400 hover:text-blue-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => onDelete(vaccination.id)}
+            className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+VaccinationCard.displayName = 'VaccinationCard';

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -5,7 +5,8 @@ import { Medication, MedicationCategory } from '../../domain/entities/Medication
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
 import { HealthLog, ConditionLevel, SymptomType, SYMPTOM_OPTIONS } from '../../domain/entities/HealthLog';
-import { BackendAppointment, BackendHealthLog, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule } from './types';
+import { Vaccination } from '../../domain/entities/Vaccination';
+import { BackendAppointment, BackendHealthLog, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -103,6 +104,20 @@ export function toSchedule(b: BackendSchedule): Schedule {
     daysOfWeek: (b.daysOfWeek?.filter((d: string) => VALID_DAYS_OF_WEEK.includes(d)) as DayOfWeek[]) ?? [],
     isEnabled: b.isEnabled ?? true,
     reminderMinutesBefore: b.reminderMinutesBefore ?? 10,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toVaccination(b: BackendVaccination): Vaccination {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    vaccineName: b.vaccineName,
+    vaccinatedAt: new Date(b.vaccinatedAt),
+    nextScheduledDate: b.nextScheduledDate ? new Date(b.nextScheduledDate) : undefined,
+    notes: b.notes,
     createdAt: new Date(b.createdAt),
   };
 }

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -79,6 +79,18 @@ export interface BackendRecord {
   dosageAmount?: string;
 }
 
+export interface BackendVaccination {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  vaccineName: string;
+  vaccinatedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendHealthLog {
   id: string;
   userId: string;

--- a/src/data/api/vaccinationApi.ts
+++ b/src/data/api/vaccinationApi.ts
@@ -1,0 +1,26 @@
+import { Vaccination } from '../../domain/entities/Vaccination';
+import { CreateVaccinationInput, UpdateVaccinationInput } from '../../domain/repositories/VaccinationRepository';
+import { apiClient } from './apiClient';
+import { toVaccination } from './mappers';
+import { BackendVaccination } from './types';
+
+export const vaccinationApi = {
+  async getVaccinations(): Promise<Vaccination[]> {
+    const data = await apiClient.get<BackendVaccination[]>('/vaccinations');
+    return data.map(toVaccination);
+  },
+
+  async createVaccination(input: CreateVaccinationInput): Promise<Vaccination> {
+    const data = await apiClient.post<BackendVaccination>('/vaccinations', input);
+    return toVaccination(data);
+  },
+
+  async updateVaccination(vaccinationId: string, input: UpdateVaccinationInput): Promise<Vaccination> {
+    const data = await apiClient.put<BackendVaccination>(`/vaccinations/${vaccinationId}`, input);
+    return toVaccination(data);
+  },
+
+  async deleteVaccination(vaccinationId: string): Promise<void> {
+    await apiClient.del(`/vaccinations/${vaccinationId}`);
+  },
+};

--- a/src/data/repositories/VaccinationRepositoryImpl.ts
+++ b/src/data/repositories/VaccinationRepositoryImpl.ts
@@ -1,0 +1,25 @@
+import {
+  VaccinationRepository,
+  CreateVaccinationInput,
+  UpdateVaccinationInput,
+} from '../../domain/repositories/VaccinationRepository';
+import { Vaccination } from '../../domain/entities/Vaccination';
+import { vaccinationApi } from '../api/vaccinationApi';
+
+export class VaccinationRepositoryImpl implements VaccinationRepository {
+  async getAll(): Promise<Vaccination[]> {
+    return vaccinationApi.getVaccinations();
+  }
+
+  async create(input: CreateVaccinationInput): Promise<Vaccination> {
+    return vaccinationApi.createVaccination(input);
+  }
+
+  async update(id: string, input: UpdateVaccinationInput): Promise<Vaccination> {
+    return vaccinationApi.updateVaccination(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return vaccinationApi.deleteVaccination(id);
+  }
+}

--- a/src/domain/entities/Vaccination.ts
+++ b/src/domain/entities/Vaccination.ts
@@ -1,0 +1,11 @@
+export interface Vaccination {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly vaccineName: string;
+  readonly vaccinatedAt: Date;
+  readonly nextScheduledDate?: Date;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/VaccinationRepository.ts
+++ b/src/domain/repositories/VaccinationRepository.ts
@@ -1,0 +1,23 @@
+import { Vaccination } from '../entities/Vaccination';
+
+export interface CreateVaccinationInput {
+  memberId: string;
+  vaccineName: string;
+  vaccinatedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+}
+
+export interface UpdateVaccinationInput {
+  vaccineName?: string;
+  vaccinatedAt?: string;
+  nextScheduledDate?: string | null;
+  notes?: string | null;
+}
+
+export interface VaccinationRepository {
+  getAll(): Promise<Vaccination[]>;
+  create(input: CreateVaccinationInput): Promise<Vaccination>;
+  update(id: string, input: UpdateVaccinationInput): Promise<Vaccination>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageVaccinations.ts
+++ b/src/domain/usecases/ManageVaccinations.ts
@@ -1,0 +1,50 @@
+import { Vaccination } from '../entities/Vaccination';
+import {
+  VaccinationRepository,
+  CreateVaccinationInput,
+  UpdateVaccinationInput,
+} from '../repositories/VaccinationRepository';
+
+export class GetVaccinations {
+  constructor(private readonly vaccinationRepository: VaccinationRepository) {}
+
+  async execute(): Promise<Vaccination[]> {
+    return this.vaccinationRepository.getAll();
+  }
+}
+
+export class CreateVaccination {
+  constructor(private readonly vaccinationRepository: VaccinationRepository) {}
+
+  async execute(input: CreateVaccinationInput): Promise<Vaccination> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.vaccineName) {
+      throw new Error('ワクチンの種類は必須です');
+    }
+    if (!input.vaccinatedAt) {
+      throw new Error('接種日は必須です');
+    }
+    return this.vaccinationRepository.create(input);
+  }
+}
+
+export class UpdateVaccination {
+  constructor(private readonly vaccinationRepository: VaccinationRepository) {}
+
+  async execute(id: string, input: UpdateVaccinationInput): Promise<Vaccination> {
+    if (!id) {
+      throw new Error('ワクチンIDは必須です');
+    }
+    return this.vaccinationRepository.update(id, input);
+  }
+}
+
+export class DeleteVaccination {
+  constructor(private readonly vaccinationRepository: VaccinationRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.vaccinationRepository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -11,6 +11,7 @@ import { HospitalRepository } from '../domain/repositories/HospitalRepository';
 import { MedicationRecordRepository } from '../domain/repositories/MedicationRecordRepository';
 import { UserProfileRepository } from '../domain/repositories/UserProfileRepository';
 import { HealthLogRepository } from '../domain/repositories/HealthLogRepository';
+import { VaccinationRepository } from '../domain/repositories/VaccinationRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -19,6 +20,7 @@ import { HospitalRepositoryImpl } from '../data/repositories/HospitalRepositoryI
 import { MedicationRecordRepositoryImpl } from '../data/repositories/MedicationRecordRepositoryImpl';
 import { UserProfileRepositoryImpl } from '../data/repositories/UserProfileRepositoryImpl';
 import { HealthLogRepositoryImpl } from '../data/repositories/HealthLogRepositoryImpl';
+import { VaccinationRepositoryImpl } from '../data/repositories/VaccinationRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -29,6 +31,7 @@ export interface DIContainer {
   medicationRecordRepository: MedicationRecordRepository;
   userProfileRepository: UserProfileRepository;
   healthLogRepository: HealthLogRepository;
+  vaccinationRepository: VaccinationRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -45,6 +48,7 @@ export const getDIContainer = (): DIContainer => {
       medicationRecordRepository: new MedicationRecordRepositoryImpl(),
       userProfileRepository: new UserProfileRepositoryImpl(),
       healthLogRepository: new HealthLogRepositoryImpl(),
+      vaccinationRepository: new VaccinationRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -150,6 +150,24 @@ export const createHealthLogSchema = z.object({
   notes: z.string().trim().max(500).optional(),
 });
 
+// ===== Vaccinations =====
+export const createVaccinationSchema = z.object({
+  memberId: idField,
+  vaccineName: z.string({ required_error: 'ワクチンの種類は必須です' }).trim().min(1, 'ワクチンの種類は必須です').max(200),
+  vaccinatedAt: dateString,
+  nextScheduledDate: dateString.optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
+export const updateVaccinationSchema = z.object({
+  vaccineName: z.string().trim().min(1).max(200).optional(),
+  vaccinatedAt: dateString.optional(),
+  nextScheduledDate: dateString.optional().nullable(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Auth =====
 export const signUpSchema = z.object({
   email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),

--- a/src/presentation/hooks/useVaccinations.ts
+++ b/src/presentation/hooks/useVaccinations.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { Vaccination } from '../../domain/entities/Vaccination';
+import { GetVaccinations, CreateVaccination, UpdateVaccination, DeleteVaccination } from '../../domain/usecases/ManageVaccinations';
+import { CreateVaccinationInput, UpdateVaccinationInput } from '../../domain/repositories/VaccinationRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseVaccinationsResult {
+  vaccinations: Vaccination[];
+  isLoading: boolean;
+  error: Error | null;
+  createVaccination: (input: CreateVaccinationInput) => Promise<void>;
+  updateVaccination: (id: string, input: UpdateVaccinationInput) => Promise<void>;
+  deleteVaccination: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useVaccinations = (): UseVaccinationsResult => {
+  const useCases = useMemo(() => {
+    const { vaccinationRepository } = getDIContainer();
+    return {
+      getVaccinations: new GetVaccinations(vaccinationRepository),
+      createVaccination: new CreateVaccination(vaccinationRepository),
+      updateVaccination: new UpdateVaccination(vaccinationRepository),
+      deleteVaccination: new DeleteVaccination(vaccinationRepository),
+    };
+  }, []);
+
+  const { data: vaccinations, isLoading, error, refetch } = useFetcher(
+    async () => useCases.getVaccinations.execute(),
+    [useCases],
+    [] as Vaccination[],
+    'vaccinations',
+  );
+
+  const handleCreate = useCallback(async (input: CreateVaccinationInput) => {
+    await useCases.createVaccination.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdateVaccinationInput) => {
+    await useCases.updateVaccination.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.deleteVaccination.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    vaccinations,
+    isLoading,
+    error,
+    createVaccination: handleCreate,
+    updateVaccination: handleUpdate,
+    deleteVaccination: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- 通院管理ページにワクチンスケジュールセクションを追加
- ワクチン接種日（必須）、ワクチンの種類（必須）、次回予定日（任意・カレンダー入力）を記録可能
- 人間・ペット共に対応、CRUD操作完備
- 次回予定日の期限切れを赤色表示
- クリーンアーキテクチャの全レイヤーを実装（Entity/Repository/UseCase/API/Hook/UI）

closes #987

## Test plan
- [x] 全テスト通過（663ファイル、8055テスト）
- [x] ビルド成功
- [ ] ワクチン記録の追加（メンバー選択・種類・接種日必須、次回予定日任意）
- [ ] ワクチン記録の編集・削除
- [ ] 次回予定日が過去の場合に期限切れ表示されること