### PR TITLE
test: 通知設定機能のエッジケーステスト追加

### DIFF
--- a/src/__tests__/components/notification-settings/NotificationSettingsForm.edge.test.tsx
+++ b/src/__tests__/components/notification-settings/NotificationSettingsForm.edge.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { NotificationSettingsForm } from '../../../components/notification-settings/NotificationSettingsForm';
+import { NotificationSetting } from '../../../domain/entities/NotificationSetting';
+
+const mockSetting: NotificationSetting = {
+  id: 'ns-1',
+  userId: 'user-1',
+  medicationReminderEnabled: true,
+  missedMedicationEnabled: true,
+  appointmentReminderEnabled: true,
+  lowStockAlertEnabled: true,
+  defaultReminderMinutesBefore: 5,
+  defaultAppointmentReminderDaysBefore: 1,
+  emailNotificationEnabled: true,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+describe('NotificationSettingsForm エッジケース', () => {
+  let mockOnSave: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockOnSave = vi.fn().mockResolvedValue(undefined);
+  });
+
+  it('メール通知無効時は個別トグルが無効化される', () => {
+    const disabledSetting: NotificationSetting = {
+      ...mockSetting,
+      emailNotificationEnabled: false,
+    };
+
+    render(
+      <NotificationSettingsForm setting={disabledSetting} onSave={mockOnSave} isLoading={false} />,
+    );
+
+    const medicationToggle = screen.getByLabelText('服薬リマインダーの切り替え');
+    expect(medicationToggle).toBeDisabled();
+  });
+
+  it('保存失敗時にメール通知トグルがロールバックされる', async () => {
+    mockOnSave.mockRejectedValueOnce(new Error('保存失敗'));
+
+    render(
+      <NotificationSettingsForm setting={mockSetting} onSave={mockOnSave} isLoading={false} />,
+    );
+
+    const emailToggle = screen.getByLabelText('メール通知の切り替え');
+    fireEvent.click(emailToggle);
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith({ emailNotificationEnabled: false });
+    });
+
+    // ロールバックの確認: aria-checkedがtrueに戻る
+    await waitFor(() => {
+      expect(emailToggle.getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('保存失敗時に個別通知トグルがロールバックされる', async () => {
+    mockOnSave.mockRejectedValueOnce(new Error('保存失敗'));
+
+    render(
+      <NotificationSettingsForm setting={mockSetting} onSave={mockOnSave} isLoading={false} />,
+    );
+
+    const toggle = screen.getByLabelText('飲み忘れ通知の切り替え');
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith({ missedMedicationEnabled: false });
+    });
+
+    await waitFor(() => {
+      expect(toggle.getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('全通知が無効の設定が正しく表示される', () => {
+    const allDisabled: NotificationSetting = {
+      ...mockSetting,
+      medicationReminderEnabled: false,
+      missedMedicationEnabled: false,
+      appointmentReminderEnabled: false,
+      lowStockAlertEnabled: false,
+      emailNotificationEnabled: false,
+    };
+
+    render(
+      <NotificationSettingsForm setting={allDisabled} onSave={mockOnSave} isLoading={false} />,
+    );
+
+    const emailToggle = screen.getByLabelText('メール通知の切り替え');
+    expect(emailToggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('リマインダー0分（なし）が正しく表示される', () => {
+    const zeroMinutes: NotificationSetting = {
+      ...mockSetting,
+      defaultReminderMinutesBefore: 0,
+    };
+
+    render(
+      <NotificationSettingsForm setting={zeroMinutes} onSave={mockOnSave} isLoading={false} />,
+    );
+
+    expect(screen.getByDisplayValue('なし')).toBeTruthy();
+  });
+
+  it('通院リマインダー当日が正しく表示される', () => {
+    const zeroDays: NotificationSetting = {
+      ...mockSetting,
+      defaultAppointmentReminderDaysBefore: 0,
+    };
+
+    render(
+      <NotificationSettingsForm setting={zeroDays} onSave={mockOnSave} isLoading={false} />,
+    );
+
+    expect(screen.getByDisplayValue('当日')).toBeTruthy();
+  });
+
+  it('htmlForとidの関連付けが正しい', () => {
+    render(
+      <NotificationSettingsForm setting={mockSetting} onSave={mockOnSave} isLoading={false} />,
+    );
+
+    const reminderLabel = document.querySelector('label[for="reminder-minutes"]');
+    const reminderSelect = document.querySelector('#reminder-minutes');
+    expect(reminderLabel).toBeTruthy();
+    expect(reminderSelect).toBeTruthy();
+
+    const appointmentLabel = document.querySelector('label[for="appointment-days"]');
+    const appointmentSelect = document.querySelector('#appointment-days');
+    expect(appointmentLabel).toBeTruthy();
+    expect(appointmentSelect).toBeTruthy();
+  });
+});

--- a/src/__tests__/domain/entities/NotificationSetting.edge.test.ts
+++ b/src/__tests__/domain/entities/NotificationSetting.edge.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  NotificationSetting,
+  createNotificationSetting,
+  isNotificationEnabled,
+  getDefaultReminderMinutes,
+  NOTIFICATION_TYPES,
+  NotificationType,
+} from '../../../domain/entities/NotificationSetting';
+
+describe('NotificationSetting エッジケース', () => {
+  describe('isNotificationEnabled - 全組み合わせ', () => {
+    const types: NotificationType[] = [
+      'medication_reminder',
+      'missed_medication',
+      'appointment_reminder',
+      'low_stock',
+    ];
+    const fieldMap: Record<NotificationType, keyof NotificationSetting> = {
+      medication_reminder: 'medicationReminderEnabled',
+      missed_medication: 'missedMedicationEnabled',
+      appointment_reminder: 'appointmentReminderEnabled',
+      low_stock: 'lowStockAlertEnabled',
+    };
+
+    const baseSetting: NotificationSetting = {
+      id: 'ns-1',
+      userId: 'user-1',
+      medicationReminderEnabled: true,
+      missedMedicationEnabled: true,
+      appointmentReminderEnabled: true,
+      lowStockAlertEnabled: true,
+      defaultReminderMinutesBefore: 5,
+      defaultAppointmentReminderDaysBefore: 1,
+      emailNotificationEnabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it.each(types)('メール有効・%s有効 → true', (type) => {
+      expect(isNotificationEnabled(baseSetting, type)).toBe(true);
+    });
+
+    it.each(types)('メール無効 → %s は常にfalse', (type) => {
+      const setting = { ...baseSetting, emailNotificationEnabled: false };
+      expect(isNotificationEnabled(setting, type)).toBe(false);
+    });
+
+    it.each(types)('メール有効・%s無効 → false', (type) => {
+      const field = fieldMap[type];
+      const setting = { ...baseSetting, [field]: false };
+      expect(isNotificationEnabled(setting, type)).toBe(false);
+    });
+  });
+
+  describe('createNotificationSetting', () => {
+    it('全フィールドをオーバーライドできる', () => {
+      const setting = createNotificationSetting('user-1', {
+        medicationReminderEnabled: false,
+        missedMedicationEnabled: false,
+        appointmentReminderEnabled: false,
+        lowStockAlertEnabled: false,
+        defaultReminderMinutesBefore: 60,
+        defaultAppointmentReminderDaysBefore: 7,
+        emailNotificationEnabled: false,
+      });
+
+      expect(setting.medicationReminderEnabled).toBe(false);
+      expect(setting.missedMedicationEnabled).toBe(false);
+      expect(setting.appointmentReminderEnabled).toBe(false);
+      expect(setting.lowStockAlertEnabled).toBe(false);
+      expect(setting.defaultReminderMinutesBefore).toBe(60);
+      expect(setting.defaultAppointmentReminderDaysBefore).toBe(7);
+      expect(setting.emailNotificationEnabled).toBe(false);
+    });
+
+    it('userIdが正しく設定される', () => {
+      const setting = createNotificationSetting('test-user-123');
+      expect(setting.userId).toBe('test-user-123');
+    });
+  });
+
+  describe('getDefaultReminderMinutes', () => {
+    it('0分を返す設定', () => {
+      const setting: NotificationSetting = {
+        id: 'ns-1',
+        userId: 'user-1',
+        medicationReminderEnabled: true,
+        missedMedicationEnabled: true,
+        appointmentReminderEnabled: true,
+        lowStockAlertEnabled: true,
+        defaultReminderMinutesBefore: 0,
+        defaultAppointmentReminderDaysBefore: 0,
+        emailNotificationEnabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      expect(getDefaultReminderMinutes(setting)).toBe(0);
+    });
+  });
+
+  describe('NOTIFICATION_TYPES', () => {
+    it('全ての通知タイプキーがユニーク', () => {
+      const keys = NOTIFICATION_TYPES.map((t) => t.key);
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('通知タイプのラベルが日本語', () => {
+      NOTIFICATION_TYPES.forEach((type) => {
+        expect(type.label).toMatch(/[\u3040-\u9FFF]/);
+        expect(type.description).toMatch(/[\u3040-\u9FFF]/);
+      });
+    });
+  });
+});

--- a/src/__tests__/domain/usecases/ManageNotificationSettings.edge.test.ts
+++ b/src/__tests__/domain/usecases/ManageNotificationSettings.edge.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GetNotificationSetting,
+  UpdateNotificationSetting,
+} from '../../../domain/usecases/ManageNotificationSettings';
+import {
+  NotificationSettingRepository,
+  UpdateNotificationSettingInput,
+} from '../../../domain/repositories/NotificationSettingRepository';
+import { NotificationSetting } from '../../../domain/entities/NotificationSetting';
+
+const mockSetting: NotificationSetting = {
+  id: 'ns-1',
+  userId: 'user-1',
+  medicationReminderEnabled: true,
+  missedMedicationEnabled: true,
+  appointmentReminderEnabled: true,
+  lowStockAlertEnabled: true,
+  defaultReminderMinutesBefore: 5,
+  defaultAppointmentReminderDaysBefore: 1,
+  emailNotificationEnabled: true,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+const createMockRepository = (): NotificationSettingRepository => ({
+  get: vi.fn(),
+  upsert: vi.fn(),
+});
+
+describe('ManageNotificationSettings エッジケース', () => {
+  let mockRepository: NotificationSettingRepository;
+
+  beforeEach(() => {
+    mockRepository = createMockRepository();
+  });
+
+  describe('UpdateNotificationSetting 許可値バリデーション', () => {
+    const allowedMinutes = [0, 5, 10, 15, 30, 60];
+    const allowedDays = [0, 1, 2, 3, 7];
+
+    it.each(allowedMinutes)('リマインダー分数 %d は許可される', async (minutes) => {
+      const input: UpdateNotificationSettingInput = {
+        defaultReminderMinutesBefore: minutes,
+      };
+      vi.mocked(mockRepository.upsert).mockResolvedValue({
+        ...mockSetting,
+        defaultReminderMinutesBefore: minutes,
+      });
+
+      const useCase = new UpdateNotificationSetting(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result.defaultReminderMinutesBefore).toBe(minutes);
+    });
+
+    it.each(allowedDays)('リマインダー日数 %d は許可される', async (days) => {
+      const input: UpdateNotificationSettingInput = {
+        defaultAppointmentReminderDaysBefore: days,
+      };
+      vi.mocked(mockRepository.upsert).mockResolvedValue({
+        ...mockSetting,
+        defaultAppointmentReminderDaysBefore: days,
+      });
+
+      const useCase = new UpdateNotificationSetting(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result.defaultAppointmentReminderDaysBefore).toBe(days);
+    });
+
+    it.each([1, 2, 3, 4, 6, 7, 8, 20, 45, 90, 120])('リマインダー分数 %d は不正', async (minutes) => {
+      const input: UpdateNotificationSettingInput = {
+        defaultReminderMinutesBefore: minutes,
+      };
+      const useCase = new UpdateNotificationSetting(mockRepository);
+
+      if ([0, 5, 10, 15, 30, 60].includes(minutes)) return;
+      await expect(useCase.execute(input)).rejects.toThrow('リマインダー時間の値が不正です');
+    });
+
+    it.each([4, 5, 6, 8, 10, 14, 30])('リマインダー日数 %d は不正', async (days) => {
+      const input: UpdateNotificationSettingInput = {
+        defaultAppointmentReminderDaysBefore: days,
+      };
+      const useCase = new UpdateNotificationSetting(mockRepository);
+      await expect(useCase.execute(input)).rejects.toThrow('リマインダー日数の値が不正です');
+    });
+
+    it('全フィールドを同時に更新できる', async () => {
+      const input: UpdateNotificationSettingInput = {
+        medicationReminderEnabled: false,
+        missedMedicationEnabled: false,
+        appointmentReminderEnabled: false,
+        lowStockAlertEnabled: false,
+        defaultReminderMinutesBefore: 30,
+        defaultAppointmentReminderDaysBefore: 3,
+        emailNotificationEnabled: false,
+      };
+      const updated = { ...mockSetting, ...input };
+      vi.mocked(mockRepository.upsert).mockResolvedValue(updated);
+
+      const useCase = new UpdateNotificationSetting(mockRepository);
+      const result = await useCase.execute(input);
+
+      expect(result.medicationReminderEnabled).toBe(false);
+      expect(result.emailNotificationEnabled).toBe(false);
+      expect(result.defaultReminderMinutesBefore).toBe(30);
+      expect(mockRepository.upsert).toHaveBeenCalledWith(input);
+    });
+
+    it('空のオブジェクトを渡してもリポジトリが呼ばれる', async () => {
+      vi.mocked(mockRepository.upsert).mockResolvedValue(mockSetting);
+      const useCase = new UpdateNotificationSetting(mockRepository);
+      await useCase.execute({});
+      expect(mockRepository.upsert).toHaveBeenCalledWith({});
+    });
+  });
+
+  describe('GetNotificationSetting', () => {
+    it('リポジトリがエラーを返す場合そのまま伝播する', async () => {
+      vi.mocked(mockRepository.get).mockRejectedValue(new Error('DB接続エラー'));
+      const useCase = new GetNotificationSetting(mockRepository);
+      await expect(useCase.execute()).rejects.toThrow('DB接続エラー');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
サイクル1で追加した通知設定機能のテスト品質を向上させる。

## 追加テスト
- **ユースケース (32件)**: 許可値バリデーションの全パターン、全フィールド同時更新、空入力、エラー伝播
- **エンティティ (17件)**: 全通知タイプ×メール有効/無効の組み合わせ、createの全オーバーライド、ラベルの日本語検証
- **コンポーネント (7件)**: メール無効時のトグル無効化、保存失敗時のUIロールバック、アクセシビリティ属性検証

## テスト結果
- 新規テスト: 56件
- 全テスト: 合格

Closes #1070