### PR TITLE
fix: useMembersでuserIdが空のときAPI呼び出しをスキップ

### DIFF
--- a/src/presentation/hooks/useMembers.ts
+++ b/src/presentation/hooks/useMembers.ts
@@ -32,10 +32,13 @@ export const useMembers = (userId: string): UseMembersResult => {
   }, []);
 
   const { data: members, isLoading, error, refetch } = useFetcher(
-    () => useCases.getMembers.execute(userId),
+    async () => {
+      if (!userId) return [] as Member[];
+      return useCases.getMembers.execute(userId);
+    },
     [userId, useCases],
     [] as Member[],
-    `members-${userId}`,
+    userId ? `members-${userId}` : undefined,
   );
 
   const handleCreateMember = useCallback(async (input: CreateMemberInput) => {


### PR DESCRIPTION
## Summary
- `useMembers(userId)` で `userId` が空文字のとき、APIを呼ばずに空配列を返すよう修正
- 認証セッション読み込み中の401エラーによるメンバー取得失敗を防止
- これにより通院管理ページで「先にメンバーを登録してください」が誤表示される問題を根本解決

## Test plan
- [ ] 通院管理ページでアレルギー・ワクチン等のフォームを開き、メンバーが正しく表示されることを確認
- [ ] 「先にメンバーを登録してください」が誤表示されないことを確認

closes #1011