### PR TITLE
refactor: クリーンアーキテクチャの違反箇所を修正（apiClient副作用・useMissedDoses DI化）

### DIFF
--- a/src/__tests__/data/api/apiClient.test.ts
+++ b/src/__tests__/data/api/apiClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { apiClient } from '@/data/api/apiClient';
+import { apiClient, UnauthorizedError } from '@/data/api/apiClient';
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -61,17 +61,10 @@ describe('apiClient', () => {
     await expect(apiClient.get('/members')).rejects.toThrow('バリデーションエラー');
   });
 
-  it('401レスポンス時にログインページへリダイレクトする', async () => {
-    const originalLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      value: { href: '' },
-      writable: true,
-    });
+  it('401レスポンス時にUnauthorizedErrorをスローする（副作用なし）', async () => {
     mockFetch.mockReturnValue(
       Promise.resolve({ status: 401, json: () => Promise.resolve({}) }),
     );
-    await expect(apiClient.get('/members')).rejects.toThrow('認証エラー');
-    expect(window.location.href).toBe('/login');
-    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    await expect(apiClient.get('/members')).rejects.toBeInstanceOf(UnauthorizedError);
   });
 });

--- a/src/data/api/apiClient.ts
+++ b/src/data/api/apiClient.ts
@@ -1,3 +1,10 @@
+export class UnauthorizedError extends Error {
+  constructor(message = '認証エラー') {
+    super(message);
+    this.name = 'UnauthorizedError';
+  }
+}
+
 const BASE_URL = '/api';
 
 interface ApiResponse<T> {
@@ -16,8 +23,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   });
 
   if (res.status === 401) {
-    window.location.href = '/login';
-    throw new Error('認証エラー');
+    throw new UnauthorizedError();
   }
 
   const json: ApiResponse<T> = await res.json();

--- a/src/data/api/scheduleApi.ts
+++ b/src/data/api/scheduleApi.ts
@@ -1,5 +1,5 @@
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
-import { TodayScheduleItem } from '../../domain/repositories/ScheduleRepository';
+import { MissedDose, TodayScheduleItem } from '../../domain/repositories/ScheduleRepository';
 import { apiClient } from './apiClient';
 import { BackendSchedule } from './types';
 import { toSchedule } from './mappers';
@@ -125,5 +125,9 @@ export const scheduleApi = {
       ...(options?.takenAt ? { takenAt: options.takenAt } : {}),
       ...(options?.notes ? { notes: options.notes } : {}),
     });
+  },
+
+  async getMissedDoses(): Promise<MissedDose[]> {
+    return apiClient.get<MissedDose[]>('/schedules/missed');
   },
 };

--- a/src/data/repositories/ScheduleRepositoryImpl.ts
+++ b/src/data/repositories/ScheduleRepositoryImpl.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  MissedDose,
   ScheduleRepository,
   ScheduleWithDetails,
   TodayScheduleQuery,
@@ -49,5 +50,9 @@ export class ScheduleRepositoryImpl implements ScheduleRepository {
 
   async markAsCompleted(scheduleId: string, completedAt: Date, options?: { takenAt?: string; notes?: string }): Promise<void> {
     await scheduleApi.markAsCompleted(scheduleId, completedAt, options);
+  }
+
+  async getMissedDoses(): Promise<MissedDose[]> {
+    return await scheduleApi.getMissedDoses();
   }
 }

--- a/src/data/repositories/server/PrismaScheduleRepository.ts
+++ b/src/data/repositories/server/PrismaScheduleRepository.ts
@@ -4,6 +4,7 @@
 
 import { prisma } from '@/lib/prisma';
 import {
+  MissedDose,
   ScheduleRepository,
   ScheduleWithDetails,
   TodayScheduleQuery,
@@ -268,5 +269,10 @@ export class PrismaScheduleRepository implements ScheduleRepository {
 
   async markAsCompleted(_scheduleId: string, _completedAt: Date, _options?: { takenAt?: string; notes?: string }): Promise<void> {
     // 服薬完了は MedicationRecord の作成で管理されるため、ここでは空実装
+  }
+
+  async getMissedDoses(): Promise<MissedDose[]> {
+    // フロントエンド専用メソッド（API ルート側で直接 Prisma を使用して実装している）
+    return [];
   }
 }

--- a/src/domain/repositories/ScheduleRepository.ts
+++ b/src/domain/repositories/ScheduleRepository.ts
@@ -25,6 +25,15 @@ export interface ScheduleWithDetails {
   memberName: string;
 }
 
+export interface MissedDose {
+  date: string;
+  scheduleId: string;
+  medicationName: string;
+  memberName: string;
+  memberId: string;
+  scheduledTime: string;
+}
+
 export interface ScheduleRepository {
   /**
    * IDでスケジュールを取得（所有権確認用）
@@ -70,4 +79,9 @@ export interface ScheduleRepository {
    * スケジュールを服薬完了にする
    */
   markAsCompleted(scheduleId: string, completedAt: Date, options?: { takenAt?: string; notes?: string }): Promise<void>;
+
+  /**
+   * 過去7日間の飲み忘れスケジュールを取得
+   */
+  getMissedDoses(): Promise<MissedDose[]>;
 }

--- a/src/presentation/hooks/useFetcher.ts
+++ b/src/presentation/hooks/useFetcher.ts
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { UnauthorizedError } from '../../data/api/apiClient';
 
 export interface UseFetcherResult<T> {
   data: T;
@@ -51,6 +52,10 @@ export function useFetcher<T>(
         }
       }
     } catch (err) {
+      if (err instanceof UnauthorizedError && typeof window !== 'undefined') {
+        window.location.href = '/login';
+        return;
+      }
       if (mountedRef.current) {
         setError(err instanceof Error ? err : new Error('Unknown error'));
       }

--- a/src/presentation/hooks/useMissedDoses.ts
+++ b/src/presentation/hooks/useMissedDoses.ts
@@ -1,14 +1,9 @@
+import { useMemo } from 'react';
+import { MissedDose } from '../../domain/repositories/ScheduleRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
 import { useFetcher } from './useFetcher';
-import { apiClient } from '../../data/api/apiClient';
 
-export interface MissedDose {
-  date: string;
-  scheduleId: string;
-  medicationName: string;
-  memberName: string;
-  memberId: string;
-  scheduledTime: string;
-}
+export type { MissedDose };
 
 export interface UseMissedDosesResult {
   missedDoses: MissedDose[];
@@ -18,9 +13,11 @@ export interface UseMissedDosesResult {
 }
 
 export const useMissedDoses = (): UseMissedDosesResult => {
+  const scheduleRepository = useMemo(() => getDIContainer().scheduleRepository, []);
+
   const { data: missedDoses, isLoading, error, refetch } = useFetcher(
-    () => apiClient.get<MissedDose[]>('/schedules/missed'),
-    [],
+    () => scheduleRepository.getMissedDoses(),
+    [scheduleRepository],
     [] as MissedDose[],
     'missed-doses',
   );


### PR DESCRIPTION
## Summary

- **data 層の副作用を除去**: `apiClient` の 401 時 `window.location.href = '/login'` を廃止し、`UnauthorizedError` を throw する設計に変更。リダイレクトは presentation 層の `useFetcher` で処理。
- **useMissedDoses を DI 経由に統一**: `apiClient` 直 import を廃止し、`ScheduleRepository.getMissedDoses()` 経由で取得。他の presentation hook と同じ DI パターンに揃えた。
- `MissedDose` 型を domain 層 (`ScheduleRepository`) に移動。
- Client/Prisma 両方の `ScheduleRepository` 実装にメソッドを追加。