### PR TITLE
feat: アレルギーの種類に「花粉」を追加

### DIFF
--- a/src/components/allergies/AllergyForm.tsx
+++ b/src/components/allergies/AllergyForm.tsx
@@ -32,6 +32,7 @@ const ALLERGY_TYPES = [
   { value: 'food', label: '食物' },
   { value: 'medication', label: '薬物' },
   { value: 'environmental', label: '環境' },
+  { value: 'pollen', label: '花粉' },
   { value: 'other', label: 'その他' },
 ];
 

--- a/src/components/allergies/AllergyList.tsx
+++ b/src/components/allergies/AllergyList.tsx
@@ -9,6 +9,7 @@ const ALLERGY_TYPE_LABELS: Record<string, string> = {
   food: '食物',
   medication: '薬物',
   environmental: '環境',
+  pollen: '花粉',
   other: 'その他',
 };
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -268,7 +268,7 @@ export const updateBodyMeasurementSchema = z.object({
 export const createAllergySchema = z.object({
   memberId: idField,
   allergenName: z.string({ required_error: 'アレルゲン名は必須です' }).trim().min(1, 'アレルゲン名は必須です').max(200),
-  allergyType: z.enum(['food', 'medication', 'environmental', 'other'], { required_error: 'アレルギーの種類は必須です' }),
+  allergyType: z.enum(['food', 'medication', 'environmental', 'pollen', 'other'], { required_error: 'アレルギーの種類は必須です' }),
   severity: z.enum(['mild', 'moderate', 'severe'], { required_error: '重症度は必須です' }),
   symptoms: z.string().trim().max(500).optional(),
   diagnosedAt: dateString.optional(),
@@ -277,7 +277,7 @@ export const createAllergySchema = z.object({
 
 export const updateAllergySchema = z.object({
   allergenName: z.string().trim().min(1).max(200).optional(),
-  allergyType: z.enum(['food', 'medication', 'environmental', 'other']).optional(),
+  allergyType: z.enum(['food', 'medication', 'environmental', 'pollen', 'other']).optional(),
   severity: z.enum(['mild', 'moderate', 'severe']).optional(),
   symptoms: z.string().trim().max(500).optional().nullable(),
   diagnosedAt: dateString.optional().nullable(),


### PR DESCRIPTION
## Summary
- アレルギーの種類の選択肢に「花粉」(pollen)を追加
- Zodスキーマ、フォーム、一覧表示の3箇所を修正

## Test plan
- [ ] アレルギー追加フォームで「花粉」が選択できることを確認
- [ ] アレルギー編集フォームで「花粉」が選択できることを確認
- [ ] 花粉で登録したアレルギーが一覧で正しく表示されることを確認

closes #1005