### PR TITLE
feat: スケジュールに間隔投与（X日ごと）の設定を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,8 @@ model Schedule {
   memberId              String
   scheduledTime         String
   daysOfWeek            String[]
+  intervalDays          Int?
+  startDate             DateTime?
   isEnabled             Boolean  @default(true)
   reminderMinutesBefore Int      @default(5)
   createdAt             DateTime @default(now())

--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -27,9 +27,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ sche
         const parsed = updateScheduleSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
+        const updateData: Record<string, unknown> = { ...parsed.data };
+        if (parsed.data.startDate !== undefined) {
+          updateData.startDate = parsed.data.startDate ? new Date(parsed.data.startDate) : null;
+        }
         const updated = await prisma.schedule.update({
           where: { id: scheduleId },
-          data: parsed.data,
+          data: updateData,
         });
         return success(updated);
       },

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -58,7 +58,12 @@ export async function POST(request: Request) {
         createdAt: new Date(),
       };
       const entity = new ScheduleEntity(newScheduleData);
-      const existingSchedule: Schedule = { ...existing, daysOfWeek: existing.daysOfWeek as Schedule['daysOfWeek'] };
+      const existingSchedule: Schedule = {
+        ...existing,
+        daysOfWeek: existing.daysOfWeek as Schedule['daysOfWeek'],
+        intervalDays: existing.intervalDays ?? undefined,
+        startDate: existing.startDate ?? undefined,
+      };
       if (entity.hasOverlap(existingSchedule)) {
         return errorResponse('同じ薬の同じ時刻に既にスケジュールが存在します');
       }
@@ -71,6 +76,8 @@ export async function POST(request: Request) {
         memberId: parsed.data.memberId,
         scheduledTime: parsed.data.scheduledTime,
         daysOfWeek,
+        intervalDays: parsed.data.intervalDays ?? null,
+        startDate: parsed.data.startDate ? new Date(parsed.data.startDate) : null,
         isEnabled: parsed.data.isEnabled ?? true,
         reminderMinutesBefore: parsed.data.reminderMinutesBefore ?? 5,
       },

--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -54,6 +54,8 @@ export const GET = withAuth(async (userId) => {
       memberType: member?.memberType || 'human',
       scheduledTime: s.scheduledTime,
       daysOfWeek: s.daysOfWeek,
+      intervalDays: s.intervalDays,
+      startDate: s.startDate?.toISOString(),
       isEnabled: s.isEnabled,
       reminderMinutesBefore: s.reminderMinutesBefore,
       isCompleted: completedScheduleIds.has(s.id) || completedMedicationIds.has(s.medicationId),

--- a/src/app/members/[memberId]/medications/page.tsx
+++ b/src/app/members/[memberId]/medications/page.tsx
@@ -51,6 +51,8 @@ export default function Medications() {
       memberId,
       scheduledTime: data.scheduledTime,
       daysOfWeek: data.daysOfWeek,
+      intervalDays: data.intervalDays,
+      startDate: data.startDate ? new Date(data.startDate) : undefined,
       reminderMinutesBefore: data.reminderMinutesBefore,
     });
     setScheduleTarget(null);

--- a/src/components/schedules/ScheduleForm.tsx
+++ b/src/components/schedules/ScheduleForm.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from 'react';
 import { DayOfWeek } from '../../domain/entities/Schedule';
 
+export type ScheduleMode = 'daily' | 'weekdays' | 'interval';
+
 export interface ScheduleFormData {
   scheduledTime: string;
   daysOfWeek: DayOfWeek[];
+  intervalDays?: number;
+  startDate?: string;
   reminderMinutesBefore: number;
 }
 
@@ -21,10 +25,27 @@ const DAY_OPTIONS: { value: DayOfWeek; label: string }[] = [
   { value: 'sun', label: '日' },
 ];
 
+const INTERVAL_OPTIONS = [
+  { value: 2, label: '2日ごと' },
+  { value: 3, label: '3日ごと' },
+  { value: 7, label: '1週間ごと' },
+  { value: 14, label: '2週間ごと' },
+  { value: 21, label: '3週間ごと' },
+  { value: 28, label: '4週間ごと' },
+  { value: 30, label: '1ヶ月ごと' },
+  { value: 60, label: '2ヶ月ごと' },
+  { value: 90, label: '3ヶ月ごと' },
+];
+
 export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
   const [scheduledTime, setScheduledTime] = useState('08:00');
+  const [mode, setMode] = useState<ScheduleMode>('daily');
   const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
-  const [isEveryDay, setIsEveryDay] = useState(true);
+  const [intervalDays, setIntervalDays] = useState('21');
+  const [startDate, setStartDate] = useState(() => {
+    const today = new Date();
+    return today.toISOString().split('T')[0];
+  });
   const [reminderMinutes, setReminderMinutes] = useState('10');
 
   const toggleDay = (day: DayOfWeek) => {
@@ -33,32 +54,32 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
     );
   };
 
-  const toggleEveryDay = () => {
-    if (isEveryDay) {
-      setIsEveryDay(false);
-      setSelectedDays([]);
-    } else {
-      setIsEveryDay(true);
-      setSelectedDays([]);
-    }
-  };
-
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!isEveryDay && selectedDays.length === 0) return;
+    if (mode === 'weekdays' && selectedDays.length === 0) return;
+    if (mode === 'interval' && !startDate) return;
 
     onSubmit({
       scheduledTime,
-      daysOfWeek: isEveryDay ? [] : selectedDays,
+      daysOfWeek: mode === 'weekdays' ? selectedDays : [],
+      intervalDays: mode === 'interval' ? parseInt(intervalDays, 10) : undefined,
+      startDate: mode === 'interval' ? startDate : undefined,
       reminderMinutesBefore: parseInt(reminderMinutes, 10) || 0,
     });
 
     setScheduledTime('08:00');
     setSelectedDays([]);
-    setIsEveryDay(true);
+    setMode('daily');
     setReminderMinutes('10');
   };
+
+  const modeButtonClass = (m: ScheduleMode) =>
+    `flex items-center justify-center px-3 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
+      mode === m
+        ? 'bg-blue-600 text-white border-blue-600'
+        : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+    }`;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -76,26 +97,20 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
       </div>
 
       <div>
-        <span className="block text-sm font-medium text-gray-700 mb-2">曜日</span>
+        <span className="block text-sm font-medium text-gray-700 mb-2">頻度</span>
         <div className="flex flex-wrap gap-2 mb-2">
-          <label
-            className={`flex items-center justify-center px-3 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
-              isEveryDay
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
-            }`}
-          >
-            <input
-              type="checkbox"
-              checked={isEveryDay}
-              onChange={toggleEveryDay}
-              className="sr-only"
-              aria-label="毎日"
-            />
+          <button type="button" className={modeButtonClass('daily')} onClick={() => setMode('daily')}>
             毎日
-          </label>
+          </button>
+          <button type="button" className={modeButtonClass('weekdays')} onClick={() => setMode('weekdays')}>
+            曜日指定
+          </button>
+          <button type="button" className={modeButtonClass('interval')} onClick={() => setMode('interval')}>
+            間隔指定
+          </button>
         </div>
-        {!isEveryDay && (
+
+        {mode === 'weekdays' && (
           <div className="flex flex-wrap gap-2">
             {DAY_OPTIONS.map(({ value, label }) => (
               <label
@@ -116,9 +131,42 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
                 {label}
               </label>
             ))}
-            {!isEveryDay && selectedDays.length === 0 && (
+            {selectedDays.length === 0 && (
               <p className="w-full text-sm text-red-500 mt-1">曜日を選択してください</p>
             )}
+          </div>
+        )}
+
+        {mode === 'interval' && (
+          <div className="space-y-3 mt-2">
+            <div>
+              <label htmlFor="interval-days" className="block text-xs text-gray-500 mb-1">
+                投与間隔
+              </label>
+              <select
+                id="interval-days"
+                value={intervalDays}
+                onChange={(e) => setIntervalDays(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+              >
+                {INTERVAL_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="start-date" className="block text-xs text-gray-500 mb-1">
+                開始日（最初の投与日）
+              </label>
+              <input
+                id="start-date"
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 text-sm"
+                required
+              />
+            </div>
           </div>
         )}
       </div>

--- a/src/components/schedules/ScheduleList.tsx
+++ b/src/components/schedules/ScheduleList.tsx
@@ -83,11 +83,13 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
   const [editTime, setEditTime] = useState(schedule.scheduledTime);
   const [editDays, setEditDays] = useState<DayOfWeek[]>([...schedule.daysOfWeek]);
 
-  const daysLabel = schedule.daysOfWeek.length === 7
-    ? '毎日'
-    : schedule.daysOfWeek.length === 0
-      ? '曜日未設定'
-      : DAY_ORDER.filter((d) => schedule.daysOfWeek.includes(d)).map((d) => DAY_LABELS[d]).join('・');
+  const daysLabel = schedule.intervalDays
+    ? `${schedule.intervalDays}日ごと`
+    : schedule.daysOfWeek.length === 7
+      ? '毎日'
+      : schedule.daysOfWeek.length === 0
+        ? '毎日'
+        : DAY_ORDER.filter((d) => schedule.daysOfWeek.includes(d)).map((d) => DAY_LABELS[d]).join('・');
 
   const toggleDay = (day: DayOfWeek) => {
     setEditDays((prev) =>

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -108,6 +108,8 @@ export function toSchedule(b: BackendSchedule): Schedule {
     memberId: b.memberId,
     scheduledTime: b.scheduledTime,
     daysOfWeek: (b.daysOfWeek?.filter((d: string) => VALID_DAYS_OF_WEEK.includes(d)) as DayOfWeek[]) ?? [],
+    intervalDays: b.intervalDays ?? undefined,
+    startDate: b.startDate ? new Date(b.startDate) : undefined,
     isEnabled: b.isEnabled ?? true,
     reminderMinutesBefore: b.reminderMinutesBefore ?? 10,
     createdAt: new Date(b.createdAt),

--- a/src/data/api/scheduleApi.ts
+++ b/src/data/api/scheduleApi.ts
@@ -20,6 +20,8 @@ interface TodayScheduleResponse {
   memberType: string;
   scheduledTime: string;
   daysOfWeek: string[];
+  intervalDays?: number;
+  startDate?: string;
   isEnabled: boolean;
   reminderMinutesBefore: number;
   isCompleted: boolean;
@@ -39,6 +41,8 @@ export const scheduleApi = {
         memberId: item.memberId,
         scheduledTime: item.scheduledTime,
         daysOfWeek: (item.daysOfWeek?.filter((d) => VALID_DAYS.includes(d)) as DayOfWeek[]) ?? [],
+        intervalDays: item.intervalDays ?? undefined,
+        startDate: item.startDate ? new Date(item.startDate) : undefined,
         isEnabled: item.isEnabled,
         reminderMinutesBefore: item.reminderMinutesBefore ?? 10,
         createdAt: new Date(item.createdAt),
@@ -58,6 +62,8 @@ export const scheduleApi = {
         memberId: item.memberId,
         scheduledTime: item.scheduledTime,
         daysOfWeek: (item.daysOfWeek?.filter((d) => VALID_DAYS.includes(d)) as DayOfWeek[]) ?? [],
+        intervalDays: item.intervalDays ?? undefined,
+        startDate: item.startDate ? new Date(item.startDate) : undefined,
         isEnabled: item.isEnabled,
         reminderMinutesBefore: item.reminderMinutesBefore ?? 10,
         createdAt: new Date(item.createdAt),
@@ -77,6 +83,8 @@ export const scheduleApi = {
       memberId: schedule.memberId,
       scheduledTime: schedule.scheduledTime,
       daysOfWeek: [...schedule.daysOfWeek],
+      intervalDays: schedule.intervalDays,
+      startDate: schedule.startDate?.toISOString(),
       isEnabled: schedule.isEnabled,
       reminderMinutesBefore: schedule.reminderMinutesBefore,
     });
@@ -87,6 +95,8 @@ export const scheduleApi = {
     const body: Record<string, unknown> = {};
     if (schedule.scheduledTime !== undefined) body.scheduledTime = schedule.scheduledTime;
     if (schedule.daysOfWeek !== undefined) body.daysOfWeek = [...schedule.daysOfWeek];
+    if (schedule.intervalDays !== undefined) body.intervalDays = schedule.intervalDays;
+    if (schedule.startDate !== undefined) body.startDate = schedule.startDate?.toISOString() ?? null;
     if (schedule.isEnabled !== undefined) body.isEnabled = schedule.isEnabled;
     if (schedule.reminderMinutesBefore !== undefined) body.reminderMinutesBefore = schedule.reminderMinutesBefore;
 

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -33,6 +33,8 @@ export interface BackendSchedule {
   memberId: string;
   scheduledTime: string;
   daysOfWeek?: string[];
+  intervalDays?: number;
+  startDate?: string;
   isEnabled?: boolean;
   reminderMinutesBefore?: number;
   createdAt: string;

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -23,6 +23,8 @@ export interface Schedule {
   readonly memberId: string;
   readonly scheduledTime: string; // HH:mm形式
   readonly daysOfWeek: readonly DayOfWeek[];
+  readonly intervalDays?: number;
+  readonly startDate?: Date;
   readonly isEnabled: boolean;
   readonly reminderMinutesBefore: number;
   readonly createdAt: Date;
@@ -72,11 +74,22 @@ export class ScheduleEntity {
   }
 
   /**
-   * 指定された曜日にスケジュールが有効かチェック
+   * 指定された日にスケジュールが有効かチェック
    */
   isActiveOnDay(date: Date): boolean {
     if (!this.schedule.isEnabled) {
       return false;
+    }
+
+    // 間隔スケジュール（X日ごと）
+    if (this.schedule.intervalDays && this.schedule.intervalDays > 0 && this.schedule.startDate) {
+      const start = new Date(this.schedule.startDate);
+      start.setHours(0, 0, 0, 0);
+      const target = new Date(date);
+      target.setHours(0, 0, 0, 0);
+      const diffDays = Math.round((target.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+      if (diffDays < 0) return false;
+      return diffDays % this.schedule.intervalDays === 0;
     }
 
     // 曜日が未設定（空配列）の場合は毎日有効

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -74,6 +74,8 @@ export const createScheduleSchema = z.object({
   memberId: idField,
   scheduledTime: z.string().trim().min(1, '予定時刻は必須です').max(10),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
+  intervalDays: z.number().int().min(1).max(365).optional(),
+  startDate: dateString.optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),
 });
@@ -81,6 +83,8 @@ export const createScheduleSchema = z.object({
 export const updateScheduleSchema = z.object({
   scheduledTime: z.string().trim().min(1, '予定時刻は必須です').max(10).optional(),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
+  intervalDays: z.number().int().min(1).max(365).optional().nullable(),
+  startDate: dateString.optional().nullable(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),
 });

--- a/src/presentation/hooks/useSchedules.ts
+++ b/src/presentation/hooks/useSchedules.ts
@@ -16,6 +16,8 @@ export interface CreateScheduleInput {
   memberId: string;
   scheduledTime: string;
   daysOfWeek: DayOfWeek[];
+  intervalDays?: number;
+  startDate?: Date;
   reminderMinutesBefore: number;
 }
 
@@ -59,6 +61,8 @@ export const useSchedules = (): UseSchedulesResult => {
         memberId: input.memberId,
         scheduledTime: input.scheduledTime,
         daysOfWeek: input.daysOfWeek,
+        intervalDays: input.intervalDays,
+        startDate: input.startDate,
         isEnabled: true,
         reminderMinutesBefore: input.reminderMinutesBefore,
       });


### PR DESCRIPTION
## Summary
- Scheduleモデルに `intervalDays`（投与間隔日数）と `startDate`（開始日）フィールドを追加
- `isActiveOnDay` ロジックを拡張し、間隔ベースのスケジュールに対応（開始日からX日ごとに有効）
- スケジュールフォームに「毎日」「曜日指定」「間隔指定」の3モード選択を追加
- 間隔指定では2日ごと〜3ヶ月ごとまでの選択肢と開始日を設定可能
- スケジュール一覧で間隔スケジュールは「21日ごと」等のラベル表示

## Test plan
- [ ] スケジュール作成で「間隔指定」を選択し、21日ごとで登録できることを確認
- [ ] 間隔スケジュールの薬が投与日以外の日に「今日の予定」に表示されないことを確認
- [ ] 投与日には正しく「今日の予定」に表示されることを確認
- [ ] 既存の「毎日」「曜日指定」スケジュールが引き続き正常に動作することを確認

closes #1015