### PR TITLE
fix: サーバー側でスケジュールの今日有効判定を追加(JST対応)

### DIFF
--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -4,14 +4,61 @@ import { withAuth } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 import { QUERY_LIMITS } from '@/lib/constants';
 
+const DAY_MAP: Record<number, string> = {
+  0: 'sun', 1: 'mon', 2: 'tue', 3: 'wed', 4: 'thu', 5: 'fri', 6: 'sat',
+};
+
+// jstDate は getJSTDate() で生成されたUTCフィールドにJST値が入ったDate
+function isScheduleActiveToday(
+  schedule: { daysOfWeek: string[]; intervalDays: number | null; startDate: Date | null },
+  jstDate: Date,
+): boolean {
+  // 間隔スケジュール（X日ごと）
+  if (schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate) {
+    const startUtc = new Date(schedule.startDate);
+    // startDateをJSTの日付として扱う(UTC+9)
+    const startJst = new Date(startUtc.getTime() + 9 * 60 * 60 * 1000);
+    // JSTの日付差を計算（UTCフィールドにJST値が入っている）
+    const startDay = Date.UTC(startJst.getUTCFullYear(), startJst.getUTCMonth(), startJst.getUTCDate());
+    const todayDay = Date.UTC(jstDate.getUTCFullYear(), jstDate.getUTCMonth(), jstDate.getUTCDate());
+    const diffDays = Math.round((todayDay - startDay) / (1000 * 60 * 60 * 24));
+    if (diffDays < 0) return false;
+    return diffDays % schedule.intervalDays === 0;
+  }
+
+  // 曜日が未設定（空配列）の場合は毎日有効
+  if (schedule.daysOfWeek.length === 0) {
+    return true;
+  }
+
+  // 曜日チェック（jstDateのUTCフィールドにJST値が入っている）
+  const todayDayCode = DAY_MAP[jstDate.getUTCDay()];
+  return schedule.daysOfWeek.includes(todayDayCode);
+}
+
+// JST (UTC+9) の今日の日付を取得
+function getJSTDate(): Date {
+  const now = new Date();
+  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  return jst;
+}
+
+function getJSTDayBoundaries(): { todayStart: Date; todayEnd: Date } {
+  const jstNow = getJSTDate();
+  const year = jstNow.getUTCFullYear();
+  const month = jstNow.getUTCMonth();
+  const day = jstNow.getUTCDate();
+  // JST 00:00:00 = UTC 前日 15:00:00
+  const todayStart = new Date(Date.UTC(year, month, day, -9, 0, 0, 0));
+  const todayEnd = new Date(Date.UTC(year, month, day, -9 + 23, 59, 59, 999));
+  return { todayStart, todayEnd };
+}
+
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`schedules-today-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const now = new Date();
-  const todayStart = new Date(now);
-  todayStart.setHours(0, 0, 0, 0);
-  const todayEnd = new Date(now);
-  todayEnd.setHours(23, 59, 59, 999);
+  const jstToday = getJSTDate();
+  const { todayStart, todayEnd } = getJSTDayBoundaries();
 
   const [schedules, todayRecords, members] = await Promise.all([
     prisma.schedule.findMany({
@@ -42,7 +89,12 @@ export const GET = withAuth(async (userId) => {
     todayRecords.map((r) => r.medicationId).filter(Boolean)
   );
 
-  const result = schedules.map((s) => {
+  // サーバー側で今日(JST)有効なスケジュールだけにフィルタリング
+  const activeSchedules = schedules.filter((s) =>
+    isScheduleActiveToday(s, jstToday)
+  );
+
+  const result = activeSchedules.map((s) => {
     const member = memberMap.get(s.memberId);
     return {
       id: s.id,


### PR DESCRIPTION
## Summary
- 今日のスケジュールAPIでサーバー側フィルタリングを追加
- 間隔指定(X日ごと)・曜日指定のスケジュールを正しく判定
- Vercel(UTC)環境でもJST基準で正しく曜日・日付を判定
- クライアント側フィルタとの二重チェックで信頼性向上

## Test plan
- [ ] 間隔指定のスケジュールが該当日のみホーム画面に表示されることを確認
- [ ] 曜日指定のスケジュールが該当曜日のみ表示されることを確認
- [ ] 毎日のスケジュールは引き続き毎日表示されることを確認
- [ ] 深夜0時〜8時台(UTC前日)でも正しくJSTの日付で判定されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the schedules API to correctly handle Japan Standard Time (JST) when determining which schedules are active today. Interval-based and weekday-based schedules are now accurately filtered based on JST date and time boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->