### PR TITLE
feat: お薬の重複登録チェック機能 (#1077)

### DIFF
--- a/src/__tests__/domain/usecases/CreateMedicationDuplicate.test.ts
+++ b/src/__tests__/domain/usecases/CreateMedicationDuplicate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { CreateMedicationWithSchedule } from '../../../domain/usecases/ManageMedications';
+import { CreateMedicationWithSchedule, DuplicateMedicationError } from '../../../domain/usecases/ManageMedications';
 import { MedicationRepository, CreateMedicationInput } from '../../../domain/repositories/MedicationRepository';
 import { ScheduleRepository } from '../../../domain/repositories/ScheduleRepository';
 import { Medication, MedicationCategory } from '../../../domain/entities/Medication';
@@ -102,7 +102,7 @@ describe('CreateMedicationWithSchedule - 重複チェック', () => {
         id: 'existing-1',
         memberId: 'm1',
         userId: 'u1',
-        name: 'クラリチン',
+        name: 'Claritin',
         category: 'internal' as MedicationCategory,
         isActive: true,
         createdAt: new Date(),
@@ -112,7 +112,28 @@ describe('CreateMedicationWithSchedule - 重複チェック', () => {
     const schedRepo = createMockScheduleRepo();
     const usecase = new CreateMedicationWithSchedule(medRepo, schedRepo);
 
-    await expect(usecase.execute({ ...baseInput, name: 'クラリチン' })).rejects.toThrow('同じ名前のお薬が既に登録されています');
+    await expect(usecase.execute({ ...baseInput, name: 'claritin' })).rejects.toThrow(DuplicateMedicationError);
+  });
+
+  it('非アクティブな薬は重複として扱わない', async () => {
+    const existingMeds: Medication[] = [
+      {
+        id: 'existing-1',
+        memberId: 'm1',
+        userId: 'u1',
+        name: 'クラリチン',
+        category: 'internal' as MedicationCategory,
+        isActive: false,
+        createdAt: new Date(),
+      },
+    ];
+    const medRepo = createMockMedicationRepo(existingMeds);
+    const schedRepo = createMockScheduleRepo();
+    const usecase = new CreateMedicationWithSchedule(medRepo, schedRepo);
+
+    const result = await usecase.execute(baseInput);
+    expect(result).toBeDefined();
+    expect(medRepo.createMedication).toHaveBeenCalled();
   });
 
   it('重複がない場合は正常に作成される', async () => {

--- a/src/domain/usecases/ManageMedications.ts
+++ b/src/domain/usecases/ManageMedications.ts
@@ -12,6 +12,13 @@ import {
 } from '../repositories/MedicationRepository';
 import { ScheduleRepository } from '../repositories/ScheduleRepository';
 
+export class DuplicateMedicationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DuplicateMedicationError';
+  }
+}
+
 export interface MedicationViewModel {
   medication: Medication;
   isLowStock: boolean;
@@ -60,12 +67,12 @@ export class CreateMedicationWithSchedule {
       throw new Error('薬の名前は必須です');
     }
 
-    // 同一メンバー内の重複チェック
+    // 同一メンバー内の重複チェック（アクティブな薬のみ）
     const existingMeds = await this.medicationRepository.getMedicationsByMember(input.memberId);
     const normalizedName = input.name.trim().toLowerCase();
-    const duplicate = existingMeds.find((m) => m.name.toLowerCase() === normalizedName);
+    const duplicate = existingMeds.find((m) => m.isActive && m.name.trim().toLowerCase() === normalizedName);
     if (duplicate) {
-      throw new Error('同じ名前のお薬が既に登録されています');
+      throw new DuplicateMedicationError('同じ名前のお薬が既に登録されています');
     }
 
     const medication = await this.medicationRepository.createMedication(input);


### PR DESCRIPTION
## Summary
- 同一メンバーに同名のお薬を重複登録しようとした場合、エラーで登録を拒否する機能を追加
- 大文字小文字を区別しない比較で重複を検出
- 異なるメンバーへの同名薬登録は引き続き許可
- TDD開発: ユニットテスト4件追加（重複あり/なし/別メンバー/大文字小文字）

Closes #1077

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented validation to prevent users from creating medications with duplicate names. The system now checks for existing medications with the same name (case-insensitive) and displays an error message to prevent duplicates.

* **Tests**
  * Added test coverage for duplicate medication validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->