### PR TITLE
fix: ダッシュボードのNaN・undefined表示を修正

### DIFF
--- a/src/__tests__/domain/usecases/CreateMedicationDuplicate.test.ts
+++ b/src/__tests__/domain/usecases/CreateMedicationDuplicate.test.ts
@@ -75,18 +75,7 @@ describe('CreateMedicationWithSchedule - 重複チェック', () => {
   });
 
   it('異なるメンバーの同一薬名は許可される', async () => {
-    const existingMeds: Medication[] = [
-      {
-        id: 'existing-1',
-        memberId: 'm2', // 別メンバー
-        userId: 'u1',
-        name: 'クラリチン',
-        category: 'internal' as MedicationCategory,
-        isActive: true,
-        createdAt: new Date(),
-      },
-    ];
-    // getMedicationsByMember returns empty for m1
+    // getMedicationsByMember returns empty for m1 (別メンバー m2 に同名薬があっても m1 では重複扱いにならない)
     const medRepo = createMockMedicationRepo([]);
     const schedRepo = createMockScheduleRepo();
     const usecase = new CreateMedicationWithSchedule(medRepo, schedRepo);

--- a/src/components/dashboard/MissedDosesAlert.tsx
+++ b/src/components/dashboard/MissedDosesAlert.tsx
@@ -20,8 +20,10 @@ const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
 
 function formatDateLabel(dateKey: string): string {
   const [y, m, d] = dateKey.split('-').map(Number);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return dateKey;
   const date = new Date(y, m - 1, d);
-  const dow = DAY_LABELS[date.getDay()];
+  if (isNaN(date.getTime())) return dateKey;
+  const dow = DAY_LABELS[date.getDay()] ?? '';
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const diffDays = Math.round((today.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));

--- a/src/components/dashboard/NextAppointmentBanner.tsx
+++ b/src/components/dashboard/NextAppointmentBanner.tsx
@@ -19,7 +19,7 @@ export const NextAppointmentBanner: React.FC<NextAppointmentBannerProps> = ({ ap
   if (!nextAppointment) return null;
 
   const date = new Date(nextAppointment.appointmentDate);
-  const formatted = `${date.getMonth() + 1}/${date.getDate()}`;
+  const formatted = isNaN(date.getTime()) ? '-' : `${date.getMonth() + 1}/${date.getDate()}`;
 
   return (
     <div className="bg-primary-50 rounded-lg p-3 mb-4 border border-primary-200">


### PR DESCRIPTION
## Summary

- `MissedDosesAlert`: 不正な `dateKey` が渡された場合に `NaN月NaN日（undefined）` が表示される問題を修正（`Number.isFinite` チェックと `Invalid Date` ガードを追加）
- `NextAppointmentBanner`: `appointmentDate` が Invalid Date の場合に `NaN/NaN` が表示される問題を修正（`isNaN(getTime())` チェックを追加、不正時は `-` を表示）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date validation across dashboard components to prevent display of invalid or malformed dates
  * Invalid dates now display placeholder values instead of potentially incorrect information
  * Enhanced date parsing with proper fallback handling for edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->