### PR TITLE
fix: ホーム画面のスケジュール表示にお薬の並び順を反映

### DIFF
--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -17,7 +17,7 @@ export const GET = withAuth(async (userId) => {
     prisma.schedule.findMany({
       where: { userId, isEnabled: true },
       include: {
-        medication: { select: { id: true, name: true } },
+        medication: { select: { id: true, name: true, displayOrder: true } },
       },
       take: QUERY_LIMITS.SCHEDULES,
     }),
@@ -58,6 +58,7 @@ export const GET = withAuth(async (userId) => {
       startDate: s.startDate?.toISOString(),
       isEnabled: s.isEnabled,
       reminderMinutesBefore: s.reminderMinutesBefore,
+      medicationDisplayOrder: s.medication.displayOrder ?? 0,
       isCompleted: completedScheduleIds.has(s.id) || completedMedicationIds.has(s.medicationId),
       createdAt: s.createdAt.toISOString(),
     };

--- a/src/data/api/scheduleApi.ts
+++ b/src/data/api/scheduleApi.ts
@@ -24,6 +24,7 @@ interface TodayScheduleResponse {
   startDate?: string;
   isEnabled: boolean;
   reminderMinutesBefore: number;
+  medicationDisplayOrder?: number;
   isCompleted: boolean;
   createdAt: string;
 }
@@ -71,6 +72,7 @@ export const scheduleApi = {
       medicationName: item.medicationName,
       memberName: item.memberName,
       memberType: (item.memberType as 'human' | 'pet') || 'human',
+      medicationDisplayOrder: item.medicationDisplayOrder ?? 0,
       isCompleted: item.isCompleted,
     }));
   },

--- a/src/domain/repositories/ScheduleRepository.ts
+++ b/src/domain/repositories/ScheduleRepository.ts
@@ -15,6 +15,7 @@ export interface TodayScheduleItem {
   medicationName: string;
   memberName: string;
   memberType: 'human' | 'pet';
+  medicationDisplayOrder: number;
   isCompleted: boolean;
 }
 

--- a/src/domain/usecases/GetTodaySchedules.ts
+++ b/src/domain/usecases/GetTodaySchedules.ts
@@ -20,6 +20,7 @@ export interface TodayScheduleViewModel {
   memberName: string;
   memberType: 'human' | 'pet';
   scheduledTime: string;
+  medicationDisplayOrder: number;
   status: ScheduleStatus;
   isEnabled: boolean;
   reminderMinutesBefore: number;
@@ -48,8 +49,12 @@ export class GetTodaySchedules {
       })
       .map((item) => this.toViewModel(item, date));
 
-    // 時刻順にソート
-    viewModels.sort((a, b) => a.scheduledTime.localeCompare(b.scheduledTime));
+    // 時刻順 → 薬の表示順でソート
+    viewModels.sort((a, b) => {
+      const timeCompare = a.scheduledTime.localeCompare(b.scheduledTime);
+      if (timeCompare !== 0) return timeCompare;
+      return a.medicationDisplayOrder - b.medicationDisplayOrder;
+    });
 
     return viewModels;
   }
@@ -67,6 +72,7 @@ export class GetTodaySchedules {
       memberName: item.memberName,
       memberType: item.memberType,
       scheduledTime: item.schedule.scheduledTime,
+      medicationDisplayOrder: item.medicationDisplayOrder,
       status,
       isEnabled: item.schedule.isEnabled,
       reminderMinutesBefore: item.schedule.reminderMinutesBefore,


### PR DESCRIPTION
## Summary
- ホーム画面の今日のスケジュールに、お薬ページで設定した並び順(displayOrder)を反映
- 同じ時刻のスケジュールはdisplayOrder順でソート
- APIレスポンスにmedicationDisplayOrderを追加

## Test plan
- [ ] お薬ページで並び順を変更後、ホーム画面で同じ時刻の薬がその順番で表示されることを確認
- [ ] 異なる時刻のスケジュールは引き続き時刻順で表示されることを確認