### PR TITLE
feat: お薬カードにスケジュール情報を表示し初見ユーザーの操作性を改善

### DIFF
--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -12,16 +12,46 @@ import { MemberEntity, Member } from '@/domain/entities/Member';
 import { Medication, MedicationCategory } from '@/domain/entities/Medication';
 import { CategoryFilter } from '@/components/shared/CategoryFilter';
 import { useMedicationRecordActions } from '@/presentation/hooks/useMedicationRecordActions';
+import { useSchedules } from '@/presentation/hooks/useSchedules';
+import { MedicationScheduleMap } from '@/components/medications/MedicationList';
+import { DayOfWeek } from '@/domain/entities/Schedule';
 import Link from 'next/link';
 import { Plus, ClipboardList, Clock } from 'lucide-react';
+
+const DAY_LABELS: Record<DayOfWeek, string> = {
+  mon: '月', tue: '火', wed: '水', thu: '木', fri: '金', sat: '土', sun: '日',
+};
+const DAY_ORDER: DayOfWeek[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+
+function getScheduleLabel(daysOfWeek: readonly DayOfWeek[], intervalDays?: number): string {
+  if (intervalDays && intervalDays > 0) return `${intervalDays}日ごと`;
+  if (daysOfWeek.length === 0 || daysOfWeek.length === 7) return '毎日';
+  return DAY_ORDER.filter((d) => daysOfWeek.includes(d)).map((d) => DAY_LABELS[d]).join('・');
+}
 
 function MemberMedications({ member, categoryFilter }: { member: Member; categoryFilter: MedicationCategory | null }) {
   const { medications, isLoading, updateMedication, deleteMedication, reorderMedications } = useMedications(member.id);
   const { markAsTaken, markAsTakenAt } = useMedicationRecordActions();
+  const { schedules } = useSchedules();
   const entity = new MemberEntity(member);
   const displayInfo = entity.getDisplayInfo();
   const [editingMed, setEditingMed] = useState<Medication | null>(null);
   const editFormRef = useRef<HTMLDivElement>(null);
+
+  const scheduleMap = useMemo<MedicationScheduleMap>(() => {
+    const map: MedicationScheduleMap = {};
+    const memberSchedules = schedules.filter((s) => s.schedule.memberId === member.id);
+    for (const item of memberSchedules) {
+      const medId = item.schedule.medicationId;
+      if (!map[medId]) map[medId] = [];
+      map[medId].push({
+        scheduleId: item.schedule.id,
+        time: item.schedule.scheduledTime,
+        label: getScheduleLabel(item.schedule.daysOfWeek, item.schedule.intervalDays),
+      });
+    }
+    return map;
+  }, [schedules, member.id]);
 
   useEffect(() => {
     if (editingMed && editFormRef.current) {
@@ -108,6 +138,8 @@ function MemberMedications({ member, categoryFilter }: { member: Member; categor
         onMarkPastTaken={handleMarkPastTaken}
         onEdit={handleEdit}
         onReorder={!categoryFilter ? reorderMedications : undefined}
+        scheduleMap={scheduleMap}
+        scheduleEditUrl={`/members/${member.id}/medications#schedules`}
       />
     </section>
   );

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -1,10 +1,20 @@
 import React, { useState } from 'react';
-import { Pill, Check, Pencil, Clock, ChevronUp, ChevronDown } from 'lucide-react';
+import { Pill, Check, Pencil, Clock, ChevronUp, ChevronDown, AlertCircle } from 'lucide-react';
 import { Medication } from '../../domain/entities/Medication';
 import { MedicationViewModel } from '../../domain/usecases/ManageMedications';
 import { ConfirmationDialog } from '../shared/ConfirmationDialog';
 import { LoadingSpinner } from '../shared/LoadingSpinner';
 import { EmptyStatePrompt } from '../shared/EmptyStatePrompt';
+
+export interface MedicationScheduleInfo {
+  scheduleId: string;
+  time: string;
+  label: string; // "毎日", "月・水・金", "21日ごと" etc.
+}
+
+export interface MedicationScheduleMap {
+  [medicationId: string]: MedicationScheduleInfo[];
+}
 
 interface MedicationListProps {
   medications: MedicationViewModel[];
@@ -14,9 +24,11 @@ interface MedicationListProps {
   onMarkPastTaken?: (medicationId: string, takenAt: string) => Promise<void>;
   onEdit?: (medication: Medication) => void;
   onReorder?: (medicationIds: string[]) => Promise<void>;
+  scheduleMap?: MedicationScheduleMap;
+  scheduleEditUrl?: string;
 }
 
-export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete, onMarkTaken, onMarkPastTaken, onEdit, onReorder }) => {
+export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete, onMarkTaken, onMarkPastTaken, onEdit, onReorder, scheduleMap, scheduleEditUrl }) => {
   if (isLoading) {
     return (
       <LoadingSpinner />
@@ -50,6 +62,8 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
           onEdit={onEdit}
           onMoveUp={onReorder && index > 0 ? () => handleMove(index, 'up') : undefined}
           onMoveDown={onReorder && index < medications.length - 1 ? () => handleMove(index, 'down') : undefined}
+          schedules={scheduleMap?.[vm.medication.id]}
+          scheduleEditUrl={scheduleEditUrl}
         />
       ))}
     </div>
@@ -64,9 +78,11 @@ export interface MedicationCardProps {
   onEdit?: (medication: Medication) => void;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
+  schedules?: MedicationScheduleInfo[];
+  scheduleEditUrl?: string;
 }
 
-const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, onDelete, onMarkTaken, onMarkPastTaken, onEdit, onMoveUp, onMoveDown }) => {
+const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, onDelete, onMarkTaken, onMarkPastTaken, onEdit, onMoveUp, onMoveDown, schedules, scheduleEditUrl }) => {
   const { medication, isLowStock, displayInfo } = viewModel;
   const [isTaken, setIsTaken] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -195,6 +211,33 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, o
           </button>
         </div>
       </div>
+      {scheduleEditUrl && (
+        <div className="mt-2 pt-2 border-t border-gray-100">
+          {schedules && schedules.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {schedules.map((s) => (
+                <a
+                  key={s.scheduleId}
+                  href={scheduleEditUrl || '#'}
+                  className="inline-flex items-center space-x-1 px-2 py-0.5 bg-primary-50 text-primary-700 rounded-full text-xs hover:bg-primary-100 transition-colors"
+                >
+                  <Clock size={10} />
+                  <span>{s.time}</span>
+                  <span className="text-primary-500">{s.label}</span>
+                </a>
+              ))}
+            </div>
+          ) : (
+            <a
+              href={scheduleEditUrl || '#'}
+              className="inline-flex items-center space-x-1 px-2 py-1 bg-amber-50 text-amber-700 rounded-full text-xs hover:bg-amber-100 transition-colors"
+            >
+              <AlertCircle size={12} />
+              <span>スケジュール未設定 - タップして設定</span>
+            </a>
+          )}
+        </div>
+      )}
       <ConfirmationDialog
         title="薬の削除"
         message={`「${displayInfo.name}」を削除しますか？この操作は取り消せません。`}


### PR DESCRIPTION
## Summary
- 各薬カードの下にスケジュール情報(時間・頻度)をバッジで表示
- 「毎日 08:00」「月・水・金 08:00」「21日ごと 08:00」などが一目で確認可能
- スケジュール未設定の薬には警告バッジ「スケジュール未設定 - タップして設定」を表示
- バッジをタップするとスケジュール管理画面に直接遷移
- 初見ユーザーがスケジュール設定の必要性と方法を直感的に理解できるUX

## Test plan
- [ ] お薬ページで各薬カードの下にスケジュール情報が表示されることを確認
- [ ] 毎日/曜日指定/間隔指定が正しいラベルで表示されることを確認
- [ ] スケジュール未設定の薬に警告バッジが表示されることを確認
- [ ] バッジタップでスケジュール管理画面に遷移することを確認
- [ ] メンバー別薬管理ページでは従来通りバッジなしで表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Medications now display their configured schedules with localized formatting (daily, interval-based, or specific days of the week).
  * Added warning indicators and quick access links for medications without configured schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->