### PR TITLE
feat: 処方箋管理機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   allergies          Allergy[]
   bodyMeasurements   BodyMeasurement[]
   emergencyContacts  EmergencyContact[]
+  prescriptions      Prescription[]
 }
 
 model Member {
@@ -61,6 +62,7 @@ model Member {
   allergies          Allergy[]
   bodyMeasurements   BodyMeasurement[]
   emergencyContacts  EmergencyContact[]
+  prescriptions      Prescription[]
 
   @@index([userId])
 }
@@ -270,6 +272,24 @@ model EmergencyContact {
   relationship  String?
   notes         String?
   createdAt     DateTime @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+}
+
+model Prescription {
+  id                String    @id @default(cuid())
+  userId            String
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId          String
+  member            Member    @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  prescriptionName  String
+  prescribedBy      String?
+  prescribedAt      DateTime
+  expiresAt         DateTime?
+  pharmacyName      String?
+  notes             String?
+  createdAt         DateTime  @default(now())
 
   @@index([userId])
   @@index([memberId])

--- a/src/__tests__/domain/usecases/ManagePrescriptions.test.ts
+++ b/src/__tests__/domain/usecases/ManagePrescriptions.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetPrescriptions, CreatePrescription, UpdatePrescription, DeletePrescription } from '../../../domain/usecases/ManagePrescriptions';
+import { PrescriptionRepository, CreatePrescriptionInput, UpdatePrescriptionInput } from '../../../domain/repositories/PrescriptionRepository';
+import { Prescription } from '../../../domain/entities/Prescription';
+
+const mockPrescription: Prescription = {
+  id: 'prescription-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: 'テスト太郎',
+  prescriptionName: '高血圧治療薬',
+  prescribedBy: '山田医師',
+  prescribedAt: new Date('2024-03-01'),
+  expiresAt: new Date('2024-06-01'),
+  pharmacyName: '調剤薬局ABC',
+  notes: '毎月リフィル可',
+  createdAt: new Date('2024-03-01'),
+};
+
+const createMockRepository = (): PrescriptionRepository => ({
+  getAll: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+});
+
+describe('ManagePrescriptions', () => {
+  let mockRepository: PrescriptionRepository;
+
+  beforeEach(() => {
+    mockRepository = createMockRepository();
+  });
+
+  describe('GetPrescriptions', () => {
+    it('全ての処方箋を取得できる', async () => {
+      vi.mocked(mockRepository.getAll).mockResolvedValue([mockPrescription]);
+
+      const useCase = new GetPrescriptions(mockRepository);
+      const result = await useCase.execute();
+
+      expect(result).toEqual([mockPrescription]);
+    });
+  });
+
+  describe('CreatePrescription', () => {
+    it('処方箋を作成できる', async () => {
+      const input: CreatePrescriptionInput = {
+        memberId: 'member-1',
+        prescriptionName: '高血圧治療薬',
+        prescribedBy: '山田医師',
+        prescribedAt: '2024-03-01',
+      };
+      vi.mocked(mockRepository.create).mockResolvedValue(mockPrescription);
+
+      const useCase = new CreatePrescription(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result).toEqual(mockPrescription);
+    });
+
+    it('メンバーIDが空の場合エラーになる', async () => {
+      const input: CreatePrescriptionInput = {
+        memberId: '',
+        prescriptionName: '高血圧治療薬',
+        prescribedAt: '2024-03-01',
+      };
+
+      const useCase = new CreatePrescription(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('メンバーIDは必須です');
+    });
+
+    it('処方箋名が空の場合エラーになる', async () => {
+      const input: CreatePrescriptionInput = {
+        memberId: 'member-1',
+        prescriptionName: '',
+        prescribedAt: '2024-03-01',
+      };
+
+      const useCase = new CreatePrescription(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('処方箋名は必須です');
+    });
+
+    it('処方日が空の場合エラーになる', async () => {
+      const input: CreatePrescriptionInput = {
+        memberId: 'member-1',
+        prescriptionName: '高血圧治療薬',
+        prescribedAt: '',
+      };
+
+      const useCase = new CreatePrescription(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('処方日は必須です');
+    });
+  });
+
+  describe('UpdatePrescription', () => {
+    it('処方箋を更新できる', async () => {
+      const input: UpdatePrescriptionInput = { prescriptionName: '降圧剤' };
+      const updated = { ...mockPrescription, prescriptionName: '降圧剤' };
+      vi.mocked(mockRepository.update).mockResolvedValue(updated);
+
+      const useCase = new UpdatePrescription(mockRepository);
+      const result = await useCase.execute('prescription-1', input);
+
+      expect(result).toEqual(updated);
+    });
+
+    it('IDが空の場合エラーになる', async () => {
+      const useCase = new UpdatePrescription(mockRepository);
+      await expect(useCase.execute('', { prescriptionName: 'test' })).rejects.toThrow('処方箋IDは必須です');
+    });
+  });
+
+  describe('DeletePrescription', () => {
+    it('処方箋を削除できる', async () => {
+      vi.mocked(mockRepository.delete).mockResolvedValue(undefined);
+
+      const useCase = new DeletePrescription(mockRepository);
+      await useCase.execute('prescription-1');
+
+      expect(mockRepository.delete).toHaveBeenCalledWith('prescription-1');
+    });
+  });
+});

--- a/src/app/api/prescriptions/[prescriptionId]/route.ts
+++ b/src/app/api/prescriptions/[prescriptionId]/route.ts
@@ -1,0 +1,63 @@
+import { prisma } from '@/lib/prisma';
+import { updatePrescriptionSchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const findPrescription = (id: string) => prisma.prescription.findUnique({ where: { id } });
+
+export async function PUT(request: Request, { params }: { params: Promise<{ prescriptionId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`prescriptions-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { prescriptionId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: prescriptionId,
+      finder: findPrescription,
+      resourceName: '処方箋',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updatePrescriptionSchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const updated = await prisma.prescription.update({
+          where: { id: prescriptionId },
+          data: {
+            prescriptionName: parsed.data.prescriptionName,
+            prescribedBy: parsed.data.prescribedBy,
+            prescribedAt: parsed.data.prescribedAt ? new Date(parsed.data.prescribedAt) : undefined,
+            expiresAt: parsed.data.expiresAt ? new Date(parsed.data.expiresAt) : parsed.data.expiresAt,
+            pharmacyName: parsed.data.pharmacyName,
+            notes: parsed.data.notes,
+          },
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ prescriptionId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`prescriptions-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const { prescriptionId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: prescriptionId,
+      finder: findPrescription,
+      resourceName: '処方箋',
+      handler: async () => {
+        await prisma.prescription.delete({ where: { id: prescriptionId } });
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/prescriptions/route.ts
+++ b/src/app/api/prescriptions/route.ts
@@ -1,0 +1,58 @@
+import { prisma } from '@/lib/prisma';
+import { createPrescriptionSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
+import { QUERY_LIMITS } from '@/lib/constants';
+import { checkRateLimit } from '@/lib/security';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`prescriptions-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const prescriptions = await prisma.prescription.findMany({
+    where: { userId },
+    orderBy: { prescribedAt: 'desc' },
+    take: QUERY_LIMITS.DEFAULT,
+    include: {
+      member: { select: { name: true } },
+    },
+  });
+  const result = prescriptions.map((p) =>
+    flattenRelations(p, { member: 'memberName' }),
+  );
+  return success(result);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`prescriptions-post:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createPrescriptionSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => prisma.member.findUnique({ where: { id: parsed.data.memberId } }), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const prescription = await prisma.prescription.create({
+      data: {
+        userId,
+        memberId: parsed.data.memberId,
+        prescriptionName: parsed.data.prescriptionName,
+        prescribedBy: parsed.data.prescribedBy,
+        prescribedAt: new Date(parsed.data.prescribedAt),
+        expiresAt: parsed.data.expiresAt ? new Date(parsed.data.expiresAt) : undefined,
+        pharmacyName: parsed.data.pharmacyName,
+        notes: parsed.data.notes,
+      },
+    });
+    return created(prescription);
+  })();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -9,6 +9,7 @@ import { useVaccinations } from '@/presentation/hooks/useVaccinations';
 import { useExaminations } from '@/presentation/hooks/useExaminations';
 import { useInsurances } from '@/presentation/hooks/useInsurances';
 import { useAllergies } from '@/presentation/hooks/useAllergies';
+import { usePrescriptions } from '@/presentation/hooks/usePrescriptions';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { AppointmentList, AppointmentFilter, getAppointmentCounts } from '@/components/appointments/AppointmentList';
 import { AppointmentForm, AppointmentFormData } from '@/components/appointments/AppointmentForm';
@@ -20,11 +21,13 @@ import { InsuranceForm, InsuranceFormData } from '@/components/insurances/Insura
 import { InsuranceList } from '@/components/insurances/InsuranceList';
 import { AllergyForm, AllergyFormData } from '@/components/allergies/AllergyForm';
 import { AllergyList } from '@/components/allergies/AllergyList';
+import { PrescriptionForm, PrescriptionFormData } from '@/components/prescriptions/PrescriptionForm';
+import { PrescriptionList } from '@/components/prescriptions/PrescriptionList';
 import { TabSwitch } from '@/components/shared/TabSwitch';
 import { Appointment } from '@/domain/entities/Appointment';
 import { MiniCalendar } from '@/components/appointments/MiniCalendar';
 import Link from 'next/link';
-import { Plus, X, MapPin, Syringe, ClipboardList, ShieldCheck, AlertTriangle } from 'lucide-react';
+import { Plus, X, MapPin, Syringe, ClipboardList, ShieldCheck, AlertTriangle, FileText } from 'lucide-react';
 
 export default function AppointmentsPage() {
   const { userId } = useAuth();
@@ -35,11 +38,13 @@ export default function AppointmentsPage() {
   const { examinations, isLoading: examinationsLoading, createExamination, updateExamination, deleteExamination } = useExaminations();
   const { insurances, isLoading: insurancesLoading, createInsurance, updateInsurance, deleteInsurance } = useInsurances();
   const { allergies, isLoading: allergiesLoading, createAllergy, updateAllergy, deleteAllergy } = useAllergies();
+  const { prescriptions, isLoading: prescriptionsLoading, createPrescription, updatePrescription, deletePrescription } = usePrescriptions();
   const [showForm, setShowForm] = useState(false);
   const [showVaccinationForm, setShowVaccinationForm] = useState(false);
   const [showExaminationForm, setShowExaminationForm] = useState(false);
   const [showInsuranceForm, setShowInsuranceForm] = useState(false);
   const [showAllergyForm, setShowAllergyForm] = useState(false);
+  const [showPrescriptionForm, setShowPrescriptionForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
   const [updateError, setUpdateError] = useState<string | null>(null);
@@ -121,6 +126,16 @@ export default function AppointmentsPage() {
   const handleDeleteAllergy = async (id: string) => {
     if (!window.confirm('このアレルギー情報を削除しますか？')) return;
     await deleteAllergy(id);
+  };
+
+  const handleCreatePrescription = async (data: PrescriptionFormData) => {
+    await createPrescription(data);
+    setShowPrescriptionForm(false);
+  };
+
+  const handleDeletePrescription = async (id: string) => {
+    if (!window.confirm('この処方箋を削除しますか？')) return;
+    await deletePrescription(id);
   };
 
   const handleCreateInsurance = async (data: InsuranceFormData) => {
@@ -321,6 +336,46 @@ export default function AppointmentsPage() {
             isLoading={allergiesLoading}
             onUpdate={updateAllergy}
             onDelete={handleDeleteAllergy}
+          />
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <FileText size={18} className="text-primary-600" />
+              <h2 className="text-base font-bold text-gray-800">処方箋管理</h2>
+            </div>
+            <button
+              onClick={() => setShowPrescriptionForm(!showPrescriptionForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showPrescriptionForm ? '閉じる' : '処方箋を追加'}
+            >
+              {showPrescriptionForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showPrescriptionForm && !membersLoading && members.length > 0 && (
+            <div className="mb-4 bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">処方箋の追加</h3>
+              <PrescriptionForm
+                members={members}
+                onSubmit={handleCreatePrescription}
+                onCancel={() => setShowPrescriptionForm(false)}
+              />
+            </div>
+          )}
+
+          {showPrescriptionForm && !membersLoading && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先にメンバーを登録してください。
+            </div>
+          )}
+
+          <PrescriptionList
+            prescriptions={prescriptions}
+            isLoading={prescriptionsLoading}
+            onUpdate={updatePrescription}
+            onDelete={handleDeletePrescription}
           />
         </div>
 

--- a/src/components/prescriptions/PrescriptionForm.tsx
+++ b/src/components/prescriptions/PrescriptionForm.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Member } from '../../domain/entities/Member';
+
+export interface PrescriptionFormData {
+  memberId: string;
+  prescriptionName: string;
+  prescribedBy?: string;
+  prescribedAt: string;
+  expiresAt?: string;
+  pharmacyName?: string;
+  notes?: string;
+}
+
+interface PrescriptionFormProps {
+  members: Member[];
+  onSubmit: (data: PrescriptionFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    prescriptionName: string;
+    prescribedBy?: string;
+    prescribedAt: string;
+    expiresAt?: string;
+    pharmacyName?: string;
+    notes?: string;
+  };
+}
+
+export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ''));
+  const [prescriptionName, setPrescriptionName] = useState(initialData?.prescriptionName || '');
+  const [prescribedBy, setPrescribedBy] = useState(initialData?.prescribedBy || '');
+  const [prescribedAt, setPrescribedAt] = useState(initialData?.prescribedAt || new Date().toISOString().split('T')[0]);
+  const [expiresAt, setExpiresAt] = useState(initialData?.expiresAt || '');
+  const [pharmacyName, setPharmacyName] = useState(initialData?.pharmacyName || '');
+  const [notes, setNotes] = useState(initialData?.notes || '');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !prescriptionName.trim() || !prescribedAt) return;
+
+    onSubmit({
+      memberId,
+      prescriptionName: prescriptionName.trim(),
+      prescribedBy: prescribedBy.trim() || undefined,
+      prescribedAt,
+      expiresAt: expiresAt || undefined,
+      pharmacyName: pharmacyName.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setPrescriptionName('');
+      setPrescribedBy('');
+      setExpiresAt('');
+      setPharmacyName('');
+      setNotes('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="rx-member" className="block text-sm font-medium text-gray-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="rx-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="rx-name" className="block text-sm font-medium text-gray-700 mb-1">
+          処方箋名
+        </label>
+        <input
+          id="rx-name"
+          type="text"
+          value={prescriptionName}
+          onChange={(e) => setPrescriptionName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          required
+          placeholder="例: 高血圧治療薬、抗生物質"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="rx-doctor" className="block text-sm font-medium text-gray-700 mb-1">
+          処方医（任意）
+        </label>
+        <input
+          id="rx-doctor"
+          type="text"
+          value={prescribedBy}
+          onChange={(e) => setPrescribedBy(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="例: 山田太郎 医師"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="rx-date" className="block text-sm font-medium text-gray-700 mb-1">
+            処方日
+          </label>
+          <input
+            id="rx-date"
+            type="date"
+            value={prescribedAt}
+            onChange={(e) => setPrescribedAt(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="rx-expires" className="block text-sm font-medium text-gray-700 mb-1">
+            有効期限（任意）
+          </label>
+          <input
+            id="rx-expires"
+            type="date"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="rx-pharmacy" className="block text-sm font-medium text-gray-700 mb-1">
+          薬局名（任意）
+        </label>
+        <input
+          id="rx-pharmacy"
+          type="text"
+          value={pharmacyName}
+          onChange={(e) => setPharmacyName(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="例: 調剤薬局ABC"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="rx-notes" className="block text-sm font-medium text-gray-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="rx-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          rows={2}
+          placeholder="リフィル回数、注意事項など"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          {initialData ? '更新する' : '登録する'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/src/components/prescriptions/PrescriptionList.tsx
+++ b/src/components/prescriptions/PrescriptionList.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Pencil, Trash2, Check, X } from 'lucide-react';
+import { Prescription } from '../../domain/entities/Prescription';
+import { UpdatePrescriptionInput } from '../../domain/repositories/PrescriptionRepository';
+
+interface PrescriptionListProps {
+  prescriptions: Prescription[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdatePrescriptionInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const PrescriptionList: React.FC<PrescriptionListProps> = ({ prescriptions, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (prescriptions.length === 0) {
+    return (
+      <div className="flex flex-col justify-center items-center py-8">
+        <p className="text-gray-500 text-sm">処方箋が登録されていません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {prescriptions.map((p) => (
+        <PrescriptionCard key={p.id} prescription={p} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface PrescriptionCardProps {
+  prescription: Prescription;
+  onUpdate: (id: string, input: UpdatePrescriptionInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescription, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(prescription.prescriptionName);
+  const [editDoctor, setEditDoctor] = useState(prescription.prescribedBy || '');
+  const [editPharmacy, setEditPharmacy] = useState(prescription.pharmacyName || '');
+  const [editNotes, setEditNotes] = useState(prescription.notes || '');
+
+  const isExpired = prescription.expiresAt && new Date(prescription.expiresAt) < new Date();
+
+  const handleSave = async () => {
+    if (!editName.trim()) return;
+    await onUpdate(prescription.id, {
+      prescriptionName: editName.trim(),
+      prescribedBy: editDoctor.trim() || null,
+      pharmacyName: editPharmacy.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(prescription.prescriptionName);
+    setEditDoctor(prescription.prescribedBy || '');
+    setEditPharmacy(prescription.pharmacyName || '');
+    setEditNotes(prescription.notes || '');
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-blue-200 space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">処方箋名</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">処方医</label>
+          <input
+            type="text"
+            value={editDoctor}
+            onChange={(e) => setEditDoctor(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">薬局名</label>
+          <input
+            type="text"
+            value={editPharmacy}
+            onChange={(e) => setEditPharmacy(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim()}
+            className="flex-1 flex items-center justify-center space-x-1 bg-blue-600 text-white py-1.5 rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-gray-200 text-gray-700 py-1.5 rounded-lg text-sm hover:bg-gray-300 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+            <p className="font-medium text-gray-800 text-sm">{prescription.prescriptionName}</p>
+            {isExpired && (
+              <span className="text-xs bg-red-100 text-red-700 px-1.5 py-0.5 rounded">期限切れ</span>
+            )}
+            {prescription.memberName && (
+              <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">{prescription.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-gray-500 mt-1 space-y-0.5">
+            <p>処方日: {new Date(prescription.prescribedAt).toLocaleDateString('ja-JP')}</p>
+            {prescription.prescribedBy && <p>処方医: {prescription.prescribedBy}</p>}
+            {prescription.expiresAt && (
+              <p>有効期限: {new Date(prescription.expiresAt).toLocaleDateString('ja-JP')}</p>
+            )}
+            {prescription.pharmacyName && <p>薬局: {prescription.pharmacyName}</p>}
+            {prescription.notes && <p className="text-gray-400">{prescription.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-gray-400 hover:text-blue-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => onDelete(prescription.id)}
+            className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+PrescriptionCard.displayName = 'PrescriptionCard';

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -10,8 +10,9 @@ import { Examination } from '../../domain/entities/Examination';
 import { Allergy } from '../../domain/entities/Allergy';
 import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
 import { EmergencyContact } from '../../domain/entities/EmergencyContact';
+import { Prescription } from '../../domain/entities/Prescription';
 import { Insurance } from '../../domain/entities/Insurance';
-import { BackendAllergy, BackendBodyMeasurement, BackendEmergencyContact, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
+import { BackendAllergy, BackendBodyMeasurement, BackendEmergencyContact, BackendPrescription, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -136,6 +137,22 @@ export function toInsurance(b: BackendInsurance): Insurance {
     insuranceType: b.insuranceType,
     providerName: b.providerName,
     policyNumber: b.policyNumber,
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toPrescription(b: BackendPrescription): Prescription {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    prescriptionName: b.prescriptionName,
+    prescribedBy: b.prescribedBy,
+    prescribedAt: new Date(b.prescribedAt),
+    expiresAt: b.expiresAt ? new Date(b.expiresAt) : undefined,
+    pharmacyName: b.pharmacyName,
     notes: b.notes,
     createdAt: new Date(b.createdAt),
   };

--- a/src/data/api/prescriptionApi.ts
+++ b/src/data/api/prescriptionApi.ts
@@ -1,0 +1,26 @@
+import { Prescription } from '../../domain/entities/Prescription';
+import { CreatePrescriptionInput, UpdatePrescriptionInput } from '../../domain/repositories/PrescriptionRepository';
+import { apiClient } from './apiClient';
+import { toPrescription } from './mappers';
+import { BackendPrescription } from './types';
+
+export const prescriptionApi = {
+  async getPrescriptions(): Promise<Prescription[]> {
+    const data = await apiClient.get<BackendPrescription[]>('/prescriptions');
+    return data.map(toPrescription);
+  },
+
+  async createPrescription(input: CreatePrescriptionInput): Promise<Prescription> {
+    const data = await apiClient.post<BackendPrescription>('/prescriptions', input);
+    return toPrescription(data);
+  },
+
+  async updatePrescription(id: string, input: UpdatePrescriptionInput): Promise<Prescription> {
+    const data = await apiClient.put<BackendPrescription>(`/prescriptions/${id}`, input);
+    return toPrescription(data);
+  },
+
+  async deletePrescription(id: string): Promise<void> {
+    await apiClient.del(`/prescriptions/${id}`);
+  },
+};

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -103,6 +103,20 @@ export interface BackendInsurance {
   createdAt: string;
 }
 
+export interface BackendPrescription {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  prescriptionName: string;
+  prescribedBy?: string;
+  prescribedAt: string;
+  expiresAt?: string;
+  pharmacyName?: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendEmergencyContact {
   id: string;
   userId: string;

--- a/src/data/repositories/PrescriptionRepositoryImpl.ts
+++ b/src/data/repositories/PrescriptionRepositoryImpl.ts
@@ -1,0 +1,25 @@
+import {
+  PrescriptionRepository,
+  CreatePrescriptionInput,
+  UpdatePrescriptionInput,
+} from '../../domain/repositories/PrescriptionRepository';
+import { Prescription } from '../../domain/entities/Prescription';
+import { prescriptionApi } from '../api/prescriptionApi';
+
+export class PrescriptionRepositoryImpl implements PrescriptionRepository {
+  async getAll(): Promise<Prescription[]> {
+    return prescriptionApi.getPrescriptions();
+  }
+
+  async create(input: CreatePrescriptionInput): Promise<Prescription> {
+    return prescriptionApi.createPrescription(input);
+  }
+
+  async update(id: string, input: UpdatePrescriptionInput): Promise<Prescription> {
+    return prescriptionApi.updatePrescription(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return prescriptionApi.deletePrescription(id);
+  }
+}

--- a/src/domain/entities/Prescription.ts
+++ b/src/domain/entities/Prescription.ts
@@ -1,0 +1,13 @@
+export interface Prescription {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly prescriptionName: string;
+  readonly prescribedBy?: string;
+  readonly prescribedAt: Date;
+  readonly expiresAt?: Date;
+  readonly pharmacyName?: string;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}

--- a/src/domain/repositories/PrescriptionRepository.ts
+++ b/src/domain/repositories/PrescriptionRepository.ts
@@ -1,0 +1,27 @@
+import { Prescription } from '../entities/Prescription';
+
+export interface CreatePrescriptionInput {
+  memberId: string;
+  prescriptionName: string;
+  prescribedBy?: string;
+  prescribedAt: string;
+  expiresAt?: string;
+  pharmacyName?: string;
+  notes?: string;
+}
+
+export interface UpdatePrescriptionInput {
+  prescriptionName?: string;
+  prescribedBy?: string | null;
+  prescribedAt?: string;
+  expiresAt?: string | null;
+  pharmacyName?: string | null;
+  notes?: string | null;
+}
+
+export interface PrescriptionRepository {
+  getAll(): Promise<Prescription[]>;
+  create(input: CreatePrescriptionInput): Promise<Prescription>;
+  update(id: string, input: UpdatePrescriptionInput): Promise<Prescription>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManagePrescriptions.ts
+++ b/src/domain/usecases/ManagePrescriptions.ts
@@ -1,0 +1,50 @@
+import { Prescription } from '../entities/Prescription';
+import {
+  PrescriptionRepository,
+  CreatePrescriptionInput,
+  UpdatePrescriptionInput,
+} from '../repositories/PrescriptionRepository';
+
+export class GetPrescriptions {
+  constructor(private readonly repository: PrescriptionRepository) {}
+
+  async execute(): Promise<Prescription[]> {
+    return this.repository.getAll();
+  }
+}
+
+export class CreatePrescription {
+  constructor(private readonly repository: PrescriptionRepository) {}
+
+  async execute(input: CreatePrescriptionInput): Promise<Prescription> {
+    if (!input.memberId) {
+      throw new Error('メンバーIDは必須です');
+    }
+    if (!input.prescriptionName) {
+      throw new Error('処方箋名は必須です');
+    }
+    if (!input.prescribedAt) {
+      throw new Error('処方日は必須です');
+    }
+    return this.repository.create(input);
+  }
+}
+
+export class UpdatePrescription {
+  constructor(private readonly repository: PrescriptionRepository) {}
+
+  async execute(id: string, input: UpdatePrescriptionInput): Promise<Prescription> {
+    if (!id) {
+      throw new Error('処方箋IDは必須です');
+    }
+    return this.repository.update(id, input);
+  }
+}
+
+export class DeletePrescription {
+  constructor(private readonly repository: PrescriptionRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.repository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -17,6 +17,7 @@ import { InsuranceRepository } from '../domain/repositories/InsuranceRepository'
 import { AllergyRepository } from '../domain/repositories/AllergyRepository';
 import { BodyMeasurementRepository } from '../domain/repositories/BodyMeasurementRepository';
 import { EmergencyContactRepository } from '../domain/repositories/EmergencyContactRepository';
+import { PrescriptionRepository } from '../domain/repositories/PrescriptionRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -31,6 +32,7 @@ import { InsuranceRepositoryImpl } from '../data/repositories/InsuranceRepositor
 import { AllergyRepositoryImpl } from '../data/repositories/AllergyRepositoryImpl';
 import { BodyMeasurementRepositoryImpl } from '../data/repositories/BodyMeasurementRepositoryImpl';
 import { EmergencyContactRepositoryImpl } from '../data/repositories/EmergencyContactRepositoryImpl';
+import { PrescriptionRepositoryImpl } from '../data/repositories/PrescriptionRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -47,6 +49,7 @@ export interface DIContainer {
   allergyRepository: AllergyRepository;
   bodyMeasurementRepository: BodyMeasurementRepository;
   emergencyContactRepository: EmergencyContactRepository;
+  prescriptionRepository: PrescriptionRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -69,6 +72,7 @@ export const getDIContainer = (): DIContainer => {
       allergyRepository: new AllergyRepositoryImpl(),
       bodyMeasurementRepository: new BodyMeasurementRepositoryImpl(),
       emergencyContactRepository: new EmergencyContactRepositoryImpl(),
+      prescriptionRepository: new PrescriptionRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -204,6 +204,28 @@ export const updateInsuranceSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Prescriptions =====
+export const createPrescriptionSchema = z.object({
+  memberId: idField,
+  prescriptionName: z.string({ required_error: '処方箋名は必須です' }).trim().min(1, '処方箋名は必須です').max(200),
+  prescribedBy: z.string().trim().max(100).optional(),
+  prescribedAt: dateString,
+  expiresAt: dateString.optional(),
+  pharmacyName: z.string().trim().max(200).optional(),
+  notes: z.string().trim().max(500).optional(),
+});
+
+export const updatePrescriptionSchema = z.object({
+  prescriptionName: z.string().trim().min(1).max(200).optional(),
+  prescribedBy: z.string().trim().max(100).optional().nullable(),
+  prescribedAt: dateString.optional(),
+  expiresAt: dateString.optional().nullable(),
+  pharmacyName: z.string().trim().max(200).optional().nullable(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Emergency Contacts =====
 export const createEmergencyContactSchema = z.object({
   memberId: idField,

--- a/src/presentation/hooks/usePrescriptions.ts
+++ b/src/presentation/hooks/usePrescriptions.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import { Prescription } from '../../domain/entities/Prescription';
+import { GetPrescriptions, CreatePrescription, UpdatePrescription, DeletePrescription } from '../../domain/usecases/ManagePrescriptions';
+import { CreatePrescriptionInput, UpdatePrescriptionInput } from '../../domain/repositories/PrescriptionRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UsePrescriptionsResult {
+  prescriptions: Prescription[];
+  isLoading: boolean;
+  error: Error | null;
+  createPrescription: (input: CreatePrescriptionInput) => Promise<void>;
+  updatePrescription: (id: string, input: UpdatePrescriptionInput) => Promise<void>;
+  deletePrescription: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const usePrescriptions = (): UsePrescriptionsResult => {
+  const useCases = useMemo(() => {
+    const { prescriptionRepository } = getDIContainer();
+    return {
+      getPrescriptions: new GetPrescriptions(prescriptionRepository),
+      createPrescription: new CreatePrescription(prescriptionRepository),
+      updatePrescription: new UpdatePrescription(prescriptionRepository),
+      deletePrescription: new DeletePrescription(prescriptionRepository),
+    };
+  }, []);
+
+  const { data: prescriptions, isLoading, error, refetch } = useFetcher(
+    async () => useCases.getPrescriptions.execute(),
+    [useCases],
+    [] as Prescription[],
+    'prescriptions',
+  );
+
+  const handleCreate = useCallback(async (input: CreatePrescriptionInput) => {
+    await useCases.createPrescription.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdatePrescriptionInput) => {
+    await useCases.updatePrescription.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.deletePrescription.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    prescriptions,
+    isLoading,
+    error,
+    createPrescription: handleCreate,
+    updatePrescription: handleUpdate,
+    deletePrescription: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- メンバーごとの処方箋情報を管理する機能を追加
- 処方箋名、処方医、処方日、有効期限、薬局名、メモを記録可能
- 有効期限切れの処方箋には赤い「期限切れ」バッジを表示
- 通院管理ページに処方箋管理セクションを追加（アレルギーと保険の間に配置）

closes #1001

## Test plan
- [x] ManagePrescriptionsユースケーステスト（8テスト全て通過）
- [x] ビルド成功