### PR TITLE
fix: 服薬履歴をメンバーごとにグループ分けして表示

### DIFF
--- a/src/components/history/MedicationHistoryList.tsx
+++ b/src/components/history/MedicationHistoryList.tsx
@@ -1,10 +1,29 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Clock, Pill, User, Trash2 } from 'lucide-react';
-import { DailyRecordGroup, MedicationRecordEntity } from '../../domain/entities/MedicationRecord';
+import { DailyRecordGroup, MedicationRecord, MedicationRecordEntity } from '../../domain/entities/MedicationRecord';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 import { EmptyStatePrompt } from '../shared/EmptyStatePrompt';
+
+interface MemberRecordGroup {
+  memberId: string;
+  memberName: string;
+  records: MedicationRecord[];
+}
+
+function groupByMember(records: MedicationRecord[]): MemberRecordGroup[] {
+  const map = new Map<string, MemberRecordGroup>();
+  for (const record of records) {
+    let group = map.get(record.memberId);
+    if (!group) {
+      group = { memberId: record.memberId, memberName: record.memberName, records: [] };
+      map.set(record.memberId, group);
+    }
+    group.records.push(record);
+  }
+  return Array.from(map.values());
+}
 
 interface MedicationHistoryListProps {
   groups: DailyRecordGroup[];
@@ -13,6 +32,13 @@ interface MedicationHistoryListProps {
 }
 
 export const MedicationHistoryList: React.FC<MedicationHistoryListProps> = ({ groups, isLoading, onDelete }) => {
+  const groupedByMember = useMemo(() => {
+    return groups.map((group) => ({
+      date: group.date,
+      memberGroups: groupByMember(group.records),
+    }));
+  }, [groups]);
+
   if (isLoading) {
     return (
       <LoadingSpinner />
@@ -27,54 +53,58 @@ export const MedicationHistoryList: React.FC<MedicationHistoryListProps> = ({ gr
 
   return (
     <div className="space-y-6">
-      {groups.map((group) => (
-        <div key={group.date}>
+      {groupedByMember.map((dayGroup) => (
+        <div key={dayGroup.date}>
           <h3 className="text-sm font-semibold text-gray-600 mb-2 px-1">
-            {MedicationRecordEntity.formatDate(group.date)}
+            {MedicationRecordEntity.formatDate(dayGroup.date)}
           </h3>
-          <div className="space-y-2">
-            {group.records.map((record) => (
-              <div
-                key={record.id}
-                className="bg-white rounded-lg shadow-sm p-3 border border-gray-200"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-3 flex-1 min-w-0">
-                    <div className="flex-shrink-0">
-                      <Pill size={18} className="text-primary-600" />
-                    </div>
-                    <div className="min-w-0">
-                      <p className="font-medium text-gray-800 truncate">{record.medicationName}</p>
-                      <div className="flex items-center space-x-2 text-xs text-gray-500 mt-0.5">
-                        <span className="flex items-center space-x-1">
-                          <User size={12} />
-                          <span>{record.memberName}</span>
-                        </span>
-                        {record.dosageAmount && (
-                          <span>{record.dosageAmount}</span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center space-x-2 flex-shrink-0 ml-2">
-                    <div className="flex items-center space-x-1 text-sm text-gray-500">
-                      <Clock size={14} />
-                      <span>{MedicationRecordEntity.formatTime(record.takenAt)}</span>
-                    </div>
-                    {onDelete && (
-                      <button
-                        onClick={() => onDelete(record.id)}
-                        className="text-gray-400 hover:text-red-500 p-1 transition-colors"
-                        aria-label="削除"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    )}
-                  </div>
+          <div className="space-y-4">
+            {dayGroup.memberGroups.map((memberGroup) => (
+              <div key={memberGroup.memberId}>
+                <div className="flex items-center space-x-1.5 mb-1.5 px-1">
+                  <User size={14} className="text-gray-400" />
+                  <span className="text-xs font-medium text-gray-500">{memberGroup.memberName}</span>
                 </div>
-                {record.notes && (
-                  <p className="text-xs text-gray-400 mt-1 pl-8">{record.notes}</p>
-                )}
+                <div className="space-y-2">
+                  {memberGroup.records.map((record) => (
+                    <div
+                      key={record.id}
+                      className="bg-white rounded-lg shadow-sm p-3 border border-gray-200"
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-3 flex-1 min-w-0">
+                          <div className="flex-shrink-0">
+                            <Pill size={18} className="text-primary-600" />
+                          </div>
+                          <div className="min-w-0">
+                            <p className="font-medium text-gray-800 truncate">{record.medicationName}</p>
+                            {record.dosageAmount && (
+                              <p className="text-xs text-gray-500 mt-0.5">{record.dosageAmount}</p>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center space-x-2 flex-shrink-0 ml-2">
+                          <div className="flex items-center space-x-1 text-sm text-gray-500">
+                            <Clock size={14} />
+                            <span>{MedicationRecordEntity.formatTime(record.takenAt)}</span>
+                          </div>
+                          {onDelete && (
+                            <button
+                              onClick={() => onDelete(record.id)}
+                              className="text-gray-400 hover:text-red-500 p-1 transition-colors"
+                              aria-label="削除"
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                      {record.notes && (
+                        <p className="text-xs text-gray-400 mt-1 pl-8">{record.notes}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- 服薬履歴の日別記録リストをメンバーごとにサブグループ化して表示
- 「ゆぅ」「やじゅ」のようにメンバー名ヘッダーで分けて見やすく整理
- カード内の冗長なメンバー名表示を削除

## Test plan
- [ ] 服薬履歴ページでメンバーごとにグループ分けされて表示されることを確認
- [ ] 「全員」フィルターで複数メンバーの記録がそれぞれ分かれて表示されることを確認
- [ ] 特定メンバーでフィルターした場合もそのメンバーの記録が正しく表示されることを確認
- [ ] カレンダーから日付を選択した際の記録表示が正しいことを確認