### PR TITLE
feat: お薬ページにスケジュール管理へのショートカットを追加

### DIFF
--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -13,7 +13,7 @@ import { Medication, MedicationCategory } from '@/domain/entities/Medication';
 import { CategoryFilter } from '@/components/shared/CategoryFilter';
 import { useMedicationRecordActions } from '@/presentation/hooks/useMedicationRecordActions';
 import Link from 'next/link';
-import { Plus, ClipboardList } from 'lucide-react';
+import { Plus, ClipboardList, Clock } from 'lucide-react';
 
 function MemberMedications({ member, categoryFilter }: { member: Member; categoryFilter: MedicationCategory | null }) {
   const { medications, isLoading, updateMedication, deleteMedication, reorderMedications } = useMedications(member.id);
@@ -71,13 +71,22 @@ function MemberMedications({ member, categoryFilter }: { member: Member; categor
           />
           <h2 className="font-semibold text-gray-800">{displayInfo.name}</h2>
         </div>
-        <Link
-          href={`/members/${member.id}/medications`}
-          className="flex items-center space-x-1 text-sm text-primary-600 hover:text-primary-700 transition-colors"
-        >
-          <Plus size={14} />
-          <span>追加</span>
-        </Link>
+        <div className="flex items-center space-x-3">
+          <Link
+            href={`/members/${member.id}/medications#schedules`}
+            className="flex items-center space-x-1 text-sm text-gray-500 hover:text-primary-600 transition-colors"
+          >
+            <Clock size={14} />
+            <span>時間</span>
+          </Link>
+          <Link
+            href={`/members/${member.id}/medications`}
+            className="flex items-center space-x-1 text-sm text-primary-600 hover:text-primary-700 transition-colors"
+          >
+            <Plus size={14} />
+            <span>追加</span>
+          </Link>
+        </div>
       </div>
 
       {editingMed && (

--- a/src/app/members/[memberId]/medications/page.tsx
+++ b/src/app/members/[memberId]/medications/page.tsx
@@ -140,7 +140,7 @@ export default function Medications() {
         )}
 
         {memberSchedules.length > 0 && (
-          <div className="mt-6">
+          <div id="schedules" className="mt-6">
             <h2 className="text-sm font-medium text-gray-600 mb-3">スケジュール管理</h2>
             <ScheduleList
               schedules={memberSchedules}


### PR DESCRIPTION
## Summary
- お薬ページの各メンバーセクションに「時間」リンクを追加
- タップするとメンバーの薬管理ページのスケジュール管理セクションに直接遷移
- スケジュール管理セクションにid属性を追加しアンカーリンクに対応

## Test plan
- [ ] お薬ページで各メンバー名の横に「時間」リンクが表示されることを確認
- [ ] 「時間」リンクをタップするとスケジュール管理セクションに遷移することを確認
- [ ] スケジュールの編集・削除が正常に動作することを確認