### PR TITLE
fix: ホーム画面の通院予定に種別とメモを表示

### DIFF
--- a/src/components/dashboard/UpcomingAppointments.tsx
+++ b/src/components/dashboard/UpcomingAppointments.tsx
@@ -51,7 +51,7 @@ export const UpcomingAppointments: React.FC<UpcomingAppointmentsProps> = ({ appo
                       </span>
                     )}
                   </p>
-                  <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+                  <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5 flex-wrap">
                     {apt.memberName && (
                       <span className="flex items-center space-x-1">
                         <User size={10} />
@@ -64,7 +64,15 @@ export const UpcomingAppointments: React.FC<UpcomingAppointmentsProps> = ({ appo
                         <span>{apt.hospitalName}</span>
                       </span>
                     )}
+                    {apt.appointmentType && AppointmentEntity.typeLabels[apt.appointmentType] && (
+                      <span className="px-1.5 py-0.5 bg-gray-100 text-gray-600 rounded text-xs">
+                        {AppointmentEntity.typeLabels[apt.appointmentType]}
+                      </span>
+                    )}
                   </div>
+                  {apt.description && (
+                    <p className="text-xs text-gray-400 mt-0.5 truncate">{apt.description}</p>
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- 通院予定カードに予約種別(トリミング、定期検診等)をバッジで表示
- メモ(description)がある場合は補足テキストとして表示
- メンバー名・病院名と並んで種別が一目で分かるように

## Test plan
- [ ] ホーム画面の通院予定にトリミング等の種別バッジが表示されることを確認
- [ ] メモがある予約ではメモテキストが表示されることを確認
- [ ] 種別・メモがない予約は従来通り表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appointment cards now display appointment type information as visual badges, making appointment categorization clearer at a glance.
  * Added support for optional appointment descriptions on cards, displaying truncated text for better readability and layout consistency.

* **Layout Improvements**
  * Enhanced appointment card layout with improved text wrapping support for better adaptation across different screen sizes and content lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->