### PR TITLE
refactor: schedules APIルートをクリーンアーキテクチャに準拠させる

### DIFF
--- a/src/__tests__/domain/usecases/ManageSchedules.test.ts
+++ b/src/__tests__/domain/usecases/ManageSchedules.test.ts
@@ -23,7 +23,9 @@ const mockScheduleWithDetails: ScheduleWithDetails = {
 
 const createMockRepository = (): ScheduleRepository => ({
   getSchedules: vi.fn().mockResolvedValue([mockScheduleWithDetails]),
+  getSchedulesRaw: vi.fn().mockResolvedValue([mockSchedule]),
   getTodaySchedules: vi.fn().mockResolvedValue([]),
+  findOverlapping: vi.fn().mockResolvedValue(null),
   createSchedule: vi.fn().mockResolvedValue(mockSchedule),
   updateSchedule: vi.fn().mockResolvedValue(mockSchedule),
   deleteSchedule: vi.fn().mockResolvedValue(undefined),

--- a/src/__tests__/presentation/hooks/useSchedules.test.ts
+++ b/src/__tests__/presentation/hooks/useSchedules.test.ts
@@ -22,10 +22,14 @@ const mockScheduleWithDetails = {
 
 const mockRepository = {
   getSchedules: vi.fn().mockResolvedValue([mockScheduleWithDetails]),
+  getSchedulesRaw: vi.fn().mockResolvedValue([]),
   getScheduleById: vi.fn(),
+  getTodaySchedules: vi.fn().mockResolvedValue([]),
+  findOverlapping: vi.fn().mockResolvedValue(null),
   createSchedule: vi.fn().mockResolvedValue(mockScheduleWithDetails.schedule),
   updateSchedule: vi.fn().mockResolvedValue(mockScheduleWithDetails.schedule),
   deleteSchedule: vi.fn().mockResolvedValue(undefined),
+  markAsCompleted: vi.fn().mockResolvedValue(undefined),
 };
 
 describe('useSchedules', () => {

--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -1,10 +1,10 @@
-import { prisma } from '@/lib/prisma';
 import { updateScheduleSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
+import { withAuth, validateBodySize, safeParseJson, validateParamId } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-
-const findSchedule = (id: string) => prisma.schedule.findUnique({ where: { id } });
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateSchedule, DeleteSchedule } from '@/domain/usecases/ManageSchedules';
+import { DayOfWeek } from '@/domain/entities/Schedule';
 
 export async function PUT(request: Request, { params }: { params: Promise<{ scheduleId: string }> }) {
   const sizeError = validateBodySize(request);
@@ -15,29 +15,43 @@ export async function PUT(request: Request, { params }: { params: Promise<{ sche
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
     const { scheduleId } = await params;
-    return withOwnershipCheck({
-      userId,
-      resourceId: scheduleId,
-      finder: findSchedule,
-      resourceName: 'スケジュール',
-      handler: async () => {
-        const jsonResult = await safeParseJson(request);
+    const idError = validateParamId(scheduleId);
+    if (idError) return idError;
+
+    const jsonResult = await safeParseJson(request);
     if ('error' in jsonResult) return jsonResult.error;
     const body = jsonResult.data;
-        const parsed = updateScheduleSchema.safeParse(body);
-        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+    const parsed = updateScheduleSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updateData: Record<string, unknown> = { ...parsed.data };
-        if (parsed.data.startDate !== undefined) {
-          updateData.startDate = parsed.data.startDate ? new Date(parsed.data.startDate) : null;
-        }
-        const updated = await prisma.schedule.update({
-          where: { id: scheduleId },
-          data: updateData,
-        });
-        return success(updated);
-      },
-    });
+    const container = createServerDIContainer(userId);
+    const usecase = new UpdateSchedule(container.scheduleRepository);
+
+    const input: Record<string, unknown> = {};
+    if (parsed.data.scheduledTime !== undefined) input.scheduledTime = parsed.data.scheduledTime;
+    if (parsed.data.daysOfWeek !== undefined) input.daysOfWeek = parsed.data.daysOfWeek as DayOfWeek[];
+    if (parsed.data.intervalDays !== undefined) input.intervalDays = parsed.data.intervalDays;
+    if (parsed.data.startDate !== undefined) {
+      input.startDate = parsed.data.startDate ? new Date(parsed.data.startDate) : undefined;
+    }
+    if (parsed.data.isEnabled !== undefined) input.isEnabled = parsed.data.isEnabled;
+    if (parsed.data.reminderMinutesBefore !== undefined) input.reminderMinutesBefore = parsed.data.reminderMinutesBefore;
+
+    const clearInterval = parsed.data.intervalDays === null;
+
+    try {
+      const updated = await usecase.execute(
+        scheduleId,
+        input,
+        clearInterval ? { clearInterval: true } : undefined,
+      );
+      return success(updated);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'スケジュールが見つかりません') {
+        return errorResponse('スケジュールが見つかりません', 404);
+      }
+      throw error;
+    }
   })();
 }
 
@@ -46,15 +60,20 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
     const { allowed } = checkRateLimit(`schedules-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
     if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
     const { scheduleId } = await params;
-    return withOwnershipCheck({
-      userId,
-      resourceId: scheduleId,
-      finder: findSchedule,
-      resourceName: 'スケジュール',
-      handler: async () => {
-        await prisma.schedule.delete({ where: { id: scheduleId } });
-        return success({ message: '削除しました' });
-      },
-    });
+    const idError = validateParamId(scheduleId);
+    if (idError) return idError;
+
+    const container = createServerDIContainer(userId);
+    const usecase = new DeleteSchedule(container.scheduleRepository);
+
+    try {
+      await usecase.execute(scheduleId);
+      return success({ message: '削除しました' });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'スケジュールが見つかりません') {
+        return errorResponse('スケジュールが見つかりません', 404);
+      }
+      throw error;
+    }
   })();
 }

--- a/src/app/api/schedules/all/route.ts
+++ b/src/app/api/schedules/all/route.ts
@@ -1,44 +1,31 @@
-import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetSchedules } from '@/domain/usecases/ManageSchedules';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`schedules-all-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
-  const [schedules, members] = await Promise.all([
-    prisma.schedule.findMany({
-      where: { userId },
-      include: {
-        medication: { select: { id: true, name: true } },
-      },
-      take: QUERY_LIMITS.SCHEDULES,
-    }),
-    prisma.member.findMany({
-      where: { userId },
-      select: { id: true, name: true },
-      take: QUERY_LIMITS.MEMBERS,
-    }),
-  ]);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetSchedules(container.scheduleRepository);
+  const schedulesWithDetails = await usecase.execute();
 
-  const memberMap = new Map(members.map((m) => [m.id, m]));
-
-  const result = schedules.map((s) => ({
-    id: s.id,
-    medicationId: s.medicationId,
-    medicationName: s.medication.name,
-    userId: s.userId,
-    memberId: s.memberId,
-    memberName: memberMap.get(s.memberId)?.name || '',
-    scheduledTime: s.scheduledTime,
-    daysOfWeek: s.daysOfWeek,
-    intervalDays: s.intervalDays,
-    startDate: s.startDate?.toISOString(),
-    isEnabled: s.isEnabled,
-    reminderMinutesBefore: s.reminderMinutesBefore,
-    createdAt: s.createdAt.toISOString(),
+  const result = schedulesWithDetails.map((item) => ({
+    id: item.schedule.id,
+    medicationId: item.schedule.medicationId,
+    medicationName: item.medicationName,
+    userId: item.schedule.userId,
+    memberId: item.schedule.memberId,
+    memberName: item.memberName,
+    scheduledTime: item.schedule.scheduledTime,
+    daysOfWeek: item.schedule.daysOfWeek,
+    intervalDays: item.schedule.intervalDays,
+    startDate: item.schedule.startDate instanceof Date ? item.schedule.startDate.toISOString() : item.schedule.startDate,
+    isEnabled: item.schedule.isEnabled,
+    reminderMinutesBefore: item.schedule.reminderMinutesBefore,
+    createdAt: item.schedule.createdAt instanceof Date ? item.schedule.createdAt.toISOString() : item.schedule.createdAt,
   }));
 
   return success(result);

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,15 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createScheduleSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize , safeParseJson } from '@/lib/api-helpers';
-import { ScheduleEntity, Schedule } from '@/domain/entities/Schedule';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { CreateSchedule } from '@/domain/usecases/ManageSchedules';
+import { DayOfWeek } from '@/domain/entities/Schedule';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`schedules-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const schedules = await prisma.schedule.findMany({ where: { userId }, take: QUERY_LIMITS.SCHEDULES });
+
+  const container = createServerDIContainer(userId);
+  const schedules = await container.scheduleRepository.getSchedulesRaw();
   return success(schedules);
 });
 
@@ -33,55 +36,27 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const daysOfWeek = parsed.data.daysOfWeek ?? [];
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateSchedule(container.scheduleRepository);
 
-    // ドメインエンティティによる重複チェック
-    const existing = await prisma.schedule.findFirst({
-      where: {
-        userId,
-        medicationId: parsed.data.medicationId,
-        scheduledTime: parsed.data.scheduledTime,
-        isEnabled: true,
-      },
-    });
-
-    if (existing) {
-      const newScheduleData: Schedule = {
-        id: '',
+    try {
+      const schedule = await usecase.execute({
         medicationId: parsed.data.medicationId,
         userId,
         memberId: parsed.data.memberId,
         scheduledTime: parsed.data.scheduledTime,
-        daysOfWeek: daysOfWeek as Schedule['daysOfWeek'],
-        isEnabled: true,
-        reminderMinutesBefore: parsed.data.reminderMinutesBefore ?? 5,
-        createdAt: new Date(),
-      };
-      const entity = new ScheduleEntity(newScheduleData);
-      const existingSchedule: Schedule = {
-        ...existing,
-        daysOfWeek: existing.daysOfWeek as Schedule['daysOfWeek'],
-        intervalDays: existing.intervalDays ?? undefined,
-        startDate: existing.startDate ?? undefined,
-      };
-      if (entity.hasOverlap(existingSchedule)) {
-        return errorResponse('同じ薬の同じ時刻に既にスケジュールが存在します');
-      }
-    }
-
-    const schedule = await prisma.schedule.create({
-      data: {
-        userId,
-        medicationId: parsed.data.medicationId,
-        memberId: parsed.data.memberId,
-        scheduledTime: parsed.data.scheduledTime,
-        daysOfWeek,
-        intervalDays: parsed.data.intervalDays ?? null,
-        startDate: parsed.data.startDate ? new Date(parsed.data.startDate) : null,
+        daysOfWeek: (parsed.data.daysOfWeek ?? []) as DayOfWeek[],
+        intervalDays: parsed.data.intervalDays ?? undefined,
+        startDate: parsed.data.startDate ? new Date(parsed.data.startDate) : undefined,
         isEnabled: parsed.data.isEnabled ?? true,
         reminderMinutesBefore: parsed.data.reminderMinutesBefore ?? 5,
-      },
-    });
-    return created(schedule);
+      });
+      return created(schedule);
+    } catch (error) {
+      if (error instanceof Error && error.message === '同じ薬の同じ時刻に既にスケジュールが存在します') {
+        return errorResponse(error.message);
+      }
+      throw error;
+    }
   })();
 }

--- a/src/app/api/schedules/today/route.ts
+++ b/src/app/api/schedules/today/route.ts
@@ -1,150 +1,36 @@
-import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-import { QUERY_LIMITS } from '@/lib/constants';
-
-const DAY_MAP: Record<number, string> = {
-  0: 'sun', 1: 'mon', 2: 'tue', 3: 'wed', 4: 'thu', 5: 'fri', 6: 'sat',
-};
-
-// jstDate は getJSTDate() で生成されたUTCフィールドにJST値が入ったDate
-function isScheduleActiveToday(
-  schedule: { daysOfWeek: string[]; intervalDays: number | null; startDate: Date | null },
-  jstDate: Date,
-): boolean {
-  // 頓服（PRN）: ホーム画面に表示しない
-  if (schedule.intervalDays === -1) {
-    return false;
-  }
-
-  // 間隔スケジュール（X日ごと）
-  if (schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate) {
-    const startUtc = new Date(schedule.startDate);
-    // startDateをJSTの日付として扱う(UTC+9)
-    const startJst = new Date(startUtc.getTime() + 9 * 60 * 60 * 1000);
-    // JSTの日付差を計算（UTCフィールドにJST値が入っている）
-    const startDay = Date.UTC(startJst.getUTCFullYear(), startJst.getUTCMonth(), startJst.getUTCDate());
-    const todayDay = Date.UTC(jstDate.getUTCFullYear(), jstDate.getUTCMonth(), jstDate.getUTCDate());
-    const diffDays = Math.round((todayDay - startDay) / (1000 * 60 * 60 * 24));
-    if (diffDays < 0) return false;
-    return diffDays % schedule.intervalDays === 0;
-  }
-
-  // 曜日が未設定（空配列）の場合は毎日有効
-  if (schedule.daysOfWeek.length === 0) {
-    return true;
-  }
-
-  // 曜日チェック（jstDateのUTCフィールドにJST値が入っている）
-  const todayDayCode = DAY_MAP[jstDate.getUTCDay()];
-  return schedule.daysOfWeek.includes(todayDayCode);
-}
-
-// JST (UTC+9) の今日の日付を取得
-function getJSTDate(): Date {
-  const now = new Date();
-  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
-  return jst;
-}
-
-function getJSTDayBoundaries(): { todayStart: Date; todayEnd: Date } {
-  const jstNow = getJSTDate();
-  const year = jstNow.getUTCFullYear();
-  const month = jstNow.getUTCMonth();
-  const day = jstNow.getUTCDate();
-  // JST 00:00:00 = UTC 前日 15:00:00
-  const todayStart = new Date(Date.UTC(year, month, day, -9, 0, 0, 0));
-  const todayEnd = new Date(Date.UTC(year, month, day, -9 + 23, 59, 59, 999));
-  return { todayStart, todayEnd };
-}
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`schedules-today-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const jstToday = getJSTDate();
-  const { todayStart, todayEnd } = getJSTDayBoundaries();
 
-  const [schedules, todayRecords, members] = await Promise.all([
-    prisma.schedule.findMany({
-      where: { userId, isEnabled: true },
-      include: {
-        medication: { select: { id: true, name: true, displayOrder: true } },
-      },
-      take: QUERY_LIMITS.SCHEDULES,
-    }),
-    prisma.medicationRecord.findMany({
-      where: { userId, takenAt: { gte: todayStart, lte: todayEnd } },
-      select: { scheduleId: true, medicationId: true },
-      take: QUERY_LIMITS.RECORDS,
-    }),
-    prisma.member.findMany({
-      where: { userId },
-      select: { id: true, name: true, memberType: true },
-      take: QUERY_LIMITS.MEMBERS,
-    }),
-  ]);
-
-  const memberMap = new Map(members.map((m) => [m.id, m]));
-
-  const completedScheduleIds = new Set(
-    todayRecords.filter((r) => r.scheduleId).map((r) => r.scheduleId as string)
-  );
-
-  const activeSchedules = schedules.filter((s) =>
-    isScheduleActiveToday(s, jstToday)
-  );
-
-  // 薬ごとの手動記録(scheduleIdなし)の件数を集計
-  const manualRecordCountByMedication = new Map<string, number>();
-  for (const r of todayRecords) {
-    if (!r.scheduleId) {
-      manualRecordCountByMedication.set(r.medicationId, (manualRecordCountByMedication.get(r.medicationId) || 0) + 1);
-    }
-  }
-
-  // 薬ごとのスケジュールを時刻順に並べ、手動記録を古い時刻のスケジュールから割り当て
-  const manualCompletedScheduleIds = new Set<string>();
-  const medScheduleGroups = new Map<string, typeof activeSchedules>();
-  for (const s of activeSchedules) {
-    const group = medScheduleGroups.get(s.medicationId) || [];
-    group.push(s);
-    medScheduleGroups.set(s.medicationId, group);
-  }
-  for (const [medId, group] of medScheduleGroups) {
-    const manualCount = manualRecordCountByMedication.get(medId) || 0;
-    if (manualCount === 0) continue;
-    // scheduleId付き記録で既に完了しているものを除外し、時刻順でソート
-    const uncompletedBySchedule = group
-      .filter((s) => !completedScheduleIds.has(s.id))
-      .sort((a, b) => a.scheduledTime.localeCompare(b.scheduledTime));
-    // 手動記録の件数分、古い時刻のスケジュールから服薬済みにする
-    for (let i = 0; i < Math.min(manualCount, uncompletedBySchedule.length); i++) {
-      manualCompletedScheduleIds.add(uncompletedBySchedule[i].id);
-    }
-  }
-
-  const result = activeSchedules.map((s) => {
-    const member = memberMap.get(s.memberId);
-    return {
-      id: s.id,
-      medicationId: s.medicationId,
-      medicationName: s.medication.name,
-      userId: s.userId,
-      memberId: s.memberId,
-      memberName: member?.name || '',
-      memberType: member?.memberType || 'human',
-      scheduledTime: s.scheduledTime,
-      daysOfWeek: s.daysOfWeek,
-      intervalDays: s.intervalDays,
-      startDate: s.startDate?.toISOString(),
-      isEnabled: s.isEnabled,
-      reminderMinutesBefore: s.reminderMinutesBefore,
-      medicationDisplayOrder: s.medication.displayOrder ?? 0,
-      isCompleted: completedScheduleIds.has(s.id) || manualCompletedScheduleIds.has(s.id),
-      createdAt: s.createdAt.toISOString(),
-    };
+  const container = createServerDIContainer(userId);
+  const items = await container.scheduleRepository.getTodaySchedules({
+    userId,
+    date: new Date(),
   });
+
+  const result = items.map((item) => ({
+    id: item.schedule.id,
+    medicationId: item.schedule.medicationId,
+    medicationName: item.medicationName,
+    userId: item.schedule.userId,
+    memberId: item.schedule.memberId,
+    memberName: item.memberName,
+    memberType: item.memberType,
+    scheduledTime: item.schedule.scheduledTime,
+    daysOfWeek: item.schedule.daysOfWeek,
+    intervalDays: item.schedule.intervalDays,
+    startDate: item.schedule.startDate instanceof Date ? item.schedule.startDate.toISOString() : item.schedule.startDate,
+    isEnabled: item.schedule.isEnabled,
+    reminderMinutesBefore: item.schedule.reminderMinutesBefore,
+    medicationDisplayOrder: item.medicationDisplayOrder,
+    isCompleted: item.isCompleted,
+    createdAt: item.schedule.createdAt instanceof Date ? item.schedule.createdAt.toISOString() : item.schedule.createdAt,
+  }));
 
   return success(result);
 });

--- a/src/data/repositories/ScheduleRepositoryImpl.ts
+++ b/src/data/repositories/ScheduleRepositoryImpl.ts
@@ -17,8 +17,18 @@ export class ScheduleRepositoryImpl implements ScheduleRepository {
     return await scheduleApi.getSchedules();
   }
 
+  async getSchedulesRaw(): Promise<Schedule[]> {
+    // フロントエンドからは使用しない（サーバーサイド専用）
+    return [];
+  }
+
   async getTodaySchedules(query: TodayScheduleQuery): Promise<TodayScheduleItem[]> {
     return await scheduleApi.getTodaySchedules(query.userId, query.date);
+  }
+
+  async findOverlapping(_medicationId: string, _scheduledTime: string): Promise<Schedule | null> {
+    // フロントエンドからは使用しない（サーバーサイド専用）
+    return null;
   }
 
   async createSchedule(schedule: Omit<Schedule, 'id' | 'createdAt'>): Promise<Schedule> {

--- a/src/data/repositories/server/PrismaScheduleRepository.ts
+++ b/src/data/repositories/server/PrismaScheduleRepository.ts
@@ -1,6 +1,5 @@
 /**
  * サーバーサイド用 スケジュールリポジトリ実装（Prisma）
- * CreateMedicationWithSchedule usecase で使用される
  */
 
 import { prisma } from '@/lib/prisma';
@@ -11,6 +10,7 @@ import {
   TodayScheduleItem,
 } from '@/domain/repositories/ScheduleRepository';
 import { Schedule, DayOfWeek } from '@/domain/entities/Schedule';
+import { QUERY_LIMITS } from '@/lib/constants';
 
 function toSchedule(row: {
   id: string;
@@ -40,6 +40,51 @@ function toSchedule(row: {
   };
 }
 
+const DAY_MAP: Record<number, string> = {
+  0: 'sun', 1: 'mon', 2: 'tue', 3: 'wed', 4: 'thu', 5: 'fri', 6: 'sat',
+};
+
+function getJSTDate(): Date {
+  const now = new Date();
+  return new Date(now.getTime() + 9 * 60 * 60 * 1000);
+}
+
+function getJSTDayBoundaries(): { todayStart: Date; todayEnd: Date } {
+  const jstNow = getJSTDate();
+  const year = jstNow.getUTCFullYear();
+  const month = jstNow.getUTCMonth();
+  const day = jstNow.getUTCDate();
+  const todayStart = new Date(Date.UTC(year, month, day, -9, 0, 0, 0));
+  const todayEnd = new Date(Date.UTC(year, month, day, -9 + 23, 59, 59, 999));
+  return { todayStart, todayEnd };
+}
+
+function isScheduleActiveToday(
+  schedule: { daysOfWeek: string[]; intervalDays: number | null; startDate: Date | null },
+  jstDate: Date,
+): boolean {
+  if (schedule.intervalDays === -1) {
+    return false;
+  }
+
+  if (schedule.intervalDays && schedule.intervalDays > 0 && schedule.startDate) {
+    const startUtc = new Date(schedule.startDate);
+    const startJst = new Date(startUtc.getTime() + 9 * 60 * 60 * 1000);
+    const startDay = Date.UTC(startJst.getUTCFullYear(), startJst.getUTCMonth(), startJst.getUTCDate());
+    const todayDay = Date.UTC(jstDate.getUTCFullYear(), jstDate.getUTCMonth(), jstDate.getUTCDate());
+    const diffDays = Math.round((todayDay - startDay) / (1000 * 60 * 60 * 24));
+    if (diffDays < 0) return false;
+    return diffDays % schedule.intervalDays === 0;
+  }
+
+  if (schedule.daysOfWeek.length === 0) {
+    return true;
+  }
+
+  const todayDayCode = DAY_MAP[jstDate.getUTCDay()];
+  return schedule.daysOfWeek.includes(todayDayCode);
+}
+
 export class PrismaScheduleRepository implements ScheduleRepository {
   constructor(private readonly userId: string) {}
 
@@ -49,6 +94,7 @@ export class PrismaScheduleRepository implements ScheduleRepository {
       include: {
         medication: { select: { name: true } },
       },
+      take: QUERY_LIMITS.SCHEDULES,
     });
 
     const memberIds = [...new Set(rows.map((r) => r.memberId))];
@@ -65,9 +111,98 @@ export class PrismaScheduleRepository implements ScheduleRepository {
     }));
   }
 
+  async getSchedulesRaw(): Promise<Schedule[]> {
+    const rows = await prisma.schedule.findMany({
+      where: { userId: this.userId },
+      take: QUERY_LIMITS.SCHEDULES,
+    });
+    return rows.map(toSchedule);
+  }
+
   async getTodaySchedules(_query: TodayScheduleQuery): Promise<TodayScheduleItem[]> {
-    // 今日のスケジュール取得は別のAPIルートで処理されるため、ここでは最小限の実装
-    return [];
+    const jstToday = getJSTDate();
+    const { todayStart, todayEnd } = getJSTDayBoundaries();
+
+    const [schedules, todayRecords, members] = await Promise.all([
+      prisma.schedule.findMany({
+        where: { userId: this.userId, isEnabled: true },
+        include: {
+          medication: { select: { id: true, name: true, displayOrder: true } },
+        },
+        take: QUERY_LIMITS.SCHEDULES,
+      }),
+      prisma.medicationRecord.findMany({
+        where: { userId: this.userId, takenAt: { gte: todayStart, lte: todayEnd } },
+        select: { scheduleId: true, medicationId: true },
+        take: QUERY_LIMITS.RECORDS,
+      }),
+      prisma.member.findMany({
+        where: { userId: this.userId },
+        select: { id: true, name: true, memberType: true },
+        take: QUERY_LIMITS.MEMBERS,
+      }),
+    ]);
+
+    const memberMap = new Map(members.map((m) => [m.id, m]));
+
+    const completedScheduleIds = new Set(
+      todayRecords.filter((r) => r.scheduleId).map((r) => r.scheduleId as string)
+    );
+
+    const activeSchedules = schedules.filter((s) =>
+      isScheduleActiveToday(s, jstToday)
+    );
+
+    // 薬ごとの手動記録(scheduleIdなし)の件数を集計
+    const manualRecordCountByMedication = new Map<string, number>();
+    for (const r of todayRecords) {
+      if (!r.scheduleId) {
+        manualRecordCountByMedication.set(r.medicationId, (manualRecordCountByMedication.get(r.medicationId) || 0) + 1);
+      }
+    }
+
+    // 薬ごとのスケジュールを時刻順に並べ、手動記録を古い時刻のスケジュールから割り当て
+    const manualCompletedScheduleIds = new Set<string>();
+    const medScheduleGroups = new Map<string, typeof activeSchedules>();
+    for (const s of activeSchedules) {
+      const group = medScheduleGroups.get(s.medicationId) || [];
+      group.push(s);
+      medScheduleGroups.set(s.medicationId, group);
+    }
+    for (const [medId, group] of medScheduleGroups) {
+      const manualCount = manualRecordCountByMedication.get(medId) || 0;
+      if (manualCount === 0) continue;
+      const uncompletedBySchedule = group
+        .filter((s) => !completedScheduleIds.has(s.id))
+        .sort((a, b) => a.scheduledTime.localeCompare(b.scheduledTime));
+      for (let i = 0; i < Math.min(manualCount, uncompletedBySchedule.length); i++) {
+        manualCompletedScheduleIds.add(uncompletedBySchedule[i].id);
+      }
+    }
+
+    return activeSchedules.map((s) => {
+      const member = memberMap.get(s.memberId);
+      return {
+        schedule: toSchedule(s),
+        medicationName: s.medication.name,
+        memberName: member?.name || '',
+        memberType: (member?.memberType as 'human' | 'pet') || 'human',
+        medicationDisplayOrder: s.medication.displayOrder ?? 0,
+        isCompleted: completedScheduleIds.has(s.id) || manualCompletedScheduleIds.has(s.id),
+      };
+    });
+  }
+
+  async findOverlapping(medicationId: string, scheduledTime: string): Promise<Schedule | null> {
+    const row = await prisma.schedule.findFirst({
+      where: {
+        userId: this.userId,
+        medicationId,
+        scheduledTime,
+        isEnabled: true,
+      },
+    });
+    return row ? toSchedule(row) : null;
   }
 
   async createSchedule(schedule: Omit<Schedule, 'id' | 'createdAt'>): Promise<Schedule> {
@@ -87,7 +222,7 @@ export class PrismaScheduleRepository implements ScheduleRepository {
     return toSchedule(row);
   }
 
-  async updateSchedule(id: string, schedule: Partial<Schedule>): Promise<Schedule> {
+  async updateSchedule(id: string, schedule: Partial<Schedule>, options?: { clearInterval?: boolean }): Promise<Schedule> {
     const data: Record<string, unknown> = {};
     if (schedule.scheduledTime !== undefined) data.scheduledTime = schedule.scheduledTime;
     if (schedule.daysOfWeek !== undefined) data.daysOfWeek = [...schedule.daysOfWeek];
@@ -95,6 +230,10 @@ export class PrismaScheduleRepository implements ScheduleRepository {
     if (schedule.startDate !== undefined) data.startDate = schedule.startDate;
     if (schedule.isEnabled !== undefined) data.isEnabled = schedule.isEnabled;
     if (schedule.reminderMinutesBefore !== undefined) data.reminderMinutesBefore = schedule.reminderMinutesBefore;
+    if (options?.clearInterval) {
+      data.intervalDays = null;
+      data.startDate = null;
+    }
 
     const existing = await prisma.schedule.findFirst({
       where: { id, userId: this.userId },

--- a/src/domain/repositories/ScheduleRepository.ts
+++ b/src/domain/repositories/ScheduleRepository.ts
@@ -32,9 +32,19 @@ export interface ScheduleRepository {
   getSchedules(): Promise<ScheduleWithDetails[]>;
 
   /**
+   * ユーザーの全スケジュールを取得（生データ）
+   */
+  getSchedulesRaw(): Promise<Schedule[]>;
+
+  /**
    * 今日のスケジュール一覧を取得
    */
   getTodaySchedules(query: TodayScheduleQuery): Promise<TodayScheduleItem[]>;
+
+  /**
+   * 同じ薬・同じ時刻の有効なスケジュールを検索（重複チェック用）
+   */
+  findOverlapping(medicationId: string, scheduledTime: string): Promise<Schedule | null>;
 
   /**
    * スケジュールを作成

--- a/src/domain/usecases/ManageSchedules.ts
+++ b/src/domain/usecases/ManageSchedules.ts
@@ -2,7 +2,7 @@
  * スケジュール管理ユースケース
  */
 
-import { Schedule } from '../entities/Schedule';
+import { Schedule, ScheduleEntity } from '../entities/Schedule';
 import { ScheduleRepository, ScheduleWithDetails } from '../repositories/ScheduleRepository';
 
 export class GetSchedules {
@@ -26,6 +26,24 @@ export class CreateSchedule {
     if (!input.scheduledTime) {
       throw new Error('スケジュール時刻は必須です');
     }
+
+    // 重複チェック
+    const existing = await this.scheduleRepository.findOverlapping(
+      input.medicationId,
+      input.scheduledTime,
+    );
+    if (existing) {
+      const newScheduleData: Schedule = {
+        id: '',
+        ...input,
+        createdAt: new Date(),
+      };
+      const entity = new ScheduleEntity(newScheduleData);
+      if (entity.hasOverlap(existing)) {
+        throw new Error('同じ薬の同じ時刻に既にスケジュールが存在します');
+      }
+    }
+
     return this.scheduleRepository.createSchedule(input);
   }
 }


### PR DESCRIPTION
## Summary
- `PrismaScheduleRepository` に `getTodaySchedules`/`getSchedulesRaw`/`findOverlapping` を実装
- `CreateSchedule` usecase に重複チェックロジックを追加（`ScheduleEntity.hasOverlap` 経由）
- `ScheduleRepository` インターフェースに `getSchedulesRaw`/`findOverlapping` を追加
- 全4 schedules APIルートをPrisma直接からUsecase/Repository経由に変更
- テストのモックリポジトリを新インターフェースに合わせて更新

## Test plan
- [x] 全8434テストがパス
- [x] ビルド成功
- [ ] スケジュールの作成・更新・削除が正常動作すること
- [ ] 今日のスケジュール取得（手動記録割り当て含む）が正常動作すること
- [ ] 全スケジュール一覧の取得が正常動作すること
- [ ] 重複スケジュールの作成がエラーになること

closes #1056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal architecture for schedule management with enhanced validation patterns.
  * Optimized schedule retrieval and overlap detection to prevent duplicate medication assignments.
  * Enhanced schedule completion tracking logic for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->