### PR TITLE
fix: アレルギー診断日の入力をテキスト入力に変更

### DIFF
--- a/src/components/allergies/AllergyForm.tsx
+++ b/src/components/allergies/AllergyForm.tsx
@@ -166,10 +166,12 @@ export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onC
         </label>
         <input
           id="allergy-diagnosed"
-          type="date"
+          type="text"
+          inputMode="numeric"
           value={diagnosedAt}
           onChange={(e) => setDiagnosedAt(e.target.value)}
           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          placeholder="例: 2024-01-15"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- アレルギーフォームの診断日をカレンダーピッカーからテキスト入力に変更
- 月を遡る操作が不要になり、直接日付を入力可能に

## Test plan
- [ ] 診断日がテキスト入力フィールドになっていることを確認
- [ ] 「2024-01-15」形式で日付を入力して登録できることを確認

closes #1009