### PR TITLE
fix: 通院予約の病院編集を有効化し、薬の並び替え機能を追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model Medication {
   stockAlertDate    DateTime?
   intervalHours     Int?
   instructions      String?
+  displayOrder      Int      @default(0)
   isActive          Boolean  @default(true)
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt

--- a/src/app/api/appointments/[appointmentId]/route.ts
+++ b/src/app/api/appointments/[appointmentId]/route.ts
@@ -31,6 +31,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ appo
           where: { id: appointmentId },
           data: {
             appointmentDate: parsed.data.appointmentDate ? new Date(parsed.data.appointmentDate) : undefined,
+            hospitalId: parsed.data.hospitalId === '' ? null : parsed.data.hospitalId,
             appointmentType: parsed.data.type,
             description: parsed.data.notes,
             reminderEnabled: parsed.data.reminderEnabled,

--- a/src/app/api/medications/member/[memberId]/route.ts
+++ b/src/app/api/medications/member/[memberId]/route.ts
@@ -11,7 +11,7 @@ export async function GET(_request: Request, { params }: { params: Promise<{ mem
     const { memberId } = await params;
     const idError = validateParamId(memberId);
     if (idError) return idError;
-    const medications = await prisma.medication.findMany({ where: { memberId, userId }, take: QUERY_LIMITS.APPOINTMENTS });
+    const medications = await prisma.medication.findMany({ where: { memberId, userId }, orderBy: { displayOrder: 'asc' }, take: QUERY_LIMITS.APPOINTMENTS });
     return success(medications);
   })();
 }

--- a/src/app/api/medications/reorder/route.ts
+++ b/src/app/api/medications/reorder/route.ts
@@ -1,0 +1,46 @@
+import { prisma } from '@/lib/prisma';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+import { z } from 'zod';
+
+const reorderSchema = z.object({
+  medicationIds: z.array(z.string().min(1).max(50)).min(1).max(100),
+});
+
+export async function PUT(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medications-reorder:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const parsed = reorderSchema.safeParse(jsonResult.data);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const { medicationIds } = parsed.data;
+
+    const medications = await prisma.medication.findMany({
+      where: { id: { in: medicationIds }, userId },
+      select: { id: true },
+    });
+
+    const ownedIds = new Set(medications.map((m) => m.id));
+    const allOwned = medicationIds.every((id) => ownedIds.has(id));
+    if (!allOwned) return errorResponse('権限がありません', 403);
+
+    await prisma.$transaction(
+      medicationIds.map((id, index) =>
+        prisma.medication.update({
+          where: { id },
+          data: { displayOrder: index },
+        })
+      )
+    );
+
+    return success({ message: '並び順を更新しました' });
+  })();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -83,6 +83,7 @@ export default function AppointmentsPage() {
     try {
       await updateAppointment(editingAppointment.id, {
         appointmentDate: data.appointmentDate,
+        hospitalId: data.hospitalId,
         type: data.type,
         notes: data.notes,
       });

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -16,7 +16,7 @@ import Link from 'next/link';
 import { Plus, ClipboardList } from 'lucide-react';
 
 function MemberMedications({ member, categoryFilter }: { member: Member; categoryFilter: MedicationCategory | null }) {
-  const { medications, isLoading, updateMedication, deleteMedication } = useMedications(member.id);
+  const { medications, isLoading, updateMedication, deleteMedication, reorderMedications } = useMedications(member.id);
   const { markAsTaken, markAsTakenAt } = useMedicationRecordActions();
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
@@ -98,6 +98,7 @@ function MemberMedications({ member, categoryFilter }: { member: Member; categor
         onMarkTaken={handleMarkTaken}
         onMarkPastTaken={handleMarkPastTaken}
         onEdit={handleEdit}
+        onReorder={!categoryFilter ? reorderMedications : undefined}
       />
     </section>
   );

--- a/src/app/members/[memberId]/medications/page.tsx
+++ b/src/app/members/[memberId]/medications/page.tsx
@@ -18,7 +18,7 @@ export default function Medications() {
   const router = useRouter();
   const memberId = params.memberId as string;
   const { userId } = useAuth();
-  const { medications, isLoading, createMedication, deleteMedication } = useMedications(memberId);
+  const { medications, isLoading, createMedication, deleteMedication, reorderMedications } = useMedications(memberId);
   const { schedules, isLoading: schedulesLoading, createSchedule, updateSchedule, deleteSchedule } = useSchedules();
   const [showMedForm, setShowMedForm] = useState(false);
   const [scheduleTarget, setScheduleTarget] = useState<MedicationViewModel | null>(null);
@@ -118,6 +118,7 @@ export default function Medications() {
           medications={medications}
           isLoading={isLoading}
           onDelete={deleteMedication}
+          onReorder={reorderMedications}
         />
 
         {medications.length > 0 && !scheduleTarget && (

--- a/src/components/appointments/AppointmentForm.tsx
+++ b/src/components/appointments/AppointmentForm.tsx
@@ -113,8 +113,7 @@ export const AppointmentForm: React.FC<AppointmentFormProps> = ({ members, hospi
             id="apt-hospital"
             value={hospitalId}
             onChange={(e) => setHospitalId(e.target.value)}
-            disabled={isEditing}
-            className={`w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${isEditing ? 'opacity-60 cursor-not-allowed' : ''}`}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
           >
             <option value="">選択しない</option>
             {hospitals.map((h) => (

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Pill, Check, Pencil, Clock } from 'lucide-react';
+import { Pill, Check, Pencil, Clock, ChevronUp, ChevronDown } from 'lucide-react';
 import { Medication } from '../../domain/entities/Medication';
 import { MedicationViewModel } from '../../domain/usecases/ManageMedications';
 import { ConfirmationDialog } from '../shared/ConfirmationDialog';
@@ -13,9 +13,10 @@ interface MedicationListProps {
   onMarkTaken?: (medicationId: string) => Promise<void>;
   onMarkPastTaken?: (medicationId: string, takenAt: string) => Promise<void>;
   onEdit?: (medication: Medication) => void;
+  onReorder?: (medicationIds: string[]) => Promise<void>;
 }
 
-export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete, onMarkTaken, onMarkPastTaken, onEdit }) => {
+export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete, onMarkTaken, onMarkPastTaken, onEdit, onReorder }) => {
   if (isLoading) {
     return (
       <LoadingSpinner />
@@ -28,10 +29,28 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
     );
   }
 
+  const handleMove = async (index: number, direction: 'up' | 'down') => {
+    if (!onReorder) return;
+    const newList = [...medications];
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= newList.length) return;
+    [newList[index], newList[targetIndex]] = [newList[targetIndex], newList[index]];
+    await onReorder(newList.map((vm) => vm.medication.id));
+  };
+
   return (
     <div className="space-y-3">
-      {medications.map((vm) => (
-        <MedicationCard key={vm.medication.id} viewModel={vm} onDelete={onDelete} onMarkTaken={onMarkTaken} onMarkPastTaken={onMarkPastTaken} onEdit={onEdit} />
+      {medications.map((vm, index) => (
+        <MedicationCard
+          key={vm.medication.id}
+          viewModel={vm}
+          onDelete={onDelete}
+          onMarkTaken={onMarkTaken}
+          onMarkPastTaken={onMarkPastTaken}
+          onEdit={onEdit}
+          onMoveUp={onReorder && index > 0 ? () => handleMove(index, 'up') : undefined}
+          onMoveDown={onReorder && index < medications.length - 1 ? () => handleMove(index, 'down') : undefined}
+        />
       ))}
     </div>
   );
@@ -43,9 +62,11 @@ export interface MedicationCardProps {
   onMarkTaken?: (medicationId: string) => Promise<void>;
   onMarkPastTaken?: (medicationId: string, takenAt: string) => Promise<void>;
   onEdit?: (medication: Medication) => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
 }
 
-const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, onDelete, onMarkTaken, onMarkPastTaken, onEdit }) => {
+const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, onDelete, onMarkTaken, onMarkPastTaken, onEdit, onMoveUp, onMoveDown }) => {
   const { medication, isLowStock, displayInfo } = viewModel;
   const [isTaken, setIsTaken] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -88,6 +109,26 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, o
   return (
     <div className="bg-white rounded-lg shadow-md p-4 border border-gray-200">
       <div className="flex items-center justify-between">
+        {(onMoveUp || onMoveDown) && (
+          <div className="flex flex-col mr-2 -my-1">
+            <button
+              onClick={onMoveUp}
+              disabled={!onMoveUp}
+              className={`p-0.5 rounded ${onMoveUp ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-100' : 'text-gray-200'}`}
+              aria-label="上に移動"
+            >
+              <ChevronUp size={16} />
+            </button>
+            <button
+              onClick={onMoveDown}
+              disabled={!onMoveDown}
+              className={`p-0.5 rounded ${onMoveDown ? 'text-gray-500 hover:text-gray-700 hover:bg-gray-100' : 'text-gray-200'}`}
+              aria-label="下に移動"
+            >
+              <ChevronDown size={16} />
+            </button>
+          </div>
+        )}
         <div className="flex-1">
           <div className="flex items-center space-x-2">
             <Pill size={20} className="text-primary-600" />

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -47,6 +47,7 @@ export function toMedication(b: BackendMedication): Medication {
     stockQuantity: b.stockQuantity,
     stockAlertDate: b.stockAlertDate ? new Date(b.stockAlertDate) : undefined,
     instructions: b.instructions,
+    displayOrder: b.displayOrder ?? 0,
     isActive: b.isActive ?? true,
     createdAt: new Date(b.createdAt),
     updatedAt: new Date(b.updatedAt),

--- a/src/data/api/medicationApi.ts
+++ b/src/data/api/medicationApi.ts
@@ -53,6 +53,10 @@ export const medicationApi = {
     await apiClient.del(`/medications/${medicationId}`);
   },
 
+  async reorderMedications(medicationIds: string[]): Promise<void> {
+    await apiClient.put('/medications/reorder', { medicationIds });
+  },
+
   async searchMedications(query: string): Promise<MedicationSearchResult[]> {
     return apiClient.get<MedicationSearchResult[]>(`/medications/search?q=${encodeURIComponent(query)}`);
   },

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -21,6 +21,7 @@ export interface BackendMedication {
   stockQuantity?: number;
   stockAlertDate?: string;
   instructions?: string;
+  displayOrder?: number;
   isActive?: boolean;
   createdAt: string;
   updatedAt: string;

--- a/src/data/repositories/MedicationRepositoryImpl.ts
+++ b/src/data/repositories/MedicationRepositoryImpl.ts
@@ -33,6 +33,10 @@ export class MedicationRepositoryImpl implements MedicationRepository {
     return medicationApi.deleteMedication(medicationId);
   }
 
+  async reorderMedications(medicationIds: string[]): Promise<void> {
+    return medicationApi.reorderMedications(medicationIds);
+  }
+
   async searchMedications(query: string): Promise<MedicationSearchResult[]> {
     return medicationApi.searchMedications(query);
   }

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -27,6 +27,7 @@ export interface Medication {
   readonly stockAlertDate?: Date;
   readonly intervalHours?: number;
   readonly instructions?: string;
+  readonly displayOrder: number;
   readonly isActive: boolean;
   readonly createdAt: Date;
   readonly updatedAt: Date;

--- a/src/domain/repositories/AppointmentRepository.ts
+++ b/src/domain/repositories/AppointmentRepository.ts
@@ -16,6 +16,7 @@ export interface CreateAppointmentInput {
 
 export interface UpdateAppointmentInput {
   appointmentDate?: string;
+  hospitalId?: string;
   type?: string;
   notes?: string;
   reminderEnabled?: boolean;

--- a/src/domain/repositories/MedicationRepository.ts
+++ b/src/domain/repositories/MedicationRepository.ts
@@ -34,6 +34,7 @@ export interface MedicationRepository {
   createMedication(input: CreateMedicationInput): Promise<Medication>;
   updateMedication(medicationId: string, input: UpdateMedicationInput): Promise<Medication>;
   deleteMedication(medicationId: string): Promise<void>;
+  reorderMedications(medicationIds: string[]): Promise<void>;
   searchMedications(query: string): Promise<MedicationSearchResult[]>;
   getStockAlerts(): Promise<StockAlert[]>;
 }

--- a/src/domain/usecases/ManageMedications.ts
+++ b/src/domain/usecases/ManageMedications.ts
@@ -68,6 +68,14 @@ export class DeleteMedication {
   }
 }
 
+export class ReorderMedications {
+  constructor(private readonly medicationRepository: MedicationRepository) {}
+
+  async execute(medicationIds: string[]): Promise<void> {
+    return this.medicationRepository.reorderMedications(medicationIds);
+  }
+}
+
 export class SearchMedications {
   constructor(private readonly medicationRepository: MedicationRepository) {}
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -137,6 +137,7 @@ export const createAppointmentSchema = z.object({
 
 export const updateAppointmentSchema = z.object({
   appointmentDate: dateString.optional(),
+  hospitalId: z.string().trim().max(50).optional().nullable(),
   appointmentTime: z.string().trim().max(10).optional(),
   type: z.string().trim().max(100).optional(),
   notes: z.string().trim().max(1000).optional(),

--- a/src/presentation/hooks/useMedications.ts
+++ b/src/presentation/hooks/useMedications.ts
@@ -4,7 +4,7 @@
  */
 
 import { useCallback, useMemo } from 'react';
-import { GetMedications, CreateMedication, UpdateMedication, DeleteMedication, MedicationViewModel } from '../../domain/usecases/ManageMedications';
+import { GetMedications, CreateMedication, UpdateMedication, DeleteMedication, ReorderMedications, MedicationViewModel } from '../../domain/usecases/ManageMedications';
 import { CreateMedicationInput, UpdateMedicationInput } from '../../domain/repositories/MedicationRepository';
 import { getDIContainer } from '../../infrastructure/DIContainer';
 import { useFetcher } from './useFetcher';
@@ -16,6 +16,7 @@ export interface UseMedicationsResult {
   createMedication: (input: CreateMedicationInput) => Promise<void>;
   updateMedication: (medicationId: string, input: UpdateMedicationInput) => Promise<void>;
   deleteMedication: (medicationId: string) => Promise<void>;
+  reorderMedications: (medicationIds: string[]) => Promise<void>;
   refetch: () => Promise<void>;
 }
 
@@ -27,6 +28,7 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
       createMedication: new CreateMedication(medicationRepository),
       updateMedication: new UpdateMedication(medicationRepository),
       deleteMedication: new DeleteMedication(medicationRepository),
+      reorderMedications: new ReorderMedications(medicationRepository),
     };
   }, []);
 
@@ -52,6 +54,11 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
     await refetch();
   }, [useCases, refetch]);
 
+  const handleReorderMedications = useCallback(async (medicationIds: string[]) => {
+    await useCases.reorderMedications.execute(medicationIds);
+    await refetch();
+  }, [useCases, refetch]);
+
   return {
     medications,
     isLoading,
@@ -59,6 +66,7 @@ export const useMedications = (memberId: string): UseMedicationsResult => {
     createMedication: handleCreateMedication,
     updateMedication: handleUpdateMedication,
     deleteMedication: handleDeleteMedication,
+    reorderMedications: handleReorderMedications,
     refetch,
   };
 };


### PR DESCRIPTION
## Summary
- 通院予約の編集時に病院を変更できない不具合を修正(disabled属性の解除、APIにhospitalIdを追加)
- 薬一覧に表示順の並び替え機能を追加(上下矢印ボタンで順番変更可能)
- MedicationモデルにdisplayOrderフィールドを追加し、並び替えAPIを新設

## Test plan
- [ ] 通院予約の編集画面で病院の選択肢が表示され、変更できることを確認
- [ ] 病院を「選択しない」に変更できることを確認
- [ ] お薬ページで上下矢印ボタンが表示されることを確認
- [ ] 矢印ボタンで薬の順番が入れ替わり、リロード後も保持されることを確認
- [ ] カテゴリフィルター使用時は並び替えボタンが非表示になることを確認
- [ ] メンバー別薬管理ページでも並び替えが機能することを確認