### PR TITLE
fix: 間隔表記を「ごと」から「毎」に変更

### DIFF
--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -25,7 +25,7 @@ const DAY_ORDER: DayOfWeek[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
 
 function getScheduleLabel(daysOfWeek: readonly DayOfWeek[], intervalDays?: number): string {
   if (intervalDays === -1) return '頓服';
-  if (intervalDays && intervalDays > 0) return `${intervalDays}日ごと`;
+  if (intervalDays && intervalDays > 0) return `${intervalDays}日毎`;
   if (daysOfWeek.length === 0 || daysOfWeek.length === 7) return '毎日';
   return DAY_ORDER.filter((d) => daysOfWeek.includes(d)).map((d) => DAY_LABELS[d]).join('・');
 }

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -9,7 +9,7 @@ import { EmptyStatePrompt } from '../shared/EmptyStatePrompt';
 export interface MedicationScheduleInfo {
   scheduleId: string;
   time: string;
-  label: string; // "毎日", "月・水・金", "21日ごと" etc.
+  label: string; // "毎日", "月・水・金", "21日毎" etc.
 }
 
 export interface MedicationScheduleMap {

--- a/src/components/schedules/ScheduleForm.tsx
+++ b/src/components/schedules/ScheduleForm.tsx
@@ -30,15 +30,15 @@ const DAY_OPTIONS: { value: DayOfWeek; label: string }[] = [
 ];
 
 const INTERVAL_OPTIONS = [
-  { value: 2, label: '2日ごと' },
-  { value: 3, label: '3日ごと' },
-  { value: 7, label: '1週間ごと' },
-  { value: 14, label: '2週間ごと' },
-  { value: 21, label: '3週間ごと' },
-  { value: 28, label: '4週間ごと' },
-  { value: 30, label: '1ヶ月ごと' },
-  { value: 60, label: '2ヶ月ごと' },
-  { value: 90, label: '3ヶ月ごと' },
+  { value: 2, label: '2日毎' },
+  { value: 3, label: '3日毎' },
+  { value: 7, label: '1週間毎' },
+  { value: 14, label: '2週間毎' },
+  { value: 21, label: '3週間毎' },
+  { value: 28, label: '4週間毎' },
+  { value: 30, label: '1ヶ月毎' },
+  { value: 60, label: '2ヶ月毎' },
+  { value: 90, label: '3ヶ月毎' },
 ];
 
 export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit, onSubmitMultiple }) => {

--- a/src/components/schedules/ScheduleList.tsx
+++ b/src/components/schedules/ScheduleList.tsx
@@ -78,15 +78,15 @@ export interface ScheduleCardProps {
 type EditMode = 'daily' | 'weekdays' | 'interval' | 'prn';
 
 const INTERVAL_OPTIONS = [
-  { value: 2, label: '2日ごと' },
-  { value: 3, label: '3日ごと' },
-  { value: 7, label: '1週間ごと' },
-  { value: 14, label: '2週間ごと' },
-  { value: 21, label: '3週間ごと' },
-  { value: 28, label: '4週間ごと' },
-  { value: 30, label: '1ヶ月ごと' },
-  { value: 60, label: '2ヶ月ごと' },
-  { value: 90, label: '3ヶ月ごと' },
+  { value: 2, label: '2日毎' },
+  { value: 3, label: '3日毎' },
+  { value: 7, label: '1週間毎' },
+  { value: 14, label: '2週間毎' },
+  { value: 21, label: '3週間毎' },
+  { value: 28, label: '4週間毎' },
+  { value: 30, label: '1ヶ月毎' },
+  { value: 60, label: '2ヶ月毎' },
+  { value: 90, label: '3ヶ月毎' },
 ];
 
 function getInitialMode(schedule: Schedule): EditMode {
@@ -114,7 +114,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(({ item, onUpdate, 
   const daysLabel = schedule.intervalDays === -1
     ? '頓服'
     : schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate
-      ? `${schedule.intervalDays}日ごと`
+      ? `${schedule.intervalDays}日毎`
       : schedule.daysOfWeek.length === 7
         ? '毎日'
         : schedule.daysOfWeek.length === 0


### PR DESCRIPTION
## Summary
- 間隔表記を「ごと」から「毎」に統一変更
- 「3日ごと」→「3日毎」、「1週間ごと」→「1週間毎」、「1ヶ月ごと」→「1ヶ月毎」等
- スケジュール作成フォーム・編集フォーム・お薬ページのバッジ全てに反映

## Test plan
- [ ] スケジュール作成の間隔指定で「3日毎」等の表記になっていることを確認
- [ ] スケジュール管理のラベルが「毎」表記になっていることを確認
- [ ] お薬ページのスケジュールバッジが「毎」表記になっていることを確認