### PR TITLE
refactor: notifications/send APIルートをクリーンアーキテクチャに準拠させる

### DIFF
--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
-import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { success, errorResponse } from '@/lib/auth-helpers';
-import { withAuth, validateBodySize , safeParseJson } from '@/lib/api-helpers';
+import { withAuth, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
 
 const sendNotificationSchema = z.object({
   type: z.enum(['medication_reminder', 'missed_medication', 'appointment_reminder', 'low_stock']),
@@ -33,12 +33,11 @@ export async function POST(request: NextRequest) {
 
     const { type, memberId, medicationId, appointmentId } = parsed.data;
 
-    const user = await prisma.user.findUnique({ where: { id: userId } });
-    if (!user) return errorResponse('認証エラー', 401);
+    const container = createServerDIContainer(userId);
 
-    const member = await prisma.member.findFirst({
-      where: { id: memberId, userId },
-    });
+    const userProfile = await container.userProfileRepository.getProfile();
+
+    const member = await container.memberRepository.getMemberById(memberId);
     if (!member) {
       return errorResponse('メンバーが見つかりません', 404);
     }
@@ -49,9 +48,7 @@ export async function POST(request: NextRequest) {
         if (!medicationId) {
           return errorResponse('薬IDは必須です');
         }
-        const medication = await prisma.medication.findFirst({
-          where: { id: medicationId, userId },
-        });
+        const medication = await container.medicationRepository.getMedicationById(medicationId);
         if (!medication) {
           return errorResponse('薬が見つかりません', 404);
         }
@@ -66,7 +63,7 @@ export async function POST(request: NextRequest) {
               medicationName: medication.name,
               scheduledTime: new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }),
             });
-        await sendEmail({ to: user.email, ...template });
+        await sendEmail({ to: userProfile.email, ...template });
         break;
       }
 
@@ -74,20 +71,17 @@ export async function POST(request: NextRequest) {
         if (!appointmentId) {
           return errorResponse('予約IDは必須です');
         }
-        const appointment = await prisma.appointment.findFirst({
-          where: { id: appointmentId, userId },
-          include: { hospital: true },
-        });
+        const appointment = await container.appointmentRepository.getAppointmentById(appointmentId);
         if (!appointment) {
           return errorResponse('予約が見つかりません', 404);
         }
         const template = emailTemplates.appointmentReminder({
           memberName: member.name,
-          hospitalName: appointment.hospital?.name ?? '未設定',
+          hospitalName: appointment.hospitalName ?? '未設定',
           appointmentDate: appointment.appointmentDate.toLocaleDateString('ja-JP'),
-          description: appointment.description ?? undefined,
+          description: appointment.description,
         });
-        await sendEmail({ to: user.email, ...template });
+        await sendEmail({ to: userProfile.email, ...template });
         break;
       }
 
@@ -95,9 +89,7 @@ export async function POST(request: NextRequest) {
         if (!medicationId) {
           return errorResponse('薬IDは必須です');
         }
-        const medication = await prisma.medication.findFirst({
-          where: { id: medicationId, userId },
-        });
+        const medication = await container.medicationRepository.getMedicationById(medicationId);
         if (!medication) {
           return errorResponse('薬が見つかりません', 404);
         }
@@ -116,7 +108,7 @@ export async function POST(request: NextRequest) {
           alertDate,
           daysUntilAlert,
         });
-        await sendEmail({ to: user.email, ...template });
+        await sendEmail({ to: userProfile.email, ...template });
         break;
       }
     }

--- a/src/data/repositories/AppointmentRepositoryImpl.ts
+++ b/src/data/repositories/AppointmentRepositoryImpl.ts
@@ -15,6 +15,11 @@ export class AppointmentRepositoryImpl implements AppointmentRepository {
     return appointmentApi.getAppointments();
   }
 
+  async getAppointmentById(_appointmentId: string): Promise<Appointment | null> {
+    // フロントエンドからは使用しない（サーバーサイド専用）
+    return null;
+  }
+
   async createAppointment(input: CreateAppointmentInput): Promise<Appointment> {
     return appointmentApi.createAppointment(input);
   }

--- a/src/data/repositories/server/PrismaAppointmentRepository.ts
+++ b/src/data/repositories/server/PrismaAppointmentRepository.ts
@@ -44,6 +44,17 @@ function toAppointment(row: {
 export class PrismaAppointmentRepository implements AppointmentRepository {
   constructor(private readonly userId: string) {}
 
+  async getAppointmentById(appointmentId: string): Promise<Appointment | null> {
+    const row = await prisma.appointment.findFirst({
+      where: { id: appointmentId, userId: this.userId },
+      include: {
+        member: { select: { name: true } },
+        hospital: { select: { name: true } },
+      },
+    });
+    return row ? toAppointment(row) : null;
+  }
+
   async getAppointments(): Promise<Appointment[]> {
     const rows = await prisma.appointment.findMany({
       where: { userId: this.userId },

--- a/src/domain/repositories/AppointmentRepository.ts
+++ b/src/domain/repositories/AppointmentRepository.ts
@@ -25,6 +25,7 @@ export interface UpdateAppointmentInput {
 
 export interface AppointmentRepository {
   getAppointments(): Promise<Appointment[]>;
+  getAppointmentById(appointmentId: string): Promise<Appointment | null>;
   createAppointment(input: CreateAppointmentInput): Promise<Appointment>;
   updateAppointment(appointmentId: string, input: UpdateAppointmentInput): Promise<Appointment>;
   deleteAppointment(appointmentId: string): Promise<void>;


### PR DESCRIPTION
## Summary
- `notifications/send` ルートのPrisma直接呼び出しをRepository経由に変更
- `AppointmentRepository` に `getAppointmentById` メソッドを追加
- これで全APIルートのクリーンアーキテクチャ違反が解消

## Test plan
- [x] 全8434テストがパス
- [x] ビルド成功
- [ ] 各種通知（服薬リマインダー、飲み忘れ、通院、在庫不足）が正常に送信されること

closes #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed appointment reminder emails to correctly display hospital names and descriptions.

* **Chores**
  * Refactored internal notification system architecture to improve code maintainability and add appointment lookup capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->