### PR TITLE
fix: ダッシュボードからお薬の達成率（週間）グラフを削除

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,14 +5,12 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTodaySchedules } from '@/presentation/hooks/useTodaySchedules';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
 import { useAdherenceStats } from '@/presentation/hooks/useAdherenceStats';
-import { useAdherenceTrends } from '@/presentation/hooks/useAdherenceTrends';
 import { useStockAlerts } from '@/presentation/hooks/useStockAlerts';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useUserProfile } from '@/presentation/hooks/useUserProfile';
 import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
 import { UpcomingAppointments } from '@/components/dashboard/UpcomingAppointments';
 import { AdherenceStatsCard } from '@/components/dashboard/AdherenceStatsCard';
-import { AdherenceTrendCard } from '@/components/dashboard/AdherenceTrendCard';
 import { StockAlertList } from '@/components/dashboard/StockAlertList';
 import { WeeklySummaryCard } from '@/components/dashboard/WeeklySummaryCard';
 import { GreetingCard } from '@/components/dashboard/GreetingCard';
@@ -24,7 +22,6 @@ export default function Dashboard() {
   const { schedules, isLoading, markAsCompleted } = useTodaySchedules(userId);
   const { appointments, isLoading: appointmentsLoading } = useAppointments();
   const { stats, isLoading: statsLoading } = useAdherenceStats();
-  const { trend, isLoading: trendLoading } = useAdherenceTrends();
   const { alerts, isLoading: alertsLoading } = useStockAlerts();
   const { members } = useMembers(userId);
   const { profile } = useUserProfile();
@@ -71,7 +68,6 @@ export default function Dashboard() {
 
         <AdherenceStatsCard stats={stats} isLoading={statsLoading} />
 
-        <AdherenceTrendCard trend={trend} isLoading={trendLoading} />
 
         <UpcomingAppointments
           appointments={appointments}


### PR DESCRIPTION
## Summary
- ダッシュボードから「お薬の達成率（週間）」の曜日別棒グラフを削除

## Test plan
- [ ] ダッシュボードにグラフが表示されないことを確認

closes #1013