### PR TITLE
fix: スケジュール管理画面で全スケジュールを表示するよう修正

### DIFF
--- a/src/__tests__/data/api/scheduleApi.test.ts
+++ b/src/__tests__/data/api/scheduleApi.test.ts
@@ -49,7 +49,7 @@ describe('scheduleApi', () => {
     vi.mocked(apiClient.get).mockResolvedValueOnce([mockTodayResponse]);
 
     const result = await scheduleApi.getSchedules();
-    expect(apiClient.get).toHaveBeenCalledWith('/schedules/today');
+    expect(apiClient.get).toHaveBeenCalledWith('/schedules/all');
     expect(result).toHaveLength(1);
     expect(result[0].medicationName).toBe('頭痛薬');
     expect(result[0].memberName).toBe('太郎');

--- a/src/app/api/schedules/all/route.ts
+++ b/src/app/api/schedules/all/route.ts
@@ -1,0 +1,45 @@
+import { prisma } from '@/lib/prisma';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`schedules-all-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+  const [schedules, members] = await Promise.all([
+    prisma.schedule.findMany({
+      where: { userId },
+      include: {
+        medication: { select: { id: true, name: true } },
+      },
+      take: QUERY_LIMITS.SCHEDULES,
+    }),
+    prisma.member.findMany({
+      where: { userId },
+      select: { id: true, name: true },
+      take: QUERY_LIMITS.MEMBERS,
+    }),
+  ]);
+
+  const memberMap = new Map(members.map((m) => [m.id, m]));
+
+  const result = schedules.map((s) => ({
+    id: s.id,
+    medicationId: s.medicationId,
+    medicationName: s.medication.name,
+    userId: s.userId,
+    memberId: s.memberId,
+    memberName: memberMap.get(s.memberId)?.name || '',
+    scheduledTime: s.scheduledTime,
+    daysOfWeek: s.daysOfWeek,
+    intervalDays: s.intervalDays,
+    startDate: s.startDate?.toISOString(),
+    isEnabled: s.isEnabled,
+    reminderMinutesBefore: s.reminderMinutesBefore,
+    createdAt: s.createdAt.toISOString(),
+  }));
+
+  return success(result);
+});

--- a/src/data/api/scheduleApi.ts
+++ b/src/data/api/scheduleApi.ts
@@ -33,7 +33,7 @@ const VALID_DAYS: readonly string[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat',
 
 export const scheduleApi = {
   async getSchedules(): Promise<ScheduleWithDetails[]> {
-    const items = await apiClient.get<TodayScheduleResponse[]>('/schedules/today');
+    const items = await apiClient.get<TodayScheduleResponse[]>('/schedules/all');
     return items.map((item) => ({
       schedule: {
         id: item.id,


### PR DESCRIPTION
## Summary
- スケジュール管理画面がgetSchedules()で/schedules/today(今日有効なもののみ)を呼んでいたバグを修正
- 全スケジュールを薬名・メンバー名付きで返す/api/schedules/all APIを新設
- 頓服(PRN)や今日対象外の間隔指定スケジュールも管理画面に正しく表示される

## Test plan
- [ ] メンバーの薬管理ページで全スケジュールが表示されることを確認
- [ ] 頓服スケジュールがスケジュール管理に表示されることを確認
- [ ] 間隔指定で今日対象外のスケジュールも管理画面に表示されることを確認
- [ ] ホーム画面は引き続き今日のスケジュールのみ表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve all user schedules with authentication and rate limiting protection.

* **Tests**
  * Updated test assertions to reflect new schedule retrieval endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->