### PR TITLE
通院ページに保険管理機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   healthLogs   HealthLog[]
   vaccinations Vaccination[]
   examinations Examination[]
+  insurances   Insurance[]
 }
 
 model Member {
@@ -53,6 +54,7 @@ model Member {
   healthLogs   HealthLog[]
   vaccinations Vaccination[]
   examinations Examination[]
+  insurances   Insurance[]
 
   @@index([userId])
 }
@@ -196,6 +198,22 @@ model Examination {
   nextScheduledDate DateTime?
   notes             String?
   createdAt         DateTime  @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+}
+
+model Insurance {
+  id              String   @id @default(cuid())
+  userId          String
+  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId        String
+  member          Member   @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  insuranceType   String
+  providerName    String?
+  policyNumber    String?
+  notes           String?
+  createdAt       DateTime @default(now())
 
   @@index([userId])
   @@index([memberId])

--- a/src/app/api/insurances/[insuranceId]/route.ts
+++ b/src/app/api/insurances/[insuranceId]/route.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/prisma';
+import { updateInsuranceSchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const findInsurance = (id: string) => prisma.insurance.findUnique({ where: { id } });
+
+export async function PUT(request: Request, { params }: { params: Promise<{ insuranceId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`insurances-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { insuranceId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: insuranceId,
+      finder: findInsurance,
+      resourceName: '保険',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updateInsuranceSchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const updated = await prisma.insurance.update({
+          where: { id: insuranceId },
+          data: {
+            insuranceType: parsed.data.insuranceType,
+            providerName: parsed.data.providerName,
+            policyNumber: parsed.data.policyNumber,
+            notes: parsed.data.notes,
+          },
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ insuranceId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`insurances-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const { insuranceId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: insuranceId,
+      finder: findInsurance,
+      resourceName: '保険',
+      handler: async () => {
+        await prisma.insurance.delete({ where: { id: insuranceId } });
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/insurances/route.ts
+++ b/src/app/api/insurances/route.ts
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+import { createInsuranceSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`insurances-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const insurances = await prisma.insurance.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: QUERY_LIMITS.DEFAULT,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = insurances.map((i) =>
+    flattenRelations(i, { member: 'memberName' }),
+  );
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`insurances-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createInsuranceSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const insurance = await prisma.insurance.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        insuranceType: parsed.data.insuranceType,
+        providerName: parsed.data.providerName,
+        policyNumber: parsed.data.policyNumber,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(insurance);
+  })();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -7,6 +7,7 @@ import { useAppointments } from '@/presentation/hooks/useAppointments';
 import { useHospitals } from '@/presentation/hooks/useHospitals';
 import { useVaccinations } from '@/presentation/hooks/useVaccinations';
 import { useExaminations } from '@/presentation/hooks/useExaminations';
+import { useInsurances } from '@/presentation/hooks/useInsurances';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { AppointmentList, AppointmentFilter, getAppointmentCounts } from '@/components/appointments/AppointmentList';
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
@@ -14,11 +15,13 @@ import { VaccinationForm, VaccinationFormData } from '@/components/vaccinations/
 import { VaccinationList } from '@/components/vaccinations/VaccinationList';
 import { ExaminationForm, ExaminationFormData } from '@/components/examinations/ExaminationForm';
 import { ExaminationList } from '@/components/examinations/ExaminationList';
+import { InsuranceForm, InsuranceFormData } from '@/components/insurances/InsuranceForm';
+import { InsuranceList } from '@/components/insurances/InsuranceList';
 import { TabSwitch } from '@/components/shared/TabSwitch';
 import { Appointment } from '@/domain/entities/Appointment';
 import { MiniCalendar } from '@/components/appointments/MiniCalendar';
 import Link from 'next/link';
-import { Plus, X, MapPin, Syringe, ClipboardList } from 'lucide-react';
+import { Plus, X, MapPin, Syringe, ClipboardList, ShieldCheck } from 'lucide-react';
 
 export default function AppointmentsPage() {
   const { userId } = useAuth();
@@ -27,9 +30,11 @@ export default function AppointmentsPage() {
   const { hospitals } = useHospitals();
   const { vaccinations, isLoading: vaccinationsLoading, createVaccination, updateVaccination, deleteVaccination } = useVaccinations();
   const { examinations, isLoading: examinationsLoading, createExamination, updateExamination, deleteExamination } = useExaminations();
+  const { insurances, isLoading: insurancesLoading, createInsurance, updateInsurance, deleteInsurance } = useInsurances();
   const [showForm, setShowForm] = useState(false);
   const [showVaccinationForm, setShowVaccinationForm] = useState(false);
   const [showExaminationForm, setShowExaminationForm] = useState(false);
+  const [showInsuranceForm, setShowInsuranceForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
   const [updateError, setUpdateError] = useState<string | null>(null);
@@ -101,6 +106,16 @@ export default function AppointmentsPage() {
   const handleDeleteExamination = async (id: string) => {
     if (!window.confirm('この検査記録を削除しますか？')) return;
     await deleteExamination(id);
+  };
+
+  const handleCreateInsurance = async (data: InsuranceFormData) => {
+    await createInsurance(data);
+    setShowInsuranceForm(false);
+  };
+
+  const handleDeleteInsurance = async (id: string) => {
+    if (!window.confirm('この保険を削除しますか？')) return;
+    await deleteInsurance(id);
   };
 
   const handleToggleForm = () => {
@@ -251,6 +266,46 @@ export default function AppointmentsPage() {
             isLoading={examinationsLoading}
             onUpdate={updateExamination}
             onDelete={handleDeleteExamination}
+          />
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <ShieldCheck size={18} className="text-primary-600" />
+              <h2 className="text-base font-bold text-gray-800">保険管理</h2>
+            </div>
+            <button
+              onClick={() => setShowInsuranceForm(!showInsuranceForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showInsuranceForm ? '閉じる' : '保険を追加'}
+            >
+              {showInsuranceForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showInsuranceForm && !membersLoading && members.length > 0 && (
+            <div className="mb-4 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">保険の追加</h3>
+              <InsuranceForm
+                members={members}
+                onSubmit={handleCreateInsurance}
+                onCancel={() => setShowInsuranceForm(false)}
+              />
+            </div>
+          )}
+
+          {showInsuranceForm && !membersLoading && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先にメンバーを登録してください。
+            </div>
+          )}
+
+          <InsuranceList
+            insurances={insurances}
+            isLoading={insurancesLoading}
+            onUpdate={updateInsurance}
+            onDelete={handleDeleteInsurance}
           />
         </div>
 

--- a/src/components/insurances/InsuranceForm.tsx
+++ b/src/components/insurances/InsuranceForm.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member } from '../../domain/entities/Member';
+
+export interface InsuranceFormData {
+  memberId: string;
+  insuranceType: string;
+  providerName?: string;
+  policyNumber?: string;
+  notes?: string;
+}
+
+interface InsuranceFormProps {
+  members: Member[];
+  onSubmit: (data: InsuranceFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    insuranceType: string;
+    providerName?: string;
+    policyNumber?: string;
+    notes?: string;
+  };
+}
+
+export const InsuranceForm: React.FC<InsuranceFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ''));
+  const [insuranceType, setInsuranceType] = useState(initialData?.insuranceType || '');
+  const [providerName, setProviderName] = useState(initialData?.providerName || '');
+  const [policyNumber, setPolicyNumber] = useState(initialData?.policyNumber || '');
+  const [notes, setNotes] = useState(initialData?.notes || '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !insuranceType.trim()) return;
+
+    onSubmit({
+      memberId,
+      insuranceType: insuranceType.trim(),
+      providerName: providerName.trim() || undefined,
+      policyNumber: policyNumber.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setInsuranceType('');
+      setProviderName('');
+      setPolicyNumber('');
+      setNotes('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="ins-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="ins-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="ins-type" className="block text-sm font-medium text-gray-700 mb-1">
+          保険の種類
+        </label>
+        <input
+          id="ins-type"
+          type="text"
+          value={insuranceType}
+          onChange={(e) => setInsuranceType(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+          placeholder="例: ガン保険、生命保険、医療保険"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ins-provider" className="block text-sm font-medium text-gray-700 mb-1">
+          保険会社名（任意）
+        </label>
+        <input
+          id="ins-provider"
+          type="text"
+          value={providerName}
+          onChange={(e) => setProviderName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="保険会社名を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ins-policy" className="block text-sm font-medium text-gray-700 mb-1">
+          証券番号（任意）
+        </label>
+        <input
+          id="ins-policy"
+          type="text"
+          value={policyNumber}
+          onChange={(e) => setPolicyNumber(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="証券番号を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ins-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="ins-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="メモを入力"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {initialData ? '更新する' : '登録する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/components/insurances/InsuranceList.tsx
+++ b/src/components/insurances/InsuranceList.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Pencil, Trash2, Check, X } from 'lucide-react';
+import { Insurance } from '../../domain/entities/Insurance';
+import { UpdateInsuranceInput } from '../../domain/repositories/InsuranceRepository';
+
+interface InsuranceListProps {
+  insurances: Insurance[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateInsuranceInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const InsuranceList: React.FC<InsuranceListProps> = ({ insurances, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (insurances.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-8">
+        <p className="text-gray-500 text-sm">保険が登録されていません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {insurances.map((insurance) => (
+        <InsuranceCard key={insurance.id} insurance={insurance} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface InsuranceCardProps {
+  insurance: Insurance;
+  onUpdate: (id: string, input: UpdateInsuranceInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const InsuranceCard: React.FC<InsuranceCardProps> = React.memo(({ insurance, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editType, setEditType] = useState(insurance.insuranceType);
+  const [editProvider, setEditProvider] = useState(insurance.providerName || '');
+  const [editPolicy, setEditPolicy] = useState(insurance.policyNumber || '');
+  const [editNotes, setEditNotes] = useState(insurance.notes || '');
+
+  const handleSave = async () => {
+    if (!editType.trim()) return;
+    await onUpdate(insurance.id, {
+      insuranceType: editType.trim(),
+      providerName: editProvider.trim() || null,
+      policyNumber: editPolicy.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditType(insurance.insuranceType);
+    setEditProvider(insurance.providerName || '');
+    setEditPolicy(insurance.policyNumber || '');
+    setEditNotes(insurance.notes || '');
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-blue-200 space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">保険の種類</label>
+          <input
+            type="text"
+            value={editType}
+            onChange={(e) => setEditType(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">保険会社名</label>
+          <input
+            type="text"
+            value={editProvider}
+            onChange={(e) => setEditProvider(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            placeholder="保険会社名を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">証券番号</label>
+          <input
+            type="text"
+            value={editPolicy}
+            onChange={(e) => setEditPolicy(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            placeholder="証券番号を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editType.trim()}
+            className="flex-1 flex items-center justify-center space-x-1 bg-blue-600 text-white py-1.5 rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-gray-200 text-gray-700 py-1.5 rounded-lg text-sm hover:bg-gray-300 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2">
+            <p className="font-medium text-gray-800 text-sm">{insurance.insuranceType}</p>
+            {insurance.memberName && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{insurance.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-gray-500 mt-1 space-y-0.5">
+            {insurance.providerName && <p>{insurance.providerName}</p>}
+            {insurance.policyNumber && <p>証券番号: {insurance.policyNumber}</p>}
+            {insurance.notes && <p className="text-gray-400">{insurance.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-gray-400 hover:text-blue-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => onDelete(insurance.id)}
+            className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+InsuranceCard.displayName = 'InsuranceCard';

--- a/src/data/api/insuranceApi.ts
+++ b/src/data/api/insuranceApi.ts
@@ -1,0 +1,26 @@
+import { Insurance } from '../../domain/entities/Insurance';
+import { CreateInsuranceInput, UpdateInsuranceInput } from '../../domain/repositories/InsuranceRepository';
+import { apiClient } from './apiClient';
+import { toInsurance } from './mappers';
+import { BackendInsurance } from './types';
+
+export const insuranceApi = {
+  async getInsurances(): Promise<Insurance[]> {
+    const data = await apiClient.get<BackendInsurance[]>('/insurances');
+    return data.map(toInsurance);
+  },
+
+  async createInsurance(input: CreateInsuranceInput): Promise<Insurance> {
+    const data = await apiClient.post<BackendInsurance>('/insurances', input);
+    return toInsurance(data);
+  },
+
+  async updateInsurance(id: string, input: UpdateInsuranceInput): Promise<Insurance> {
+    const data = await apiClient.put<BackendInsurance>(`/insurances/${id}`, input);
+    return toInsurance(data);
+  },
+
+  async deleteInsurance(id: string): Promise<void> {
+    await apiClient.del(`/insurances/${id}`);
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -7,7 +7,8 @@ import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
 import { HealthLog, ConditionLevel, SymptomType, SYMPTOM_OPTIONS } from '../../domain/entities/HealthLog';
 import { Vaccination } from '../../domain/entities/Vaccination';
 import { Examination } from '../../domain/entities/Examination';
-import { BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
+import { Insurance } from '../../domain/entities/Insurance';
+import { BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -118,6 +119,20 @@ export function toVaccination(b: BackendVaccination): Vaccination {
     vaccineName: b.vaccineName,
     vaccinatedAt: new Date(b.vaccinatedAt),
     nextScheduledDate: b.nextScheduledDate ? new Date(b.nextScheduledDate) : undefined,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toInsurance(b: BackendInsurance): Insurance {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    insuranceType: b.insuranceType,
+    providerName: b.providerName,
+    policyNumber: b.policyNumber,
     notes: b.notes,
     createdAt: new Date(b.createdAt),
   };

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -91,6 +91,18 @@ export interface BackendVaccination {
   createdAt: string;
 }
 
+export interface BackendInsurance {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  insuranceType: string;
+  providerName?: string;
+  policyNumber?: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendExamination {
   id: string;
   userId: string;

--- a/src/data/repositories/InsuranceRepositoryImpl.ts
+++ b/src/data/repositories/InsuranceRepositoryImpl.ts
@@ -1,0 +1,25 @@
+import {
+  InsuranceRepository,
+  CreateInsuranceInput,
+  UpdateInsuranceInput,
+} from '../../domain/repositories/InsuranceRepository';
+import { Insurance } from '../../domain/entities/Insurance';
+import { insuranceApi } from '../api/insuranceApi';
+
+export class InsuranceRepositoryImpl implements InsuranceRepository {
+  async getAll(): Promise<Insurance[]> {
+    return insuranceApi.getInsurances();
+  }
+
+  async create(input: CreateInsuranceInput): Promise<Insurance> {
+    return insuranceApi.createInsurance(input);
+  }
+
+  async update(id: string, input: UpdateInsuranceInput): Promise<Insurance> {
+    return insuranceApi.updateInsurance(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return insuranceApi.deleteInsurance(id);
+  }
+}

--- a/src/domain/entities/Insurance.ts
+++ b/src/domain/entities/Insurance.ts
@@ -1,0 +1,11 @@
+export interface Insurance {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly insuranceType: string;
+  readonly providerName?: string;
+  readonly policyNumber?: string;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/InsuranceRepository.ts
+++ b/src/domain/repositories/InsuranceRepository.ts
@@ -1,0 +1,23 @@
+import { Insurance } from '../entities/Insurance';
+
+export interface CreateInsuranceInput {
+  memberId: string;
+  insuranceType: string;
+  providerName?: string;
+  policyNumber?: string;
+  notes?: string;
+}
+
+export interface UpdateInsuranceInput {
+  insuranceType?: string;
+  providerName?: string | null;
+  policyNumber?: string | null;
+  notes?: string | null;
+}
+
+export interface InsuranceRepository {
+  getAll(): Promise<Insurance[]>;
+  create(input: CreateInsuranceInput): Promise<Insurance>;
+  update(id: string, input: UpdateInsuranceInput): Promise<Insurance>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageInsurances.ts
+++ b/src/domain/usecases/ManageInsurances.ts
@@ -1,0 +1,47 @@
+import { Insurance } from '../entities/Insurance';
+import {
+  InsuranceRepository,
+  CreateInsuranceInput,
+  UpdateInsuranceInput,
+} from '../repositories/InsuranceRepository';
+
+export class GetInsurances {
+  constructor(private readonly insuranceRepository: InsuranceRepository) {}
+
+  async execute(): Promise<Insurance[]> {
+    return this.insuranceRepository.getAll();
+  }
+}
+
+export class CreateInsurance {
+  constructor(private readonly insuranceRepository: InsuranceRepository) {}
+
+  async execute(input: CreateInsuranceInput): Promise<Insurance> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.insuranceType) {
+      throw new Error('保険の種類は必須です');
+    }
+    return this.insuranceRepository.create(input);
+  }
+}
+
+export class UpdateInsurance {
+  constructor(private readonly insuranceRepository: InsuranceRepository) {}
+
+  async execute(id: string, input: UpdateInsuranceInput): Promise<Insurance> {
+    if (!id) {
+      throw new Error('保険IDは必須です');
+    }
+    return this.insuranceRepository.update(id, input);
+  }
+}
+
+export class DeleteInsurance {
+  constructor(private readonly insuranceRepository: InsuranceRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.insuranceRepository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -13,6 +13,7 @@ import { UserProfileRepository } from '../domain/repositories/UserProfileReposit
 import { HealthLogRepository } from '../domain/repositories/HealthLogRepository';
 import { VaccinationRepository } from '../domain/repositories/VaccinationRepository';
 import { ExaminationRepository } from '../domain/repositories/ExaminationRepository';
+import { InsuranceRepository } from '../domain/repositories/InsuranceRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -23,6 +24,7 @@ import { UserProfileRepositoryImpl } from '../data/repositories/UserProfileRepos
 import { HealthLogRepositoryImpl } from '../data/repositories/HealthLogRepositoryImpl';
 import { VaccinationRepositoryImpl } from '../data/repositories/VaccinationRepositoryImpl';
 import { ExaminationRepositoryImpl } from '../data/repositories/ExaminationRepositoryImpl';
+import { InsuranceRepositoryImpl } from '../data/repositories/InsuranceRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -35,6 +37,7 @@ export interface DIContainer {
   healthLogRepository: HealthLogRepository;
   vaccinationRepository: VaccinationRepository;
   examinationRepository: ExaminationRepository;
+  insuranceRepository: InsuranceRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -53,6 +56,7 @@ export const getDIContainer = (): DIContainer => {
       healthLogRepository: new HealthLogRepositoryImpl(),
       vaccinationRepository: new VaccinationRepositoryImpl(),
       examinationRepository: new ExaminationRepositoryImpl(),
+      insuranceRepository: new InsuranceRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -186,6 +186,24 @@ export const updateExaminationSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Insurances =====
+export const createInsuranceSchema = z.object({
+  memberId: idField,
+  insuranceType: z.string({ required_error: '保険の種類は必須です' }).trim().min(1, '保険の種類は必須です').max(200),
+  providerName: z.string().trim().max(200).optional(),
+  policyNumber: z.string().trim().max(100).optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
+export const updateInsuranceSchema = z.object({
+  insuranceType: z.string().trim().min(1).max(200).optional(),
+  providerName: z.string().trim().max(200).optional().nullable(),
+  policyNumber: z.string().trim().max(100).optional().nullable(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Auth =====
 export const signUpSchema = z.object({
   email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),

--- a/src/presentation/hooks/useInsurances.ts
+++ b/src/presentation/hooks/useInsurances.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { Insurance } from '../../domain/entities/Insurance';
+import { GetInsurances, CreateInsurance, UpdateInsurance, DeleteInsurance } from '../../domain/usecases/ManageInsurances';
+import { CreateInsuranceInput, UpdateInsuranceInput } from '../../domain/repositories/InsuranceRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseInsurancesResult {
+  insurances: Insurance[];
+  isLoading: boolean;
+  error: Error | null;
+  createInsurance: (input: CreateInsuranceInput) => Promise<void>;
+  updateInsurance: (id: string, input: UpdateInsuranceInput) => Promise<void>;
+  deleteInsurance: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useInsurances = (): UseInsurancesResult => {
+  const useCases = useMemo(() => {
+    const { insuranceRepository } = getDIContainer();
+    return {
+      getInsurances: new GetInsurances(insuranceRepository),
+      createInsurance: new CreateInsurance(insuranceRepository),
+      updateInsurance: new UpdateInsurance(insuranceRepository),
+      deleteInsurance: new DeleteInsurance(insuranceRepository),
+    };
+  }, []);
+
+  const { data: insurances, isLoading, error, refetch } = useFetcher(
+    async () => useCases.getInsurances.execute(),
+    [useCases],
+    [] as Insurance[],
+    'insurances',
+  );
+
+  const handleCreate = useCallback(async (input: CreateInsuranceInput) => {
+    await useCases.createInsurance.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdateInsuranceInput) => {
+    await useCases.updateInsurance.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.deleteInsurance.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    insurances,
+    isLoading,
+    error,
+    createInsurance: handleCreate,
+    updateInsurance: handleUpdate,
+    deleteInsurance: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- 通院管理ページに保険管理セクションを追加
- 保険の種類（必須）、保険会社名（任意）、証券番号（任意）、メモ（任意）を登録可能
- メンバーごとに保険情報を紐付けて管理（ガン保険・生命保険・医療保険・ペット保険等）
- CRUD操作完備、クリーンアーキテクチャの全レイヤーを実装

closes #993

## Test plan
- [x] 全テスト通過（663ファイル、8055テスト）
- [x] ビルド成功
- [ ] 保険の追加（メンバー選択・種類必須、保険会社名・証券番号・メモ任意）
- [ ] 保険の編集・削除