### PR TITLE
fix: ホーム画面のスケジュールを時刻→メンバー名順でソート

### DIFF
--- a/src/domain/usecases/GetTodaySchedules.ts
+++ b/src/domain/usecases/GetTodaySchedules.ts
@@ -49,10 +49,12 @@ export class GetTodaySchedules {
       })
       .map((item) => this.toViewModel(item, date));
 
-    // 時刻順 → 薬の表示順でソート
+    // 時刻順 → メンバー名順 → 薬の表示順でソート
     viewModels.sort((a, b) => {
       const timeCompare = a.scheduledTime.localeCompare(b.scheduledTime);
       if (timeCompare !== 0) return timeCompare;
+      const memberCompare = a.memberName.localeCompare(b.memberName);
+      if (memberCompare !== 0) return memberCompare;
       return a.medicationDisplayOrder - b.medicationDisplayOrder;
     });
 


### PR DESCRIPTION
## Summary
- 同じ時刻のスケジュールをメンバー名の五十音順でグループ化
- ソート順: 時刻 → メンバー名 → 薬の表示順(displayOrder)
- 「ゆぅ」の薬がまとまった後に「やじゅ」の薬が表示される

## Test plan
- [ ] 同じ時刻の薬がメンバー名順でグループ化されることを確認
- [ ] 異なる時刻の薬は引き続き時刻順で表示されることを確認