### PR TITLE
ワクチン一覧を次回予定日の直近順にソート

### DIFF
--- a/src/app/api/vaccinations/route.ts
+++ b/src/app/api/vaccinations/route.ts
@@ -10,7 +10,7 @@ export const GET = withAuth(async (userId) => {
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const vaccinations = await prisma.vaccination.findMany({
     where: { userId },
-    orderBy: { vaccinatedAt: 'desc' },
+    orderBy: { nextScheduledDate: { sort: 'asc', nulls: 'last' } },
     take: QUERY_LIMITS.DEFAULT,
     include: {
       member: { select: { name: true } },


### PR DESCRIPTION
## Summary
- ワクチン一覧の並び順を次回予定日(nextScheduledDate)の昇順に変更
- 次回予定日未設定のものは末尾に配置

closes #989

## Test plan
- [x] ビルド成功
- [ ] 次回予定日が近い順に表示されること
- [ ] 次回予定日未設定のワクチンが末尾に表示されること