### PR TITLE
feat: スケジュール頻度に頓服モードを追加

### DIFF
--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -13,6 +13,11 @@ function isScheduleActiveToday(
   schedule: { daysOfWeek: string[]; intervalDays: number | null; startDate: Date | null },
   jstDate: Date,
 ): boolean {
+  // 頓服（PRN）: ホーム画面に表示しない
+  if (schedule.intervalDays === -1) {
+    return false;
+  }
+
   // 間隔スケジュール（X日ごと）
   if (schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate) {
     const startUtc = new Date(schedule.startDate);

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -24,6 +24,7 @@ const DAY_LABELS: Record<DayOfWeek, string> = {
 const DAY_ORDER: DayOfWeek[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 
 function getScheduleLabel(daysOfWeek: readonly DayOfWeek[], intervalDays?: number): string {
+  if (intervalDays === -1) return '頓服';
   if (intervalDays && intervalDays > 0) return `${intervalDays}日ごと`;
   if (daysOfWeek.length === 0 || daysOfWeek.length === 7) return '毎日';
   return DAY_ORDER.filter((d) => daysOfWeek.includes(d)).map((d) => DAY_LABELS[d]).join('・');

--- a/src/components/schedules/ScheduleForm.tsx
+++ b/src/components/schedules/ScheduleForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { DayOfWeek } from '../../domain/entities/Schedule';
 
-export type ScheduleMode = 'daily' | 'weekdays' | 'interval';
+export type ScheduleMode = 'daily' | 'weekdays' | 'interval' | 'prn';
 
 export interface ScheduleFormData {
   scheduledTime: string;
@@ -61,11 +61,11 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
     if (mode === 'interval' && !startDate) return;
 
     onSubmit({
-      scheduledTime,
+      scheduledTime: mode === 'prn' ? '00:00' : scheduledTime,
       daysOfWeek: mode === 'weekdays' ? selectedDays : [],
-      intervalDays: mode === 'interval' ? parseInt(intervalDays, 10) : undefined,
+      intervalDays: mode === 'prn' ? -1 : mode === 'interval' ? parseInt(intervalDays, 10) : undefined,
       startDate: mode === 'interval' ? startDate : undefined,
-      reminderMinutesBefore: parseInt(reminderMinutes, 10) || 0,
+      reminderMinutesBefore: mode === 'prn' ? 0 : parseInt(reminderMinutes, 10) || 0,
     });
 
     setScheduledTime('08:00');
@@ -84,19 +84,6 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label htmlFor="schedule-time" className="block text-sm font-medium text-gray-700 mb-1">
-          服薬時刻
-        </label>
-        <input
-          id="schedule-time"
-          type="time"
-          value={scheduledTime}
-          onChange={(e) => setScheduledTime(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-        />
-      </div>
-
-      <div>
         <span className="block text-sm font-medium text-gray-700 mb-2">頻度</span>
         <div className="flex flex-wrap gap-2 mb-2">
           <button type="button" className={modeButtonClass('daily')} onClick={() => setMode('daily')}>
@@ -108,7 +95,35 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
           <button type="button" className={modeButtonClass('interval')} onClick={() => setMode('interval')}>
             間隔指定
           </button>
+          <button type="button" className={modeButtonClass('prn')} onClick={() => setMode('prn')}>
+            頓服
+          </button>
         </div>
+
+        {mode === 'prn' && (
+          <p className="text-xs text-gray-500 mt-1">
+            症状がある時だけ服用する薬です。ホーム画面には表示されません。
+          </p>
+        )}
+      </div>
+
+      {mode !== 'prn' && (
+      <div>
+        <label htmlFor="schedule-time" className="block text-sm font-medium text-gray-700 mb-1">
+          服薬時刻
+        </label>
+        <input
+          id="schedule-time"
+          type="time"
+          value={scheduledTime}
+          onChange={(e) => setScheduledTime(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+        />
+      </div>
+      )}
+
+      {mode !== 'prn' && (
+      <div>
 
         {mode === 'weekdays' && (
           <div className="flex flex-wrap gap-2">
@@ -170,7 +185,9 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
           </div>
         )}
       </div>
+      )}
 
+      {mode !== 'prn' && (
       <div>
         <label htmlFor="reminder-minutes" className="block text-sm font-medium text-gray-700 mb-1">
           リマインダー（分前）
@@ -189,6 +206,7 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
           <option value="60">1時間前</option>
         </select>
       </div>
+      )}
 
       <button
         type="submit"

--- a/src/components/schedules/ScheduleList.tsx
+++ b/src/components/schedules/ScheduleList.tsx
@@ -75,7 +75,7 @@ export interface ScheduleCardProps {
   onDelete: (scheduleId: string) => void;
 }
 
-type EditMode = 'daily' | 'weekdays' | 'interval';
+type EditMode = 'daily' | 'weekdays' | 'interval' | 'prn';
 
 const INTERVAL_OPTIONS = [
   { value: 2, label: '2日ごと' },
@@ -90,6 +90,7 @@ const INTERVAL_OPTIONS = [
 ];
 
 function getInitialMode(schedule: Schedule): EditMode {
+  if (schedule.intervalDays === -1) return 'prn';
   if (schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate) return 'interval';
   if (schedule.daysOfWeek.length > 0) return 'weekdays';
   return 'daily';
@@ -110,13 +111,15 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
     return new Date().toISOString().split('T')[0];
   });
 
-  const daysLabel = schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate
-    ? `${schedule.intervalDays}日ごと`
-    : schedule.daysOfWeek.length === 7
-      ? '毎日'
-      : schedule.daysOfWeek.length === 0
+  const daysLabel = schedule.intervalDays === -1
+    ? '頓服'
+    : schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate
+      ? `${schedule.intervalDays}日ごと`
+      : schedule.daysOfWeek.length === 7
         ? '毎日'
-        : DAY_ORDER.filter((d) => schedule.daysOfWeek.includes(d)).map((d) => DAY_LABELS[d]).join('・');
+        : schedule.daysOfWeek.length === 0
+          ? '毎日'
+          : DAY_ORDER.filter((d) => schedule.daysOfWeek.includes(d)).map((d) => DAY_LABELS[d]).join('・');
 
   const toggleDay = (day: DayOfWeek) => {
     setEditDays((prev) =>
@@ -125,15 +128,19 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
   };
 
   const canSave = editMode === 'daily'
+    || editMode === 'prn'
     || (editMode === 'weekdays' && editDays.length > 0)
     || (editMode === 'interval' && editStartDate);
 
   const handleSave = async () => {
     if (!canSave) return;
     const wasInterval = getInitialMode(schedule) === 'interval';
-    const shouldClearInterval = wasInterval && editMode !== 'interval';
+    const wasPrn = getInitialMode(schedule) === 'prn';
+    const shouldClearInterval = (wasInterval || wasPrn) && editMode !== 'interval' && editMode !== 'prn';
     let updateData: Partial<Schedule>;
-    if (editMode === 'interval') {
+    if (editMode === 'prn') {
+      updateData = { scheduledTime: '00:00', daysOfWeek: [], intervalDays: -1 };
+    } else if (editMode === 'interval') {
       updateData = {
         scheduledTime: editTime,
         daysOfWeek: [],
@@ -173,17 +180,8 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
       <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200">
         <div className="space-y-3">
           <div>
-            <label className="block text-xs text-gray-500 mb-1">服薬時刻</label>
-            <input
-              type="time"
-              value={editTime}
-              onChange={(e) => setEditTime(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm"
-            />
-          </div>
-          <div>
             <label className="block text-xs text-gray-500 mb-2">頻度</label>
-            <div className="flex gap-2 mb-2">
+            <div className="flex flex-wrap gap-2 mb-2">
               <button type="button" className={modeButtonClass('daily')} onClick={() => setEditMode('daily')}>
                 毎日
               </button>
@@ -193,7 +191,30 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
               <button type="button" className={modeButtonClass('interval')} onClick={() => setEditMode('interval')}>
                 間隔指定
               </button>
+              <button type="button" className={modeButtonClass('prn')} onClick={() => setEditMode('prn')}>
+                頓服
+              </button>
             </div>
+
+            {editMode === 'prn' && (
+              <p className="text-xs text-gray-500">症状がある時だけ服用。ホーム画面には表示されません。</p>
+            )}
+          </div>
+
+          {editMode !== 'prn' && (
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">服薬時刻</label>
+            <input
+              type="time"
+              value={editTime}
+              onChange={(e) => setEditTime(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm"
+            />
+          </div>
+          )}
+
+          {editMode !== 'prn' && (
+          <div>
 
             {editMode === 'weekdays' && (
               <div>
@@ -246,6 +267,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
               </div>
             )}
           </div>
+          )}
           <div className="flex space-x-2">
             <button
               onClick={handleSave}

--- a/src/domain/entities/Schedule.ts
+++ b/src/domain/entities/Schedule.ts
@@ -81,6 +81,11 @@ export class ScheduleEntity {
       return false;
     }
 
+    // 頓服（PRN）: 定期スケジュールではないため常にfalse
+    if (this.schedule.intervalDays === -1) {
+      return false;
+    }
+
     // 間隔スケジュール（X日ごと）
     if (this.schedule.intervalDays && this.schedule.intervalDays > 0 && this.schedule.startDate) {
       const start = new Date(this.schedule.startDate);

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -74,7 +74,7 @@ export const createScheduleSchema = z.object({
   memberId: idField,
   scheduledTime: z.string().trim().min(1, '予定時刻は必須です').max(10),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
-  intervalDays: z.number().int().min(1).max(365).optional(),
+  intervalDays: z.number().int().min(-1).max(365).refine((v) => v !== 0, { message: '間隔日数は0以外を指定してください' }).optional(),
   startDate: dateString.optional(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),
@@ -83,7 +83,7 @@ export const createScheduleSchema = z.object({
 export const updateScheduleSchema = z.object({
   scheduledTime: z.string().trim().min(1, '予定時刻は必須です').max(10).optional(),
   daysOfWeek: z.array(dayOfWeekEnum).optional(),
-  intervalDays: z.number().int().min(1).max(365).optional().nullable(),
+  intervalDays: z.number().int().min(-1).max(365).refine((v) => v !== 0, { message: '間隔日数は0以外を指定してください' }).optional().nullable(),
   startDate: dateString.optional().nullable(),
   isEnabled: z.boolean().optional(),
   reminderMinutesBefore: z.number().int().min(0).max(1440).optional(),


### PR DESCRIPTION
## Summary
- スケジュールの頻度選択に「頓服」(PRN)モードを追加
- 頓服: 症状がある時だけ服用する薬。ホーム画面の今日の予定には表示されない
- intervalDays=-1 で保存し、サーバー・クライアント両方でフィルタリング
- 頓服選択時は服薬時刻・リマインダーの入力欄を非表示にしてUIを簡潔化
- お薬ページのスケジュールバッジに「頓服」ラベルを表示

## Test plan
- [ ] スケジュール作成フォームで「頓服」ボタンが表示されることを確認
- [ ] 頓服選択時に服薬時刻・リマインダーが非表示になることを確認
- [ ] 頓服で保存後、ホーム画面に表示されないことを確認
- [ ] スケジュール管理で「頓服」ラベルが表示されることを確認
- [ ] 頓服から他モード(毎日等)に編集変更できることを確認
- [ ] お薬ページのバッジに「頓服」と表示されることを確認