### PR TITLE
feat: 服薬データのCSVエクスポート機能 (#1075)

### DIFF
--- a/src/__tests__/domain/entities/CsvExport.test.ts
+++ b/src/__tests__/domain/entities/CsvExport.test.ts
@@ -32,14 +32,11 @@ describe('CsvExportEntity', () => {
       expect(csv.charCodeAt(0)).toBe(0xFEFF); // BOM
     });
 
-    it('ヘッダー行が日本語で出力される', () => {
+    it('ヘッダー行が正確に出力される', () => {
       const csv = CsvExportEntity.toCsvString(sampleRecords);
       const lines = csv.split('\n');
-      expect(lines[0]).toContain('日付');
-      expect(lines[0]).toContain('メンバー');
-      expect(lines[0]).toContain('お薬名');
-      expect(lines[0]).toContain('服薬時刻');
-      expect(lines[0]).toContain('メモ');
+      const header = lines[0].replace(/^\uFEFF/, '');
+      expect(header).toBe('日付,メンバー名,お薬名,服薬時刻,メモ');
     });
 
     it('レコードが正しくCSV行に変換される', () => {
@@ -84,6 +81,19 @@ describe('CsvExportEntity', () => {
       ];
       const csv = CsvExportEntity.toCsvString(records);
       expect(csv).toContain('"""重要""なメモ"');
+    });
+    it('数式として解釈される先頭文字が無害化される', () => {
+      const formulaTests = ['=1+1', '+cmd', '-danger', '@SUM(A1)'];
+      for (const notes of formulaTests) {
+        const records: MedicationRecord[] = [
+          { ...sampleRecords[0], notes },
+        ];
+        const csv = CsvExportEntity.toCsvString(records);
+        // 先頭にシングルクォートが付加されること
+        expect(csv).toContain(`'${notes}`);
+        // 元の値がそのまま出力されないこと
+        expect(csv).not.toContain(`,${notes}`);
+      }
     });
   });
 

--- a/src/app/api/records/export/route.ts
+++ b/src/app/api/records/export/route.ts
@@ -5,22 +5,48 @@ import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
 import { GetMedicationHistory } from '@/domain/usecases/ManageMedicationRecords';
 import { CsvExportEntity } from '@/domain/entities/CsvExport';
 
-export const GET = withAuth(async (userId) => {
-  const { allowed } = checkRateLimit(`records-export:${userId}`, { maxAttempts: 5, windowMs: 60000 });
-  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+export async function GET(request: Request) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`records-export:${userId}`, { maxAttempts: 5, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
 
-  const container = createServerDIContainer(userId);
-  const usecase = new GetMedicationHistory(container.medicationRecordRepository);
-  const groups = await usecase.execute();
-  const records = groups.flatMap((g) => g.records);
+    const url = new URL(request.url);
+    const memberId = url.searchParams.get('memberId');
+    const from = url.searchParams.get('from');
+    const to = url.searchParams.get('to');
 
-  const csv = CsvExportEntity.toCsvString(records);
-  const filename = CsvExportEntity.getFilename();
+    const container = createServerDIContainer(userId);
+    const usecase = new GetMedicationHistory(container.medicationRecordRepository);
+    const groups = await usecase.execute();
+    let records = groups.flatMap((g) => g.records);
 
-  return new Response(csv, {
-    headers: {
-      'Content-Type': 'text/csv; charset=utf-8',
-      'Content-Disposition': `attachment; filename="${encodeURIComponent(filename)}"`,
-    },
-  });
-});
+    if (memberId) {
+      records = records.filter((r) => r.memberId === memberId);
+    }
+    if (from) {
+      const fromDate = new Date(from);
+      if (!isNaN(fromDate.getTime())) {
+        records = records.filter((r) => r.takenAt >= fromDate);
+      }
+    }
+    if (to) {
+      const toDate = new Date(to);
+      if (!isNaN(toDate.getTime())) {
+        toDate.setHours(23, 59, 59, 999);
+        records = records.filter((r) => r.takenAt <= toDate);
+      }
+    }
+
+    const csv = CsvExportEntity.toCsvString(records);
+    const filename = CsvExportEntity.getFilename();
+
+    return new Response(csv, {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="medication_history.csv"; filename*=UTF-8''${encodeURIComponent(filename)}`,
+        'Cache-Control': 'no-store',
+        'Pragma': 'no-cache',
+      },
+    });
+  })();
+}

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -85,7 +85,7 @@ export default function HistoryPage() {
           <h1 className="text-xl font-bold text-primary-600">服薬履歴</h1>
           <div className="flex items-center space-x-2">
             <a
-              href="/api/records/export"
+              href={`/api/records/export${selectedMemberId ? `?memberId=${encodeURIComponent(selectedMemberId)}` : ''}`}
               download
               className="p-1.5 text-gray-500 hover:text-primary-600 transition-colors"
               aria-label="CSVエクスポート"

--- a/src/domain/entities/CsvExport.ts
+++ b/src/domain/entities/CsvExport.ts
@@ -1,10 +1,15 @@
 import { MedicationRecord } from './MedicationRecord';
 
 function escapeCsvField(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-    return `"${value.replace(/"/g, '""')}"`;
+  // CSVインジェクション対策: 数式として解釈される先頭文字を無害化
+  let sanitized = value;
+  if (/^[=+\-@]/.test(sanitized)) {
+    sanitized = `'${sanitized}`;
   }
-  return value;
+  if (sanitized.includes(',') || sanitized.includes('"') || sanitized.includes('\n') || sanitized !== value) {
+    return `"${sanitized.replace(/"/g, '""')}"`;
+  }
+  return sanitized;
 }
 
 function formatDateJST(date: Date): string {
@@ -22,7 +27,7 @@ function formatTimeJST(date: Date): string {
   return `${h}:${min}`;
 }
 
-const CSV_HEADERS = ['日付', 'メンバー', 'お薬名', '服薬時刻', 'メモ'];
+const CSV_HEADERS = ['日付', 'メンバー名', 'お薬名', '服薬時刻', 'メモ'];
 const BOM = '\uFEFF';
 
 export class CsvExportEntity {
@@ -42,10 +47,10 @@ export class CsvExportEntity {
   }
 
   static getFilename(): string {
-    const now = new Date();
-    const y = now.getFullYear();
-    const m = String(now.getMonth() + 1).padStart(2, '0');
-    const d = String(now.getDate()).padStart(2, '0');
+    const jst = new Date(Date.now() + 9 * 60 * 60 * 1000);
+    const y = jst.getUTCFullYear();
+    const m = String(jst.getUTCMonth() + 1).padStart(2, '0');
+    const d = String(jst.getUTCDate()).padStart(2, '0');
     return `服薬履歴_${y}-${m}-${d}.csv`;
   }
 }


### PR DESCRIPTION
## Summary
- 服薬履歴データをCSV形式でエクスポートする機能を追加
- BOM付きUTF-8でExcelでの文字化けを防止
- カンマ・ダブルクォートのエスケープ処理対応
- 履歴ページヘッダーにダウンロードアイコンを追加
- CsvExportEntityのユニットテスト8件追加（TDD開発）
- APIレート制限あり（5回/分）

Closes #1075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download medication history as UTF‑8 CSV from the history page (download button added).
  * Exports respect selected member and date range; filenames use a daily, localized pattern (e.g., 服薬履歴_YYYY-MM-DD.csv).

* **Stability**
  * Per‑user rate limiting for exports with a clear retry response when limits are exceeded.

* **Tests**
  * Added comprehensive tests covering CSV output, encoding, escaping, and filename generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->