### PR TITLE
fix: 手動記録でも複数スケジュールの薬の服薬済みを正しく反映

### DIFF
--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -91,21 +91,38 @@ export const GET = withAuth(async (userId) => {
     todayRecords.filter((r) => r.scheduleId).map((r) => r.scheduleId as string)
   );
 
-  // 同じ薬に複数スケジュールがあるかを判定するためのマップ
   const activeSchedules = schedules.filter((s) =>
     isScheduleActiveToday(s, jstToday)
   );
-  const medicationScheduleCount = new Map<string, number>();
-  for (const s of activeSchedules) {
-    medicationScheduleCount.set(s.medicationId, (medicationScheduleCount.get(s.medicationId) || 0) + 1);
+
+  // 薬ごとの手動記録(scheduleIdなし)の件数を集計
+  const manualRecordCountByMedication = new Map<string, number>();
+  for (const r of todayRecords) {
+    if (!r.scheduleId) {
+      manualRecordCountByMedication.set(r.medicationId, (manualRecordCountByMedication.get(r.medicationId) || 0) + 1);
+    }
   }
 
-  // scheduleIdなしの記録(手動記録)はスケジュールが1つだけの薬にのみ適用
-  const manualCompletedMedicationIds = new Set(
-    todayRecords
-      .filter((r) => !r.scheduleId && (medicationScheduleCount.get(r.medicationId) || 0) <= 1)
-      .map((r) => r.medicationId)
-  );
+  // 薬ごとのスケジュールを時刻順に並べ、手動記録を古い時刻のスケジュールから割り当て
+  const manualCompletedScheduleIds = new Set<string>();
+  const medScheduleGroups = new Map<string, typeof activeSchedules>();
+  for (const s of activeSchedules) {
+    const group = medScheduleGroups.get(s.medicationId) || [];
+    group.push(s);
+    medScheduleGroups.set(s.medicationId, group);
+  }
+  for (const [medId, group] of medScheduleGroups) {
+    const manualCount = manualRecordCountByMedication.get(medId) || 0;
+    if (manualCount === 0) continue;
+    // scheduleId付き記録で既に完了しているものを除外し、時刻順でソート
+    const uncompletedBySchedule = group
+      .filter((s) => !completedScheduleIds.has(s.id))
+      .sort((a, b) => a.scheduledTime.localeCompare(b.scheduledTime));
+    // 手動記録の件数分、古い時刻のスケジュールから服薬済みにする
+    for (let i = 0; i < Math.min(manualCount, uncompletedBySchedule.length); i++) {
+      manualCompletedScheduleIds.add(uncompletedBySchedule[i].id);
+    }
+  }
 
   const result = activeSchedules.map((s) => {
     const member = memberMap.get(s.memberId);
@@ -124,7 +141,7 @@ export const GET = withAuth(async (userId) => {
       isEnabled: s.isEnabled,
       reminderMinutesBefore: s.reminderMinutesBefore,
       medicationDisplayOrder: s.medication.displayOrder ?? 0,
-      isCompleted: completedScheduleIds.has(s.id) || manualCompletedMedicationIds.has(s.medicationId),
+      isCompleted: completedScheduleIds.has(s.id) || manualCompletedScheduleIds.has(s.id),
       createdAt: s.createdAt.toISOString(),
     };
   });


### PR DESCRIPTION
## Summary
- scheduleIdなしの手動記録(お薬ページの「飲んだ」や「過去の記録」)でも、複数スケジュールの薬が正しく服薬済みになるよう修正
- 手動記録の件数分、時刻順で古いスケジュールから服薬済みに割り当て
- 例: ピモベハート(08:00/20:00)で手動記録1件→08:00が服薬済み、2件→両方服薬済み

## Test plan
- [ ] ピモベハート(08:00/20:00)の朝分を「過去の記録」で登録後、08:00が服薬済みになることを確認
- [ ] 夜分も登録すると20:00も服薬済みになることを確認
- [ ] scheduleId付きの記録(ホーム画面のチェックボタン)も引き続き正常に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated manual medication record allocation to match specific schedules by timing rather than by medication count, ensuring more accurate record assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->