### PR TITLE
fix: アレルギーフォームの症状ラベルとプレースホルダーを改善

### DIFF
--- a/src/components/allergies/AllergyForm.tsx
+++ b/src/components/allergies/AllergyForm.tsx
@@ -148,7 +148,7 @@ export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onC
 
       <div>
         <label htmlFor="allergy-symptoms" className="block text-sm font-medium text-gray-700 mb-1">
-          症状・反応（任意）
+          症状（任意）
         </label>
         <textarea
           id="allergy-symptoms"
@@ -156,7 +156,7 @@ export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onC
           onChange={(e) => setSymptoms(e.target.value)}
           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
           rows={2}
-          placeholder="例: じんましん、呼吸困難、腫れ"
+          placeholder="例: アナフィラキシー、じんましん、呼吸困難"
         />
       </div>
 

--- a/src/components/allergies/AllergyList.tsx
+++ b/src/components/allergies/AllergyList.tsx
@@ -131,7 +131,7 @@ const AllergyCard: React.FC<AllergyCardProps> = React.memo(({ allergy, onUpdate,
           </select>
         </div>
         <div>
-          <label className="block text-xs text-gray-500 mb-1">症状・反応</label>
+          <label className="block text-xs text-gray-500 mb-1">症状</label>
           <textarea
             value={editSymptoms}
             onChange={(e) => setEditSymptoms(e.target.value)}


### PR DESCRIPTION
## Summary
- 「症状・反応（任意）」を「症状（任意）」に変更
- プレースホルダーを「例: アナフィラキシー、じんましん、呼吸困難」に変更（アナフィラキシーを先頭に、腫れを削除）
- 編集フォームのラベルも同様に修正

## Test plan
- [ ] アレルギー追加フォームでラベルが「症状（任意）」になっていることを確認
- [ ] プレースホルダーが「例: アナフィラキシー、じんましん、呼吸困難」になっていることを確認

closes #1007