### PR TITLE
feat: アレルギー管理機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   vaccinations Vaccination[]
   examinations Examination[]
   insurances   Insurance[]
+  allergies    Allergy[]
 }
 
 model Member {
@@ -55,6 +56,7 @@ model Member {
   vaccinations Vaccination[]
   examinations Examination[]
   insurances   Insurance[]
+  allergies    Allergy[]
 
   @@index([userId])
 }
@@ -214,6 +216,24 @@ model Insurance {
   policyNumber    String?
   notes           String?
   createdAt       DateTime @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+}
+
+model Allergy {
+  id            String    @id @default(cuid())
+  userId        String
+  user          User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId      String
+  member        Member    @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  allergenName  String
+  allergyType   String
+  severity      String
+  symptoms      String?
+  diagnosedAt   DateTime?
+  notes         String?
+  createdAt     DateTime  @default(now())
 
   @@index([userId])
   @@index([memberId])

--- a/src/__tests__/domain/usecases/ManageAllergies.test.ts
+++ b/src/__tests__/domain/usecases/ManageAllergies.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetAllergies, CreateAllergy, UpdateAllergy, DeleteAllergy } from '../../../domain/usecases/ManageAllergies';
+import { AllergyRepository, CreateAllergyInput, UpdateAllergyInput } from '../../../domain/repositories/AllergyRepository';
+import { Allergy } from '../../../domain/entities/Allergy';
+
+const mockAllergy: Allergy = {
+  id: 'allergy-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  allergenName: 'ピーナッツ',
+  allergyType: 'food',
+  severity: 'severe',
+  symptoms: 'じんましん、呼吸困難',
+  diagnosedAt: new Date('2024-01-15'),
+  notes: 'エピペン携帯',
+  createdAt: new Date('2024-01-15'),
+};
+
+const createMockRepository = (): AllergyRepository => ({
+  getAll: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+});
+
+describe('ManageAllergies', () => {
+  let mockRepository: AllergyRepository;
+
+  beforeEach(() => {
+    mockRepository = createMockRepository();
+  });
+
+  describe('GetAllergies', () => {
+    it('全てのアレルギーを取得できる', async () => {
+      const allergies = [mockAllergy];
+      vi.mocked(mockRepository.getAll).mockResolvedValue(allergies);
+
+      const useCase = new GetAllergies(mockRepository);
+      const result = await useCase.execute();
+
+      expect(result).toEqual(allergies);
+      expect(mockRepository.getAll).toHaveBeenCalledOnce();
+    });
+
+    it('アレルギーが0件の場合は空配列を返す', async () => {
+      vi.mocked(mockRepository.getAll).mockResolvedValue([]);
+
+      const useCase = new GetAllergies(mockRepository);
+      const result = await useCase.execute();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('CreateAllergy', () => {
+    it('アレルギーを作成できる', async () => {
+      const input: CreateAllergyInput = {
+        memberId: 'member-1',
+        allergenName: 'ピーナッツ',
+        allergyType: 'food',
+        severity: 'severe',
+        symptoms: 'じんましん',
+        notes: 'エピペン携帯',
+      };
+      vi.mocked(mockRepository.create).mockResolvedValue(mockAllergy);
+
+      const useCase = new CreateAllergy(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result).toEqual(mockAllergy);
+      expect(mockRepository.create).toHaveBeenCalledWith(input);
+    });
+
+    it('メンバーIDが空の場合エラーになる', async () => {
+      const input: CreateAllergyInput = {
+        memberId: '',
+        allergenName: 'ピーナッツ',
+        allergyType: 'food',
+        severity: 'severe',
+      };
+
+      const useCase = new CreateAllergy(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('メンバーIDは必須です');
+    });
+
+    it('アレルゲン名が空の場合エラーになる', async () => {
+      const input: CreateAllergyInput = {
+        memberId: 'member-1',
+        allergenName: '',
+        allergyType: 'food',
+        severity: 'severe',
+      };
+
+      const useCase = new CreateAllergy(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('アレルゲン名は必須です');
+    });
+
+    it('アレルギー種類が空の場合エラーになる', async () => {
+      const input: CreateAllergyInput = {
+        memberId: 'member-1',
+        allergenName: 'ピーナッツ',
+        allergyType: '',
+        severity: 'severe',
+      };
+
+      const useCase = new CreateAllergy(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('アレルギーの種類は必須です');
+    });
+
+    it('重症度が空の場合エラーになる', async () => {
+      const input: CreateAllergyInput = {
+        memberId: 'member-1',
+        allergenName: 'ピーナッツ',
+        allergyType: 'food',
+        severity: '',
+      };
+
+      const useCase = new CreateAllergy(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('重症度は必須です');
+    });
+  });
+
+  describe('UpdateAllergy', () => {
+    it('アレルギーを更新できる', async () => {
+      const input: UpdateAllergyInput = {
+        allergenName: '卵',
+        severity: 'mild',
+      };
+      const updated = { ...mockAllergy, allergenName: '卵', severity: 'mild' as const };
+      vi.mocked(mockRepository.update).mockResolvedValue(updated);
+
+      const useCase = new UpdateAllergy(mockRepository);
+      const result = await useCase.execute('allergy-1', input);
+
+      expect(result).toEqual(updated);
+      expect(mockRepository.update).toHaveBeenCalledWith('allergy-1', input);
+    });
+
+    it('IDが空の場合エラーになる', async () => {
+      const useCase = new UpdateAllergy(mockRepository);
+      await expect(useCase.execute('', { allergenName: '卵' })).rejects.toThrow('アレルギーIDは必須です');
+    });
+  });
+
+  describe('DeleteAllergy', () => {
+    it('アレルギーを削除できる', async () => {
+      vi.mocked(mockRepository.delete).mockResolvedValue(undefined);
+
+      const useCase = new DeleteAllergy(mockRepository);
+      await useCase.execute('allergy-1');
+
+      expect(mockRepository.delete).toHaveBeenCalledWith('allergy-1');
+    });
+  });
+});

--- a/src/app/api/allergies/[allergyId]/route.ts
+++ b/src/app/api/allergies/[allergyId]/route.ts
@@ -1,0 +1,63 @@
+import { prisma } from '@/lib/prisma';
+import { updateAllergySchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const findAllergy = (id: string) => prisma.allergy.findUnique({ where: { id } });
+
+export async function PUT(request: Request, { params }: { params: Promise<{ allergyId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`allergies-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { allergyId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: allergyId,
+      finder: findAllergy,
+      resourceName: 'アレルギー',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updateAllergySchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const updated = await prisma.allergy.update({
+          where: { id: allergyId },
+          data: {
+            allergenName: parsed.data.allergenName,
+            allergyType: parsed.data.allergyType,
+            severity: parsed.data.severity,
+            symptoms: parsed.data.symptoms,
+            diagnosedAt: parsed.data.diagnosedAt ? new Date(parsed.data.diagnosedAt) : parsed.data.diagnosedAt,
+            notes: parsed.data.notes,
+          },
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ allergyId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`allergies-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const { allergyId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: allergyId,
+      finder: findAllergy,
+      resourceName: 'アレルギー',
+      handler: async () => {
+        await prisma.allergy.delete({ where: { id: allergyId } });
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/allergies/route.ts
+++ b/src/app/api/allergies/route.ts
@@ -1,0 +1,58 @@
+import { prisma } from '@/lib/prisma';
+import { createAllergySchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`allergies-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const allergies = await prisma.allergy.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: QUERY_LIMITS.DEFAULT,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = allergies.map((a) =>
+    flattenRelations(a, { member: 'memberName' }),
+  );
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`allergies-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createAllergySchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const allergy = await prisma.allergy.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        allergenName: parsed.data.allergenName,
+        allergyType: parsed.data.allergyType,
+        severity: parsed.data.severity,
+        symptoms: parsed.data.symptoms,
+        diagnosedAt: parsed.data.diagnosedAt ? new Date(parsed.data.diagnosedAt) : undefined,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(allergy);
+  })();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -8,6 +8,7 @@ import { useHospitals } from '@/presentation/hooks/useHospitals';
 import { useVaccinations } from '@/presentation/hooks/useVaccinations';
 import { useExaminations } from '@/presentation/hooks/useExaminations';
 import { useInsurances } from '@/presentation/hooks/useInsurances';
+import { useAllergies } from '@/presentation/hooks/useAllergies';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { AppointmentList, AppointmentFilter, getAppointmentCounts } from '@/components/appointments/AppointmentList';
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
@@ -17,11 +18,13 @@ import { ExaminationForm, ExaminationFormData } from '@/components/examinations/
 import { ExaminationList } from '@/components/examinations/ExaminationList';
 import { InsuranceForm, InsuranceFormData } from '@/components/insurances/InsuranceForm';
 import { InsuranceList } from '@/components/insurances/InsuranceList';
+import { AllergyForm, AllergyFormData } from '@/components/allergies/AllergyForm';
+import { AllergyList } from '@/components/allergies/AllergyList';
 import { TabSwitch } from '@/components/shared/TabSwitch';
 import { Appointment } from '@/domain/entities/Appointment';
 import { MiniCalendar } from '@/components/appointments/MiniCalendar';
 import Link from 'next/link';
-import { Plus, X, MapPin, Syringe, ClipboardList, ShieldCheck } from 'lucide-react';
+import { Plus, X, MapPin, Syringe, ClipboardList, ShieldCheck, AlertTriangle } from 'lucide-react';
 
 export default function AppointmentsPage() {
   const { userId } = useAuth();
@@ -31,10 +34,12 @@ export default function AppointmentsPage() {
   const { vaccinations, isLoading: vaccinationsLoading, createVaccination, updateVaccination, deleteVaccination } = useVaccinations();
   const { examinations, isLoading: examinationsLoading, createExamination, updateExamination, deleteExamination } = useExaminations();
   const { insurances, isLoading: insurancesLoading, createInsurance, updateInsurance, deleteInsurance } = useInsurances();
+  const { allergies, isLoading: allergiesLoading, createAllergy, updateAllergy, deleteAllergy } = useAllergies();
   const [showForm, setShowForm] = useState(false);
   const [showVaccinationForm, setShowVaccinationForm] = useState(false);
   const [showExaminationForm, setShowExaminationForm] = useState(false);
   const [showInsuranceForm, setShowInsuranceForm] = useState(false);
+  const [showAllergyForm, setShowAllergyForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
   const [updateError, setUpdateError] = useState<string | null>(null);
@@ -106,6 +111,16 @@ export default function AppointmentsPage() {
   const handleDeleteExamination = async (id: string) => {
     if (!window.confirm('この検査記録を削除しますか？')) return;
     await deleteExamination(id);
+  };
+
+  const handleCreateAllergy = async (data: AllergyFormData) => {
+    await createAllergy(data);
+    setShowAllergyForm(false);
+  };
+
+  const handleDeleteAllergy = async (id: string) => {
+    if (!window.confirm('このアレルギー情報を削除しますか？')) return;
+    await deleteAllergy(id);
   };
 
   const handleCreateInsurance = async (data: InsuranceFormData) => {
@@ -266,6 +281,46 @@ export default function AppointmentsPage() {
             isLoading={examinationsLoading}
             onUpdate={updateExamination}
             onDelete={handleDeleteExamination}
+          />
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <AlertTriangle size={18} className="text-primary-600" />
+              <h2 className="text-base font-bold text-gray-800">アレルギー管理</h2>
+            </div>
+            <button
+              onClick={() => setShowAllergyForm(!showAllergyForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showAllergyForm ? '閉じる' : 'アレルギーを追加'}
+            >
+              {showAllergyForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showAllergyForm && !membersLoading && members.length > 0 && (
+            <div className="mb-4 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">アレルギーの追加</h3>
+              <AllergyForm
+                members={members}
+                onSubmit={handleCreateAllergy}
+                onCancel={() => setShowAllergyForm(false)}
+              />
+            </div>
+          )}
+
+          {showAllergyForm && !membersLoading && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先にメンバーを登録してください。
+            </div>
+          )}
+
+          <AllergyList
+            allergies={allergies}
+            isLoading={allergiesLoading}
+            onUpdate={updateAllergy}
+            onDelete={handleDeleteAllergy}
           />
         </div>
 

--- a/src/components/allergies/AllergyForm.tsx
+++ b/src/components/allergies/AllergyForm.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member } from '../../domain/entities/Member';
+
+export interface AllergyFormData {
+  memberId: string;
+  allergenName: string;
+  allergyType: string;
+  severity: string;
+  symptoms?: string;
+  diagnosedAt?: string;
+  notes?: string;
+}
+
+interface AllergyFormProps {
+  members: Member[];
+  onSubmit: (data: AllergyFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    allergenName: string;
+    allergyType: string;
+    severity: string;
+    symptoms?: string;
+    diagnosedAt?: string;
+    notes?: string;
+  };
+}
+
+const ALLERGY_TYPES = [
+  { value: 'food', label: '食物' },
+  { value: 'medication', label: '薬物' },
+  { value: 'environmental', label: '環境' },
+  { value: 'other', label: 'その他' },
+];
+
+const SEVERITY_LEVELS = [
+  { value: 'mild', label: '軽度' },
+  { value: 'moderate', label: '中度' },
+  { value: 'severe', label: '重度' },
+];
+
+export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ''));
+  const [allergenName, setAllergenName] = useState(initialData?.allergenName || '');
+  const [allergyType, setAllergyType] = useState(initialData?.allergyType || '');
+  const [severity, setSeverity] = useState(initialData?.severity || '');
+  const [symptoms, setSymptoms] = useState(initialData?.symptoms || '');
+  const [diagnosedAt, setDiagnosedAt] = useState(initialData?.diagnosedAt || '');
+  const [notes, setNotes] = useState(initialData?.notes || '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !allergenName.trim() || !allergyType || !severity) return;
+
+    onSubmit({
+      memberId,
+      allergenName: allergenName.trim(),
+      allergyType,
+      severity,
+      symptoms: symptoms.trim() || undefined,
+      diagnosedAt: diagnosedAt || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setAllergenName('');
+      setAllergyType('');
+      setSeverity('');
+      setSymptoms('');
+      setDiagnosedAt('');
+      setNotes('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="allergy-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="allergy-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="allergy-name" className="block text-sm font-medium text-gray-700 mb-1">
+          アレルゲン名
+        </label>
+        <input
+          id="allergy-name"
+          type="text"
+          value={allergenName}
+          onChange={(e) => setAllergenName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+          placeholder="例: ピーナッツ、ペニシリン、花粉"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="allergy-type" className="block text-sm font-medium text-gray-700 mb-1">
+          アレルギーの種類
+        </label>
+        <select
+          id="allergy-type"
+          value={allergyType}
+          onChange={(e) => setAllergyType(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {ALLERGY_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>{t.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="allergy-severity" className="block text-sm font-medium text-gray-700 mb-1">
+          重症度
+        </label>
+        <select
+          id="allergy-severity"
+          value={severity}
+          onChange={(e) => setSeverity(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {SEVERITY_LEVELS.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="allergy-symptoms" className="block text-sm font-medium text-gray-700 mb-1">
+          症状・反応（任意）
+        </label>
+        <textarea
+          id="allergy-symptoms"
+          value={symptoms}
+          onChange={(e) => setSymptoms(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="例: じんましん、呼吸困難、腫れ"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="allergy-diagnosed" className="block text-sm font-medium text-gray-700 mb-1">
+          診断日（任意）
+        </label>
+        <input
+          id="allergy-diagnosed"
+          type="date"
+          value={diagnosedAt}
+          onChange={(e) => setDiagnosedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="allergy-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="allergy-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="例: エピペン携帯必要"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {initialData ? '更新する' : '登録する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/components/allergies/AllergyList.tsx
+++ b/src/components/allergies/AllergyList.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Pencil, Trash2, Check, X } from 'lucide-react';
+import { Allergy } from '../../domain/entities/Allergy';
+import { UpdateAllergyInput } from '../../domain/repositories/AllergyRepository';
+
+const ALLERGY_TYPE_LABELS: Record<string, string> = {
+  food: '食物',
+  medication: '薬物',
+  environmental: '環境',
+  other: 'その他',
+};
+
+const SEVERITY_LABELS: Record<string, string> = {
+  mild: '軽度',
+  moderate: '中度',
+  severe: '重度',
+};
+
+const SEVERITY_COLORS: Record<string, string> = {
+  mild: 'bg-green-100 text-green-700',
+  moderate: 'bg-yellow-100 text-yellow-700',
+  severe: 'bg-red-100 text-red-700',
+};
+
+interface AllergyListProps {
+  allergies: Allergy[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateAllergyInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const AllergyList: React.FC<AllergyListProps> = ({ allergies, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (allergies.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-8">
+        <p className="text-gray-500 text-sm">アレルギーが登録されていません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {allergies.map((allergy) => (
+        <AllergyCard key={allergy.id} allergy={allergy} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface AllergyCardProps {
+  allergy: Allergy;
+  onUpdate: (id: string, input: UpdateAllergyInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const AllergyCard: React.FC<AllergyCardProps> = React.memo(({ allergy, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(allergy.allergenName);
+  const [editType, setEditType] = useState(allergy.allergyType);
+  const [editSeverity, setEditSeverity] = useState(allergy.severity);
+  const [editSymptoms, setEditSymptoms] = useState(allergy.symptoms || '');
+  const [editNotes, setEditNotes] = useState(allergy.notes || '');
+
+  const handleSave = async () => {
+    if (!editName.trim() || !editType || !editSeverity) return;
+    await onUpdate(allergy.id, {
+      allergenName: editName.trim(),
+      allergyType: editType,
+      severity: editSeverity,
+      symptoms: editSymptoms.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(allergy.allergenName);
+    setEditType(allergy.allergyType);
+    setEditSeverity(allergy.severity);
+    setEditSymptoms(allergy.symptoms || '');
+    setEditNotes(allergy.notes || '');
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-blue-200 space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">アレルゲン名</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">種類</label>
+          <select
+            value={editType}
+            onChange={(e) => setEditType(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          >
+            {Object.entries(ALLERGY_TYPE_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">重症度</label>
+          <select
+            value={editSeverity}
+            onChange={(e) => setEditSeverity(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          >
+            {Object.entries(SEVERITY_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">症状・反応</label>
+          <textarea
+            value={editSymptoms}
+            onChange={(e) => setEditSymptoms(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim() || !editType || !editSeverity}
+            className="flex-1 flex items-center justify-center space-x-1 bg-blue-600 text-white py-1.5 rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-gray-200 text-gray-700 py-1.5 rounded-lg text-sm hover:bg-gray-300 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+            <p className="font-medium text-gray-800 text-sm">{allergy.allergenName}</p>
+            <span className={`text-xs px-1.5 py-0.5 rounded ${SEVERITY_COLORS[allergy.severity] || 'bg-gray-100 text-gray-600'}`}>
+              {SEVERITY_LABELS[allergy.severity] || allergy.severity}
+            </span>
+            <span className="text-xs bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded">
+              {ALLERGY_TYPE_LABELS[allergy.allergyType] || allergy.allergyType}
+            </span>
+            {allergy.memberName && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{allergy.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-gray-500 mt-1 space-y-0.5">
+            {allergy.symptoms && <p>{allergy.symptoms}</p>}
+            {allergy.diagnosedAt && (
+              <p>診断日: {new Date(allergy.diagnosedAt).toLocaleDateString('ja-JP')}</p>
+            )}
+            {allergy.notes && <p className="text-gray-400">{allergy.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-gray-400 hover:text-blue-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => onDelete(allergy.id)}
+            className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+AllergyCard.displayName = 'AllergyCard';

--- a/src/data/api/allergyApi.ts
+++ b/src/data/api/allergyApi.ts
@@ -1,0 +1,26 @@
+import { Allergy } from '../../domain/entities/Allergy';
+import { CreateAllergyInput, UpdateAllergyInput } from '../../domain/repositories/AllergyRepository';
+import { apiClient } from './apiClient';
+import { toAllergy } from './mappers';
+import { BackendAllergy } from './types';
+
+export const allergyApi = {
+  async getAllergies(): Promise<Allergy[]> {
+    const data = await apiClient.get<BackendAllergy[]>('/allergies');
+    return data.map(toAllergy);
+  },
+
+  async createAllergy(input: CreateAllergyInput): Promise<Allergy> {
+    const data = await apiClient.post<BackendAllergy>('/allergies', input);
+    return toAllergy(data);
+  },
+
+  async updateAllergy(id: string, input: UpdateAllergyInput): Promise<Allergy> {
+    const data = await apiClient.put<BackendAllergy>(`/allergies/${id}`, input);
+    return toAllergy(data);
+  },
+
+  async deleteAllergy(id: string): Promise<void> {
+    await apiClient.del(`/allergies/${id}`);
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -7,8 +7,9 @@ import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
 import { HealthLog, ConditionLevel, SymptomType, SYMPTOM_OPTIONS } from '../../domain/entities/HealthLog';
 import { Vaccination } from '../../domain/entities/Vaccination';
 import { Examination } from '../../domain/entities/Examination';
+import { Allergy } from '../../domain/entities/Allergy';
 import { Insurance } from '../../domain/entities/Insurance';
-import { BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
+import { BackendAllergy, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -133,6 +134,22 @@ export function toInsurance(b: BackendInsurance): Insurance {
     insuranceType: b.insuranceType,
     providerName: b.providerName,
     policyNumber: b.policyNumber,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toAllergy(b: BackendAllergy): Allergy {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    allergenName: b.allergenName,
+    allergyType: b.allergyType,
+    severity: b.severity,
+    symptoms: b.symptoms,
+    diagnosedAt: b.diagnosedAt ? new Date(b.diagnosedAt) : undefined,
     notes: b.notes,
     createdAt: new Date(b.createdAt),
   };

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -103,6 +103,20 @@ export interface BackendInsurance {
   createdAt: string;
 }
 
+export interface BackendAllergy {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  allergenName: string;
+  allergyType: string;
+  severity: string;
+  symptoms?: string;
+  diagnosedAt?: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendExamination {
   id: string;
   userId: string;

--- a/src/data/repositories/AllergyRepositoryImpl.ts
+++ b/src/data/repositories/AllergyRepositoryImpl.ts
@@ -1,0 +1,25 @@
+import {
+  AllergyRepository,
+  CreateAllergyInput,
+  UpdateAllergyInput,
+} from '../../domain/repositories/AllergyRepository';
+import { Allergy } from '../../domain/entities/Allergy';
+import { allergyApi } from '../api/allergyApi';
+
+export class AllergyRepositoryImpl implements AllergyRepository {
+  async getAll(): Promise<Allergy[]> {
+    return allergyApi.getAllergies();
+  }
+
+  async create(input: CreateAllergyInput): Promise<Allergy> {
+    return allergyApi.createAllergy(input);
+  }
+
+  async update(id: string, input: UpdateAllergyInput): Promise<Allergy> {
+    return allergyApi.updateAllergy(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return allergyApi.deleteAllergy(id);
+  }
+}

--- a/src/domain/entities/Allergy.ts
+++ b/src/domain/entities/Allergy.ts
@@ -1,0 +1,13 @@
+export interface Allergy {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly allergenName: string;
+  readonly allergyType: string;
+  readonly severity: string;
+  readonly symptoms?: string;
+  readonly diagnosedAt?: Date;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/AllergyRepository.ts
+++ b/src/domain/repositories/AllergyRepository.ts
@@ -1,0 +1,27 @@
+import { Allergy } from '../entities/Allergy';
+
+export interface CreateAllergyInput {
+  memberId: string;
+  allergenName: string;
+  allergyType: string;
+  severity: string;
+  symptoms?: string;
+  diagnosedAt?: string;
+  notes?: string;
+}
+
+export interface UpdateAllergyInput {
+  allergenName?: string;
+  allergyType?: string;
+  severity?: string;
+  symptoms?: string | null;
+  diagnosedAt?: string | null;
+  notes?: string | null;
+}
+
+export interface AllergyRepository {
+  getAll(): Promise<Allergy[]>;
+  create(input: CreateAllergyInput): Promise<Allergy>;
+  update(id: string, input: UpdateAllergyInput): Promise<Allergy>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageAllergies.ts
+++ b/src/domain/usecases/ManageAllergies.ts
@@ -1,0 +1,53 @@
+import { Allergy } from '../entities/Allergy';
+import {
+  AllergyRepository,
+  CreateAllergyInput,
+  UpdateAllergyInput,
+} from '../repositories/AllergyRepository';
+
+export class GetAllergies {
+  constructor(private readonly allergyRepository: AllergyRepository) {}
+
+  async execute(): Promise<Allergy[]> {
+    return this.allergyRepository.getAll();
+  }
+}
+
+export class CreateAllergy {
+  constructor(private readonly allergyRepository: AllergyRepository) {}
+
+  async execute(input: CreateAllergyInput): Promise<Allergy> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.allergenName) {
+      throw new Error('アレルゲン名は必須です');
+    }
+    if (!input.allergyType) {
+      throw new Error('アレルギーの種類は必須です');
+    }
+    if (!input.severity) {
+      throw new Error('重症度は必須です');
+    }
+    return this.allergyRepository.create(input);
+  }
+}
+
+export class UpdateAllergy {
+  constructor(private readonly allergyRepository: AllergyRepository) {}
+
+  async execute(id: string, input: UpdateAllergyInput): Promise<Allergy> {
+    if (!id) {
+      throw new Error('アレルギーIDは必須です');
+    }
+    return this.allergyRepository.update(id, input);
+  }
+}
+
+export class DeleteAllergy {
+  constructor(private readonly allergyRepository: AllergyRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.allergyRepository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -14,6 +14,7 @@ import { HealthLogRepository } from '../domain/repositories/HealthLogRepository'
 import { VaccinationRepository } from '../domain/repositories/VaccinationRepository';
 import { ExaminationRepository } from '../domain/repositories/ExaminationRepository';
 import { InsuranceRepository } from '../domain/repositories/InsuranceRepository';
+import { AllergyRepository } from '../domain/repositories/AllergyRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -25,6 +26,7 @@ import { HealthLogRepositoryImpl } from '../data/repositories/HealthLogRepositor
 import { VaccinationRepositoryImpl } from '../data/repositories/VaccinationRepositoryImpl';
 import { ExaminationRepositoryImpl } from '../data/repositories/ExaminationRepositoryImpl';
 import { InsuranceRepositoryImpl } from '../data/repositories/InsuranceRepositoryImpl';
+import { AllergyRepositoryImpl } from '../data/repositories/AllergyRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -38,6 +40,7 @@ export interface DIContainer {
   vaccinationRepository: VaccinationRepository;
   examinationRepository: ExaminationRepository;
   insuranceRepository: InsuranceRepository;
+  allergyRepository: AllergyRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -57,6 +60,7 @@ export const getDIContainer = (): DIContainer => {
       vaccinationRepository: new VaccinationRepositoryImpl(),
       examinationRepository: new ExaminationRepositoryImpl(),
       insuranceRepository: new InsuranceRepositoryImpl(),
+      allergyRepository: new AllergyRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -204,6 +204,28 @@ export const updateInsuranceSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Allergies =====
+export const createAllergySchema = z.object({
+  memberId: idField,
+  allergenName: z.string({ required_error: 'アレルゲン名は必須です' }).trim().min(1, 'アレルゲン名は必須です').max(200),
+  allergyType: z.enum(['food', 'medication', 'environmental', 'other'], { required_error: 'アレルギーの種類は必須です' }),
+  severity: z.enum(['mild', 'moderate', 'severe'], { required_error: '重症度は必須です' }),
+  symptoms: z.string().trim().max(500).optional(),
+  diagnosedAt: dateString.optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
+export const updateAllergySchema = z.object({
+  allergenName: z.string().trim().min(1).max(200).optional(),
+  allergyType: z.enum(['food', 'medication', 'environmental', 'other']).optional(),
+  severity: z.enum(['mild', 'moderate', 'severe']).optional(),
+  symptoms: z.string().trim().max(500).optional().nullable(),
+  diagnosedAt: dateString.optional().nullable(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Auth =====
 export const signUpSchema = z.object({
   email: z.string().trim().toLowerCase().max(254, 'メールアドレスが長すぎます').email('有効なメールアドレスを入力してください'),

--- a/src/presentation/hooks/useAllergies.ts
+++ b/src/presentation/hooks/useAllergies.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { Allergy } from '../../domain/entities/Allergy';
+import { GetAllergies, CreateAllergy, UpdateAllergy, DeleteAllergy } from '../../domain/usecases/ManageAllergies';
+import { CreateAllergyInput, UpdateAllergyInput } from '../../domain/repositories/AllergyRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseAllergiesResult {
+  allergies: Allergy[];
+  isLoading: boolean;
+  error: Error | null;
+  createAllergy: (input: CreateAllergyInput) => Promise<void>;
+  updateAllergy: (id: string, input: UpdateAllergyInput) => Promise<void>;
+  deleteAllergy: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useAllergies = (): UseAllergiesResult => {
+  const useCases = useMemo(() => {
+    const { allergyRepository } = getDIContainer();
+    return {
+      getAllergies: new GetAllergies(allergyRepository),
+      createAllergy: new CreateAllergy(allergyRepository),
+      updateAllergy: new UpdateAllergy(allergyRepository),
+      deleteAllergy: new DeleteAllergy(allergyRepository),
+    };
+  }, []);
+
+  const { data: allergies, isLoading, error, refetch } = useFetcher(
+    async () => useCases.getAllergies.execute(),
+    [useCases],
+    [] as Allergy[],
+    'allergies',
+  );
+
+  const handleCreate = useCallback(async (input: CreateAllergyInput) => {
+    await useCases.createAllergy.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdateAllergyInput) => {
+    await useCases.updateAllergy.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.deleteAllergy.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    allergies,
+    isLoading,
+    error,
+    createAllergy: handleCreate,
+    updateAllergy: handleUpdate,
+    deleteAllergy: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- メンバーごとのアレルギー情報を管理する機能を追加
- アレルゲン名、種類（食物・薬物・環境・その他）、重症度（軽度・中度・重度）を記録可能
- 症状・反応、診断日、メモを任意で記録
- 通院管理ページにアレルギー管理セクションを追加（保険管理の前に配置）
- 重症度に応じた色分けバッジ表示（軽度:緑、中度:黄、重度:赤）

closes #995

## Test plan
- [x] ManageAllergiesユースケーステスト（10テスト全て通過）
- [x] 全テスト通過（8065テスト）
- [x] ビルド成功