### PR TITLE
fix: スケジュール編集で頻度モードを変更可能に

### DIFF
--- a/src/__tests__/domain/usecases/ManageSchedules.test.ts
+++ b/src/__tests__/domain/usecases/ManageSchedules.test.ts
@@ -130,7 +130,7 @@ describe('UpdateSchedule', () => {
     const result = await useCase.execute('sch-1', { scheduledTime: '09:00' });
 
     expect(result).toBe(mockSchedule);
-    expect(repo.updateSchedule).toHaveBeenCalledWith('sch-1', { scheduledTime: '09:00' });
+    expect(repo.updateSchedule).toHaveBeenCalledWith('sch-1', { scheduledTime: '09:00' }, undefined);
   });
 
   it('スケジュールIDが空の場合エラーを投げる', async () => {
@@ -156,7 +156,7 @@ describe('UpdateSchedule', () => {
     const useCase = new UpdateSchedule(repo);
     await useCase.execute('sch-1', { isEnabled: false });
 
-    expect(repo.updateSchedule).toHaveBeenCalledWith('sch-1', { isEnabled: false });
+    expect(repo.updateSchedule).toHaveBeenCalledWith('sch-1', { isEnabled: false }, undefined);
   });
 });
 

--- a/src/components/schedules/ScheduleList.tsx
+++ b/src/components/schedules/ScheduleList.tsx
@@ -22,7 +22,7 @@ const DAY_ORDER: DayOfWeek[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
 interface ScheduleListProps {
   schedules: ScheduleWithDetails[];
   isLoading: boolean;
-  onUpdate: (scheduleId: string, input: Partial<Schedule>) => Promise<void>;
+  onUpdate: (scheduleId: string, input: Partial<Schedule>, options?: { clearInterval?: boolean }) => Promise<void>;
   onDelete: (scheduleId: string) => void;
 }
 
@@ -71,17 +71,46 @@ export const ScheduleList: React.FC<ScheduleListProps> = ({ schedules, isLoading
 
 export interface ScheduleCardProps {
   item: ScheduleWithDetails;
-  onUpdate: (scheduleId: string, input: Partial<Schedule>) => Promise<void>;
+  onUpdate: (scheduleId: string, input: Partial<Schedule>, options?: { clearInterval?: boolean }) => Promise<void>;
   onDelete: (scheduleId: string) => void;
+}
+
+type EditMode = 'daily' | 'weekdays' | 'interval';
+
+const INTERVAL_OPTIONS = [
+  { value: 2, label: '2日ごと' },
+  { value: 3, label: '3日ごと' },
+  { value: 7, label: '1週間ごと' },
+  { value: 14, label: '2週間ごと' },
+  { value: 21, label: '3週間ごと' },
+  { value: 28, label: '4週間ごと' },
+  { value: 30, label: '1ヶ月ごと' },
+  { value: 60, label: '2ヶ月ごと' },
+  { value: 90, label: '3ヶ月ごと' },
+];
+
+function getInitialMode(schedule: Schedule): EditMode {
+  if (schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate) return 'interval';
+  if (schedule.daysOfWeek.length > 0) return 'weekdays';
+  return 'daily';
 }
 
 const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, onDelete }) => {
   const { schedule, medicationName, memberName } = item;
   const [isEditing, setIsEditing] = useState(false);
   const [editTime, setEditTime] = useState(schedule.scheduledTime);
+  const [editMode, setEditMode] = useState<EditMode>(() => getInitialMode(schedule));
   const [editDays, setEditDays] = useState<DayOfWeek[]>([...schedule.daysOfWeek]);
+  const [editIntervalDays, setEditIntervalDays] = useState(String(schedule.intervalDays || 21));
+  const [editStartDate, setEditStartDate] = useState(() => {
+    if (schedule.startDate) {
+      const d = new Date(schedule.startDate);
+      return d.toISOString().split('T')[0];
+    }
+    return new Date().toISOString().split('T')[0];
+  });
 
-  const daysLabel = schedule.intervalDays
+  const daysLabel = schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate
     ? `${schedule.intervalDays}日ごと`
     : schedule.daysOfWeek.length === 7
       ? '毎日'
@@ -95,23 +124,49 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
     );
   };
 
+  const canSave = editMode === 'daily'
+    || (editMode === 'weekdays' && editDays.length > 0)
+    || (editMode === 'interval' && editStartDate);
+
   const handleSave = async () => {
-    await onUpdate(schedule.id, {
-      scheduledTime: editTime,
-      daysOfWeek: editDays,
-    });
+    if (!canSave) return;
+    const wasInterval = getInitialMode(schedule) === 'interval';
+    const shouldClearInterval = wasInterval && editMode !== 'interval';
+    let updateData: Partial<Schedule>;
+    if (editMode === 'interval') {
+      updateData = {
+        scheduledTime: editTime,
+        daysOfWeek: [],
+        intervalDays: parseInt(editIntervalDays, 10),
+        startDate: new Date(editStartDate),
+      };
+    } else if (editMode === 'weekdays') {
+      updateData = { scheduledTime: editTime, daysOfWeek: editDays };
+    } else {
+      updateData = { scheduledTime: editTime, daysOfWeek: [] };
+    }
+    await onUpdate(schedule.id, updateData, shouldClearInterval ? { clearInterval: true } : undefined);
     setIsEditing(false);
   };
 
   const handleCancel = () => {
     setEditTime(schedule.scheduledTime);
+    setEditMode(getInitialMode(schedule));
     setEditDays([...schedule.daysOfWeek]);
+    setEditIntervalDays(String(schedule.intervalDays || 21));
     setIsEditing(false);
   };
 
   const handleToggleEnabled = () => {
     onUpdate(schedule.id, { isEnabled: !schedule.isEnabled });
   };
+
+  const modeButtonClass = (m: EditMode) =>
+    `px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+      editMode === m
+        ? 'bg-primary-600 text-white'
+        : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+    }`;
 
   if (isEditing) {
     return (
@@ -127,28 +182,74 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
             />
           </div>
           <div>
-            <label className="block text-xs text-gray-500 mb-1">曜日</label>
-            <div className="flex gap-1">
-              {DAY_ORDER.map((day) => (
-                <button
-                  key={day}
-                  type="button"
-                  onClick={() => toggleDay(day)}
-                  className={`w-8 h-8 rounded-full text-xs font-medium transition-colors ${
-                    editDays.includes(day)
-                      ? 'bg-primary-600 text-white'
-                      : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                  }`}
-                >
-                  {DAY_LABELS[day]}
-                </button>
-              ))}
+            <label className="block text-xs text-gray-500 mb-2">頻度</label>
+            <div className="flex gap-2 mb-2">
+              <button type="button" className={modeButtonClass('daily')} onClick={() => setEditMode('daily')}>
+                毎日
+              </button>
+              <button type="button" className={modeButtonClass('weekdays')} onClick={() => setEditMode('weekdays')}>
+                曜日指定
+              </button>
+              <button type="button" className={modeButtonClass('interval')} onClick={() => setEditMode('interval')}>
+                間隔指定
+              </button>
             </div>
+
+            {editMode === 'weekdays' && (
+              <div>
+                <div className="flex gap-1">
+                  {DAY_ORDER.map((day) => (
+                    <button
+                      key={day}
+                      type="button"
+                      onClick={() => toggleDay(day)}
+                      className={`w-8 h-8 rounded-full text-xs font-medium transition-colors ${
+                        editDays.includes(day)
+                          ? 'bg-primary-600 text-white'
+                          : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+                      }`}
+                    >
+                      {DAY_LABELS[day]}
+                    </button>
+                  ))}
+                </div>
+                {editDays.length === 0 && (
+                  <p className="text-xs text-red-500 mt-1">曜日を選択してください</p>
+                )}
+              </div>
+            )}
+
+            {editMode === 'interval' && (
+              <div className="space-y-2">
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">投与間隔</label>
+                  <select
+                    value={editIntervalDays}
+                    onChange={(e) => setEditIntervalDays(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm"
+                  >
+                    {INTERVAL_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">開始日（最初の投与日）</label>
+                  <input
+                    type="date"
+                    value={editStartDate}
+                    onChange={(e) => setEditStartDate(e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm"
+                    required
+                  />
+                </div>
+              </div>
+            )}
           </div>
           <div className="flex space-x-2">
             <button
               onClick={handleSave}
-              disabled={editDays.length === 0}
+              disabled={!canSave}
               className="flex-1 flex items-center justify-center space-x-1 bg-primary-600 text-white py-1.5 rounded-lg text-sm hover:bg-primary-700 transition-colors disabled:opacity-50"
             >
               <Check size={14} />

--- a/src/data/api/scheduleApi.ts
+++ b/src/data/api/scheduleApi.ts
@@ -91,7 +91,7 @@ export const scheduleApi = {
     return toSchedule(data);
   },
 
-  async updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule> {
+  async updateSchedule(id: string, schedule: Partial<Schedule>, clearInterval?: boolean): Promise<Schedule> {
     const body: Record<string, unknown> = {};
     if (schedule.scheduledTime !== undefined) body.scheduledTime = schedule.scheduledTime;
     if (schedule.daysOfWeek !== undefined) body.daysOfWeek = [...schedule.daysOfWeek];
@@ -99,6 +99,10 @@ export const scheduleApi = {
     if (schedule.startDate !== undefined) body.startDate = schedule.startDate?.toISOString() ?? null;
     if (schedule.isEnabled !== undefined) body.isEnabled = schedule.isEnabled;
     if (schedule.reminderMinutesBefore !== undefined) body.reminderMinutesBefore = schedule.reminderMinutesBefore;
+    if (clearInterval) {
+      body.intervalDays = null;
+      body.startDate = null;
+    }
 
     const data = await apiClient.put<BackendSchedule>(`/schedules/${id}`, body);
     return toSchedule(data);

--- a/src/data/repositories/ScheduleRepositoryImpl.ts
+++ b/src/data/repositories/ScheduleRepositoryImpl.ts
@@ -25,8 +25,8 @@ export class ScheduleRepositoryImpl implements ScheduleRepository {
     return await scheduleApi.createSchedule(schedule);
   }
 
-  async updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule> {
-    return await scheduleApi.updateSchedule(id, schedule);
+  async updateSchedule(id: string, schedule: Partial<Schedule>, options?: { clearInterval?: boolean }): Promise<Schedule> {
+    return await scheduleApi.updateSchedule(id, schedule, options?.clearInterval);
   }
 
   async deleteSchedule(id: string): Promise<void> {

--- a/src/domain/repositories/ScheduleRepository.ts
+++ b/src/domain/repositories/ScheduleRepository.ts
@@ -43,7 +43,7 @@ export interface ScheduleRepository {
   /**
    * スケジュールを更新
    */
-  updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule>;
+  updateSchedule(id: string, schedule: Partial<Schedule>, options?: { clearInterval?: boolean }): Promise<Schedule>;
 
   /**
    * スケジュールを削除

--- a/src/domain/usecases/ManageSchedules.ts
+++ b/src/domain/usecases/ManageSchedules.ts
@@ -33,14 +33,14 @@ export class CreateSchedule {
 export class UpdateSchedule {
   constructor(private readonly scheduleRepository: ScheduleRepository) {}
 
-  async execute(scheduleId: string, input: Partial<Schedule>): Promise<Schedule> {
+  async execute(scheduleId: string, input: Partial<Schedule>, options?: { clearInterval?: boolean }): Promise<Schedule> {
     if (!scheduleId) {
       throw new Error('スケジュールIDは必須です');
     }
     if (Object.keys(input).length === 0) {
       throw new Error('更新するフィールドがありません');
     }
-    return this.scheduleRepository.updateSchedule(scheduleId, input);
+    return this.scheduleRepository.updateSchedule(scheduleId, input, options);
   }
 }
 

--- a/src/presentation/hooks/useSchedules.ts
+++ b/src/presentation/hooks/useSchedules.ts
@@ -27,7 +27,7 @@ export interface UseSchedulesResult {
   isCreating: boolean;
   error: Error | null;
   createSchedule: (input: CreateScheduleInput) => Promise<void>;
-  updateSchedule: (scheduleId: string, input: Partial<Schedule>) => Promise<void>;
+  updateSchedule: (scheduleId: string, input: Partial<Schedule>, options?: { clearInterval?: boolean }) => Promise<void>;
   deleteSchedule: (scheduleId: string) => Promise<void>;
   refetch: () => Promise<void>;
 }
@@ -72,8 +72,8 @@ export const useSchedules = (): UseSchedulesResult => {
     }
   }, [useCases, refetch]);
 
-  const handleUpdateSchedule = useCallback(async (scheduleId: string, input: Partial<Schedule>) => {
-    await useCases.updateSchedule.execute(scheduleId, input);
+  const handleUpdateSchedule = useCallback(async (scheduleId: string, input: Partial<Schedule>, options?: { clearInterval?: boolean }) => {
+    await useCases.updateSchedule.execute(scheduleId, input, options);
     await refetch();
   }, [useCases, refetch]);
 


### PR DESCRIPTION
## Summary
- スケジュールカードの編集UIに「毎日/曜日指定/間隔指定」の頻度モード切り替えを追加
- 間隔指定モードでは投与間隔(2日〜3ヶ月ごと)と開始日の設定が可能
- 毎日モードのスケジュール編集時に保存ボタンが無効になるバグを修正
- モード切り替え時にintervalDays/startDateを適切にクリアする処理を追加

## Test plan
- [ ] スケジュール管理画面でスケジュールの編集ボタンを押すと頻度モード選択が表示されることを確認
- [ ] 「毎日」から「間隔指定」に変更し保存後、ホーム画面で該当日のみ表示されることを確認
- [ ] 「間隔指定」から「毎日」に変更し保存後、毎日表示されることを確認
- [ ] 「曜日指定」で特定曜日を選択して保存後、その曜日のみ表示されることを確認