### PR TITLE
通院ページに検査スケジュール管理機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   appointments Appointment[]
   healthLogs   HealthLog[]
   vaccinations Vaccination[]
+  examinations Examination[]
 }
 
 model Member {
@@ -51,6 +52,7 @@ model Member {
   appointments Appointment[]
   healthLogs   HealthLog[]
   vaccinations Vaccination[]
+  examinations Examination[]
 
   @@index([userId])
 }
@@ -175,6 +177,22 @@ model Vaccination {
   member            Member    @relation(fields: [memberId], references: [id], onDelete: Cascade)
   vaccineName       String
   vaccinatedAt      DateTime
+  nextScheduledDate DateTime?
+  notes             String?
+  createdAt         DateTime  @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+}
+
+model Examination {
+  id                String    @id @default(cuid())
+  userId            String
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId          String
+  member            Member    @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  examinationType   String
+  examinedAt        DateTime
   nextScheduledDate DateTime?
   notes             String?
   createdAt         DateTime  @default(now())

--- a/src/app/api/examinations/[examinationId]/route.ts
+++ b/src/app/api/examinations/[examinationId]/route.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/prisma';
+import { updateExaminationSchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const findExamination = (id: string) => prisma.examination.findUnique({ where: { id } });
+
+export async function PUT(request: Request, { params }: { params: Promise<{ examinationId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`examinations-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { examinationId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: examinationId,
+      finder: findExamination,
+      resourceName: '検査記録',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updateExaminationSchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const updated = await prisma.examination.update({
+          where: { id: examinationId },
+          data: {
+            examinationType: parsed.data.examinationType,
+            examinedAt: parsed.data.examinedAt ? new Date(parsed.data.examinedAt) : undefined,
+            nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : parsed.data.nextScheduledDate === null ? null : undefined,
+            notes: parsed.data.notes,
+          },
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ examinationId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`examinations-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const { examinationId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: examinationId,
+      finder: findExamination,
+      resourceName: '検査記録',
+      handler: async () => {
+        await prisma.examination.delete({ where: { id: examinationId } });
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/examinations/route.ts
+++ b/src/app/api/examinations/route.ts
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+import { createExaminationSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`examinations-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const examinations = await prisma.examination.findMany({
+    where: { userId },
+    orderBy: { nextScheduledDate: { sort: 'asc', nulls: 'last' } },
+    take: QUERY_LIMITS.DEFAULT,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = examinations.map((e) =>
+    flattenRelations(e, { member: 'memberName' }),
+  );
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`examinations-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createExaminationSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const examination = await prisma.examination.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        examinationType: parsed.data.examinationType,
+        examinedAt: new Date(parsed.data.examinedAt),
+        nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : undefined,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(examination);
+  })();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -6,16 +6,19 @@ import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
 import { useHospitals } from '@/presentation/hooks/useHospitals';
 import { useVaccinations } from '@/presentation/hooks/useVaccinations';
+import { useExaminations } from '@/presentation/hooks/useExaminations';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { AppointmentList, AppointmentFilter, getAppointmentCounts } from '@/components/appointments/AppointmentList';
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
 import { VaccinationForm, VaccinationFormData } from '@/components/vaccinations/VaccinationForm';
 import { VaccinationList } from '@/components/vaccinations/VaccinationList';
+import { ExaminationForm, ExaminationFormData } from '@/components/examinations/ExaminationForm';
+import { ExaminationList } from '@/components/examinations/ExaminationList';
 import { TabSwitch } from '@/components/shared/TabSwitch';
 import { Appointment } from '@/domain/entities/Appointment';
 import { MiniCalendar } from '@/components/appointments/MiniCalendar';
 import Link from 'next/link';
-import { Plus, X, MapPin, Syringe } from 'lucide-react';
+import { Plus, X, MapPin, Syringe, ClipboardList } from 'lucide-react';
 
 export default function AppointmentsPage() {
   const { userId } = useAuth();
@@ -23,8 +26,10 @@ export default function AppointmentsPage() {
   const { appointments, isLoading, createAppointment, updateAppointment, deleteAppointment } = useAppointments();
   const { hospitals } = useHospitals();
   const { vaccinations, isLoading: vaccinationsLoading, createVaccination, updateVaccination, deleteVaccination } = useVaccinations();
+  const { examinations, isLoading: examinationsLoading, createExamination, updateExamination, deleteExamination } = useExaminations();
   const [showForm, setShowForm] = useState(false);
   const [showVaccinationForm, setShowVaccinationForm] = useState(false);
+  const [showExaminationForm, setShowExaminationForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
   const [updateError, setUpdateError] = useState<string | null>(null);
@@ -86,6 +91,16 @@ export default function AppointmentsPage() {
   const handleDeleteVaccination = async (id: string) => {
     if (!window.confirm('このワクチン記録を削除しますか？')) return;
     await deleteVaccination(id);
+  };
+
+  const handleCreateExamination = async (data: ExaminationFormData) => {
+    await createExamination(data);
+    setShowExaminationForm(false);
+  };
+
+  const handleDeleteExamination = async (id: string) => {
+    if (!window.confirm('この検査記録を削除しますか？')) return;
+    await deleteExamination(id);
   };
 
   const handleToggleForm = () => {
@@ -196,6 +211,46 @@ export default function AppointmentsPage() {
             isLoading={vaccinationsLoading}
             onUpdate={updateVaccination}
             onDelete={handleDeleteVaccination}
+          />
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <ClipboardList size={18} className="text-primary-600" />
+              <h2 className="text-base font-bold text-gray-800">検査スケジュール</h2>
+            </div>
+            <button
+              onClick={() => setShowExaminationForm(!showExaminationForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showExaminationForm ? '閉じる' : '検査記録を追加'}
+            >
+              {showExaminationForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showExaminationForm && !membersLoading && members.length > 0 && (
+            <div className="mb-4 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">検査記録の追加</h3>
+              <ExaminationForm
+                members={members}
+                onSubmit={handleCreateExamination}
+                onCancel={() => setShowExaminationForm(false)}
+              />
+            </div>
+          )}
+
+          {showExaminationForm && !membersLoading && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先にメンバーを登録してください。
+            </div>
+          )}
+
+          <ExaminationList
+            examinations={examinations}
+            isLoading={examinationsLoading}
+            onUpdate={updateExamination}
+            onDelete={handleDeleteExamination}
           />
         </div>
 

--- a/src/components/examinations/ExaminationForm.tsx
+++ b/src/components/examinations/ExaminationForm.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member } from '../../domain/entities/Member';
+
+export interface ExaminationFormData {
+  memberId: string;
+  examinationType: string;
+  examinedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+}
+
+interface ExaminationFormProps {
+  members: Member[];
+  onSubmit: (data: ExaminationFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    examinationType: string;
+    examinedAt: Date;
+    nextScheduledDate?: Date;
+    notes?: string;
+  };
+}
+
+export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ''));
+  const [examinationType, setExaminationType] = useState(initialData?.examinationType || '');
+  const [examinedAt, setExaminedAt] = useState(
+    initialData?.examinedAt ? initialData.examinedAt.toISOString().split('T')[0] : new Date().toISOString().split('T')[0],
+  );
+  const [nextScheduledDate, setNextScheduledDate] = useState(
+    initialData?.nextScheduledDate ? initialData.nextScheduledDate.toISOString().split('T')[0] : '',
+  );
+  const [notes, setNotes] = useState(initialData?.notes || '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !examinationType.trim() || !examinedAt) return;
+
+    onSubmit({
+      memberId,
+      examinationType: examinationType.trim(),
+      examinedAt: new Date(examinedAt).toISOString(),
+      nextScheduledDate: nextScheduledDate ? new Date(nextScheduledDate).toISOString() : undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setExaminationType('');
+      setExaminedAt(new Date().toISOString().split('T')[0]);
+      setNextScheduledDate('');
+      setNotes('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="exam-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="exam-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="exam-type" className="block text-sm font-medium text-gray-700 mb-1">
+          検査の種類
+        </label>
+        <input
+          id="exam-type"
+          type="text"
+          value={examinationType}
+          onChange={(e) => setExaminationType(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+          placeholder="例: 健康診断、血液検査、歯科検診"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="exam-date" className="block text-sm font-medium text-gray-700 mb-1">
+          検査日
+        </label>
+        <input
+          id="exam-date"
+          type="date"
+          value={examinedAt}
+          onChange={(e) => setExaminedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label htmlFor="exam-next" className="block text-sm font-medium text-gray-700 mb-1">
+          次回検査日（任意）
+        </label>
+        <input
+          id="exam-next"
+          type="date"
+          value={nextScheduledDate}
+          onChange={(e) => setNextScheduledDate(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="exam-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="exam-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="メモを入力"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {initialData ? '更新する' : '登録する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/components/examinations/ExaminationList.tsx
+++ b/src/components/examinations/ExaminationList.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Pencil, Trash2, Check, X, Calendar } from 'lucide-react';
+import { Examination } from '../../domain/entities/Examination';
+import { UpdateExaminationInput } from '../../domain/repositories/ExaminationRepository';
+
+interface ExaminationListProps {
+  examinations: Examination[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateExaminationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const ExaminationList: React.FC<ExaminationListProps> = ({ examinations, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (examinations.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-8">
+        <p className="text-gray-500 text-sm">検査記録がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {examinations.map((examination) => (
+        <ExaminationCard key={examination.id} examination={examination} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface ExaminationCardProps {
+  examination: Examination;
+  onUpdate: (id: string, input: UpdateExaminationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const formatDate = (date: Date) => {
+  return date.toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' });
+};
+
+const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examination, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editType, setEditType] = useState(examination.examinationType);
+  const [editDate, setEditDate] = useState(examination.examinedAt.toISOString().split('T')[0]);
+  const [editNextDate, setEditNextDate] = useState(
+    examination.nextScheduledDate ? examination.nextScheduledDate.toISOString().split('T')[0] : '',
+  );
+  const [editNotes, setEditNotes] = useState(examination.notes || '');
+
+  const handleSave = async () => {
+    if (!editType.trim() || !editDate) return;
+    await onUpdate(examination.id, {
+      examinationType: editType.trim(),
+      examinedAt: new Date(editDate).toISOString(),
+      nextScheduledDate: editNextDate ? new Date(editNextDate).toISOString() : null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditType(examination.examinationType);
+    setEditDate(examination.examinedAt.toISOString().split('T')[0]);
+    setEditNextDate(examination.nextScheduledDate ? examination.nextScheduledDate.toISOString().split('T')[0] : '');
+    setEditNotes(examination.notes || '');
+    setIsEditing(false);
+  };
+
+  const isNextDateUpcoming = examination.nextScheduledDate && examination.nextScheduledDate > new Date();
+  const isNextDatePast = examination.nextScheduledDate && examination.nextScheduledDate <= new Date();
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-blue-200 space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">検査の種類</label>
+          <input
+            type="text"
+            value={editType}
+            onChange={(e) => setEditType(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">検査日</label>
+          <input
+            type="date"
+            value={editDate}
+            onChange={(e) => setEditDate(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">次回検査日</label>
+          <input
+            type="date"
+            value={editNextDate}
+            onChange={(e) => setEditNextDate(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editType.trim() || !editDate}
+            className="flex-1 flex items-center justify-center space-x-1 bg-blue-600 text-white py-1.5 rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-gray-200 text-gray-700 py-1.5 rounded-lg text-sm hover:bg-gray-300 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2">
+            <p className="font-medium text-gray-800 text-sm">{examination.examinationType}</p>
+            {examination.memberName && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{examination.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-gray-500 mt-1 space-y-0.5">
+            <p className="flex items-center space-x-1">
+              <Calendar size={10} />
+              <span>検査日: {formatDate(examination.examinedAt)}</span>
+            </p>
+            {examination.nextScheduledDate && (
+              <p className={`flex items-center space-x-1 ${isNextDatePast ? 'text-red-500 font-medium' : isNextDateUpcoming ? 'text-blue-500' : ''}`}>
+                <Calendar size={10} />
+                <span>次回予定: {formatDate(examination.nextScheduledDate)}</span>
+                {isNextDatePast && <span>(期限切れ)</span>}
+              </p>
+            )}
+            {examination.notes && <p className="text-gray-400">{examination.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-gray-400 hover:text-blue-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => onDelete(examination.id)}
+            className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ExaminationCard.displayName = 'ExaminationCard';

--- a/src/data/api/examinationApi.ts
+++ b/src/data/api/examinationApi.ts
@@ -1,0 +1,26 @@
+import { Examination } from '../../domain/entities/Examination';
+import { CreateExaminationInput, UpdateExaminationInput } from '../../domain/repositories/ExaminationRepository';
+import { apiClient } from './apiClient';
+import { toExamination } from './mappers';
+import { BackendExamination } from './types';
+
+export const examinationApi = {
+  async getExaminations(): Promise<Examination[]> {
+    const data = await apiClient.get<BackendExamination[]>('/examinations');
+    return data.map(toExamination);
+  },
+
+  async createExamination(input: CreateExaminationInput): Promise<Examination> {
+    const data = await apiClient.post<BackendExamination>('/examinations', input);
+    return toExamination(data);
+  },
+
+  async updateExamination(id: string, input: UpdateExaminationInput): Promise<Examination> {
+    const data = await apiClient.put<BackendExamination>(`/examinations/${id}`, input);
+    return toExamination(data);
+  },
+
+  async deleteExamination(id: string): Promise<void> {
+    await apiClient.del(`/examinations/${id}`);
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -6,7 +6,8 @@ import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
 import { HealthLog, ConditionLevel, SymptomType, SYMPTOM_OPTIONS } from '../../domain/entities/HealthLog';
 import { Vaccination } from '../../domain/entities/Vaccination';
-import { BackendAppointment, BackendHealthLog, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
+import { Examination } from '../../domain/entities/Examination';
+import { BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -116,6 +117,20 @@ export function toVaccination(b: BackendVaccination): Vaccination {
     memberName: b.memberName,
     vaccineName: b.vaccineName,
     vaccinatedAt: new Date(b.vaccinatedAt),
+    nextScheduledDate: b.nextScheduledDate ? new Date(b.nextScheduledDate) : undefined,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toExamination(b: BackendExamination): Examination {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    examinationType: b.examinationType,
+    examinedAt: new Date(b.examinedAt),
     nextScheduledDate: b.nextScheduledDate ? new Date(b.nextScheduledDate) : undefined,
     notes: b.notes,
     createdAt: new Date(b.createdAt),

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -91,6 +91,18 @@ export interface BackendVaccination {
   createdAt: string;
 }
 
+export interface BackendExamination {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  examinationType: string;
+  examinedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendHealthLog {
   id: string;
   userId: string;

--- a/src/data/repositories/ExaminationRepositoryImpl.ts
+++ b/src/data/repositories/ExaminationRepositoryImpl.ts
@@ -1,0 +1,25 @@
+import {
+  ExaminationRepository,
+  CreateExaminationInput,
+  UpdateExaminationInput,
+} from '../../domain/repositories/ExaminationRepository';
+import { Examination } from '../../domain/entities/Examination';
+import { examinationApi } from '../api/examinationApi';
+
+export class ExaminationRepositoryImpl implements ExaminationRepository {
+  async getAll(): Promise<Examination[]> {
+    return examinationApi.getExaminations();
+  }
+
+  async create(input: CreateExaminationInput): Promise<Examination> {
+    return examinationApi.createExamination(input);
+  }
+
+  async update(id: string, input: UpdateExaminationInput): Promise<Examination> {
+    return examinationApi.updateExamination(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return examinationApi.deleteExamination(id);
+  }
+}

--- a/src/domain/entities/Examination.ts
+++ b/src/domain/entities/Examination.ts
@@ -1,0 +1,11 @@
+export interface Examination {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly examinationType: string;
+  readonly examinedAt: Date;
+  readonly nextScheduledDate?: Date;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/ExaminationRepository.ts
+++ b/src/domain/repositories/ExaminationRepository.ts
@@ -1,0 +1,23 @@
+import { Examination } from '../entities/Examination';
+
+export interface CreateExaminationInput {
+  memberId: string;
+  examinationType: string;
+  examinedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+}
+
+export interface UpdateExaminationInput {
+  examinationType?: string;
+  examinedAt?: string;
+  nextScheduledDate?: string | null;
+  notes?: string | null;
+}
+
+export interface ExaminationRepository {
+  getAll(): Promise<Examination[]>;
+  create(input: CreateExaminationInput): Promise<Examination>;
+  update(id: string, input: UpdateExaminationInput): Promise<Examination>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageExaminations.ts
+++ b/src/domain/usecases/ManageExaminations.ts
@@ -1,0 +1,50 @@
+import { Examination } from '../entities/Examination';
+import {
+  ExaminationRepository,
+  CreateExaminationInput,
+  UpdateExaminationInput,
+} from '../repositories/ExaminationRepository';
+
+export class GetExaminations {
+  constructor(private readonly examinationRepository: ExaminationRepository) {}
+
+  async execute(): Promise<Examination[]> {
+    return this.examinationRepository.getAll();
+  }
+}
+
+export class CreateExamination {
+  constructor(private readonly examinationRepository: ExaminationRepository) {}
+
+  async execute(input: CreateExaminationInput): Promise<Examination> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.examinationType) {
+      throw new Error('検査の種類は必須です');
+    }
+    if (!input.examinedAt) {
+      throw new Error('検査日は必須です');
+    }
+    return this.examinationRepository.create(input);
+  }
+}
+
+export class UpdateExamination {
+  constructor(private readonly examinationRepository: ExaminationRepository) {}
+
+  async execute(id: string, input: UpdateExaminationInput): Promise<Examination> {
+    if (!id) {
+      throw new Error('検査IDは必須です');
+    }
+    return this.examinationRepository.update(id, input);
+  }
+}
+
+export class DeleteExamination {
+  constructor(private readonly examinationRepository: ExaminationRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.examinationRepository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -12,6 +12,7 @@ import { MedicationRecordRepository } from '../domain/repositories/MedicationRec
 import { UserProfileRepository } from '../domain/repositories/UserProfileRepository';
 import { HealthLogRepository } from '../domain/repositories/HealthLogRepository';
 import { VaccinationRepository } from '../domain/repositories/VaccinationRepository';
+import { ExaminationRepository } from '../domain/repositories/ExaminationRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -21,6 +22,7 @@ import { MedicationRecordRepositoryImpl } from '../data/repositories/MedicationR
 import { UserProfileRepositoryImpl } from '../data/repositories/UserProfileRepositoryImpl';
 import { HealthLogRepositoryImpl } from '../data/repositories/HealthLogRepositoryImpl';
 import { VaccinationRepositoryImpl } from '../data/repositories/VaccinationRepositoryImpl';
+import { ExaminationRepositoryImpl } from '../data/repositories/ExaminationRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -32,6 +34,7 @@ export interface DIContainer {
   userProfileRepository: UserProfileRepository;
   healthLogRepository: HealthLogRepository;
   vaccinationRepository: VaccinationRepository;
+  examinationRepository: ExaminationRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -49,6 +52,7 @@ export const getDIContainer = (): DIContainer => {
       userProfileRepository: new UserProfileRepositoryImpl(),
       healthLogRepository: new HealthLogRepositoryImpl(),
       vaccinationRepository: new VaccinationRepositoryImpl(),
+      examinationRepository: new ExaminationRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -168,6 +168,24 @@ export const updateVaccinationSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Examinations =====
+export const createExaminationSchema = z.object({
+  memberId: idField,
+  examinationType: z.string({ required_error: '検査の種類は必須です' }).trim().min(1, '検査の種類は必須です').max(200),
+  examinedAt: dateString,
+  nextScheduledDate: dateString.optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
+export const updateExaminationSchema = z.object({
+  examinationType: z.string().trim().min(1).max(200).optional(),
+  examinedAt: dateString.optional(),
+  nextScheduledDate: dateString.optional().nullable(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Auth =====
 export const signUpSchema = z.object({
   email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),

--- a/src/presentation/hooks/useExaminations.ts
+++ b/src/presentation/hooks/useExaminations.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { Examination } from '../../domain/entities/Examination';
+import { GetExaminations, CreateExamination, UpdateExamination, DeleteExamination } from '../../domain/usecases/ManageExaminations';
+import { CreateExaminationInput, UpdateExaminationInput } from '../../domain/repositories/ExaminationRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseExaminationsResult {
+  examinations: Examination[];
+  isLoading: boolean;
+  error: Error | null;
+  createExamination: (input: CreateExaminationInput) => Promise<void>;
+  updateExamination: (id: string, input: UpdateExaminationInput) => Promise<void>;
+  deleteExamination: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useExaminations = (): UseExaminationsResult => {
+  const useCases = useMemo(() => {
+    const { examinationRepository } = getDIContainer();
+    return {
+      getExaminations: new GetExaminations(examinationRepository),
+      createExamination: new CreateExamination(examinationRepository),
+      updateExamination: new UpdateExamination(examinationRepository),
+      deleteExamination: new DeleteExamination(examinationRepository),
+    };
+  }, []);
+
+  const { data: examinations, isLoading, error, refetch } = useFetcher(
+    async () => useCases.getExaminations.execute(),
+    [useCases],
+    [] as Examination[],
+    'examinations',
+  );
+
+  const handleCreate = useCallback(async (input: CreateExaminationInput) => {
+    await useCases.createExamination.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdateExaminationInput) => {
+    await useCases.updateExamination.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.deleteExamination.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    examinations,
+    isLoading,
+    error,
+    createExamination: handleCreate,
+    updateExamination: handleUpdate,
+    deleteExamination: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- 通院管理ページに検査スケジュールセクションを追加
- 検査の種類（必須）、検査日（必須）、次回検査日（任意・カレンダー入力）を記録可能
- 人間・ペット共に対応（健康診断・血液検査・歯科検診・胃カメラ・MRI・CT・レントゲン等）
- CRUD操作完備、次回検査日の直近順ソート、期限切れ赤色表示
- クリーンアーキテクチャの全レイヤーを実装

closes #991

## Test plan
- [x] 全テスト通過（663ファイル、8055テスト）
- [x] ビルド成功
- [ ] 検査記録の追加（メンバー選択・種類・検査日必須、次回検査日任意）
- [ ] 検査記録の編集・削除
- [ ] 次回検査日が過去の場合に期限切れ表示されること