### PR TITLE
refactor: 残り全ドメインのAPIルートをクリーンアーキテクチャに準拠させる

### DIFF
--- a/src/app/api/allergies/[allergyId]/route.ts
+++ b/src/app/api/allergies/[allergyId]/route.ts
@@ -3,6 +3,8 @@ import { updateAllergySchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateAllergy, DeleteAllergy } from '@/domain/usecases/ManageAllergies';
 
 const findAllergy = (id: string) => prisma.allergy.findUnique({ where: { id } });
 
@@ -27,16 +29,15 @@ export async function PUT(request: Request, { params }: { params: Promise<{ alle
         const parsed = updateAllergySchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.allergy.update({
-          where: { id: allergyId },
-          data: {
-            allergenName: parsed.data.allergenName,
-            allergyType: parsed.data.allergyType,
-            severity: parsed.data.severity,
-            symptoms: parsed.data.symptoms,
-            diagnosedAt: parsed.data.diagnosedAt ? new Date(parsed.data.diagnosedAt) : parsed.data.diagnosedAt,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateAllergy(container.allergyRepository);
+        const updated = await usecase.execute(allergyId, {
+          allergenName: parsed.data.allergenName,
+          allergyType: parsed.data.allergyType,
+          severity: parsed.data.severity,
+          symptoms: parsed.data.symptoms,
+          diagnosedAt: parsed.data.diagnosedAt,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -55,7 +56,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findAllergy,
       resourceName: 'アレルギー',
       handler: async () => {
-        await prisma.allergy.delete({ where: { id: allergyId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteAllergy(container.allergyRepository);
+        await usecase.execute(allergyId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/allergies/route.ts
+++ b/src/app/api/allergies/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createAllergySchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetAllergies, CreateAllergy } from '@/domain/usecases/ManageAllergies';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`allergies-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const allergies = await prisma.allergy.findMany({
-    where: { userId },
-    orderBy: { createdAt: 'desc' },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = allergies.map((a) =>
-    flattenRelations(a, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetAllergies(container.allergyRepository);
+  const allergies = await usecase.execute();
+  return success(allergies);
 });
 
 export async function POST(request: Request) {
@@ -41,17 +34,16 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const allergy = await prisma.allergy.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        allergenName: parsed.data.allergenName,
-        allergyType: parsed.data.allergyType,
-        severity: parsed.data.severity,
-        symptoms: parsed.data.symptoms,
-        diagnosedAt: parsed.data.diagnosedAt ? new Date(parsed.data.diagnosedAt) : undefined,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateAllergy(container.allergyRepository);
+    const allergy = await usecase.execute({
+      memberId: parsed.data.memberId,
+      allergenName: parsed.data.allergenName,
+      allergyType: parsed.data.allergyType,
+      severity: parsed.data.severity,
+      symptoms: parsed.data.symptoms,
+      diagnosedAt: parsed.data.diagnosedAt,
+      notes: parsed.data.notes,
     });
     return created(allergy);
   })();

--- a/src/app/api/appointments/[appointmentId]/route.ts
+++ b/src/app/api/appointments/[appointmentId]/route.ts
@@ -1,8 +1,10 @@
 import { prisma } from '@/lib/prisma';
 import { updateAppointmentSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateAppointment, DeleteAppointment } from '@/domain/usecases/ManageAppointments';
 
 const findAppointment = (id: string) => prisma.appointment.findUnique({ where: { id } });
 
@@ -27,16 +29,15 @@ export async function PUT(request: Request, { params }: { params: Promise<{ appo
         const parsed = updateAppointmentSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.appointment.update({
-          where: { id: appointmentId },
-          data: {
-            appointmentDate: parsed.data.appointmentDate ? new Date(parsed.data.appointmentDate) : undefined,
-            hospitalId: parsed.data.hospitalId === '' ? null : parsed.data.hospitalId,
-            appointmentType: parsed.data.type,
-            description: parsed.data.notes,
-            reminderEnabled: parsed.data.reminderEnabled,
-            reminderDaysBefore: parsed.data.reminderDaysBefore,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateAppointment(container.appointmentRepository);
+        const updated = await usecase.execute(appointmentId, {
+          appointmentDate: parsed.data.appointmentDate,
+          hospitalId: parsed.data.hospitalId === '' ? undefined : (parsed.data.hospitalId ?? undefined),
+          type: parsed.data.type,
+          notes: parsed.data.notes,
+          reminderEnabled: parsed.data.reminderEnabled,
+          reminderDaysBefore: parsed.data.reminderDaysBefore,
         });
         return success(updated);
       },
@@ -55,7 +56,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findAppointment,
       resourceName: '予約',
       handler: async () => {
-        await prisma.appointment.delete({ where: { id: appointmentId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteAppointment(container.appointmentRepository);
+        await usecase.execute(appointmentId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -1,26 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createAppointmentSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations , safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetAppointments, CreateAppointment } from '@/domain/usecases/ManageAppointments';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`appointments-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const appointments = await prisma.appointment.findMany({
-    where: { userId },
-    orderBy: { appointmentDate: 'asc' },
-    take: QUERY_LIMITS.APPOINTMENTS,
-    include: {
-      member: { select: { name: true } },
-      hospital: { select: { name: true } },
-    },
-  });
-  const result = appointments.map((a) =>
-    flattenRelations(a, { member: 'memberName', hospital: 'hospitalName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetAppointments(container.appointmentRepository);
+  const appointments = await usecase.execute();
+  return success(appointments);
 });
 
 export async function POST(request: Request) {
@@ -49,17 +41,16 @@ export async function POST(request: Request) {
     const ownershipError = await verifyResourceOwnership(userId, checks);
     if (ownershipError) return ownershipError;
 
-    const appointment = await prisma.appointment.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        hospitalId: parsed.data.hospitalId,
-        appointmentType: parsed.data.type,
-        appointmentDate: new Date(parsed.data.appointmentDate),
-        description: parsed.data.notes,
-        reminderEnabled: parsed.data.reminderEnabled ?? true,
-        reminderDaysBefore: parsed.data.reminderDaysBefore ?? 1,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateAppointment(container.appointmentRepository);
+    const appointment = await usecase.execute({
+      memberId: parsed.data.memberId,
+      hospitalId: parsed.data.hospitalId,
+      appointmentDate: parsed.data.appointmentDate,
+      type: parsed.data.type,
+      notes: parsed.data.notes,
+      reminderEnabled: parsed.data.reminderEnabled ?? true,
+      reminderDaysBefore: parsed.data.reminderDaysBefore ?? 1,
     });
     return created(appointment);
   })();

--- a/src/app/api/body-measurements/[measurementId]/route.ts
+++ b/src/app/api/body-measurements/[measurementId]/route.ts
@@ -3,6 +3,8 @@ import { updateBodyMeasurementSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateBodyMeasurement, DeleteBodyMeasurement } from '@/domain/usecases/ManageBodyMeasurements';
 
 const findMeasurement = (id: string) => prisma.bodyMeasurement.findUnique({ where: { id } });
 
@@ -27,14 +29,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ meas
         const parsed = updateBodyMeasurementSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.bodyMeasurement.update({
-          where: { id: measurementId },
-          data: {
-            weight: parsed.data.weight,
-            height: parsed.data.height,
-            recordedAt: parsed.data.recordedAt ? new Date(parsed.data.recordedAt) : undefined,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateBodyMeasurement(container.bodyMeasurementRepository);
+        const updated = await usecase.execute(measurementId, {
+          weight: parsed.data.weight,
+          height: parsed.data.height,
+          recordedAt: parsed.data.recordedAt,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -53,7 +54,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findMeasurement,
       resourceName: '体重・身長記録',
       handler: async () => {
-        await prisma.bodyMeasurement.delete({ where: { id: measurementId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteBodyMeasurement(container.bodyMeasurementRepository);
+        await usecase.execute(measurementId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/body-measurements/route.ts
+++ b/src/app/api/body-measurements/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createBodyMeasurementSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetBodyMeasurements, CreateBodyMeasurement } from '@/domain/usecases/ManageBodyMeasurements';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`body-measurements-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const measurements = await prisma.bodyMeasurement.findMany({
-    where: { userId },
-    orderBy: { recordedAt: 'desc' },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = measurements.map((m) =>
-    flattenRelations(m, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetBodyMeasurements(container.bodyMeasurementRepository);
+  const measurements = await usecase.execute();
+  return success(measurements);
 });
 
 export async function POST(request: Request) {
@@ -41,15 +34,14 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const measurement = await prisma.bodyMeasurement.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        weight: parsed.data.weight,
-        height: parsed.data.height,
-        recordedAt: new Date(parsed.data.recordedAt),
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateBodyMeasurement(container.bodyMeasurementRepository);
+    const measurement = await usecase.execute({
+      memberId: parsed.data.memberId,
+      weight: parsed.data.weight,
+      height: parsed.data.height,
+      recordedAt: parsed.data.recordedAt,
+      notes: parsed.data.notes,
     });
     return created(measurement);
   })();

--- a/src/app/api/emergency-contacts/[contactId]/route.ts
+++ b/src/app/api/emergency-contacts/[contactId]/route.ts
@@ -3,6 +3,8 @@ import { updateEmergencyContactSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateEmergencyContact, DeleteEmergencyContact } from '@/domain/usecases/ManageEmergencyContacts';
 
 const findContact = (id: string) => prisma.emergencyContact.findUnique({ where: { id } });
 
@@ -27,14 +29,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ cont
         const parsed = updateEmergencyContactSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.emergencyContact.update({
-          where: { id: contactId },
-          data: {
-            contactName: parsed.data.contactName,
-            phoneNumber: parsed.data.phoneNumber,
-            relationship: parsed.data.relationship,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateEmergencyContact(container.emergencyContactRepository);
+        const updated = await usecase.execute(contactId, {
+          contactName: parsed.data.contactName,
+          phoneNumber: parsed.data.phoneNumber,
+          relationship: parsed.data.relationship,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -53,7 +54,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findContact,
       resourceName: '緊急連絡先',
       handler: async () => {
-        await prisma.emergencyContact.delete({ where: { id: contactId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteEmergencyContact(container.emergencyContactRepository);
+        await usecase.execute(contactId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/emergency-contacts/route.ts
+++ b/src/app/api/emergency-contacts/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createEmergencyContactSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetEmergencyContacts, CreateEmergencyContact } from '@/domain/usecases/ManageEmergencyContacts';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`emergency-contacts-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const contacts = await prisma.emergencyContact.findMany({
-    where: { userId },
-    orderBy: { createdAt: 'desc' },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = contacts.map((c) =>
-    flattenRelations(c, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetEmergencyContacts(container.emergencyContactRepository);
+  const contacts = await usecase.execute();
+  return success(contacts);
 });
 
 export async function POST(request: Request) {
@@ -41,15 +34,14 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const contact = await prisma.emergencyContact.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        contactName: parsed.data.contactName,
-        phoneNumber: parsed.data.phoneNumber,
-        relationship: parsed.data.relationship,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateEmergencyContact(container.emergencyContactRepository);
+    const contact = await usecase.execute({
+      memberId: parsed.data.memberId,
+      contactName: parsed.data.contactName,
+      phoneNumber: parsed.data.phoneNumber,
+      relationship: parsed.data.relationship,
+      notes: parsed.data.notes,
     });
     return created(contact);
   })();

--- a/src/app/api/examinations/[examinationId]/route.ts
+++ b/src/app/api/examinations/[examinationId]/route.ts
@@ -3,6 +3,8 @@ import { updateExaminationSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateExamination, DeleteExamination } from '@/domain/usecases/ManageExaminations';
 
 const findExamination = (id: string) => prisma.examination.findUnique({ where: { id } });
 
@@ -27,14 +29,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ exam
         const parsed = updateExaminationSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.examination.update({
-          where: { id: examinationId },
-          data: {
-            examinationType: parsed.data.examinationType,
-            examinedAt: parsed.data.examinedAt ? new Date(parsed.data.examinedAt) : undefined,
-            nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : parsed.data.nextScheduledDate === null ? null : undefined,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateExamination(container.examinationRepository);
+        const updated = await usecase.execute(examinationId, {
+          examinationType: parsed.data.examinationType,
+          examinedAt: parsed.data.examinedAt,
+          nextScheduledDate: parsed.data.nextScheduledDate,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -53,7 +54,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findExamination,
       resourceName: '検査記録',
       handler: async () => {
-        await prisma.examination.delete({ where: { id: examinationId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteExamination(container.examinationRepository);
+        await usecase.execute(examinationId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/examinations/route.ts
+++ b/src/app/api/examinations/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createExaminationSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetExaminations, CreateExamination } from '@/domain/usecases/ManageExaminations';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`examinations-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const examinations = await prisma.examination.findMany({
-    where: { userId },
-    orderBy: { nextScheduledDate: { sort: 'asc', nulls: 'last' } },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = examinations.map((e) =>
-    flattenRelations(e, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetExaminations(container.examinationRepository);
+  const examinations = await usecase.execute();
+  return success(examinations);
 });
 
 export async function POST(request: Request) {
@@ -41,15 +34,14 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const examination = await prisma.examination.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        examinationType: parsed.data.examinationType,
-        examinedAt: new Date(parsed.data.examinedAt),
-        nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : undefined,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateExamination(container.examinationRepository);
+    const examination = await usecase.execute({
+      memberId: parsed.data.memberId,
+      examinationType: parsed.data.examinationType,
+      examinedAt: parsed.data.examinedAt,
+      nextScheduledDate: parsed.data.nextScheduledDate,
+      notes: parsed.data.notes,
     });
     return created(examination);
   })();

--- a/src/app/api/health-logs/[logId]/route.ts
+++ b/src/app/api/health-logs/[logId]/route.ts
@@ -2,6 +2,8 @@ import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { DeleteHealthLog } from '@/domain/usecases/ManageHealthLogs';
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ logId: string }> }) {
   return withAuth(async (userId) => {
@@ -14,7 +16,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: (id) => prisma.healthLog.findUnique({ where: { id } }),
       resourceName: '体調記録',
       handler: async (log) => {
-        await prisma.healthLog.delete({ where: { id: log.id } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteHealthLog(container.healthLogRepository);
+        await usecase.execute(log.id);
         return success({ deleted: true });
       },
     });

--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createHealthLogSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations , safeParseJson } from '@/lib/api-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetHealthLogs, CreateHealthLog } from '@/domain/usecases/ManageHealthLogs';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`health-logs-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const logs = await prisma.healthLog.findMany({
-    where: { userId },
-    orderBy: { recordedAt: 'desc' },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = logs.map((log) =>
-    flattenRelations(log, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetHealthLogs(container.healthLogRepository);
+  const logs = await usecase.execute();
+  return success(logs);
 });
 
 export async function POST(request: Request) {
@@ -43,15 +36,14 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const log = await prisma.healthLog.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        conditionLevel: parsed.data.conditionLevel,
-        symptoms: parsed.data.symptoms ?? [],
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateHealthLog(container.healthLogRepository);
+    await usecase.execute({
+      memberId: parsed.data.memberId,
+      conditionLevel: parsed.data.conditionLevel,
+      symptoms: parsed.data.symptoms ?? [],
+      notes: parsed.data.notes,
     });
-    return created(log);
+    return created({ success: true });
   })();
 }

--- a/src/app/api/hospitals/[hospitalId]/route.ts
+++ b/src/app/api/hospitals/[hospitalId]/route.ts
@@ -1,8 +1,10 @@
 import { prisma } from '@/lib/prisma';
 import { updateHospitalSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateHospital, DeleteHospital } from '@/domain/usecases/ManageHospitals';
 
 const findHospital = (id: string) => prisma.hospital.findUnique({ where: { id } });
 
@@ -27,17 +29,16 @@ export async function PUT(request: Request, { params }: { params: Promise<{ hosp
         const parsed = updateHospitalSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.hospital.update({
-          where: { id: hospitalId },
-          data: {
-            name: parsed.data.name,
-            hospitalType: parsed.data.type,
-            address: parsed.data.address,
-            phoneNumber: parsed.data.phone,
-            department: parsed.data.department,
-            doctorName: parsed.data.doctorName,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateHospital(container.hospitalRepository);
+        const updated = await usecase.execute(hospitalId, {
+          name: parsed.data.name,
+          type: parsed.data.type,
+          address: parsed.data.address,
+          phone: parsed.data.phone,
+          department: parsed.data.department,
+          doctorName: parsed.data.doctorName,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -56,7 +57,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findHospital,
       resourceName: '病院',
       handler: async () => {
-        await prisma.hospital.delete({ where: { id: hospitalId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteHospital(container.hospitalRepository);
+        await usecase.execute(hospitalId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/hospitals/route.ts
+++ b/src/app/api/hospitals/route.ts
@@ -1,14 +1,16 @@
-import { prisma } from '@/lib/prisma';
 import { createHospitalSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetHospitals, CreateHospital } from '@/domain/usecases/ManageHospitals';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`hospitals-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const hospitals = await prisma.hospital.findMany({ where: { userId }, take: QUERY_LIMITS.DEFAULT });
+  const container = createServerDIContainer(userId);
+  const usecase = new GetHospitals(container.hospitalRepository);
+  const hospitals = await usecase.execute();
   return success(hospitals);
 });
 
@@ -26,17 +28,16 @@ export async function POST(request: Request) {
     const parsed = createHospitalSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-    const hospital = await prisma.hospital.create({
-      data: {
-        userId,
-        name: parsed.data.name,
-        hospitalType: parsed.data.type,
-        address: parsed.data.address,
-        phoneNumber: parsed.data.phone,
-        department: parsed.data.department,
-        doctorName: parsed.data.doctorName,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateHospital(container.hospitalRepository);
+    const hospital = await usecase.execute({
+      name: parsed.data.name,
+      type: parsed.data.type,
+      address: parsed.data.address,
+      phone: parsed.data.phone,
+      department: parsed.data.department,
+      doctorName: parsed.data.doctorName,
+      notes: parsed.data.notes,
     });
     return created(hospital);
   })();

--- a/src/app/api/insurances/[insuranceId]/route.ts
+++ b/src/app/api/insurances/[insuranceId]/route.ts
@@ -3,6 +3,8 @@ import { updateInsuranceSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateInsurance, DeleteInsurance } from '@/domain/usecases/ManageInsurances';
 
 const findInsurance = (id: string) => prisma.insurance.findUnique({ where: { id } });
 
@@ -27,14 +29,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ insu
         const parsed = updateInsuranceSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.insurance.update({
-          where: { id: insuranceId },
-          data: {
-            insuranceType: parsed.data.insuranceType,
-            providerName: parsed.data.providerName,
-            policyNumber: parsed.data.policyNumber,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateInsurance(container.insuranceRepository);
+        const updated = await usecase.execute(insuranceId, {
+          insuranceType: parsed.data.insuranceType,
+          providerName: parsed.data.providerName,
+          policyNumber: parsed.data.policyNumber,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -53,7 +54,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findInsurance,
       resourceName: '保険',
       handler: async () => {
-        await prisma.insurance.delete({ where: { id: insuranceId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteInsurance(container.insuranceRepository);
+        await usecase.execute(insuranceId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/insurances/route.ts
+++ b/src/app/api/insurances/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createInsuranceSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetInsurances, CreateInsurance } from '@/domain/usecases/ManageInsurances';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`insurances-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const insurances = await prisma.insurance.findMany({
-    where: { userId },
-    orderBy: { createdAt: 'desc' },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = insurances.map((i) =>
-    flattenRelations(i, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetInsurances(container.insuranceRepository);
+  const insurances = await usecase.execute();
+  return success(insurances);
 });
 
 export async function POST(request: Request) {
@@ -41,15 +34,14 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const insurance = await prisma.insurance.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        insuranceType: parsed.data.insuranceType,
-        providerName: parsed.data.providerName,
-        policyNumber: parsed.data.policyNumber,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateInsurance(container.insuranceRepository);
+    const insurance = await usecase.execute({
+      memberId: parsed.data.memberId,
+      insuranceType: parsed.data.insuranceType,
+      providerName: parsed.data.providerName,
+      policyNumber: parsed.data.policyNumber,
+      notes: parsed.data.notes,
     });
     return created(insurance);
   })();

--- a/src/app/api/members/[memberId]/route.ts
+++ b/src/app/api/members/[memberId]/route.ts
@@ -1,8 +1,10 @@
 import { prisma } from '@/lib/prisma';
 import { updateMemberSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, withOwnershipCheck, validateBodySize , safeParseJson } from '@/lib/api-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateMember, DeleteMember } from '@/domain/usecases/ManageMembers';
 
 const findMember = (id: string) => prisma.member.findUnique({ where: { id } });
 
@@ -49,10 +51,9 @@ export async function PUT(request: Request, { params }: { params: Promise<{ memb
         }
         if (parsed.data.notes !== undefined) data.notes = parsed.data.notes;
 
-        const updated = await prisma.member.update({
-          where: { id: memberId },
-          data,
-        });
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateMember(container.memberRepository);
+        const updated = await usecase.execute(memberId, data);
         return success(updated);
       },
     });
@@ -70,7 +71,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findMember,
       resourceName: 'メンバー',
       handler: async () => {
-        await prisma.member.delete({ where: { id: memberId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteMember(container.memberRepository);
+        await usecase.execute(memberId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,14 +1,17 @@
-import { prisma } from '@/lib/prisma';
 import { createMemberSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
+import { withAuth, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetMembers, CreateMember } from '@/domain/usecases/ManageMembers';
+import { CreateMemberInput } from '@/domain/repositories/MemberRepository';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`members-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const members = await prisma.member.findMany({ where: { userId }, take: QUERY_LIMITS.MEMBERS });
+  const container = createServerDIContainer(userId);
+  const usecase = new GetMembers(container.memberRepository);
+  const members = await usecase.execute(userId);
   return success(members);
 });
 
@@ -28,15 +31,15 @@ export async function POST(request: Request) {
     const parsed = createMemberSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-    const member = await prisma.member.create({
-      data: {
-        userId,
-        name: parsed.data.name,
-        memberType: parsed.data.memberType ?? 'human',
-        petType: parsed.data.petType,
-        birthDate: parsed.data.birthDate ? new Date(parsed.data.birthDate) : undefined,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateMember(container.memberRepository);
+    const member = await usecase.execute({
+      userId,
+      name: parsed.data.name,
+      memberType: parsed.data.memberType ?? 'human',
+      petType: parsed.data.petType as CreateMemberInput['petType'],
+      birthDate: parsed.data.birthDate ? new Date(parsed.data.birthDate) : undefined,
+      notes: parsed.data.notes,
     });
     return created(member);
   })();

--- a/src/app/api/members/summary/route.ts
+++ b/src/app/api/members/summary/route.ts
@@ -1,43 +1,14 @@
-import { prisma } from '@/lib/prisma';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetMemberSummaries } from '@/domain/usecases/ManageMembers';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`members-summary-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const [members, medications, appointments] = await Promise.all([
-    prisma.member.findMany({
-      where: { userId },
-      select: { id: true, name: true, memberType: true },
-      take: QUERY_LIMITS.MEMBERS,
-    }),
-    prisma.medication.findMany({
-      where: { userId, isActive: true },
-      select: { memberId: true },
-      take: QUERY_LIMITS.SCHEDULES,
-    }),
-    prisma.appointment.findMany({
-      where: { userId, appointmentDate: { gte: new Date() } },
-      select: { memberId: true, appointmentDate: true },
-      orderBy: { appointmentDate: 'asc' },
-      take: QUERY_LIMITS.APPOINTMENTS,
-    }),
-  ]);
-
-  const summary = members.map((member) => {
-    const medicationCount = medications.filter((m) => m.memberId === member.id).length;
-    const nextAppointment = appointments.find((a) => a.memberId === member.id);
-
-    return {
-      memberId: member.id,
-      memberName: member.name,
-      memberType: member.memberType,
-      medicationCount,
-      nextAppointmentDate: nextAppointment?.appointmentDate.toISOString() ?? null,
-    };
-  });
-
+  const container = createServerDIContainer(userId);
+  const usecase = new GetMemberSummaries(container.memberRepository);
+  const summary = await usecase.execute();
   return success(summary);
 });

--- a/src/app/api/prescriptions/[prescriptionId]/route.ts
+++ b/src/app/api/prescriptions/[prescriptionId]/route.ts
@@ -3,6 +3,8 @@ import { updatePrescriptionSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdatePrescription, DeletePrescription } from '@/domain/usecases/ManagePrescriptions';
 
 const findPrescription = (id: string) => prisma.prescription.findUnique({ where: { id } });
 
@@ -27,16 +29,15 @@ export async function PUT(request: Request, { params }: { params: Promise<{ pres
         const parsed = updatePrescriptionSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.prescription.update({
-          where: { id: prescriptionId },
-          data: {
-            prescriptionName: parsed.data.prescriptionName,
-            prescribedBy: parsed.data.prescribedBy,
-            prescribedAt: parsed.data.prescribedAt ? new Date(parsed.data.prescribedAt) : undefined,
-            expiresAt: parsed.data.expiresAt ? new Date(parsed.data.expiresAt) : parsed.data.expiresAt,
-            pharmacyName: parsed.data.pharmacyName,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdatePrescription(container.prescriptionRepository);
+        const updated = await usecase.execute(prescriptionId, {
+          prescriptionName: parsed.data.prescriptionName,
+          prescribedBy: parsed.data.prescribedBy,
+          prescribedAt: parsed.data.prescribedAt,
+          expiresAt: parsed.data.expiresAt,
+          pharmacyName: parsed.data.pharmacyName,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -55,7 +56,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findPrescription,
       resourceName: '処方箋',
       handler: async () => {
-        await prisma.prescription.delete({ where: { id: prescriptionId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeletePrescription(container.prescriptionRepository);
+        await usecase.execute(prescriptionId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/prescriptions/route.ts
+++ b/src/app/api/prescriptions/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createPrescriptionSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetPrescriptions, CreatePrescription } from '@/domain/usecases/ManagePrescriptions';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`prescriptions-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const prescriptions = await prisma.prescription.findMany({
-    where: { userId },
-    orderBy: { prescribedAt: 'desc' },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = prescriptions.map((p) =>
-    flattenRelations(p, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetPrescriptions(container.prescriptionRepository);
+  const prescriptions = await usecase.execute();
+  return success(prescriptions);
 });
 
 export async function POST(request: Request) {
@@ -41,17 +34,16 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const prescription = await prisma.prescription.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        prescriptionName: parsed.data.prescriptionName,
-        prescribedBy: parsed.data.prescribedBy,
-        prescribedAt: new Date(parsed.data.prescribedAt),
-        expiresAt: parsed.data.expiresAt ? new Date(parsed.data.expiresAt) : undefined,
-        pharmacyName: parsed.data.pharmacyName,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreatePrescription(container.prescriptionRepository);
+    const prescription = await usecase.execute({
+      memberId: parsed.data.memberId,
+      prescriptionName: parsed.data.prescriptionName,
+      prescribedBy: parsed.data.prescribedBy,
+      prescribedAt: parsed.data.prescribedAt,
+      expiresAt: parsed.data.expiresAt,
+      pharmacyName: parsed.data.pharmacyName,
+      notes: parsed.data.notes,
     });
     return created(prescription);
   })();

--- a/src/app/api/vaccinations/[vaccinationId]/route.ts
+++ b/src/app/api/vaccinations/[vaccinationId]/route.ts
@@ -3,6 +3,8 @@ import { updateVaccinationSchema } from '@/lib/schemas';
 import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateVaccination, DeleteVaccination } from '@/domain/usecases/ManageVaccinations';
 
 const findVaccination = (id: string) => prisma.vaccination.findUnique({ where: { id } });
 
@@ -27,14 +29,13 @@ export async function PUT(request: Request, { params }: { params: Promise<{ vacc
         const parsed = updateVaccinationSchema.safeParse(body);
         if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-        const updated = await prisma.vaccination.update({
-          where: { id: vaccinationId },
-          data: {
-            vaccineName: parsed.data.vaccineName,
-            vaccinatedAt: parsed.data.vaccinatedAt ? new Date(parsed.data.vaccinatedAt) : undefined,
-            nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : parsed.data.nextScheduledDate === null ? null : undefined,
-            notes: parsed.data.notes,
-          },
+        const container = createServerDIContainer(userId);
+        const usecase = new UpdateVaccination(container.vaccinationRepository);
+        const updated = await usecase.execute(vaccinationId, {
+          vaccineName: parsed.data.vaccineName,
+          vaccinatedAt: parsed.data.vaccinatedAt,
+          nextScheduledDate: parsed.data.nextScheduledDate,
+          notes: parsed.data.notes,
         });
         return success(updated);
       },
@@ -53,7 +54,9 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
       finder: findVaccination,
       resourceName: 'ワクチン記録',
       handler: async () => {
-        await prisma.vaccination.delete({ where: { id: vaccinationId } });
+        const container = createServerDIContainer(userId);
+        const usecase = new DeleteVaccination(container.vaccinationRepository);
+        await usecase.execute(vaccinationId);
         return success({ message: '削除しました' });
       },
     });

--- a/src/app/api/vaccinations/route.ts
+++ b/src/app/api/vaccinations/route.ts
@@ -1,25 +1,18 @@
 import { prisma } from '@/lib/prisma';
 import { createVaccinationSchema } from '@/lib/schemas';
 import { success, created, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, verifyResourceOwnership, validateBodySize, flattenRelations, safeParseJson } from '@/lib/api-helpers';
-import { QUERY_LIMITS } from '@/lib/constants';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetVaccinations, CreateVaccination } from '@/domain/usecases/ManageVaccinations';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`vaccinations-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const vaccinations = await prisma.vaccination.findMany({
-    where: { userId },
-    orderBy: { nextScheduledDate: { sort: 'asc', nulls: 'last' } },
-    take: QUERY_LIMITS.DEFAULT,
-    include: {
-      member: { select: { name: true } },
-    },
-  });
-  const result = vaccinations.map((v) =>
-    flattenRelations(v, { member: 'memberName' }),
-  );
-  return success(result);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetVaccinations(container.vaccinationRepository);
+  const vaccinations = await usecase.execute();
+  return success(vaccinations);
 });
 
 export async function POST(request: Request) {
@@ -41,15 +34,14 @@ export async function POST(request: Request) {
     ]);
     if (ownershipError) return ownershipError;
 
-    const vaccination = await prisma.vaccination.create({
-      data: {
-        userId,
-        memberId: parsed.data.memberId,
-        vaccineName: parsed.data.vaccineName,
-        vaccinatedAt: new Date(parsed.data.vaccinatedAt),
-        nextScheduledDate: parsed.data.nextScheduledDate ? new Date(parsed.data.nextScheduledDate) : undefined,
-        notes: parsed.data.notes,
-      },
+    const container = createServerDIContainer(userId);
+    const usecase = new CreateVaccination(container.vaccinationRepository);
+    const vaccination = await usecase.execute({
+      memberId: parsed.data.memberId,
+      vaccineName: parsed.data.vaccineName,
+      vaccinatedAt: parsed.data.vaccinatedAt,
+      nextScheduledDate: parsed.data.nextScheduledDate,
+      notes: parsed.data.notes,
     });
     return created(vaccination);
   })();

--- a/src/data/repositories/server/PrismaAllergyRepository.ts
+++ b/src/data/repositories/server/PrismaAllergyRepository.ts
@@ -1,0 +1,107 @@
+/**
+ * サーバーサイド用 アレルギーリポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  AllergyRepository,
+  CreateAllergyInput,
+  UpdateAllergyInput,
+} from '@/domain/repositories/AllergyRepository';
+import { Allergy } from '@/domain/entities/Allergy';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toAllergy(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  allergenName: string;
+  allergyType: string;
+  severity: string;
+  symptoms: string | null;
+  diagnosedAt: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): Allergy {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    allergenName: row.allergenName,
+    allergyType: row.allergyType,
+    severity: row.severity,
+    symptoms: row.symptoms ?? undefined,
+    diagnosedAt: row.diagnosedAt ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaAllergyRepository implements AllergyRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAll(): Promise<Allergy[]> {
+    const rows = await prisma.allergy.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { createdAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toAllergy);
+  }
+
+  async create(input: CreateAllergyInput): Promise<Allergy> {
+    const row = await prisma.allergy.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        allergenName: input.allergenName,
+        allergyType: input.allergyType,
+        severity: input.severity,
+        symptoms: input.symptoms,
+        diagnosedAt: input.diagnosedAt ? new Date(input.diagnosedAt) : undefined,
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toAllergy(row);
+  }
+
+  async update(id: string, input: UpdateAllergyInput): Promise<Allergy> {
+    const existing = await prisma.allergy.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('アレルギー情報が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.allergenName !== undefined) data.allergenName = input.allergenName;
+    if (input.allergyType !== undefined) data.allergyType = input.allergyType;
+    if (input.severity !== undefined) data.severity = input.severity;
+    if (input.symptoms !== undefined) data.symptoms = input.symptoms;
+    if (input.diagnosedAt !== undefined) {
+      data.diagnosedAt = input.diagnosedAt ? new Date(input.diagnosedAt) : null;
+    }
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.allergy.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toAllergy(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.allergy.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('アレルギー情報が見つかりません');
+    }
+    await prisma.allergy.delete({ where: { id } });
+  }
+}

--- a/src/data/repositories/server/PrismaAppointmentRepository.ts
+++ b/src/data/repositories/server/PrismaAppointmentRepository.ts
@@ -1,0 +1,116 @@
+/**
+ * サーバーサイド用 通院予約リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  AppointmentRepository,
+  CreateAppointmentInput,
+  UpdateAppointmentInput,
+} from '@/domain/repositories/AppointmentRepository';
+import { Appointment } from '@/domain/entities/Appointment';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toAppointment(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  hospitalId: string | null;
+  appointmentType: string | null;
+  appointmentDate: Date;
+  description: string | null;
+  reminderEnabled: boolean;
+  reminderDaysBefore: number;
+  createdAt: Date;
+  member?: { name: string };
+  hospital?: { name: string } | null;
+}): Appointment {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    hospitalId: row.hospitalId ?? undefined,
+    hospitalName: row.hospital?.name ?? undefined,
+    appointmentType: row.appointmentType ?? undefined,
+    appointmentDate: row.appointmentDate,
+    description: row.description ?? undefined,
+    reminderEnabled: row.reminderEnabled,
+    reminderDaysBefore: row.reminderDaysBefore,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaAppointmentRepository implements AppointmentRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAppointments(): Promise<Appointment[]> {
+    const rows = await prisma.appointment.findMany({
+      where: { userId: this.userId },
+      include: {
+        member: { select: { name: true } },
+        hospital: { select: { name: true } },
+      },
+      orderBy: { appointmentDate: 'asc' },
+      take: QUERY_LIMITS.APPOINTMENTS,
+    });
+    return rows.map(toAppointment);
+  }
+
+  async createAppointment(input: CreateAppointmentInput): Promise<Appointment> {
+    const row = await prisma.appointment.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        hospitalId: input.hospitalId,
+        appointmentType: input.type,
+        appointmentDate: new Date(input.appointmentDate),
+        description: input.notes,
+        reminderEnabled: input.reminderEnabled ?? true,
+        reminderDaysBefore: input.reminderDaysBefore ?? 1,
+      },
+      include: {
+        member: { select: { name: true } },
+        hospital: { select: { name: true } },
+      },
+    });
+    return toAppointment(row);
+  }
+
+  async updateAppointment(appointmentId: string, input: UpdateAppointmentInput): Promise<Appointment> {
+    const existing = await prisma.appointment.findFirst({
+      where: { id: appointmentId, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('予約が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.appointmentDate !== undefined) data.appointmentDate = new Date(input.appointmentDate);
+    if (input.hospitalId !== undefined) data.hospitalId = input.hospitalId;
+    if (input.type !== undefined) data.appointmentType = input.type;
+    if (input.notes !== undefined) data.description = input.notes;
+    if (input.reminderEnabled !== undefined) data.reminderEnabled = input.reminderEnabled;
+    if (input.reminderDaysBefore !== undefined) data.reminderDaysBefore = input.reminderDaysBefore;
+
+    const row = await prisma.appointment.update({
+      where: { id: appointmentId },
+      data,
+      include: {
+        member: { select: { name: true } },
+        hospital: { select: { name: true } },
+      },
+    });
+    return toAppointment(row);
+  }
+
+  async deleteAppointment(appointmentId: string): Promise<void> {
+    const existing = await prisma.appointment.findFirst({
+      where: { id: appointmentId, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('予約が見つかりません');
+    }
+    await prisma.appointment.delete({ where: { id: appointmentId } });
+  }
+}

--- a/src/data/repositories/server/PrismaBodyMeasurementRepository.ts
+++ b/src/data/repositories/server/PrismaBodyMeasurementRepository.ts
@@ -1,0 +1,97 @@
+/**
+ * サーバーサイド用 身体測定リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  BodyMeasurementRepository,
+  CreateBodyMeasurementInput,
+  UpdateBodyMeasurementInput,
+} from '@/domain/repositories/BodyMeasurementRepository';
+import { BodyMeasurement } from '@/domain/entities/BodyMeasurement';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toBodyMeasurement(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  weight: number | null;
+  height: number | null;
+  recordedAt: Date;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): BodyMeasurement {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    weight: row.weight ?? undefined,
+    height: row.height ?? undefined,
+    recordedAt: row.recordedAt,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaBodyMeasurementRepository implements BodyMeasurementRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAll(): Promise<BodyMeasurement[]> {
+    const rows = await prisma.bodyMeasurement.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { recordedAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toBodyMeasurement);
+  }
+
+  async create(input: CreateBodyMeasurementInput): Promise<BodyMeasurement> {
+    const row = await prisma.bodyMeasurement.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        weight: input.weight,
+        height: input.height,
+        recordedAt: new Date(input.recordedAt),
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toBodyMeasurement(row);
+  }
+
+  async update(id: string, input: UpdateBodyMeasurementInput): Promise<BodyMeasurement> {
+    const existing = await prisma.bodyMeasurement.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('身体測定記録が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.weight !== undefined) data.weight = input.weight;
+    if (input.height !== undefined) data.height = input.height;
+    if (input.recordedAt !== undefined) data.recordedAt = new Date(input.recordedAt);
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.bodyMeasurement.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toBodyMeasurement(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.bodyMeasurement.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('身体測定記録が見つかりません');
+    }
+    await prisma.bodyMeasurement.delete({ where: { id } });
+  }
+}

--- a/src/data/repositories/server/PrismaEmergencyContactRepository.ts
+++ b/src/data/repositories/server/PrismaEmergencyContactRepository.ts
@@ -1,0 +1,97 @@
+/**
+ * サーバーサイド用 緊急連絡先リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  EmergencyContactRepository,
+  CreateEmergencyContactInput,
+  UpdateEmergencyContactInput,
+} from '@/domain/repositories/EmergencyContactRepository';
+import { EmergencyContact } from '@/domain/entities/EmergencyContact';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toEmergencyContact(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  contactName: string;
+  phoneNumber: string;
+  relationship: string | null;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): EmergencyContact {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    contactName: row.contactName,
+    phoneNumber: row.phoneNumber,
+    relationship: row.relationship ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaEmergencyContactRepository implements EmergencyContactRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAll(): Promise<EmergencyContact[]> {
+    const rows = await prisma.emergencyContact.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { createdAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toEmergencyContact);
+  }
+
+  async create(input: CreateEmergencyContactInput): Promise<EmergencyContact> {
+    const row = await prisma.emergencyContact.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        contactName: input.contactName,
+        phoneNumber: input.phoneNumber,
+        relationship: input.relationship,
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toEmergencyContact(row);
+  }
+
+  async update(id: string, input: UpdateEmergencyContactInput): Promise<EmergencyContact> {
+    const existing = await prisma.emergencyContact.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('緊急連絡先が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.contactName !== undefined) data.contactName = input.contactName;
+    if (input.phoneNumber !== undefined) data.phoneNumber = input.phoneNumber;
+    if (input.relationship !== undefined) data.relationship = input.relationship;
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.emergencyContact.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toEmergencyContact(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.emergencyContact.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('緊急連絡先が見つかりません');
+    }
+    await prisma.emergencyContact.delete({ where: { id } });
+  }
+}

--- a/src/data/repositories/server/PrismaExaminationRepository.ts
+++ b/src/data/repositories/server/PrismaExaminationRepository.ts
@@ -1,0 +1,99 @@
+/**
+ * サーバーサイド用 検査リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  ExaminationRepository,
+  CreateExaminationInput,
+  UpdateExaminationInput,
+} from '@/domain/repositories/ExaminationRepository';
+import { Examination } from '@/domain/entities/Examination';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toExamination(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  examinationType: string;
+  examinedAt: Date;
+  nextScheduledDate: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): Examination {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    examinationType: row.examinationType,
+    examinedAt: row.examinedAt,
+    nextScheduledDate: row.nextScheduledDate ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaExaminationRepository implements ExaminationRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAll(): Promise<Examination[]> {
+    const rows = await prisma.examination.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { examinedAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toExamination);
+  }
+
+  async create(input: CreateExaminationInput): Promise<Examination> {
+    const row = await prisma.examination.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        examinationType: input.examinationType,
+        examinedAt: new Date(input.examinedAt),
+        nextScheduledDate: input.nextScheduledDate ? new Date(input.nextScheduledDate) : undefined,
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toExamination(row);
+  }
+
+  async update(id: string, input: UpdateExaminationInput): Promise<Examination> {
+    const existing = await prisma.examination.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('検査記録が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.examinationType !== undefined) data.examinationType = input.examinationType;
+    if (input.examinedAt !== undefined) data.examinedAt = new Date(input.examinedAt);
+    if (input.nextScheduledDate !== undefined) {
+      data.nextScheduledDate = input.nextScheduledDate ? new Date(input.nextScheduledDate) : null;
+    }
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.examination.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toExamination(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.examination.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('検査記録が見つかりません');
+    }
+    await prisma.examination.delete({ where: { id } });
+  }
+}

--- a/src/data/repositories/server/PrismaHealthLogRepository.ts
+++ b/src/data/repositories/server/PrismaHealthLogRepository.ts
@@ -1,0 +1,69 @@
+/**
+ * サーバーサイド用 体調記録リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  HealthLogRepository,
+  CreateHealthLogInput,
+} from '@/domain/repositories/HealthLogRepository';
+import { HealthLog, ConditionLevel, SymptomType } from '@/domain/entities/HealthLog';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toHealthLog(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  conditionLevel: number;
+  symptoms: string[];
+  notes: string | null;
+  recordedAt: Date;
+  member?: { name: string };
+}): HealthLog {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name ?? '',
+    conditionLevel: row.conditionLevel as ConditionLevel,
+    symptoms: row.symptoms as SymptomType[],
+    notes: row.notes ?? undefined,
+    recordedAt: row.recordedAt,
+  };
+}
+
+export class PrismaHealthLogRepository implements HealthLogRepository {
+  constructor(private readonly userId: string) {}
+
+  async getLogs(): Promise<HealthLog[]> {
+    const rows = await prisma.healthLog.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { recordedAt: 'desc' },
+      take: QUERY_LIMITS.RECORDS,
+    });
+    return rows.map(toHealthLog);
+  }
+
+  async createLog(input: CreateHealthLogInput): Promise<void> {
+    await prisma.healthLog.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        conditionLevel: input.conditionLevel,
+        symptoms: input.symptoms ?? [],
+        notes: input.notes,
+      },
+    });
+  }
+
+  async deleteLog(logId: string): Promise<void> {
+    const existing = await prisma.healthLog.findFirst({
+      where: { id: logId, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('体調記録が見つかりません');
+    }
+    await prisma.healthLog.delete({ where: { id: logId } });
+  }
+}

--- a/src/data/repositories/server/PrismaHospitalRepository.ts
+++ b/src/data/repositories/server/PrismaHospitalRepository.ts
@@ -1,0 +1,101 @@
+/**
+ * サーバーサイド用 病院リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  HospitalRepository,
+  CreateHospitalInput,
+  UpdateHospitalInput,
+} from '@/domain/repositories/HospitalRepository';
+import { Hospital } from '@/domain/entities/Hospital';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toHospital(row: {
+  id: string;
+  userId: string;
+  name: string;
+  hospitalType: string | null;
+  address: string | null;
+  phoneNumber: string | null;
+  department: string | null;
+  doctorName: string | null;
+  notes: string | null;
+  createdAt: Date;
+}): Hospital {
+  return {
+    id: row.id,
+    userId: row.userId,
+    name: row.name,
+    hospitalType: row.hospitalType ?? undefined,
+    address: row.address ?? undefined,
+    phoneNumber: row.phoneNumber ?? undefined,
+    department: row.department ?? undefined,
+    doctorName: row.doctorName ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaHospitalRepository implements HospitalRepository {
+  constructor(private readonly userId: string) {}
+
+  async getHospitals(): Promise<Hospital[]> {
+    const rows = await prisma.hospital.findMany({
+      where: { userId: this.userId },
+      orderBy: { createdAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toHospital);
+  }
+
+  async createHospital(input: CreateHospitalInput): Promise<Hospital> {
+    const row = await prisma.hospital.create({
+      data: {
+        userId: this.userId,
+        name: input.name,
+        hospitalType: input.type,
+        address: input.address,
+        phoneNumber: input.phone,
+        department: input.department,
+        doctorName: input.doctorName,
+        notes: input.notes,
+      },
+    });
+    return toHospital(row);
+  }
+
+  async updateHospital(hospitalId: string, input: UpdateHospitalInput): Promise<Hospital> {
+    const existing = await prisma.hospital.findFirst({
+      where: { id: hospitalId, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('病院が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.name !== undefined) data.name = input.name;
+    if (input.type !== undefined) data.hospitalType = input.type;
+    if (input.address !== undefined) data.address = input.address;
+    if (input.phone !== undefined) data.phoneNumber = input.phone;
+    if (input.department !== undefined) data.department = input.department;
+    if (input.doctorName !== undefined) data.doctorName = input.doctorName;
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.hospital.update({
+      where: { id: hospitalId },
+      data,
+    });
+    return toHospital(row);
+  }
+
+  async deleteHospital(hospitalId: string): Promise<void> {
+    const existing = await prisma.hospital.findFirst({
+      where: { id: hospitalId, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('病院が見つかりません');
+    }
+    await prisma.hospital.delete({ where: { id: hospitalId } });
+  }
+}

--- a/src/data/repositories/server/PrismaInsuranceRepository.ts
+++ b/src/data/repositories/server/PrismaInsuranceRepository.ts
@@ -1,0 +1,97 @@
+/**
+ * サーバーサイド用 保険リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  InsuranceRepository,
+  CreateInsuranceInput,
+  UpdateInsuranceInput,
+} from '@/domain/repositories/InsuranceRepository';
+import { Insurance } from '@/domain/entities/Insurance';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toInsurance(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  insuranceType: string;
+  providerName: string | null;
+  policyNumber: string | null;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): Insurance {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    insuranceType: row.insuranceType,
+    providerName: row.providerName ?? undefined,
+    policyNumber: row.policyNumber ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaInsuranceRepository implements InsuranceRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAll(): Promise<Insurance[]> {
+    const rows = await prisma.insurance.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { createdAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toInsurance);
+  }
+
+  async create(input: CreateInsuranceInput): Promise<Insurance> {
+    const row = await prisma.insurance.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        insuranceType: input.insuranceType,
+        providerName: input.providerName,
+        policyNumber: input.policyNumber,
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toInsurance(row);
+  }
+
+  async update(id: string, input: UpdateInsuranceInput): Promise<Insurance> {
+    const existing = await prisma.insurance.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('保険情報が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.insuranceType !== undefined) data.insuranceType = input.insuranceType;
+    if (input.providerName !== undefined) data.providerName = input.providerName;
+    if (input.policyNumber !== undefined) data.policyNumber = input.policyNumber;
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.insurance.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toInsurance(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.insurance.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('保険情報が見つかりません');
+    }
+    await prisma.insurance.delete({ where: { id } });
+  }
+}

--- a/src/data/repositories/server/PrismaMemberRepository.ts
+++ b/src/data/repositories/server/PrismaMemberRepository.ts
@@ -1,0 +1,139 @@
+/**
+ * サーバーサイド用 メンバーリポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  MemberRepository,
+  CreateMemberInput,
+  UpdateMemberInput,
+} from '@/domain/repositories/MemberRepository';
+import { Member, MemberType, PetType } from '@/domain/entities/Member';
+import { MemberSummary } from '@/domain/entities/MemberSummary';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toMember(row: {
+  id: string;
+  userId: string;
+  memberType: string;
+  name: string;
+  petType: string | null;
+  photoUrl: string | null;
+  birthDate: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}): Member {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberType: row.memberType as MemberType,
+    name: row.name,
+    petType: (row.petType as PetType) ?? undefined,
+    photoUrl: row.photoUrl ?? undefined,
+    birthDate: row.birthDate ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class PrismaMemberRepository implements MemberRepository {
+  constructor(private readonly userId: string) {}
+
+  async getMembers(_userId: string): Promise<Member[]> {
+    const rows = await prisma.member.findMany({
+      where: { userId: this.userId },
+      orderBy: { createdAt: 'asc' },
+      take: QUERY_LIMITS.MEMBERS,
+    });
+    return rows.map(toMember);
+  }
+
+  async getMemberById(memberId: string): Promise<Member | null> {
+    const row = await prisma.member.findUnique({
+      where: { id: memberId },
+    });
+    if (!row || row.userId !== this.userId) return null;
+    return toMember(row);
+  }
+
+  async createMember(input: CreateMemberInput): Promise<Member> {
+    const row = await prisma.member.create({
+      data: {
+        userId: this.userId,
+        name: input.name,
+        memberType: input.memberType ?? 'human',
+        petType: input.petType,
+        birthDate: input.birthDate,
+        notes: input.notes,
+      },
+    });
+    return toMember(row);
+  }
+
+  async updateMember(memberId: string, input: UpdateMemberInput): Promise<Member> {
+    const existing = await prisma.member.findFirst({
+      where: { id: memberId, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('メンバーが見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.name !== undefined) data.name = input.name;
+    if (input.petType !== undefined) data.petType = input.petType;
+    if (input.birthDate !== undefined) data.birthDate = input.birthDate;
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.member.update({
+      where: { id: memberId },
+      data,
+    });
+    return toMember(row);
+  }
+
+  async deleteMember(memberId: string): Promise<void> {
+    const existing = await prisma.member.findFirst({
+      where: { id: memberId, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('メンバーが見つかりません');
+    }
+    await prisma.member.delete({ where: { id: memberId } });
+  }
+
+  async getMemberSummaries(): Promise<MemberSummary[]> {
+    const [members, medications, appointments] = await Promise.all([
+      prisma.member.findMany({
+        where: { userId: this.userId },
+        select: { id: true, name: true, memberType: true },
+        take: QUERY_LIMITS.MEMBERS,
+      }),
+      prisma.medication.findMany({
+        where: { userId: this.userId, isActive: true },
+        select: { memberId: true },
+        take: QUERY_LIMITS.SCHEDULES,
+      }),
+      prisma.appointment.findMany({
+        where: { userId: this.userId, appointmentDate: { gte: new Date() } },
+        select: { memberId: true, appointmentDate: true },
+        orderBy: { appointmentDate: 'asc' },
+        take: QUERY_LIMITS.APPOINTMENTS,
+      }),
+    ]);
+
+    return members.map((member) => {
+      const medicationCount = medications.filter((m) => m.memberId === member.id).length;
+      const nextAppointment = appointments.find((a) => a.memberId === member.id);
+
+      return {
+        memberId: member.id,
+        memberName: member.name,
+        memberType: member.memberType,
+        medicationCount,
+        nextAppointmentDate: nextAppointment?.appointmentDate.toISOString() ?? null,
+      };
+    });
+  }
+}

--- a/src/data/repositories/server/PrismaPrescriptionRepository.ts
+++ b/src/data/repositories/server/PrismaPrescriptionRepository.ts
@@ -1,0 +1,107 @@
+/**
+ * サーバーサイド用 処方箋リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  PrescriptionRepository,
+  CreatePrescriptionInput,
+  UpdatePrescriptionInput,
+} from '@/domain/repositories/PrescriptionRepository';
+import { Prescription } from '@/domain/entities/Prescription';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toPrescription(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  prescriptionName: string;
+  prescribedBy: string | null;
+  prescribedAt: Date;
+  expiresAt: Date | null;
+  pharmacyName: string | null;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): Prescription {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    prescriptionName: row.prescriptionName,
+    prescribedBy: row.prescribedBy ?? undefined,
+    prescribedAt: row.prescribedAt,
+    expiresAt: row.expiresAt ?? undefined,
+    pharmacyName: row.pharmacyName ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaPrescriptionRepository implements PrescriptionRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAll(): Promise<Prescription[]> {
+    const rows = await prisma.prescription.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { prescribedAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toPrescription);
+  }
+
+  async create(input: CreatePrescriptionInput): Promise<Prescription> {
+    const row = await prisma.prescription.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        prescriptionName: input.prescriptionName,
+        prescribedBy: input.prescribedBy,
+        prescribedAt: new Date(input.prescribedAt),
+        expiresAt: input.expiresAt ? new Date(input.expiresAt) : undefined,
+        pharmacyName: input.pharmacyName,
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toPrescription(row);
+  }
+
+  async update(id: string, input: UpdatePrescriptionInput): Promise<Prescription> {
+    const existing = await prisma.prescription.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('処方箋が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.prescriptionName !== undefined) data.prescriptionName = input.prescriptionName;
+    if (input.prescribedBy !== undefined) data.prescribedBy = input.prescribedBy;
+    if (input.prescribedAt !== undefined) data.prescribedAt = new Date(input.prescribedAt);
+    if (input.expiresAt !== undefined) {
+      data.expiresAt = input.expiresAt ? new Date(input.expiresAt) : null;
+    }
+    if (input.pharmacyName !== undefined) data.pharmacyName = input.pharmacyName;
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.prescription.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toPrescription(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.prescription.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('処方箋が見つかりません');
+    }
+    await prisma.prescription.delete({ where: { id } });
+  }
+}

--- a/src/data/repositories/server/PrismaVaccinationRepository.ts
+++ b/src/data/repositories/server/PrismaVaccinationRepository.ts
@@ -1,0 +1,99 @@
+/**
+ * サーバーサイド用 ワクチンリポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  VaccinationRepository,
+  CreateVaccinationInput,
+  UpdateVaccinationInput,
+} from '@/domain/repositories/VaccinationRepository';
+import { Vaccination } from '@/domain/entities/Vaccination';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toVaccination(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  vaccineName: string;
+  vaccinatedAt: Date;
+  nextScheduledDate: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): Vaccination {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    vaccineName: row.vaccineName,
+    vaccinatedAt: row.vaccinatedAt,
+    nextScheduledDate: row.nextScheduledDate ?? undefined,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaVaccinationRepository implements VaccinationRepository {
+  constructor(private readonly userId: string) {}
+
+  async getAll(): Promise<Vaccination[]> {
+    const rows = await prisma.vaccination.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { vaccinatedAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toVaccination);
+  }
+
+  async create(input: CreateVaccinationInput): Promise<Vaccination> {
+    const row = await prisma.vaccination.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        vaccineName: input.vaccineName,
+        vaccinatedAt: new Date(input.vaccinatedAt),
+        nextScheduledDate: input.nextScheduledDate ? new Date(input.nextScheduledDate) : undefined,
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toVaccination(row);
+  }
+
+  async update(id: string, input: UpdateVaccinationInput): Promise<Vaccination> {
+    const existing = await prisma.vaccination.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('ワクチン記録が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.vaccineName !== undefined) data.vaccineName = input.vaccineName;
+    if (input.vaccinatedAt !== undefined) data.vaccinatedAt = new Date(input.vaccinatedAt);
+    if (input.nextScheduledDate !== undefined) {
+      data.nextScheduledDate = input.nextScheduledDate ? new Date(input.nextScheduledDate) : null;
+    }
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.vaccination.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toVaccination(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.vaccination.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('ワクチン記録が見つかりません');
+    }
+    await prisma.vaccination.delete({ where: { id } });
+  }
+}

--- a/src/infrastructure/ServerDIContainer.ts
+++ b/src/infrastructure/ServerDIContainer.ts
@@ -7,14 +7,47 @@
 import { MedicationRepository } from '@/domain/repositories/MedicationRepository';
 import { ScheduleRepository } from '@/domain/repositories/ScheduleRepository';
 import { MedicationRecordRepository } from '@/domain/repositories/MedicationRecordRepository';
+import { HospitalRepository } from '@/domain/repositories/HospitalRepository';
+import { ExaminationRepository } from '@/domain/repositories/ExaminationRepository';
+import { VaccinationRepository } from '@/domain/repositories/VaccinationRepository';
+import { InsuranceRepository } from '@/domain/repositories/InsuranceRepository';
+import { BodyMeasurementRepository } from '@/domain/repositories/BodyMeasurementRepository';
+import { EmergencyContactRepository } from '@/domain/repositories/EmergencyContactRepository';
+import { PrescriptionRepository } from '@/domain/repositories/PrescriptionRepository';
+import { AllergyRepository } from '@/domain/repositories/AllergyRepository';
+import { HealthLogRepository } from '@/domain/repositories/HealthLogRepository';
+import { MemberRepository } from '@/domain/repositories/MemberRepository';
+import { AppointmentRepository } from '@/domain/repositories/AppointmentRepository';
 import { PrismaMedicationRepository } from '@/data/repositories/server/PrismaMedicationRepository';
 import { PrismaScheduleRepository } from '@/data/repositories/server/PrismaScheduleRepository';
 import { PrismaMedicationRecordRepository } from '@/data/repositories/server/PrismaMedicationRecordRepository';
+import { PrismaHospitalRepository } from '@/data/repositories/server/PrismaHospitalRepository';
+import { PrismaExaminationRepository } from '@/data/repositories/server/PrismaExaminationRepository';
+import { PrismaVaccinationRepository } from '@/data/repositories/server/PrismaVaccinationRepository';
+import { PrismaInsuranceRepository } from '@/data/repositories/server/PrismaInsuranceRepository';
+import { PrismaBodyMeasurementRepository } from '@/data/repositories/server/PrismaBodyMeasurementRepository';
+import { PrismaEmergencyContactRepository } from '@/data/repositories/server/PrismaEmergencyContactRepository';
+import { PrismaPrescriptionRepository } from '@/data/repositories/server/PrismaPrescriptionRepository';
+import { PrismaAllergyRepository } from '@/data/repositories/server/PrismaAllergyRepository';
+import { PrismaHealthLogRepository } from '@/data/repositories/server/PrismaHealthLogRepository';
+import { PrismaMemberRepository } from '@/data/repositories/server/PrismaMemberRepository';
+import { PrismaAppointmentRepository } from '@/data/repositories/server/PrismaAppointmentRepository';
 
 export interface ServerDIContainer {
   medicationRepository: MedicationRepository;
   scheduleRepository: ScheduleRepository;
   medicationRecordRepository: MedicationRecordRepository;
+  hospitalRepository: HospitalRepository;
+  examinationRepository: ExaminationRepository;
+  vaccinationRepository: VaccinationRepository;
+  insuranceRepository: InsuranceRepository;
+  bodyMeasurementRepository: BodyMeasurementRepository;
+  emergencyContactRepository: EmergencyContactRepository;
+  prescriptionRepository: PrescriptionRepository;
+  allergyRepository: AllergyRepository;
+  healthLogRepository: HealthLogRepository;
+  memberRepository: MemberRepository;
+  appointmentRepository: AppointmentRepository;
 }
 
 /**
@@ -26,5 +59,16 @@ export function createServerDIContainer(userId: string): ServerDIContainer {
     medicationRepository: new PrismaMedicationRepository(userId),
     scheduleRepository: new PrismaScheduleRepository(userId),
     medicationRecordRepository: new PrismaMedicationRecordRepository(userId),
+    hospitalRepository: new PrismaHospitalRepository(userId),
+    examinationRepository: new PrismaExaminationRepository(userId),
+    vaccinationRepository: new PrismaVaccinationRepository(userId),
+    insuranceRepository: new PrismaInsuranceRepository(userId),
+    bodyMeasurementRepository: new PrismaBodyMeasurementRepository(userId),
+    emergencyContactRepository: new PrismaEmergencyContactRepository(userId),
+    prescriptionRepository: new PrismaPrescriptionRepository(userId),
+    allergyRepository: new PrismaAllergyRepository(userId),
+    healthLogRepository: new PrismaHealthLogRepository(userId),
+    memberRepository: new PrismaMemberRepository(userId),
+    appointmentRepository: new PrismaAppointmentRepository(userId),
   };
 }


### PR DESCRIPTION
## Summary
- 11ドメインのサーバーサイド用Prismaリポジトリを新規作成
- 22 APIルートファイルをPrisma直接からUsecase/Repository経由に変更
- ServerDIContainer に全14リポジトリを統合

### 対象ドメイン
hospitals, examinations, vaccinations, insurances, body-measurements,
emergency-contacts, prescriptions, allergies, health-logs, members, appointments

## Test plan
- [x] 全8434テストがパス
- [x] ビルド成功（ESLintエラーなし）
- [ ] 各ドメインのCRUD操作が正常に動作すること

closes #1060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* **Architecture improvements**: Restructured internal data access layer to enhance code maintainability and separation of concerns across health tracking, member management, and related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->