### PR TITLE
feat: アレルギーの種類に「アトピー」を追加

### DIFF
--- a/src/components/allergies/AllergyForm.tsx
+++ b/src/components/allergies/AllergyForm.tsx
@@ -33,6 +33,7 @@ const ALLERGY_TYPES = [
   { value: 'medication', label: '薬物' },
   { value: 'environmental', label: '環境' },
   { value: 'pollen', label: '花粉' },
+  { value: 'atopy', label: 'アトピー' },
   { value: 'other', label: 'その他' },
 ];
 

--- a/src/components/allergies/AllergyList.tsx
+++ b/src/components/allergies/AllergyList.tsx
@@ -10,6 +10,7 @@ const ALLERGY_TYPE_LABELS: Record<string, string> = {
   medication: '薬物',
   environmental: '環境',
   pollen: '花粉',
+  atopy: 'アトピー',
   other: 'その他',
 };
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -272,7 +272,7 @@ export const updateBodyMeasurementSchema = z.object({
 export const createAllergySchema = z.object({
   memberId: idField,
   allergenName: z.string({ required_error: 'アレルゲン名は必須です' }).trim().min(1, 'アレルゲン名は必須です').max(200),
-  allergyType: z.enum(['food', 'medication', 'environmental', 'pollen', 'other'], { required_error: 'アレルギーの種類は必須です' }),
+  allergyType: z.enum(['food', 'medication', 'environmental', 'pollen', 'atopy', 'other'], { required_error: 'アレルギーの種類は必須です' }),
   severity: z.enum(['mild', 'moderate', 'severe'], { required_error: '重症度は必須です' }),
   symptoms: z.string().trim().max(500).optional(),
   diagnosedAt: dateString.optional(),
@@ -281,7 +281,7 @@ export const createAllergySchema = z.object({
 
 export const updateAllergySchema = z.object({
   allergenName: z.string().trim().min(1).max(200).optional(),
-  allergyType: z.enum(['food', 'medication', 'environmental', 'pollen', 'other']).optional(),
+  allergyType: z.enum(['food', 'medication', 'environmental', 'pollen', 'atopy', 'other']).optional(),
   severity: z.enum(['mild', 'moderate', 'severe']).optional(),
   symptoms: z.string().trim().max(500).optional().nullable(),
   diagnosedAt: dateString.optional().nullable(),


### PR DESCRIPTION
## Summary
- アレルギーの種類の選択肢に「アトピー」(atopy)を追加

## Test plan
- [ ] アレルギー追加・編集フォームで「アトピー」が選択できることを確認
- [ ] アトピーで登録したアレルギーが一覧で正しく表示されることを確認

closes #1017