### PR TITLE
feat: 体重・身長記録機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,8 +32,9 @@ model User {
   healthLogs   HealthLog[]
   vaccinations Vaccination[]
   examinations Examination[]
-  insurances   Insurance[]
-  allergies    Allergy[]
+  insurances       Insurance[]
+  allergies        Allergy[]
+  bodyMeasurements BodyMeasurement[]
 }
 
 model Member {
@@ -55,8 +56,9 @@ model Member {
   healthLogs   HealthLog[]
   vaccinations Vaccination[]
   examinations Examination[]
-  insurances   Insurance[]
-  allergies    Allergy[]
+  insurances       Insurance[]
+  allergies        Allergy[]
+  bodyMeasurements BodyMeasurement[]
 
   @@index([userId])
 }
@@ -234,6 +236,22 @@ model Allergy {
   diagnosedAt   DateTime?
   notes         String?
   createdAt     DateTime  @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+}
+
+model BodyMeasurement {
+  id          String    @id @default(cuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId    String
+  member      Member    @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  weight      Float?
+  height      Float?
+  recordedAt  DateTime
+  notes       String?
+  createdAt   DateTime  @default(now())
 
   @@index([userId])
   @@index([memberId])

--- a/src/__tests__/domain/usecases/ManageBodyMeasurements.test.ts
+++ b/src/__tests__/domain/usecases/ManageBodyMeasurements.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetBodyMeasurements, CreateBodyMeasurement, UpdateBodyMeasurement, DeleteBodyMeasurement } from '../../../domain/usecases/ManageBodyMeasurements';
+import { BodyMeasurementRepository, CreateBodyMeasurementInput, UpdateBodyMeasurementInput } from '../../../domain/repositories/BodyMeasurementRepository';
+import { BodyMeasurement } from '../../../domain/entities/BodyMeasurement';
+
+const mockMeasurement: BodyMeasurement = {
+  id: 'measurement-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  weight: 65.5,
+  height: 170.0,
+  recordedAt: new Date('2024-03-15'),
+  notes: '朝食前に測定',
+  createdAt: new Date('2024-03-15'),
+};
+
+const createMockRepository = (): BodyMeasurementRepository => ({
+  getAll: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+});
+
+describe('ManageBodyMeasurements', () => {
+  let mockRepository: BodyMeasurementRepository;
+
+  beforeEach(() => {
+    mockRepository = createMockRepository();
+  });
+
+  describe('GetBodyMeasurements', () => {
+    it('全ての体重・身長記録を取得できる', async () => {
+      const measurements = [mockMeasurement];
+      vi.mocked(mockRepository.getAll).mockResolvedValue(measurements);
+
+      const useCase = new GetBodyMeasurements(mockRepository);
+      const result = await useCase.execute();
+
+      expect(result).toEqual(measurements);
+      expect(mockRepository.getAll).toHaveBeenCalledOnce();
+    });
+
+    it('記録が0件の場合は空配列を返す', async () => {
+      vi.mocked(mockRepository.getAll).mockResolvedValue([]);
+
+      const useCase = new GetBodyMeasurements(mockRepository);
+      const result = await useCase.execute();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('CreateBodyMeasurement', () => {
+    it('体重・身長記録を作成できる', async () => {
+      const input: CreateBodyMeasurementInput = {
+        memberId: 'member-1',
+        weight: 65.5,
+        height: 170.0,
+        recordedAt: '2024-03-15',
+        notes: '朝食前に測定',
+      };
+      vi.mocked(mockRepository.create).mockResolvedValue(mockMeasurement);
+
+      const useCase = new CreateBodyMeasurement(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result).toEqual(mockMeasurement);
+      expect(mockRepository.create).toHaveBeenCalledWith(input);
+    });
+
+    it('体重のみで作成できる', async () => {
+      const input: CreateBodyMeasurementInput = {
+        memberId: 'member-1',
+        weight: 65.5,
+        recordedAt: '2024-03-15',
+      };
+      vi.mocked(mockRepository.create).mockResolvedValue({ ...mockMeasurement, height: undefined });
+
+      const useCase = new CreateBodyMeasurement(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result.height).toBeUndefined();
+    });
+
+    it('身長のみで作成できる', async () => {
+      const input: CreateBodyMeasurementInput = {
+        memberId: 'member-1',
+        height: 170.0,
+        recordedAt: '2024-03-15',
+      };
+      vi.mocked(mockRepository.create).mockResolvedValue({ ...mockMeasurement, weight: undefined });
+
+      const useCase = new CreateBodyMeasurement(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result.weight).toBeUndefined();
+    });
+
+    it('メンバーIDが空の場合エラーになる', async () => {
+      const input: CreateBodyMeasurementInput = {
+        memberId: '',
+        weight: 65.5,
+        recordedAt: '2024-03-15',
+      };
+
+      const useCase = new CreateBodyMeasurement(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('メンバーIDは必須です');
+    });
+
+    it('記録日が空の場合エラーになる', async () => {
+      const input: CreateBodyMeasurementInput = {
+        memberId: 'member-1',
+        weight: 65.5,
+        recordedAt: '',
+      };
+
+      const useCase = new CreateBodyMeasurement(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('記録日は必須です');
+    });
+
+    it('体重も身長も未入力の場合エラーになる', async () => {
+      const input: CreateBodyMeasurementInput = {
+        memberId: 'member-1',
+        recordedAt: '2024-03-15',
+      };
+
+      const useCase = new CreateBodyMeasurement(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('体重または身長のいずれかは必須です');
+    });
+  });
+
+  describe('UpdateBodyMeasurement', () => {
+    it('記録を更新できる', async () => {
+      const input: UpdateBodyMeasurementInput = {
+        weight: 64.0,
+      };
+      const updated = { ...mockMeasurement, weight: 64.0 };
+      vi.mocked(mockRepository.update).mockResolvedValue(updated);
+
+      const useCase = new UpdateBodyMeasurement(mockRepository);
+      const result = await useCase.execute('measurement-1', input);
+
+      expect(result).toEqual(updated);
+      expect(mockRepository.update).toHaveBeenCalledWith('measurement-1', input);
+    });
+
+    it('IDが空の場合エラーになる', async () => {
+      const useCase = new UpdateBodyMeasurement(mockRepository);
+      await expect(useCase.execute('', { weight: 64.0 })).rejects.toThrow('記録IDは必須です');
+    });
+  });
+
+  describe('DeleteBodyMeasurement', () => {
+    it('記録を削除できる', async () => {
+      vi.mocked(mockRepository.delete).mockResolvedValue(undefined);
+
+      const useCase = new DeleteBodyMeasurement(mockRepository);
+      await useCase.execute('measurement-1');
+
+      expect(mockRepository.delete).toHaveBeenCalledWith('measurement-1');
+    });
+  });
+});

--- a/src/app/api/body-measurements/[measurementId]/route.ts
+++ b/src/app/api/body-measurements/[measurementId]/route.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/prisma';
+import { updateBodyMeasurementSchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const findMeasurement = (id: string) => prisma.bodyMeasurement.findUnique({ where: { id } });
+
+export async function PUT(request: Request, { params }: { params: Promise<{ measurementId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`body-measurements-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { measurementId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: measurementId,
+      finder: findMeasurement,
+      resourceName: '体重・身長記録',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updateBodyMeasurementSchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const updated = await prisma.bodyMeasurement.update({
+          where: { id: measurementId },
+          data: {
+            weight: parsed.data.weight,
+            height: parsed.data.height,
+            recordedAt: parsed.data.recordedAt ? new Date(parsed.data.recordedAt) : undefined,
+            notes: parsed.data.notes,
+          },
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ measurementId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`body-measurements-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const { measurementId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: measurementId,
+      finder: findMeasurement,
+      resourceName: '体重・身長記録',
+      handler: async () => {
+        await prisma.bodyMeasurement.delete({ where: { id: measurementId } });
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/body-measurements/route.ts
+++ b/src/app/api/body-measurements/route.ts
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+import { createBodyMeasurementSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`body-measurements-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const measurements = await prisma.bodyMeasurement.findMany({
+    where: { userId },
+    orderBy: { recordedAt: 'desc' },
+    take: QUERY_LIMITS.DEFAULT,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = measurements.map((m) =>
+    flattenRelations(m, { member: 'memberName' }),
+  );
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`body-measurements-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createBodyMeasurementSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const measurement = await prisma.bodyMeasurement.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        weight: parsed.data.weight,
+        height: parsed.data.height,
+        recordedAt: new Date(parsed.data.recordedAt),
+        notes: parsed.data.notes,
+      },
+    });
+    return created(measurement);
+  })();
+}

--- a/src/app/health-logs/page.tsx
+++ b/src/app/health-logs/page.tsx
@@ -1,22 +1,27 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { Plus, Activity } from 'lucide-react';
+import { Plus, X, Activity, Ruler } from 'lucide-react';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { HealthLogList } from '@/components/health-logs/HealthLogList';
 import { HealthLogForm } from '@/components/health-logs/HealthLogForm';
 import { HealthWeeklyTrend } from '@/components/health-logs/HealthWeeklyTrend';
 import { SymptomFrequencySummary } from '@/components/health-logs/SymptomFrequencySummary';
 import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
+import { useBodyMeasurements } from '@/presentation/hooks/useBodyMeasurements';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAuth } from '@/hooks/useAuth';
 import { HealthLogEntity } from '@/domain/entities/HealthLog';
+import { BodyMeasurementForm, BodyMeasurementFormData } from '@/components/body-measurements/BodyMeasurementForm';
+import { BodyMeasurementList } from '@/components/body-measurements/BodyMeasurementList';
 
 export default function HealthLogsPage() {
   const { userId } = useAuth();
   const { groups, isLoading, createLog, deleteLog } = useHealthLogs();
   const { members } = useMembers(userId ?? '');
+  const { measurements, isLoading: measurementsLoading, createMeasurement, updateMeasurement, deleteMeasurement } = useBodyMeasurements();
   const [showForm, setShowForm] = useState(false);
+  const [showMeasurementForm, setShowMeasurementForm] = useState(false);
 
   const allLogs = useMemo(
     () => groups.flatMap((g) => g.logs),
@@ -41,6 +46,16 @@ export default function HealthLogsPage() {
   }) => {
     await createLog(input);
     setShowForm(false);
+  };
+
+  const handleCreateMeasurement = async (data: BodyMeasurementFormData) => {
+    await createMeasurement(data);
+    setShowMeasurementForm(false);
+  };
+
+  const handleDeleteMeasurement = async (id: string) => {
+    if (!window.confirm('この記録を削除しますか？')) return;
+    await deleteMeasurement(id);
   };
 
   return (
@@ -79,6 +94,46 @@ export default function HealthLogsPage() {
         <SymptomFrequencySummary symptoms={frequentSymptoms} />
 
         <HealthLogList groups={groups} isLoading={isLoading} onDelete={deleteLog} />
+
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <Ruler size={18} className="text-primary-600" />
+              <h2 className="text-base font-bold text-gray-800">体重・身長記録</h2>
+            </div>
+            <button
+              onClick={() => setShowMeasurementForm(!showMeasurementForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showMeasurementForm ? '閉じる' : '記録を追加'}
+            >
+              {showMeasurementForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showMeasurementForm && members.length > 0 && (
+            <div className="mb-4 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">体重・身長の記録</h3>
+              <BodyMeasurementForm
+                members={members}
+                onSubmit={handleCreateMeasurement}
+                onCancel={() => setShowMeasurementForm(false)}
+              />
+            </div>
+          )}
+
+          {showMeasurementForm && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先にメンバーを登録してください。
+            </div>
+          )}
+
+          <BodyMeasurementList
+            measurements={measurements}
+            isLoading={measurementsLoading}
+            onUpdate={updateMeasurement}
+            onDelete={handleDeleteMeasurement}
+          />
+        </div>
       </main>
 
       <BottomNavigation activePath="/health-logs" />

--- a/src/components/body-measurements/BodyMeasurementForm.tsx
+++ b/src/components/body-measurements/BodyMeasurementForm.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member } from '../../domain/entities/Member';
+
+export interface BodyMeasurementFormData {
+  memberId: string;
+  weight?: number;
+  height?: number;
+  recordedAt: string;
+  notes?: string;
+}
+
+interface BodyMeasurementFormProps {
+  members: Member[];
+  onSubmit: (data: BodyMeasurementFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    weight?: number;
+    height?: number;
+    recordedAt: string;
+    notes?: string;
+  };
+}
+
+export const BodyMeasurementForm: React.FC<BodyMeasurementFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ''));
+  const [weight, setWeight] = useState(initialData?.weight?.toString() || '');
+  const [height, setHeight] = useState(initialData?.height?.toString() || '');
+  const [recordedAt, setRecordedAt] = useState(initialData?.recordedAt || new Date().toISOString().split('T')[0]);
+  const [notes, setNotes] = useState(initialData?.notes || '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !recordedAt) return;
+    const w = weight ? parseFloat(weight) : undefined;
+    const h = height ? parseFloat(height) : undefined;
+    if (w == null && h == null) return;
+
+    onSubmit({
+      memberId,
+      weight: w,
+      height: h,
+      recordedAt,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setWeight('');
+      setHeight('');
+      setNotes('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="bm-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="bm-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="bm-weight" className="block text-sm font-medium text-gray-700 mb-1">
+            体重 (kg)
+          </label>
+          <input
+            id="bm-weight"
+            type="number"
+            step="0.1"
+            min="0.1"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="65.5"
+          />
+        </div>
+        <div>
+          <label htmlFor="bm-height" className="block text-sm font-medium text-gray-700 mb-1">
+            身長 (cm)
+          </label>
+          <input
+            id="bm-height"
+            type="number"
+            step="0.1"
+            min="0.1"
+            value={height}
+            onChange={(e) => setHeight(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="170.0"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="bm-date" className="block text-sm font-medium text-gray-700 mb-1">
+          記録日
+        </label>
+        <input
+          id="bm-date"
+          type="date"
+          value={recordedAt}
+          onChange={(e) => setRecordedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label htmlFor="bm-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="bm-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="朝食前に測定、など"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {initialData ? '更新する' : '記録する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/components/body-measurements/BodyMeasurementList.tsx
+++ b/src/components/body-measurements/BodyMeasurementList.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Pencil, Trash2, Check, X } from 'lucide-react';
+import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
+import { UpdateBodyMeasurementInput } from '../../domain/repositories/BodyMeasurementRepository';
+
+interface BodyMeasurementListProps {
+  measurements: BodyMeasurement[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateBodyMeasurementInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const BodyMeasurementList: React.FC<BodyMeasurementListProps> = ({ measurements, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (measurements.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-8">
+        <p className="text-gray-500 text-sm">記録がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {measurements.map((m) => (
+        <MeasurementCard key={m.id} measurement={m} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface MeasurementCardProps {
+  measurement: BodyMeasurement;
+  onUpdate: (id: string, input: UpdateBodyMeasurementInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const MeasurementCard: React.FC<MeasurementCardProps> = React.memo(({ measurement, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editWeight, setEditWeight] = useState(measurement.weight?.toString() || '');
+  const [editHeight, setEditHeight] = useState(measurement.height?.toString() || '');
+  const [editNotes, setEditNotes] = useState(measurement.notes || '');
+
+  const handleSave = async () => {
+    const w = editWeight ? parseFloat(editWeight) : null;
+    const h = editHeight ? parseFloat(editHeight) : null;
+    if (w == null && h == null) return;
+    await onUpdate(measurement.id, {
+      weight: w,
+      height: h,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditWeight(measurement.weight?.toString() || '');
+    setEditHeight(measurement.height?.toString() || '');
+    setEditNotes(measurement.notes || '');
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-blue-200 space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">体重 (kg)</label>
+            <input
+              type="number"
+              step="0.1"
+              min="0.1"
+              value={editWeight}
+              onChange={(e) => setEditWeight(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">身長 (cm)</label>
+            <input
+              type="number"
+              step="0.1"
+              min="0.1"
+              value={editHeight}
+              onChange={(e) => setEditHeight(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editWeight && !editHeight}
+            className="flex-1 flex items-center justify-center space-x-1 bg-blue-600 text-white py-1.5 rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-gray-200 text-gray-700 py-1.5 rounded-lg text-sm hover:bg-gray-300 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+            <p className="text-xs text-gray-500">
+              {new Date(measurement.recordedAt).toLocaleDateString('ja-JP')}
+            </p>
+            {measurement.memberName && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{measurement.memberName}</span>
+            )}
+          </div>
+          <div className="flex items-center space-x-3 mt-1">
+            {measurement.weight != null && (
+              <p className="font-medium text-gray-800 text-sm">
+                体重: {measurement.weight} kg
+              </p>
+            )}
+            {measurement.height != null && (
+              <p className="font-medium text-gray-800 text-sm">
+                身長: {measurement.height} cm
+              </p>
+            )}
+          </div>
+          {measurement.notes && (
+            <p className="text-xs text-gray-400 mt-1">{measurement.notes}</p>
+          )}
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-gray-400 hover:text-blue-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => onDelete(measurement.id)}
+            className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+MeasurementCard.displayName = 'MeasurementCard';

--- a/src/data/api/bodyMeasurementApi.ts
+++ b/src/data/api/bodyMeasurementApi.ts
@@ -1,0 +1,26 @@
+import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
+import { CreateBodyMeasurementInput, UpdateBodyMeasurementInput } from '../../domain/repositories/BodyMeasurementRepository';
+import { apiClient } from './apiClient';
+import { toBodyMeasurement } from './mappers';
+import { BackendBodyMeasurement } from './types';
+
+export const bodyMeasurementApi = {
+  async getBodyMeasurements(): Promise<BodyMeasurement[]> {
+    const data = await apiClient.get<BackendBodyMeasurement[]>('/body-measurements');
+    return data.map(toBodyMeasurement);
+  },
+
+  async createBodyMeasurement(input: CreateBodyMeasurementInput): Promise<BodyMeasurement> {
+    const data = await apiClient.post<BackendBodyMeasurement>('/body-measurements', input);
+    return toBodyMeasurement(data);
+  },
+
+  async updateBodyMeasurement(id: string, input: UpdateBodyMeasurementInput): Promise<BodyMeasurement> {
+    const data = await apiClient.put<BackendBodyMeasurement>(`/body-measurements/${id}`, input);
+    return toBodyMeasurement(data);
+  },
+
+  async deleteBodyMeasurement(id: string): Promise<void> {
+    await apiClient.del(`/body-measurements/${id}`);
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -8,8 +8,9 @@ import { HealthLog, ConditionLevel, SymptomType, SYMPTOM_OPTIONS } from '../../d
 import { Vaccination } from '../../domain/entities/Vaccination';
 import { Examination } from '../../domain/entities/Examination';
 import { Allergy } from '../../domain/entities/Allergy';
+import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
 import { Insurance } from '../../domain/entities/Insurance';
-import { BackendAllergy, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
+import { BackendAllergy, BackendBodyMeasurement, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -134,6 +135,20 @@ export function toInsurance(b: BackendInsurance): Insurance {
     insuranceType: b.insuranceType,
     providerName: b.providerName,
     policyNumber: b.policyNumber,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toBodyMeasurement(b: BackendBodyMeasurement): BodyMeasurement {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    weight: b.weight,
+    height: b.height,
+    recordedAt: new Date(b.recordedAt),
     notes: b.notes,
     createdAt: new Date(b.createdAt),
   };

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -103,6 +103,18 @@ export interface BackendInsurance {
   createdAt: string;
 }
 
+export interface BackendBodyMeasurement {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  weight?: number;
+  height?: number;
+  recordedAt: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendAllergy {
   id: string;
   userId: string;

--- a/src/data/repositories/BodyMeasurementRepositoryImpl.ts
+++ b/src/data/repositories/BodyMeasurementRepositoryImpl.ts
@@ -1,0 +1,25 @@
+import {
+  BodyMeasurementRepository,
+  CreateBodyMeasurementInput,
+  UpdateBodyMeasurementInput,
+} from '../../domain/repositories/BodyMeasurementRepository';
+import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
+import { bodyMeasurementApi } from '../api/bodyMeasurementApi';
+
+export class BodyMeasurementRepositoryImpl implements BodyMeasurementRepository {
+  async getAll(): Promise<BodyMeasurement[]> {
+    return bodyMeasurementApi.getBodyMeasurements();
+  }
+
+  async create(input: CreateBodyMeasurementInput): Promise<BodyMeasurement> {
+    return bodyMeasurementApi.createBodyMeasurement(input);
+  }
+
+  async update(id: string, input: UpdateBodyMeasurementInput): Promise<BodyMeasurement> {
+    return bodyMeasurementApi.updateBodyMeasurement(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return bodyMeasurementApi.deleteBodyMeasurement(id);
+  }
+}

--- a/src/domain/entities/BodyMeasurement.ts
+++ b/src/domain/entities/BodyMeasurement.ts
@@ -1,0 +1,11 @@
+export interface BodyMeasurement {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly weight?: number;
+  readonly height?: number;
+  readonly recordedAt: Date;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/BodyMeasurementRepository.ts
+++ b/src/domain/repositories/BodyMeasurementRepository.ts
@@ -1,0 +1,23 @@
+import { BodyMeasurement } from '../entities/BodyMeasurement';
+
+export interface CreateBodyMeasurementInput {
+  memberId: string;
+  weight?: number;
+  height?: number;
+  recordedAt: string;
+  notes?: string;
+}
+
+export interface UpdateBodyMeasurementInput {
+  weight?: number | null;
+  height?: number | null;
+  recordedAt?: string;
+  notes?: string | null;
+}
+
+export interface BodyMeasurementRepository {
+  getAll(): Promise<BodyMeasurement[]>;
+  create(input: CreateBodyMeasurementInput): Promise<BodyMeasurement>;
+  update(id: string, input: UpdateBodyMeasurementInput): Promise<BodyMeasurement>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageBodyMeasurements.ts
+++ b/src/domain/usecases/ManageBodyMeasurements.ts
@@ -1,0 +1,50 @@
+import { BodyMeasurement } from '../entities/BodyMeasurement';
+import {
+  BodyMeasurementRepository,
+  CreateBodyMeasurementInput,
+  UpdateBodyMeasurementInput,
+} from '../repositories/BodyMeasurementRepository';
+
+export class GetBodyMeasurements {
+  constructor(private readonly repository: BodyMeasurementRepository) {}
+
+  async execute(): Promise<BodyMeasurement[]> {
+    return this.repository.getAll();
+  }
+}
+
+export class CreateBodyMeasurement {
+  constructor(private readonly repository: BodyMeasurementRepository) {}
+
+  async execute(input: CreateBodyMeasurementInput): Promise<BodyMeasurement> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.recordedAt) {
+      throw new Error('記録日は必須です');
+    }
+    if (input.weight == null && input.height == null) {
+      throw new Error('体重または身長のいずれかは必須です');
+    }
+    return this.repository.create(input);
+  }
+}
+
+export class UpdateBodyMeasurement {
+  constructor(private readonly repository: BodyMeasurementRepository) {}
+
+  async execute(id: string, input: UpdateBodyMeasurementInput): Promise<BodyMeasurement> {
+    if (!id) {
+      throw new Error('記録IDは必須です');
+    }
+    return this.repository.update(id, input);
+  }
+}
+
+export class DeleteBodyMeasurement {
+  constructor(private readonly repository: BodyMeasurementRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.repository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -15,6 +15,7 @@ import { VaccinationRepository } from '../domain/repositories/VaccinationReposit
 import { ExaminationRepository } from '../domain/repositories/ExaminationRepository';
 import { InsuranceRepository } from '../domain/repositories/InsuranceRepository';
 import { AllergyRepository } from '../domain/repositories/AllergyRepository';
+import { BodyMeasurementRepository } from '../domain/repositories/BodyMeasurementRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -27,6 +28,7 @@ import { VaccinationRepositoryImpl } from '../data/repositories/VaccinationRepos
 import { ExaminationRepositoryImpl } from '../data/repositories/ExaminationRepositoryImpl';
 import { InsuranceRepositoryImpl } from '../data/repositories/InsuranceRepositoryImpl';
 import { AllergyRepositoryImpl } from '../data/repositories/AllergyRepositoryImpl';
+import { BodyMeasurementRepositoryImpl } from '../data/repositories/BodyMeasurementRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -41,6 +43,7 @@ export interface DIContainer {
   examinationRepository: ExaminationRepository;
   insuranceRepository: InsuranceRepository;
   allergyRepository: AllergyRepository;
+  bodyMeasurementRepository: BodyMeasurementRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -61,6 +64,7 @@ export const getDIContainer = (): DIContainer => {
       examinationRepository: new ExaminationRepositoryImpl(),
       insuranceRepository: new InsuranceRepositoryImpl(),
       allergyRepository: new AllergyRepositoryImpl(),
+      bodyMeasurementRepository: new BodyMeasurementRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -204,6 +204,26 @@ export const updateInsuranceSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Body Measurements =====
+export const createBodyMeasurementSchema = z.object({
+  memberId: idField,
+  weight: z.number().min(0.1, '体重は0.1以上を指定してください').max(9999).optional(),
+  height: z.number().min(0.1, '身長は0.1以上を指定してください').max(9999).optional(),
+  recordedAt: dateString,
+  notes: z.string().trim().max(500).optional(),
+}).refine((data) => data.weight != null || data.height != null, {
+  message: '体重または身長のいずれかは必須です',
+});
+
+export const updateBodyMeasurementSchema = z.object({
+  weight: z.number().min(0.1).max(9999).optional().nullable(),
+  height: z.number().min(0.1).max(9999).optional().nullable(),
+  recordedAt: dateString.optional(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Allergies =====
 export const createAllergySchema = z.object({
   memberId: idField,

--- a/src/presentation/hooks/useBodyMeasurements.ts
+++ b/src/presentation/hooks/useBodyMeasurements.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
+import { GetBodyMeasurements, CreateBodyMeasurement, UpdateBodyMeasurement, DeleteBodyMeasurement } from '../../domain/usecases/ManageBodyMeasurements';
+import { CreateBodyMeasurementInput, UpdateBodyMeasurementInput } from '../../domain/repositories/BodyMeasurementRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseBodyMeasurementsResult {
+  measurements: BodyMeasurement[];
+  isLoading: boolean;
+  error: Error | null;
+  createMeasurement: (input: CreateBodyMeasurementInput) => Promise<void>;
+  updateMeasurement: (id: string, input: UpdateBodyMeasurementInput) => Promise<void>;
+  deleteMeasurement: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useBodyMeasurements = (): UseBodyMeasurementsResult => {
+  const useCases = useMemo(() => {
+    const { bodyMeasurementRepository } = getDIContainer();
+    return {
+      getMeasurements: new GetBodyMeasurements(bodyMeasurementRepository),
+      createMeasurement: new CreateBodyMeasurement(bodyMeasurementRepository),
+      updateMeasurement: new UpdateBodyMeasurement(bodyMeasurementRepository),
+      deleteMeasurement: new DeleteBodyMeasurement(bodyMeasurementRepository),
+    };
+  }, []);
+
+  const { data: measurements, isLoading, error, refetch } = useFetcher(
+    async () => useCases.getMeasurements.execute(),
+    [useCases],
+    [] as BodyMeasurement[],
+    'bodyMeasurements',
+  );
+
+  const handleCreate = useCallback(async (input: CreateBodyMeasurementInput) => {
+    await useCases.createMeasurement.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdateBodyMeasurementInput) => {
+    await useCases.updateMeasurement.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.deleteMeasurement.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    measurements,
+    isLoading,
+    error,
+    createMeasurement: handleCreate,
+    updateMeasurement: handleUpdate,
+    deleteMeasurement: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- メンバーごとの体重(kg)・身長(cm)を記録する機能を追加
- 記録日指定、メモ記入が可能
- 体調記録ページに体重・身長記録セクションを追加
- CRUD操作（作成・一覧・インライン編集・削除）

closes #997

## Test plan
- [x] ManageBodyMeasurementsユースケーステスト（11テスト全て通過）
- [x] ビルド成功