### PR TITLE
fix: 1日複数回の薬の服薬済み判定を修正し、1日2回/3回プリセットを追加

### DIFF
--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -88,15 +88,23 @@ export const GET = withAuth(async (userId) => {
   const memberMap = new Map(members.map((m) => [m.id, m]));
 
   const completedScheduleIds = new Set(
-    todayRecords.map((r) => r.scheduleId).filter(Boolean)
-  );
-  const completedMedicationIds = new Set(
-    todayRecords.map((r) => r.medicationId).filter(Boolean)
+    todayRecords.filter((r) => r.scheduleId).map((r) => r.scheduleId as string)
   );
 
-  // サーバー側で今日(JST)有効なスケジュールだけにフィルタリング
+  // 同じ薬に複数スケジュールがあるかを判定するためのマップ
   const activeSchedules = schedules.filter((s) =>
     isScheduleActiveToday(s, jstToday)
+  );
+  const medicationScheduleCount = new Map<string, number>();
+  for (const s of activeSchedules) {
+    medicationScheduleCount.set(s.medicationId, (medicationScheduleCount.get(s.medicationId) || 0) + 1);
+  }
+
+  // scheduleIdなしの記録(手動記録)はスケジュールが1つだけの薬にのみ適用
+  const manualCompletedMedicationIds = new Set(
+    todayRecords
+      .filter((r) => !r.scheduleId && (medicationScheduleCount.get(r.medicationId) || 0) <= 1)
+      .map((r) => r.medicationId)
   );
 
   const result = activeSchedules.map((s) => {
@@ -116,7 +124,7 @@ export const GET = withAuth(async (userId) => {
       isEnabled: s.isEnabled,
       reminderMinutesBefore: s.reminderMinutesBefore,
       medicationDisplayOrder: s.medication.displayOrder ?? 0,
-      isCompleted: completedScheduleIds.has(s.id) || completedMedicationIds.has(s.medicationId),
+      isCompleted: completedScheduleIds.has(s.id) || manualCompletedMedicationIds.has(s.medicationId),
       createdAt: s.createdAt.toISOString(),
     };
   });

--- a/src/app/members/[memberId]/medications/page.tsx
+++ b/src/app/members/[memberId]/medications/page.tsx
@@ -58,6 +58,23 @@ export default function Medications() {
     setScheduleTarget(null);
   };
 
+  const handleCreateMultipleSchedules = async (items: ScheduleFormData[]) => {
+    if (!scheduleTarget) return;
+    for (const data of items) {
+      await createSchedule({
+        medicationId: scheduleTarget.medication.id,
+        userId,
+        memberId,
+        scheduledTime: data.scheduledTime,
+        daysOfWeek: data.daysOfWeek,
+        intervalDays: data.intervalDays,
+        startDate: data.startDate ? new Date(data.startDate) : undefined,
+        reminderMinutesBefore: data.reminderMinutesBefore,
+      });
+    }
+    setScheduleTarget(null);
+  };
+
   const handleDeleteSchedule = async (scheduleId: string) => {
     await deleteSchedule(scheduleId);
   };
@@ -110,7 +127,7 @@ export default function Medications() {
                 <X size={18} />
               </button>
             </div>
-            <ScheduleForm onSubmit={handleCreateSchedule} />
+            <ScheduleForm onSubmit={handleCreateSchedule} onSubmitMultiple={handleCreateMultipleSchedules} />
           </div>
         )}
 

--- a/src/components/schedules/ScheduleForm.tsx
+++ b/src/components/schedules/ScheduleForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { DayOfWeek } from '../../domain/entities/Schedule';
 
-export type ScheduleMode = 'daily' | 'weekdays' | 'interval' | 'prn';
+export type ScheduleMode = 'daily' | 'weekdays' | 'interval' | 'prn' | 'twice_daily' | 'three_daily';
 
 export interface ScheduleFormData {
   scheduledTime: string;
@@ -13,7 +13,11 @@ export interface ScheduleFormData {
 
 interface ScheduleFormProps {
   onSubmit: (data: ScheduleFormData) => void;
+  onSubmitMultiple?: (data: ScheduleFormData[]) => void;
 }
+
+const TWICE_DAILY_TIMES = ['08:00', '20:00'];
+const THREE_DAILY_TIMES = ['08:00', '13:00', '20:00'];
 
 const DAY_OPTIONS: { value: DayOfWeek; label: string }[] = [
   { value: 'mon', label: '月' },
@@ -37,7 +41,7 @@ const INTERVAL_OPTIONS = [
   { value: 90, label: '3ヶ月ごと' },
 ];
 
-export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
+export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit, onSubmitMultiple }) => {
   const [scheduledTime, setScheduledTime] = useState('08:00');
   const [mode, setMode] = useState<ScheduleMode>('daily');
   const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
@@ -60,13 +64,24 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
     if (mode === 'weekdays' && selectedDays.length === 0) return;
     if (mode === 'interval' && !startDate) return;
 
-    onSubmit({
-      scheduledTime: mode === 'prn' ? '00:00' : scheduledTime,
-      daysOfWeek: mode === 'weekdays' ? selectedDays : [],
+    const baseData = {
+      daysOfWeek: mode === 'weekdays' ? selectedDays : [] as DayOfWeek[],
       intervalDays: mode === 'prn' ? -1 : mode === 'interval' ? parseInt(intervalDays, 10) : undefined,
       startDate: mode === 'interval' ? startDate : undefined,
       reminderMinutesBefore: mode === 'prn' ? 0 : parseInt(reminderMinutes, 10) || 0,
-    });
+    };
+
+    if (mode === 'twice_daily' || mode === 'three_daily') {
+      const times = mode === 'twice_daily' ? TWICE_DAILY_TIMES : THREE_DAILY_TIMES;
+      const items = times.map((time) => ({ ...baseData, scheduledTime: time }));
+      if (onSubmitMultiple) {
+        onSubmitMultiple(items);
+      } else {
+        items.forEach((item) => onSubmit(item));
+      }
+    } else {
+      onSubmit({ ...baseData, scheduledTime: mode === 'prn' ? '00:00' : scheduledTime });
+    }
 
     setScheduledTime('08:00');
     setSelectedDays([]);
@@ -95,11 +110,27 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
           <button type="button" className={modeButtonClass('interval')} onClick={() => setMode('interval')}>
             間隔指定
           </button>
+          <button type="button" className={modeButtonClass('twice_daily')} onClick={() => setMode('twice_daily')}>
+            1日2回
+          </button>
+          <button type="button" className={modeButtonClass('three_daily')} onClick={() => setMode('three_daily')}>
+            1日3回
+          </button>
           <button type="button" className={modeButtonClass('prn')} onClick={() => setMode('prn')}>
             頓服
           </button>
         </div>
 
+        {mode === 'twice_daily' && (
+          <p className="text-xs text-gray-500 mt-1">
+            朝(08:00)と夜(20:00)の2回分のスケジュールを追加します。
+          </p>
+        )}
+        {mode === 'three_daily' && (
+          <p className="text-xs text-gray-500 mt-1">
+            朝(08:00)・昼(13:00)・夜(20:00)の3回分のスケジュールを追加します。
+          </p>
+        )}
         {mode === 'prn' && (
           <p className="text-xs text-gray-500 mt-1">
             症状がある時だけ服用する薬です。ホーム画面には表示されません。
@@ -107,7 +138,7 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
         )}
       </div>
 
-      {mode !== 'prn' && (
+      {mode !== 'prn' && mode !== 'twice_daily' && mode !== 'three_daily' && (
       <div>
         <label htmlFor="schedule-time" className="block text-sm font-medium text-gray-700 mb-1">
           服薬時刻
@@ -122,7 +153,7 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
       </div>
       )}
 
-      {mode !== 'prn' && (
+      {mode !== 'prn' && mode !== 'twice_daily' && mode !== 'three_daily' && (
       <div>
 
         {mode === 'weekdays' && (
@@ -187,7 +218,7 @@ export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit }) => {
       </div>
       )}
 
-      {mode !== 'prn' && (
+      {mode !== 'prn' && mode !== 'twice_daily' && mode !== 'three_daily' && (
       <div>
         <label htmlFor="reminder-minutes" className="block text-sm font-medium text-gray-700 mb-1">
           リマインダー（分前）


### PR DESCRIPTION
## Summary
- 服薬済み判定をmedicationId単位からscheduleId単位に変更
- 同じ薬で朝(08:00)と夜(20:00)にスケジュールがある場合、朝の服薬済みが夜に影響しなくなった
- スケジュール作成フォームに「1日2回」「1日3回」のプリセットボタンを追加
- 1日2回: 朝(08:00)と夜(20:00)のスケジュールを一括作成
- 1日3回: 朝(08:00)・昼(13:00)・夜(20:00)を一括作成

## Test plan
- [ ] 1日2回の薬で朝の分を服薬済みにした後、夜の分が未服薬のまま残ることを確認
- [ ] 夜の分を個別に服薬済みにできることを確認
- [ ] 「1日2回」プリセットで2つのスケジュールが一括作成されることを確認
- [ ] 「1日3回」プリセットで3つのスケジュールが一括作成されることを確認
- [ ] 1日1回(毎日)の薬は従来通り正常に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Twice Daily" and "Three Daily" frequency options for medication scheduling
  * Enabled batch creation of multiple medication schedules in a single operation

* **Improvements**
  * Enhanced medication completion tracking to better handle medications with multiple active schedules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->