### PR TITLE
feat: 初心者向けUX改善 - セットアップガイド・フォーム簡略化

### DIFF
--- a/src/__tests__/components/dashboard/TodayScheduleList.test.tsx
+++ b/src/__tests__/components/dashboard/TodayScheduleList.test.tsx
@@ -24,9 +24,14 @@ describe('TodayScheduleList', () => {
     expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
-  it('スケジュールが空の場合はメッセージを表示する', () => {
-    render(<TodayScheduleList schedules={[]} isLoading={false} />);
+  it('スケジュールが空でメンバーがいる場合はメッセージを表示する', () => {
+    render(<TodayScheduleList schedules={[]} isLoading={false} hasMembers={true} />);
     expect(screen.getByText('今日の服薬スケジュールはありません')).toBeInTheDocument();
+  });
+
+  it('スケジュールが空でメンバーもいない場合はセットアップガイドを表示する', () => {
+    render(<TodayScheduleList schedules={[]} isLoading={false} hasMembers={false} />);
+    expect(screen.getByText('はじめての方へ')).toBeInTheDocument();
   });
 
   it('スケジュール一覧を表示する', () => {

--- a/src/__tests__/components/medications/MedicationForm.test.tsx
+++ b/src/__tests__/components/medications/MedicationForm.test.tsx
@@ -14,8 +14,8 @@ describe('MedicationForm', () => {
     render(<MedicationForm onSubmit={mockOnSubmit} />);
     expect(screen.getByLabelText('薬の名前')).toBeInTheDocument();
     expect(screen.getByLabelText('カテゴリ')).toBeInTheDocument();
-    expect(screen.getByLabelText('用量')).toBeInTheDocument();
-    expect(screen.getByLabelText('頻度')).toBeInTheDocument();
+    expect(screen.getByLabelText(/用量/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/頻度/)).toBeInTheDocument();
   });
 
   it('名前が空の場合送信しない', () => {
@@ -72,7 +72,9 @@ describe('MedicationForm', () => {
   it('在庫数を含めて送信する', () => {
     render(<MedicationForm onSubmit={mockOnSubmit} />);
     fireEvent.change(screen.getByLabelText('薬の名前'), { target: { value: '薬A' } });
-    fireEvent.change(screen.getByLabelText('在庫数(何日分)'), { target: { value: '30' } });
+    // 詳細設定を開く
+    fireEvent.click(screen.getByText(/詳細設定/));
+    fireEvent.change(screen.getByLabelText(/在庫数/), { target: { value: '30' } });
     fireEvent.click(screen.getByText('追加する'));
     expect(mockOnSubmit).toHaveBeenCalledWith(expect.objectContaining({
       name: '薬A',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,6 +62,7 @@ export default function Dashboard() {
           schedules={filteredSchedules}
           isLoading={isLoading}
           onMarkCompleted={markAsCompleted}
+          hasMembers={members.length > 0}
         />
 
         <StockAlertList alerts={alerts} isLoading={alertsLoading} />

--- a/src/components/dashboard/TodayScheduleList.tsx
+++ b/src/components/dashboard/TodayScheduleList.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { Check } from 'lucide-react';
+import Link from 'next/link';
+import { Check, Users, Pill, Clock } from 'lucide-react';
 import { TodayScheduleViewModel } from '../../domain/usecases/GetTodaySchedules';
 import { ScheduleEntity } from '../../domain/entities/Schedule';
 import { MissedDoseIndicator } from './MissedDoseIndicator';
@@ -9,9 +10,10 @@ interface TodayScheduleListProps {
   schedules: TodayScheduleViewModel[];
   isLoading: boolean;
   onMarkCompleted?: (scheduleId: string) => void;
+  hasMembers?: boolean;
 }
 
-export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules, isLoading, onMarkCompleted }) => {
+export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules, isLoading, onMarkCompleted, hasMembers }) => {
   if (isLoading) {
     return (
       <LoadingSpinner />
@@ -19,9 +21,28 @@ export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({ schedules,
   }
 
   if (schedules.length === 0) {
+    if (!hasMembers) {
+      return (
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <p className="text-sm font-medium text-gray-700 mb-4">はじめての方へ</p>
+          <div className="space-y-3">
+            <SetupStep icon={Users} label="メンバーを登録" href="/members" description="家族やペットを追加" step={1} />
+            <SetupStep icon={Pill} label="お薬を登録" href="/medications" description="メンバーごとに薬を追加" step={2} />
+            <SetupStep icon={Clock} label="スケジュールを設定" href="/medications" description="飲む時間と頻度を設定" step={3} />
+          </div>
+        </div>
+      );
+    }
     return (
-      <div className="flex flex-col justify-center items-center py-12">
-        <p className="text-gray-500 text-lg">今日の服薬スケジュールはありません</p>
+      <div className="bg-white rounded-lg border border-gray-200 p-6 text-center">
+        <p className="text-gray-500 mb-3">今日の服薬スケジュールはありません</p>
+        <Link
+          href="/medications"
+          className="inline-flex items-center space-x-1 text-sm text-primary-600 hover:text-primary-700 font-medium"
+        >
+          <Pill size={14} />
+          <span>お薬ページでスケジュールを確認</span>
+        </Link>
       </div>
     );
   }
@@ -158,3 +179,29 @@ const StatusBadge: React.FC<StatusBadgeProps> = React.memo(({ status }) => {
 });
 
 StatusBadge.displayName = 'StatusBadge';
+
+interface SetupStepProps {
+  icon: React.FC<{ size?: number; className?: string }>;
+  label: string;
+  description: string;
+  href: string;
+  step: number;
+}
+
+const SetupStep: React.FC<SetupStepProps> = ({ icon: Icon, label, description, href, step }) => (
+  <Link
+    href={href}
+    className="flex items-center space-x-3 p-3 rounded-lg border border-gray-100 hover:border-primary-200 hover:bg-primary-50/50 transition-colors"
+  >
+    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary-100 text-primary-600 flex items-center justify-center text-xs font-bold">
+      {step}
+    </div>
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center space-x-1.5">
+        <Icon size={14} className="text-primary-600" />
+        <span className="text-sm font-medium text-gray-800">{label}</span>
+      </div>
+      <p className="text-xs text-gray-500 mt-0.5">{description}</p>
+    </div>
+  </Link>
+);

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { Medication, MedicationCategory } from '../../domain/entities/Medication';
 
 export interface MedicationFormData {
@@ -30,6 +31,8 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
     initialData?.stockAlertDate ? new Date(initialData.stockAlertDate).toISOString().split('T')[0] : ''
   );
   const [instructions, setInstructions] = useState(initialData?.instructions || '');
+  const hasOptionalData = !!(initialData?.stockQuantity || initialData?.stockAlertDate || initialData?.instructions);
+  const [showOptional, setShowOptional] = useState(isEditing && hasOptionalData);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -100,7 +103,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label htmlFor="med-dosage" className="block text-sm font-medium text-gray-700 mb-1">
-            用量
+            用量 <span className="text-xs text-gray-400 font-normal">任意</span>
           </label>
           <input
             id="med-dosage"
@@ -113,7 +116,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
         </div>
         <div>
           <label htmlFor="med-frequency" className="block text-sm font-medium text-gray-700 mb-1">
-            頻度
+            頻度 <span className="text-xs text-gray-400 font-normal">任意</span>
           </label>
           <input
             id="med-frequency"
@@ -126,47 +129,61 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
         </div>
       </div>
 
-      <div>
-        <label htmlFor="med-stock" className="block text-sm font-medium text-gray-700 mb-1">
-          在庫数(何日分)
-        </label>
-        <input
-          id="med-stock"
-          type="number"
-          min="0"
-          value={stockQuantity}
-          onChange={(e) => setStockQuantity(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-          placeholder="例: 30"
-        />
-      </div>
+      <button
+        type="button"
+        onClick={() => setShowOptional(!showOptional)}
+        className="flex items-center space-x-1 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+      >
+        {showOptional ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        <span>詳細設定（在庫・服用方法など）</span>
+      </button>
 
-      <div>
-        <label htmlFor="med-alert-date" className="block text-sm font-medium text-gray-700 mb-1">
-          在庫警告日(この日までに在庫が不足する場合に通知)
-        </label>
-        <input
-          id="med-alert-date"
-          type="date"
-          value={stockAlertDate}
-          onChange={(e) => setStockAlertDate(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-        />
-      </div>
+      {showOptional && (
+        <div className="space-y-4 pt-1">
+          <div>
+            <label htmlFor="med-stock" className="block text-sm font-medium text-gray-700 mb-1">
+              在庫数(何日分)
+            </label>
+            <input
+              id="med-stock"
+              type="number"
+              min="0"
+              value={stockQuantity}
+              onChange={(e) => setStockQuantity(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+              placeholder="例: 30"
+            />
+          </div>
 
-      <div>
-        <label htmlFor="med-instructions" className="block text-sm font-medium text-gray-700 mb-1">
-          服用方法
-        </label>
-        <textarea
-          id="med-instructions"
-          value={instructions}
-          onChange={(e) => setInstructions(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-          rows={2}
-          placeholder="例: 食後に水と一緒に服用"
-        />
-      </div>
+          <div>
+            <label htmlFor="med-alert-date" className="block text-sm font-medium text-gray-700 mb-1">
+              在庫警告日
+            </label>
+            <input
+              id="med-alert-date"
+              type="date"
+              value={stockAlertDate}
+              onChange={(e) => setStockAlertDate(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+            />
+            <p className="text-xs text-gray-400 mt-1">この日までに在庫が不足する場合に通知します</p>
+          </div>
+
+          <div>
+            <label htmlFor="med-instructions" className="block text-sm font-medium text-gray-700 mb-1">
+              服用方法
+            </label>
+            <textarea
+              id="med-instructions"
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+              rows={2}
+              placeholder="例: 食後に水と一緒に服用"
+            />
+          </div>
+        </div>
+      )}
 
       <div className="flex space-x-2">
         <button


### PR DESCRIPTION
## Summary
- ホーム画面にメンバー未登録時の3ステップセットアップガイドを追加(メンバー登録→お薬登録→スケジュール設定)
- スケジュール0件時に「お薬ページでスケジュールを確認」リンクを追加
- 薬登録フォームの在庫数・在庫警告日・服用方法を「詳細設定」トグルに折りたたみ
- 用量・頻度フィールドに「任意」ラベルを追加
- 在庫警告日のラベルを簡潔にし、説明を補足テキストに分離

## Test plan
- [x] メンバー未登録のアカウントでホーム画面にセットアップガイドが表示されることを確認
- [x] ガイドの各リンクが正しいページに遷移することを確認
- [x] メンバー登録済み・スケジュール0件でお薬ページへのリンクが表示されることを確認
- [x] 薬登録フォームで初期表示が名前・カテゴリ・用量・頻度のみであることを確認
- [x] 「詳細設定」をタップすると在庫・警告日・服用方法が展開されることを確認
- [x] 編集モードで在庫データがある場合は詳細設定が自動展開されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added setup guide for first-time users to get started with the app.

* **Improvements**
  * Simplified medication form by collapsing optional fields (stock, instructions, warnings) into an expandable details section.
  * Clarified which medication form fields are optional (dose and frequency).
  * Enhanced empty-state messaging in schedule list to guide users toward next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->