### PR TITLE
test: プレゼンテーション層フックテスト追加（usePrescriptions, useBodyMeasurements, useHealthLogs）

### DIFF
--- a/src/__tests__/presentation/hooks/useBodyMeasurements.test.ts
+++ b/src/__tests__/presentation/hooks/useBodyMeasurements.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useBodyMeasurements } from '@/presentation/hooks/useBodyMeasurements';
+import { setDIContainer, resetDIContainer, DIContainer } from '@/infrastructure/DIContainer';
+import { clearFetcherCache } from '@/presentation/hooks/useFetcher';
+
+const mockMeasurement = {
+  id: 'bm-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  weight: 65.5,
+  height: 170.0,
+  recordedAt: new Date('2025-12-01'),
+  notes: '',
+  createdAt: new Date(),
+};
+
+const mockRepository = {
+  getAll: vi.fn().mockResolvedValue([mockMeasurement]),
+  getById: vi.fn(),
+  create: vi.fn().mockResolvedValue(mockMeasurement),
+  update: vi.fn().mockResolvedValue(mockMeasurement),
+  delete: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('useBodyMeasurements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearFetcherCache();
+    setDIContainer({
+      bodyMeasurementRepository: mockRepository,
+    } as unknown as DIContainer);
+  });
+
+  afterEach(() => {
+    resetDIContainer();
+  });
+
+  it('計測記録一覧を取得する', async () => {
+    const { result } = renderHook(() => useBodyMeasurements());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.measurements).toEqual([mockMeasurement]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('createMeasurementで記録を登録しrefetchする', async () => {
+    const { result } = renderHook(() => useBodyMeasurements());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.createMeasurement({
+        memberId: 'member-1',
+        weight: 66.0,
+        recordedAt: '2025-12-15',
+      });
+    });
+
+    expect(mockRepository.create).toHaveBeenCalled();
+    expect(mockRepository.getAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('deleteMeasurementで記録を削除しrefetchする', async () => {
+    const { result } = renderHook(() => useBodyMeasurements());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.deleteMeasurement('bm-1');
+    });
+
+    expect(mockRepository.delete).toHaveBeenCalledWith('bm-1');
+    expect(mockRepository.getAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('取得エラー時にerrorを設定する', async () => {
+    mockRepository.getAll.mockRejectedValueOnce(new Error('取得失敗'));
+
+    const { result } = renderHook(() => useBodyMeasurements());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toEqual(new Error('取得失敗'));
+    expect(result.current.measurements).toEqual([]);
+  });
+});

--- a/src/__tests__/presentation/hooks/useHealthLogs.test.ts
+++ b/src/__tests__/presentation/hooks/useHealthLogs.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
+import { setDIContainer, resetDIContainer, DIContainer } from '@/infrastructure/DIContainer';
+import { clearFetcherCache } from '@/presentation/hooks/useFetcher';
+
+const mockLog = {
+  id: 'log-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  userId: 'user-1',
+  conditionLevel: 4,
+  symptoms: [],
+  notes: '',
+  recordedAt: new Date('2025-12-01T09:00:00'),
+};
+
+const mockRepository = {
+  getLogs: vi.fn().mockResolvedValue([mockLog]),
+  createLog: vi.fn().mockResolvedValue(undefined),
+  deleteLog: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('useHealthLogs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearFetcherCache();
+    setDIContainer({
+      healthLogRepository: mockRepository,
+    } as unknown as DIContainer);
+  });
+
+  afterEach(() => {
+    resetDIContainer();
+  });
+
+  it('体調記録をグループ化して取得する', async () => {
+    const { result } = renderHook(() => useHealthLogs());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.groups.length).toBeGreaterThanOrEqual(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('createLogで体調記録を作成しrefetchする', async () => {
+    const { result } = renderHook(() => useHealthLogs());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.createLog({
+        memberId: 'member-1',
+        conditionLevel: 3,
+        symptoms: ['headache'],
+      });
+    });
+
+    expect(mockRepository.createLog).toHaveBeenCalled();
+    expect(mockRepository.getLogs).toHaveBeenCalledTimes(2);
+  });
+
+  it('deleteLogで体調記録を削除しrefetchする', async () => {
+    const { result } = renderHook(() => useHealthLogs());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.deleteLog('log-1');
+    });
+
+    expect(mockRepository.deleteLog).toHaveBeenCalledWith('log-1');
+    expect(mockRepository.getLogs).toHaveBeenCalledTimes(2);
+  });
+
+  it('取得エラー時にerrorを設定する', async () => {
+    mockRepository.getLogs.mockRejectedValueOnce(new Error('取得失敗'));
+
+    const { result } = renderHook(() => useHealthLogs());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toEqual(new Error('取得失敗'));
+    expect(result.current.groups).toEqual([]);
+  });
+});

--- a/src/__tests__/presentation/hooks/usePrescriptions.test.ts
+++ b/src/__tests__/presentation/hooks/usePrescriptions.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { usePrescriptions } from '@/presentation/hooks/usePrescriptions';
+import { setDIContainer, resetDIContainer, DIContainer } from '@/infrastructure/DIContainer';
+import { clearFetcherCache } from '@/presentation/hooks/useFetcher';
+
+const mockPrescription = {
+  id: 'presc-1',
+  userId: 'user-1',
+  memberId: 'member-1',
+  memberName: '太郎',
+  prescriptionName: '高血圧治療薬',
+  prescribedBy: '山田医師',
+  prescribedAt: '2025-12-01',
+  expiresAt: null,
+  pharmacyName: null,
+  notes: '',
+  createdAt: new Date(),
+};
+
+const mockRepository = {
+  getAll: vi.fn().mockResolvedValue([mockPrescription]),
+  getById: vi.fn(),
+  create: vi.fn().mockResolvedValue(mockPrescription),
+  update: vi.fn().mockResolvedValue(mockPrescription),
+  delete: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('usePrescriptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearFetcherCache();
+    setDIContainer({
+      prescriptionRepository: mockRepository,
+    } as unknown as DIContainer);
+  });
+
+  afterEach(() => {
+    resetDIContainer();
+  });
+
+  it('処方箋一覧を取得する', async () => {
+    const { result } = renderHook(() => usePrescriptions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.prescriptions).toEqual([mockPrescription]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('createPrescriptionで処方箋を登録しrefetchする', async () => {
+    const { result } = renderHook(() => usePrescriptions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.createPrescription({
+        memberId: 'member-1',
+        prescriptionName: '抗生物質',
+        prescribedAt: '2025-12-15',
+      });
+    });
+
+    expect(mockRepository.create).toHaveBeenCalled();
+    expect(mockRepository.getAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletePrescriptionで処方箋を削除しrefetchする', async () => {
+    const { result } = renderHook(() => usePrescriptions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.deletePrescription('presc-1');
+    });
+
+    expect(mockRepository.delete).toHaveBeenCalledWith('presc-1');
+    expect(mockRepository.getAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('取得エラー時にerrorを設定する', async () => {
+    mockRepository.getAll.mockRejectedValueOnce(new Error('取得失敗'));
+
+    const { result } = renderHook(() => usePrescriptions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toEqual(new Error('取得失敗'));
+    expect(result.current.prescriptions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- usePrescriptions, useBodyMeasurements, useHealthLogsのプレゼンテーション層フックテストを追加（12テスト）
- これでプレゼンテーション層フックの半数以上がテスト済み（10/24フック）

## Test plan
- [x] 全8399テスト通過
- [x] ビルド成功