### PR TITLE
feat: 緊急連絡先管理機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,8 +33,9 @@ model User {
   vaccinations Vaccination[]
   examinations Examination[]
   insurances       Insurance[]
-  allergies        Allergy[]
-  bodyMeasurements BodyMeasurement[]
+  allergies          Allergy[]
+  bodyMeasurements   BodyMeasurement[]
+  emergencyContacts  EmergencyContact[]
 }
 
 model Member {
@@ -57,8 +58,9 @@ model Member {
   vaccinations Vaccination[]
   examinations Examination[]
   insurances       Insurance[]
-  allergies        Allergy[]
-  bodyMeasurements BodyMeasurement[]
+  allergies          Allergy[]
+  bodyMeasurements   BodyMeasurement[]
+  emergencyContacts  EmergencyContact[]
 
   @@index([userId])
 }
@@ -252,6 +254,22 @@ model BodyMeasurement {
   recordedAt  DateTime
   notes       String?
   createdAt   DateTime  @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+}
+
+model EmergencyContact {
+  id            String   @id @default(cuid())
+  userId        String
+  user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId      String
+  member        Member   @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  contactName   String
+  phoneNumber   String
+  relationship  String?
+  notes         String?
+  createdAt     DateTime @default(now())
 
   @@index([userId])
   @@index([memberId])

--- a/src/__tests__/domain/usecases/ManageEmergencyContacts.test.ts
+++ b/src/__tests__/domain/usecases/ManageEmergencyContacts.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetEmergencyContacts, CreateEmergencyContact, UpdateEmergencyContact, DeleteEmergencyContact } from '../../../domain/usecases/ManageEmergencyContacts';
+import { EmergencyContactRepository, CreateEmergencyContactInput, UpdateEmergencyContactInput } from '../../../domain/repositories/EmergencyContactRepository';
+import { EmergencyContact } from '../../../domain/entities/EmergencyContact';
+
+const mockContact: EmergencyContact = {
+  id: 'contact-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  contactName: '田中花子',
+  phoneNumber: '090-1234-5678',
+  relationship: '母',
+  notes: '日中連絡可',
+  createdAt: new Date('2024-01-15'),
+};
+
+const createMockRepository = (): EmergencyContactRepository => ({
+  getAll: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+});
+
+describe('ManageEmergencyContacts', () => {
+  let mockRepository: EmergencyContactRepository;
+
+  beforeEach(() => {
+    mockRepository = createMockRepository();
+  });
+
+  describe('GetEmergencyContacts', () => {
+    it('全ての緊急連絡先を取得できる', async () => {
+      vi.mocked(mockRepository.getAll).mockResolvedValue([mockContact]);
+
+      const useCase = new GetEmergencyContacts(mockRepository);
+      const result = await useCase.execute();
+
+      expect(result).toEqual([mockContact]);
+      expect(mockRepository.getAll).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('CreateEmergencyContact', () => {
+    it('緊急連絡先を作成できる', async () => {
+      const input: CreateEmergencyContactInput = {
+        memberId: 'member-1',
+        contactName: '田中花子',
+        phoneNumber: '090-1234-5678',
+        relationship: '母',
+      };
+      vi.mocked(mockRepository.create).mockResolvedValue(mockContact);
+
+      const useCase = new CreateEmergencyContact(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result).toEqual(mockContact);
+    });
+
+    it('メンバーIDが空の場合エラーになる', async () => {
+      const input: CreateEmergencyContactInput = {
+        memberId: '',
+        contactName: '田中花子',
+        phoneNumber: '090-1234-5678',
+      };
+
+      const useCase = new CreateEmergencyContact(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('メンバーIDは必須です');
+    });
+
+    it('連絡先名が空の場合エラーになる', async () => {
+      const input: CreateEmergencyContactInput = {
+        memberId: 'member-1',
+        contactName: '',
+        phoneNumber: '090-1234-5678',
+      };
+
+      const useCase = new CreateEmergencyContact(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('連絡先名は必須です');
+    });
+
+    it('電話番号が空の場合エラーになる', async () => {
+      const input: CreateEmergencyContactInput = {
+        memberId: 'member-1',
+        contactName: '田中花子',
+        phoneNumber: '',
+      };
+
+      const useCase = new CreateEmergencyContact(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('電話番号は必須です');
+    });
+  });
+
+  describe('UpdateEmergencyContact', () => {
+    it('連絡先を更新できる', async () => {
+      const input: UpdateEmergencyContactInput = { contactName: '山田太郎' };
+      const updated = { ...mockContact, contactName: '山田太郎' };
+      vi.mocked(mockRepository.update).mockResolvedValue(updated);
+
+      const useCase = new UpdateEmergencyContact(mockRepository);
+      const result = await useCase.execute('contact-1', input);
+
+      expect(result).toEqual(updated);
+    });
+
+    it('IDが空の場合エラーになる', async () => {
+      const useCase = new UpdateEmergencyContact(mockRepository);
+      await expect(useCase.execute('', { contactName: 'test' })).rejects.toThrow('連絡先IDは必須です');
+    });
+  });
+
+  describe('DeleteEmergencyContact', () => {
+    it('連絡先を削除できる', async () => {
+      vi.mocked(mockRepository.delete).mockResolvedValue(undefined);
+
+      const useCase = new DeleteEmergencyContact(mockRepository);
+      await useCase.execute('contact-1');
+
+      expect(mockRepository.delete).toHaveBeenCalledWith('contact-1');
+    });
+  });
+});

--- a/src/app/api/emergency-contacts/[contactId]/route.ts
+++ b/src/app/api/emergency-contacts/[contactId]/route.ts
@@ -1,0 +1,61 @@
+import { prisma } from '@/lib/prisma';
+import { updateEmergencyContactSchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const findContact = (id: string) => prisma.emergencyContact.findUnique({ where: { id } });
+
+export async function PUT(request: Request, { params }: { params: Promise<{ contactId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`emergency-contacts-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { contactId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: contactId,
+      finder: findContact,
+      resourceName: '緊急連絡先',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updateEmergencyContactSchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const updated = await prisma.emergencyContact.update({
+          where: { id: contactId },
+          data: {
+            contactName: parsed.data.contactName,
+            phoneNumber: parsed.data.phoneNumber,
+            relationship: parsed.data.relationship,
+            notes: parsed.data.notes,
+          },
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ contactId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`emergency-contacts-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const { contactId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: contactId,
+      finder: findContact,
+      resourceName: '緊急連絡先',
+      handler: async () => {
+        await prisma.emergencyContact.delete({ where: { id: contactId } });
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/emergency-contacts/route.ts
+++ b/src/app/api/emergency-contacts/route.ts
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+import { createEmergencyContactSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`emergency-contacts-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const contacts = await prisma.emergencyContact.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    take: QUERY_LIMITS.DEFAULT,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = contacts.map((c) =>
+    flattenRelations(c, { member: 'memberName' }),
+  );
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`emergency-contacts-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createEmergencyContactSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const contact = await prisma.emergencyContact.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        contactName: parsed.data.contactName,
+        phoneNumber: parsed.data.phoneNumber,
+        relationship: parsed.data.relationship,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(contact);
+  })();
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,17 +3,24 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useUserProfile } from '@/presentation/hooks/useUserProfile';
+import { useMembers } from '@/presentation/hooks/useMembers';
+import { useEmergencyContacts } from '@/presentation/hooks/useEmergencyContacts';
 import { CharacterSelector } from '@/components/character/CharacterSelector';
+import { EmergencyContactForm, EmergencyContactFormData } from '@/components/emergency-contacts/EmergencyContactForm';
+import { EmergencyContactList } from '@/components/emergency-contacts/EmergencyContactList';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { signOut } from 'next-auth/react';
-import { LogOut, Pencil, Check, X } from 'lucide-react';
+import { LogOut, Pencil, Check, X, Plus, Phone } from 'lucide-react';
 
 export default function Settings() {
-  const { email } = useAuth();
+  const { email, userId } = useAuth();
   const { profile, updateProfile } = useUserProfile();
+  const { members } = useMembers(userId ?? '');
+  const { contacts, isLoading: contactsLoading, createContact, updateContact, deleteContact } = useEmergencyContacts();
   const [isEditingName, setIsEditingName] = useState(false);
   const [displayName, setDisplayName] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  const [showContactForm, setShowContactForm] = useState(false);
 
   useEffect(() => {
     if (profile) {
@@ -35,6 +42,16 @@ export default function Settings() {
   const handleCancelEdit = () => {
     setDisplayName(profile?.displayName || '');
     setIsEditingName(false);
+  };
+
+  const handleCreateContact = async (data: EmergencyContactFormData) => {
+    await createContact(data);
+    setShowContactForm(false);
+  };
+
+  const handleDeleteContact = async (id: string) => {
+    if (!window.confirm('この緊急連絡先を削除しますか？')) return;
+    await deleteContact(id);
   };
 
   const handleLogout = async () => {
@@ -106,6 +123,46 @@ export default function Settings() {
         <section className="bg-white rounded-lg shadow-md p-4 border border-gray-200">
           <h2 className="text-lg font-semibold text-gray-800 mb-4">キャラクター選択</h2>
           <CharacterSelector />
+        </section>
+
+        <section className="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <Phone size={18} className="text-primary-600" />
+              <h2 className="text-lg font-semibold text-gray-800">緊急連絡先</h2>
+            </div>
+            <button
+              onClick={() => setShowContactForm(!showContactForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showContactForm ? '閉じる' : '緊急連絡先を追加'}
+            >
+              {showContactForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showContactForm && members.length > 0 && (
+            <div className="mb-4 bg-gray-50 rounded-lg p-4 border border-gray-100">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">緊急連絡先の追加</h3>
+              <EmergencyContactForm
+                members={members}
+                onSubmit={handleCreateContact}
+                onCancel={() => setShowContactForm(false)}
+              />
+            </div>
+          )}
+
+          {showContactForm && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先にメンバーを登録してください。
+            </div>
+          )}
+
+          <EmergencyContactList
+            contacts={contacts}
+            isLoading={contactsLoading}
+            onUpdate={updateContact}
+            onDelete={handleDeleteContact}
+          />
         </section>
 
         <button

--- a/src/components/emergency-contacts/EmergencyContactForm.tsx
+++ b/src/components/emergency-contacts/EmergencyContactForm.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member } from '../../domain/entities/Member';
+
+export interface EmergencyContactFormData {
+  memberId: string;
+  contactName: string;
+  phoneNumber: string;
+  relationship?: string;
+  notes?: string;
+}
+
+interface EmergencyContactFormProps {
+  members: Member[];
+  onSubmit: (data: EmergencyContactFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    contactName: string;
+    phoneNumber: string;
+    relationship?: string;
+    notes?: string;
+  };
+}
+
+export const EmergencyContactForm: React.FC<EmergencyContactFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ''));
+  const [contactName, setContactName] = useState(initialData?.contactName || '');
+  const [phoneNumber, setPhoneNumber] = useState(initialData?.phoneNumber || '');
+  const [relationship, setRelationship] = useState(initialData?.relationship || '');
+  const [notes, setNotes] = useState(initialData?.notes || '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !contactName.trim() || !phoneNumber.trim()) return;
+
+    onSubmit({
+      memberId,
+      contactName: contactName.trim(),
+      phoneNumber: phoneNumber.trim(),
+      relationship: relationship.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setContactName('');
+      setPhoneNumber('');
+      setRelationship('');
+      setNotes('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="ec-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="ec-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="ec-name" className="block text-sm font-medium text-gray-700 mb-1">
+          連絡先名
+        </label>
+        <input
+          id="ec-name"
+          type="text"
+          value={contactName}
+          onChange={(e) => setContactName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+          placeholder="例: 田中花子"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ec-phone" className="block text-sm font-medium text-gray-700 mb-1">
+          電話番号
+        </label>
+        <input
+          id="ec-phone"
+          type="tel"
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+          placeholder="例: 090-1234-5678"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ec-relationship" className="block text-sm font-medium text-gray-700 mb-1">
+          続柄（任意）
+        </label>
+        <input
+          id="ec-relationship"
+          type="text"
+          value={relationship}
+          onChange={(e) => setRelationship(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="例: 母、父、配偶者、かかりつけ医"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ec-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="ec-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="日中連絡可、夜間のみ等"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {initialData ? '更新する' : '登録する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/components/emergency-contacts/EmergencyContactList.tsx
+++ b/src/components/emergency-contacts/EmergencyContactList.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Pencil, Trash2, Check, X, Phone } from 'lucide-react';
+import { EmergencyContact } from '../../domain/entities/EmergencyContact';
+import { UpdateEmergencyContactInput } from '../../domain/repositories/EmergencyContactRepository';
+
+interface EmergencyContactListProps {
+  contacts: EmergencyContact[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateEmergencyContactInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const EmergencyContactList: React.FC<EmergencyContactListProps> = ({ contacts, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (contacts.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-8">
+        <p className="text-gray-500 text-sm">緊急連絡先が登録されていません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {contacts.map((contact) => (
+        <ContactCard key={contact.id} contact={contact} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface ContactCardProps {
+  contact: EmergencyContact;
+  onUpdate: (id: string, input: UpdateEmergencyContactInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const ContactCard: React.FC<ContactCardProps> = React.memo(({ contact, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(contact.contactName);
+  const [editPhone, setEditPhone] = useState(contact.phoneNumber);
+  const [editRelationship, setEditRelationship] = useState(contact.relationship || '');
+  const [editNotes, setEditNotes] = useState(contact.notes || '');
+
+  const handleSave = async () => {
+    if (!editName.trim() || !editPhone.trim()) return;
+    await onUpdate(contact.id, {
+      contactName: editName.trim(),
+      phoneNumber: editPhone.trim(),
+      relationship: editRelationship.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(contact.contactName);
+    setEditPhone(contact.phoneNumber);
+    setEditRelationship(contact.relationship || '');
+    setEditNotes(contact.notes || '');
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-blue-200 space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">連絡先名</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">電話番号</label>
+          <input
+            type="tel"
+            value={editPhone}
+            onChange={(e) => setEditPhone(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">続柄</label>
+          <input
+            type="text"
+            value={editRelationship}
+            onChange={(e) => setEditRelationship(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim() || !editPhone.trim()}
+            className="flex-1 flex items-center justify-center space-x-1 bg-blue-600 text-white py-1.5 rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-gray-200 text-gray-700 py-1.5 rounded-lg text-sm hover:bg-gray-300 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+            <p className="font-medium text-gray-800 text-sm">{contact.contactName}</p>
+            {contact.relationship && (
+              <span className="text-xs bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded">{contact.relationship}</span>
+            )}
+            {contact.memberName && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{contact.memberName}</span>
+            )}
+          </div>
+          <div className="flex items-center space-x-1 mt-1">
+            <Phone size={12} className="text-gray-400" />
+            <a href={`tel:${contact.phoneNumber}`} className="text-sm text-primary-600 hover:underline">
+              {contact.phoneNumber}
+            </a>
+          </div>
+          {contact.notes && (
+            <p className="text-xs text-gray-400 mt-1">{contact.notes}</p>
+          )}
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-gray-400 hover:text-blue-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => onDelete(contact.id)}
+            className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ContactCard.displayName = 'ContactCard';

--- a/src/data/api/emergencyContactApi.ts
+++ b/src/data/api/emergencyContactApi.ts
@@ -1,0 +1,26 @@
+import { EmergencyContact } from '../../domain/entities/EmergencyContact';
+import { CreateEmergencyContactInput, UpdateEmergencyContactInput } from '../../domain/repositories/EmergencyContactRepository';
+import { apiClient } from './apiClient';
+import { toEmergencyContact } from './mappers';
+import { BackendEmergencyContact } from './types';
+
+export const emergencyContactApi = {
+  async getEmergencyContacts(): Promise<EmergencyContact[]> {
+    const data = await apiClient.get<BackendEmergencyContact[]>('/emergency-contacts');
+    return data.map(toEmergencyContact);
+  },
+
+  async createEmergencyContact(input: CreateEmergencyContactInput): Promise<EmergencyContact> {
+    const data = await apiClient.post<BackendEmergencyContact>('/emergency-contacts', input);
+    return toEmergencyContact(data);
+  },
+
+  async updateEmergencyContact(id: string, input: UpdateEmergencyContactInput): Promise<EmergencyContact> {
+    const data = await apiClient.put<BackendEmergencyContact>(`/emergency-contacts/${id}`, input);
+    return toEmergencyContact(data);
+  },
+
+  async deleteEmergencyContact(id: string): Promise<void> {
+    await apiClient.del(`/emergency-contacts/${id}`);
+  },
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -9,8 +9,9 @@ import { Vaccination } from '../../domain/entities/Vaccination';
 import { Examination } from '../../domain/entities/Examination';
 import { Allergy } from '../../domain/entities/Allergy';
 import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
+import { EmergencyContact } from '../../domain/entities/EmergencyContact';
 import { Insurance } from '../../domain/entities/Insurance';
-import { BackendAllergy, BackendBodyMeasurement, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
+import { BackendAllergy, BackendBodyMeasurement, BackendEmergencyContact, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -135,6 +136,20 @@ export function toInsurance(b: BackendInsurance): Insurance {
     insuranceType: b.insuranceType,
     providerName: b.providerName,
     policyNumber: b.policyNumber,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toEmergencyContact(b: BackendEmergencyContact): EmergencyContact {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    contactName: b.contactName,
+    phoneNumber: b.phoneNumber,
+    relationship: b.relationship,
     notes: b.notes,
     createdAt: new Date(b.createdAt),
   };

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -103,6 +103,18 @@ export interface BackendInsurance {
   createdAt: string;
 }
 
+export interface BackendEmergencyContact {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  contactName: string;
+  phoneNumber: string;
+  relationship?: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendBodyMeasurement {
   id: string;
   userId: string;

--- a/src/data/repositories/EmergencyContactRepositoryImpl.ts
+++ b/src/data/repositories/EmergencyContactRepositoryImpl.ts
@@ -1,0 +1,25 @@
+import {
+  EmergencyContactRepository,
+  CreateEmergencyContactInput,
+  UpdateEmergencyContactInput,
+} from '../../domain/repositories/EmergencyContactRepository';
+import { EmergencyContact } from '../../domain/entities/EmergencyContact';
+import { emergencyContactApi } from '../api/emergencyContactApi';
+
+export class EmergencyContactRepositoryImpl implements EmergencyContactRepository {
+  async getAll(): Promise<EmergencyContact[]> {
+    return emergencyContactApi.getEmergencyContacts();
+  }
+
+  async create(input: CreateEmergencyContactInput): Promise<EmergencyContact> {
+    return emergencyContactApi.createEmergencyContact(input);
+  }
+
+  async update(id: string, input: UpdateEmergencyContactInput): Promise<EmergencyContact> {
+    return emergencyContactApi.updateEmergencyContact(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return emergencyContactApi.deleteEmergencyContact(id);
+  }
+}

--- a/src/domain/entities/EmergencyContact.ts
+++ b/src/domain/entities/EmergencyContact.ts
@@ -1,0 +1,11 @@
+export interface EmergencyContact {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly contactName: string;
+  readonly phoneNumber: string;
+  readonly relationship?: string;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/EmergencyContactRepository.ts
+++ b/src/domain/repositories/EmergencyContactRepository.ts
@@ -1,0 +1,23 @@
+import { EmergencyContact } from '../entities/EmergencyContact';
+
+export interface CreateEmergencyContactInput {
+  memberId: string;
+  contactName: string;
+  phoneNumber: string;
+  relationship?: string;
+  notes?: string;
+}
+
+export interface UpdateEmergencyContactInput {
+  contactName?: string;
+  phoneNumber?: string;
+  relationship?: string | null;
+  notes?: string | null;
+}
+
+export interface EmergencyContactRepository {
+  getAll(): Promise<EmergencyContact[]>;
+  create(input: CreateEmergencyContactInput): Promise<EmergencyContact>;
+  update(id: string, input: UpdateEmergencyContactInput): Promise<EmergencyContact>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageEmergencyContacts.ts
+++ b/src/domain/usecases/ManageEmergencyContacts.ts
@@ -1,0 +1,50 @@
+import { EmergencyContact } from '../entities/EmergencyContact';
+import {
+  EmergencyContactRepository,
+  CreateEmergencyContactInput,
+  UpdateEmergencyContactInput,
+} from '../repositories/EmergencyContactRepository';
+
+export class GetEmergencyContacts {
+  constructor(private readonly repository: EmergencyContactRepository) {}
+
+  async execute(): Promise<EmergencyContact[]> {
+    return this.repository.getAll();
+  }
+}
+
+export class CreateEmergencyContact {
+  constructor(private readonly repository: EmergencyContactRepository) {}
+
+  async execute(input: CreateEmergencyContactInput): Promise<EmergencyContact> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.contactName) {
+      throw new Error('連絡先名は必須です');
+    }
+    if (!input.phoneNumber) {
+      throw new Error('電話番号は必須です');
+    }
+    return this.repository.create(input);
+  }
+}
+
+export class UpdateEmergencyContact {
+  constructor(private readonly repository: EmergencyContactRepository) {}
+
+  async execute(id: string, input: UpdateEmergencyContactInput): Promise<EmergencyContact> {
+    if (!id) {
+      throw new Error('連絡先IDは必須です');
+    }
+    return this.repository.update(id, input);
+  }
+}
+
+export class DeleteEmergencyContact {
+  constructor(private readonly repository: EmergencyContactRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.repository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -16,6 +16,7 @@ import { ExaminationRepository } from '../domain/repositories/ExaminationReposit
 import { InsuranceRepository } from '../domain/repositories/InsuranceRepository';
 import { AllergyRepository } from '../domain/repositories/AllergyRepository';
 import { BodyMeasurementRepository } from '../domain/repositories/BodyMeasurementRepository';
+import { EmergencyContactRepository } from '../domain/repositories/EmergencyContactRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -29,6 +30,7 @@ import { ExaminationRepositoryImpl } from '../data/repositories/ExaminationRepos
 import { InsuranceRepositoryImpl } from '../data/repositories/InsuranceRepositoryImpl';
 import { AllergyRepositoryImpl } from '../data/repositories/AllergyRepositoryImpl';
 import { BodyMeasurementRepositoryImpl } from '../data/repositories/BodyMeasurementRepositoryImpl';
+import { EmergencyContactRepositoryImpl } from '../data/repositories/EmergencyContactRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -44,6 +46,7 @@ export interface DIContainer {
   insuranceRepository: InsuranceRepository;
   allergyRepository: AllergyRepository;
   bodyMeasurementRepository: BodyMeasurementRepository;
+  emergencyContactRepository: EmergencyContactRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -65,6 +68,7 @@ export const getDIContainer = (): DIContainer => {
       insuranceRepository: new InsuranceRepositoryImpl(),
       allergyRepository: new AllergyRepositoryImpl(),
       bodyMeasurementRepository: new BodyMeasurementRepositoryImpl(),
+      emergencyContactRepository: new EmergencyContactRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -204,6 +204,24 @@ export const updateInsuranceSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Emergency Contacts =====
+export const createEmergencyContactSchema = z.object({
+  memberId: idField,
+  contactName: z.string({ required_error: '連絡先名は必須です' }).trim().min(1, '連絡先名は必須です').max(100),
+  phoneNumber: z.string({ required_error: '電話番号は必須です' }).trim().min(1, '電話番号は必須です').max(20),
+  relationship: z.string().trim().max(50).optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
+export const updateEmergencyContactSchema = z.object({
+  contactName: z.string().trim().min(1).max(100).optional(),
+  phoneNumber: z.string().trim().min(1).max(20).optional(),
+  relationship: z.string().trim().max(50).optional().nullable(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Body Measurements =====
 export const createBodyMeasurementSchema = z.object({
   memberId: idField,

--- a/src/presentation/hooks/useEmergencyContacts.ts
+++ b/src/presentation/hooks/useEmergencyContacts.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { EmergencyContact } from '../../domain/entities/EmergencyContact';
+import { GetEmergencyContacts, CreateEmergencyContact, UpdateEmergencyContact, DeleteEmergencyContact } from '../../domain/usecases/ManageEmergencyContacts';
+import { CreateEmergencyContactInput, UpdateEmergencyContactInput } from '../../domain/repositories/EmergencyContactRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseEmergencyContactsResult {
+  contacts: EmergencyContact[];
+  isLoading: boolean;
+  error: Error | null;
+  createContact: (input: CreateEmergencyContactInput) => Promise<void>;
+  updateContact: (id: string, input: UpdateEmergencyContactInput) => Promise<void>;
+  deleteContact: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useEmergencyContacts = (): UseEmergencyContactsResult => {
+  const useCases = useMemo(() => {
+    const { emergencyContactRepository } = getDIContainer();
+    return {
+      getContacts: new GetEmergencyContacts(emergencyContactRepository),
+      createContact: new CreateEmergencyContact(emergencyContactRepository),
+      updateContact: new UpdateEmergencyContact(emergencyContactRepository),
+      deleteContact: new DeleteEmergencyContact(emergencyContactRepository),
+    };
+  }, []);
+
+  const { data: contacts, isLoading, error, refetch } = useFetcher(
+    async () => useCases.getContacts.execute(),
+    [useCases],
+    [] as EmergencyContact[],
+    'emergencyContacts',
+  );
+
+  const handleCreate = useCallback(async (input: CreateEmergencyContactInput) => {
+    await useCases.createContact.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdateEmergencyContactInput) => {
+    await useCases.updateContact.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.deleteContact.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    contacts,
+    isLoading,
+    error,
+    createContact: handleCreate,
+    updateContact: handleUpdate,
+    deleteContact: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- メンバーごとの緊急連絡先を管理する機能を追加
- 連絡先名、電話番号、続柄、メモを記録可能
- 電話番号はタップで発信可能なリンク表示
- 設定ページに緊急連絡先セクションを追加

closes #999

## Test plan
- [x] ManageEmergencyContactsユースケーステスト（8テスト全て通過）
- [x] ビルド成功