### PR TITLE
refactor: 残りのクリーンアーキテクチャ違反を修正

### DIFF
--- a/src/app/api/members/[memberId]/profile/route.ts
+++ b/src/app/api/members/[memberId]/profile/route.ts
@@ -1,8 +1,7 @@
-import { prisma } from '@/lib/prisma';
-import { success, notFound, errorResponse } from '@/lib/auth-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, validateParamId } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-import { DateRangeHelper } from '@/domain/entities/DateRange';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
 
 export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
   return withAuth(async (userId) => {
@@ -12,35 +11,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ mem
     const idError = validateParamId(memberId);
     if (idError) return idError;
 
-    const member = await prisma.member.findUnique({ where: { id: memberId } });
-    if (!member || member.userId !== userId) return notFound('メンバー');
+    const container = createServerDIContainer(userId);
+    const profile = await container.memberRepository.getMemberProfile(memberId);
+    if (!profile) return errorResponse('メンバーが見つかりません', 404);
 
-    const [medicationCount, activeScheduleCount, upcomingAppointmentCount] = await Promise.all([
-      prisma.medication.count({ where: { memberId, userId, isActive: true } }),
-      prisma.schedule.count({ where: { memberId, userId, isEnabled: true } }),
-      prisma.appointment.count({
-        where: { memberId, userId, appointmentDate: { gte: new Date() } },
-      }),
-    ]);
-
-    const sevenDaysAgo = DateRangeHelper.daysAgo(7);
-
-    const [recordCount, scheduleCount] = await Promise.all([
-      prisma.medicationRecord.count({ where: { memberId, userId, takenAt: { gte: sevenDaysAgo } } }),
-      prisma.schedule.count({ where: { memberId, userId, isEnabled: true } }),
-    ]);
-
-    const expectedRecords = scheduleCount * 7;
-    const recentAdherenceRate = expectedRecords > 0
-      ? Math.round((recordCount / expectedRecords) * 100)
-      : null;
-
-    return success({
-      member,
-      medicationCount,
-      activeScheduleCount,
-      upcomingAppointmentCount,
-      recentAdherenceRate,
-    });
+    return success(profile);
   })();
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,27 +1,26 @@
-import { prisma } from '@/lib/prisma';
 import { updateUserProfileSchema } from '@/lib/schemas';
-import { success, errorResponse, notFound } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
-
-const USER_SELECT = {
-  id: true,
-  email: true,
-  displayName: true,
-  characterType: true,
-  characterName: true,
-} as const;
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetUserProfile, UpdateUserProfile } from '@/domain/usecases/ManageUserProfile';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`users-me-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: USER_SELECT,
-  });
-  if (!user) return notFound('ユーザー');
 
-  return success(user);
+  const container = createServerDIContainer(userId);
+  const usecase = new GetUserProfile(container.userProfileRepository);
+
+  try {
+    const user = await usecase.execute();
+    return success(user);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'ユーザーが見つかりません') {
+      return errorResponse('ユーザーが見つかりません', 404);
+    }
+    throw error;
+  }
 });
 
 export async function PUT(request: Request) {
@@ -40,11 +39,9 @@ export async function PUT(request: Request) {
     const parsed = updateUserProfileSchema.safeParse(body);
     if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
 
-    const updated = await prisma.user.update({
-      where: { id: userId },
-      data: { displayName: parsed.data.displayName },
-      select: USER_SELECT,
-    });
+    const container = createServerDIContainer(userId);
+    const usecase = new UpdateUserProfile(container.userProfileRepository);
+    const updated = await usecase.execute({ displayName: parsed.data.displayName });
 
     return success(updated);
   })();

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Calendar, List, Plus } from 'lucide-react';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { MedicationHistoryList } from '@/components/history/MedicationHistoryList';
@@ -12,6 +12,7 @@ import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAuth } from '@/hooks/useAuth';
 import { MedicationRecordEntity } from '@/domain/entities/MedicationRecord';
+import { getDIContainer } from '@/infrastructure/DIContainer';
 
 type ViewMode = 'list' | 'calendar';
 
@@ -29,6 +30,12 @@ export default function HistoryPage() {
     () => members.map((m) => ({ id: m.id, name: m.name })),
     [members],
   );
+
+  const fetchMedicationsByMember = useCallback(async (memberId: string) => {
+    const { medicationRepository } = getDIContainer();
+    const meds = await medicationRepository.getMedicationsByMember(memberId);
+    return meds.map((m) => ({ id: m.id, name: m.name, memberId: m.memberId }));
+  }, []);
 
   // メンバーフィルタ適用済みグループ
   const memberFilteredGroups = useMemo(
@@ -135,6 +142,7 @@ export default function HistoryPage() {
                     <AddPastRecordForm
                       selectedDate={selectedDate}
                       members={memberOptions}
+                      fetchMedicationsByMember={fetchMedicationsByMember}
                       onSubmit={createRecord}
                       onClose={() => setShowAddForm(false)}
                     />

--- a/src/components/history/AddPastRecordForm.tsx
+++ b/src/components/history/AddPastRecordForm.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { Plus, X } from 'lucide-react';
-import { apiClient } from '../../data/api/apiClient';
 
 interface Medication {
   id: string;
@@ -18,6 +17,7 @@ interface Member {
 interface AddPastRecordFormProps {
   selectedDate: string;
   members: Member[];
+  fetchMedicationsByMember: (memberId: string) => Promise<Medication[]>;
   onSubmit: (input: {
     memberId: string;
     medicationId: string;
@@ -30,6 +30,7 @@ interface AddPastRecordFormProps {
 export const AddPastRecordForm: React.FC<AddPastRecordFormProps> = ({
   selectedDate,
   members,
+  fetchMedicationsByMember,
   onSubmit,
   onClose,
 }) => {
@@ -46,7 +47,7 @@ export const AddPastRecordForm: React.FC<AddPastRecordFormProps> = ({
       setSelectedMedicationId('');
       return;
     }
-    apiClient.get<Medication[]>(`/medications/member/${selectedMemberId}`)
+    fetchMedicationsByMember(selectedMemberId)
       .then((data) => {
         setMedications(data);
         setSelectedMedicationId('');
@@ -54,7 +55,7 @@ export const AddPastRecordForm: React.FC<AddPastRecordFormProps> = ({
       .catch(() => {
         setMedications([]);
       });
-  }, [selectedMemberId]);
+  }, [selectedMemberId, fetchMedicationsByMember]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/data/repositories/MemberRepositoryImpl.ts
+++ b/src/data/repositories/MemberRepositoryImpl.ts
@@ -10,6 +10,7 @@ import {
 } from '../../domain/repositories/MemberRepository';
 import { Member } from '../../domain/entities/Member';
 import { MemberSummary } from '../../domain/entities/MemberSummary';
+import { MemberProfile } from '../../domain/entities/MemberProfile';
 import { memberApi } from '../api/memberApi';
 
 export class MemberRepositoryImpl implements MemberRepository {
@@ -35,5 +36,10 @@ export class MemberRepositoryImpl implements MemberRepository {
 
   async getMemberSummaries(): Promise<MemberSummary[]> {
     return memberApi.getMemberSummaries();
+  }
+
+  async getMemberProfile(_memberId: string): Promise<MemberProfile | null> {
+    // フロントエンドからは使用しない（サーバーサイド専用）
+    return null;
   }
 }

--- a/src/data/repositories/server/PrismaMemberRepository.ts
+++ b/src/data/repositories/server/PrismaMemberRepository.ts
@@ -10,6 +10,8 @@ import {
 } from '@/domain/repositories/MemberRepository';
 import { Member, MemberType, PetType } from '@/domain/entities/Member';
 import { MemberSummary } from '@/domain/entities/MemberSummary';
+import { MemberProfile } from '@/domain/entities/MemberProfile';
+import { DateRangeHelper } from '@/domain/entities/DateRange';
 import { QUERY_LIMITS } from '@/lib/constants';
 
 function toMember(row: {
@@ -135,5 +137,40 @@ export class PrismaMemberRepository implements MemberRepository {
         nextAppointmentDate: nextAppointment?.appointmentDate.toISOString() ?? null,
       };
     });
+  }
+
+  async getMemberProfile(memberId: string): Promise<MemberProfile | null> {
+    const row = await prisma.member.findUnique({ where: { id: memberId } });
+    if (!row || row.userId !== this.userId) return null;
+
+    const member = toMember(row);
+
+    const [medicationCount, activeScheduleCount, upcomingAppointmentCount] = await Promise.all([
+      prisma.medication.count({ where: { memberId, userId: this.userId, isActive: true } }),
+      prisma.schedule.count({ where: { memberId, userId: this.userId, isEnabled: true } }),
+      prisma.appointment.count({
+        where: { memberId, userId: this.userId, appointmentDate: { gte: new Date() } },
+      }),
+    ]);
+
+    const sevenDaysAgo = DateRangeHelper.daysAgo(7);
+
+    const [recordCount, scheduleCount] = await Promise.all([
+      prisma.medicationRecord.count({ where: { memberId, userId: this.userId, takenAt: { gte: sevenDaysAgo } } }),
+      prisma.schedule.count({ where: { memberId, userId: this.userId, isEnabled: true } }),
+    ]);
+
+    const expectedRecords = scheduleCount * 7;
+    const recentAdherenceRate = expectedRecords > 0
+      ? Math.round((recordCount / expectedRecords) * 100)
+      : null;
+
+    return {
+      member,
+      medicationCount,
+      activeScheduleCount,
+      upcomingAppointmentCount,
+      recentAdherenceRate,
+    };
   }
 }

--- a/src/data/repositories/server/PrismaUserProfileRepository.ts
+++ b/src/data/repositories/server/PrismaUserProfileRepository.ts
@@ -1,0 +1,54 @@
+/**
+ * サーバーサイド用 ユーザープロフィールリポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  UserProfileRepository,
+  UserProfile,
+  UpdateUserProfileInput,
+} from '@/domain/repositories/UserProfileRepository';
+
+const USER_SELECT = {
+  id: true,
+  email: true,
+  displayName: true,
+  characterType: true,
+  characterName: true,
+} as const;
+
+export class PrismaUserProfileRepository implements UserProfileRepository {
+  constructor(private readonly userId: string) {}
+
+  async getProfile(): Promise<UserProfile> {
+    const user = await prisma.user.findUnique({
+      where: { id: this.userId },
+      select: USER_SELECT,
+    });
+    if (!user) {
+      throw new Error('ユーザーが見つかりません');
+    }
+    return {
+      id: user.id,
+      email: user.email,
+      displayName: user.displayName,
+      characterType: user.characterType,
+      characterName: user.characterName,
+    };
+  }
+
+  async updateProfile(input: UpdateUserProfileInput): Promise<UserProfile> {
+    const updated = await prisma.user.update({
+      where: { id: this.userId },
+      data: { displayName: input.displayName },
+      select: USER_SELECT,
+    });
+    return {
+      id: updated.id,
+      email: updated.email,
+      displayName: updated.displayName,
+      characterType: updated.characterType,
+      characterName: updated.characterName,
+    };
+  }
+}

--- a/src/domain/repositories/MemberRepository.ts
+++ b/src/domain/repositories/MemberRepository.ts
@@ -5,6 +5,7 @@
 
 import { Member } from '../entities/Member';
 import { MemberSummary } from '../entities/MemberSummary';
+import { MemberProfile } from '../entities/MemberProfile';
 
 export interface CreateMemberInput {
   userId: string;
@@ -29,4 +30,5 @@ export interface MemberRepository {
   updateMember(memberId: string, input: UpdateMemberInput): Promise<Member>;
   deleteMember(memberId: string): Promise<void>;
   getMemberSummaries(): Promise<MemberSummary[]>;
+  getMemberProfile(memberId: string): Promise<MemberProfile | null>;
 }

--- a/src/infrastructure/ServerDIContainer.ts
+++ b/src/infrastructure/ServerDIContainer.ts
@@ -18,6 +18,7 @@ import { AllergyRepository } from '@/domain/repositories/AllergyRepository';
 import { HealthLogRepository } from '@/domain/repositories/HealthLogRepository';
 import { MemberRepository } from '@/domain/repositories/MemberRepository';
 import { AppointmentRepository } from '@/domain/repositories/AppointmentRepository';
+import { UserProfileRepository } from '@/domain/repositories/UserProfileRepository';
 import { PrismaMedicationRepository } from '@/data/repositories/server/PrismaMedicationRepository';
 import { PrismaScheduleRepository } from '@/data/repositories/server/PrismaScheduleRepository';
 import { PrismaMedicationRecordRepository } from '@/data/repositories/server/PrismaMedicationRecordRepository';
@@ -32,6 +33,7 @@ import { PrismaAllergyRepository } from '@/data/repositories/server/PrismaAllerg
 import { PrismaHealthLogRepository } from '@/data/repositories/server/PrismaHealthLogRepository';
 import { PrismaMemberRepository } from '@/data/repositories/server/PrismaMemberRepository';
 import { PrismaAppointmentRepository } from '@/data/repositories/server/PrismaAppointmentRepository';
+import { PrismaUserProfileRepository } from '@/data/repositories/server/PrismaUserProfileRepository';
 
 export interface ServerDIContainer {
   medicationRepository: MedicationRepository;
@@ -48,6 +50,7 @@ export interface ServerDIContainer {
   healthLogRepository: HealthLogRepository;
   memberRepository: MemberRepository;
   appointmentRepository: AppointmentRepository;
+  userProfileRepository: UserProfileRepository;
 }
 
 /**
@@ -70,5 +73,6 @@ export function createServerDIContainer(userId: string): ServerDIContainer {
     healthLogRepository: new PrismaHealthLogRepository(userId),
     memberRepository: new PrismaMemberRepository(userId),
     appointmentRepository: new PrismaAppointmentRepository(userId),
+    userProfileRepository: new PrismaUserProfileRepository(userId),
   };
 }


### PR DESCRIPTION
## Summary
- `AddPastRecordForm` の `apiClient` 直接import をコールバックprops経由に変更（レイヤー違反修正）
- `members/[memberId]/profile` ルートをRepository経由に変更
- `users/me` ルートをUsecase/Repository経由に変更
- `PrismaUserProfileRepository` を新規作成
- `MemberRepository` に `getMemberProfile` メソッドを追加

## Test plan
- [x] 全8434テストがパス
- [x] ビルド成功
- [ ] 過去記録追加フォームが正常動作すること
- [ ] メンバープロフィール取得が正常動作すること
- [ ] ユーザープロフィール取得・更新が正常動作すること

closes #1062