### PR TITLE
test: プレゼンテーション層フックテスト完了（useAdherenceTrends等3フック）

### DIFF
--- a/src/__tests__/presentation/hooks/useAdherenceTrends.test.ts
+++ b/src/__tests__/presentation/hooks/useAdherenceTrends.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAdherenceTrends } from '@/presentation/hooks/useAdherenceTrends';
+import { setDIContainer, resetDIContainer, DIContainer } from '@/infrastructure/DIContainer';
+import { clearFetcherCache } from '@/presentation/hooks/useFetcher';
+
+const mockTrend = {
+  dailyRates: [80, 85, 90, 95, 100],
+  weeklyAverage: 90,
+  direction: 'up' as const,
+};
+
+const mockRepository = {
+  getRecords: vi.fn(),
+  createRecord: vi.fn(),
+  deleteRecord: vi.fn(),
+  getAdherenceStats: vi.fn(),
+  getHistory: vi.fn(),
+  getAdherenceTrends: vi.fn().mockResolvedValue(mockTrend),
+};
+
+describe('useAdherenceTrends', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearFetcherCache();
+    setDIContainer({
+      medicationRecordRepository: mockRepository,
+    } as unknown as DIContainer);
+  });
+
+  afterEach(() => {
+    resetDIContainer();
+  });
+
+  it('アドヒアランストレンドを取得する', async () => {
+    const { result } = renderHook(() => useAdherenceTrends());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.trend).toBeTruthy();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('取得エラー時にerrorを設定する', async () => {
+    mockRepository.getAdherenceTrends.mockRejectedValueOnce(new Error('取得失敗'));
+
+    const { result } = renderHook(() => useAdherenceTrends());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.trend).toBeNull();
+  });
+});

--- a/src/__tests__/presentation/hooks/useMedicationRecordActions.test.ts
+++ b/src/__tests__/presentation/hooks/useMedicationRecordActions.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMedicationRecordActions } from '@/presentation/hooks/useMedicationRecordActions';
+import { setDIContainer, resetDIContainer, DIContainer } from '@/infrastructure/DIContainer';
+
+const mockRepository = {
+  getRecords: vi.fn(),
+  createRecord: vi.fn().mockResolvedValue(undefined),
+  deleteRecord: vi.fn(),
+  getAdherenceStats: vi.fn(),
+  getHistory: vi.fn(),
+  getAdherenceTrends: vi.fn(),
+};
+
+describe('useMedicationRecordActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDIContainer({
+      medicationRecordRepository: mockRepository,
+    } as unknown as DIContainer);
+  });
+
+  afterEach(() => {
+    resetDIContainer();
+  });
+
+  it('初期状態でisLoadingがfalseでerrorがnullである', () => {
+    const { result } = renderHook(() => useMedicationRecordActions());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('markAsTakenで服薬記録を作成する', async () => {
+    const { result } = renderHook(() => useMedicationRecordActions());
+
+    await act(async () => {
+      await result.current.markAsTaken('member-1', 'med-1', 'メモ');
+    });
+
+    expect(mockRepository.createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberId: 'member-1',
+        medicationId: 'med-1',
+        notes: 'メモ',
+      })
+    );
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('markAsTakenAtで指定時刻の服薬記録を作成する', async () => {
+    const { result } = renderHook(() => useMedicationRecordActions());
+
+    await act(async () => {
+      await result.current.markAsTakenAt('member-1', 'med-1', '2025-12-01T08:00:00');
+    });
+
+    expect(mockRepository.createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memberId: 'member-1',
+        medicationId: 'med-1',
+        takenAt: '2025-12-01T08:00:00',
+      })
+    );
+  });
+
+  it('エラー時にerrorを設定しthrowする', async () => {
+    mockRepository.createRecord.mockRejectedValueOnce(new Error('記録失敗'));
+    const { result } = renderHook(() => useMedicationRecordActions());
+
+    await act(async () => {
+      try {
+        await result.current.markAsTaken('member-1', 'med-1');
+      } catch {
+        // expected
+      }
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/__tests__/presentation/hooks/useScheduleManagement.test.ts
+++ b/src/__tests__/presentation/hooks/useScheduleManagement.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useScheduleManagement } from '@/presentation/hooks/useScheduleManagement';
+import { setDIContainer, resetDIContainer, DIContainer } from '@/infrastructure/DIContainer';
+
+const mockRepository = {
+  getSchedules: vi.fn(),
+  getScheduleById: vi.fn(),
+  createSchedule: vi.fn().mockResolvedValue({ id: 'sch-new' }),
+  updateSchedule: vi.fn(),
+  deleteSchedule: vi.fn(),
+  getTodaySchedules: vi.fn(),
+  markAsCompleted: vi.fn(),
+};
+
+describe('useScheduleManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDIContainer({
+      scheduleRepository: mockRepository,
+    } as unknown as DIContainer);
+  });
+
+  afterEach(() => {
+    resetDIContainer();
+  });
+
+  it('初期状態でisCreatingがfalseでerrorがnullである', () => {
+    const { result } = renderHook(() => useScheduleManagement());
+
+    expect(result.current.isCreating).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('createScheduleでスケジュールを作成する', async () => {
+    const { result } = renderHook(() => useScheduleManagement());
+
+    await act(async () => {
+      await result.current.createSchedule({
+        medicationId: 'med-1',
+        userId: 'user-1',
+        memberId: 'member-1',
+        scheduledTime: '08:00',
+        daysOfWeek: [],
+        reminderMinutesBefore: 10,
+      });
+    });
+
+    expect(mockRepository.createSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        medicationId: 'med-1',
+        scheduledTime: '08:00',
+        isEnabled: true,
+      })
+    );
+    expect(result.current.isCreating).toBe(false);
+  });
+
+  it('作成エラー時にerrorを設定する', async () => {
+    mockRepository.createSchedule.mockRejectedValueOnce(new Error('作成失敗'));
+    const { result } = renderHook(() => useScheduleManagement());
+
+    await act(async () => {
+      await result.current.createSchedule({
+        medicationId: 'med-1',
+        userId: 'user-1',
+        memberId: 'member-1',
+        scheduledTime: '08:00',
+        daysOfWeek: [],
+        reminderMinutesBefore: 10,
+      });
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.isCreating).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- useAdherenceTrends, useMedicationRecordActions, useScheduleManagementのテストを追加（9テスト）
- これでプレゼンテーション層フック21/24がテスト済み（残り3フックは他フックと機能重複あり）

## Test plan
- [x] 全8433テスト通過
- [x] ビルド成功