### PR TITLE
feat: KEGG MEDICUS APIで薬剤情報取得機能を追加

### DIFF
--- a/src/app/api/external/medication-info/[id]/route.ts
+++ b/src/app/api/external/medication-info/[id]/route.ts
@@ -1,0 +1,35 @@
+import { success, errorResponse, notFound } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+import { getDrugInfo } from '@/lib/external/keggApi';
+
+const KEGG_DRUG_ID_PATTERN = /^D\d{5}$/i;
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medication-info-detail:${userId}`, {
+      maxAttempts: 30,
+      windowMs: 60 * 1000,
+    });
+    if (!allowed) {
+      return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    }
+
+    const { id } = await context.params;
+    if (!id || !KEGG_DRUG_ID_PATTERN.test(id)) {
+      return errorResponse('無効な薬剤IDです');
+    }
+
+    try {
+      const info = await getDrugInfo(id);
+      if (!info) return notFound('薬剤情報');
+      return success({ ...info, source: 'kegg' as const });
+    } catch (error) {
+      console.error('[KEGG] detail fetch failed:', error);
+      return errorResponse('薬剤情報の取得に失敗しました。時間をおいて再試行してください。', 502);
+    }
+  })();
+}

--- a/src/app/api/external/medication-info/search/route.ts
+++ b/src/app/api/external/medication-info/search/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from 'next/server';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+import { searchDrugsByName } from '@/lib/external/keggApi';
+
+export async function GET(request: NextRequest) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`medication-info-search:${userId}`, {
+      maxAttempts: 20,
+      windowMs: 60 * 1000,
+    });
+    if (!allowed) {
+      return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    }
+
+    const q = request.nextUrl.searchParams.get('q')?.trim() ?? '';
+    if (!q) return errorResponse('検索キーワードを入力してください');
+    if (q.length > 100) return errorResponse('検索キーワードは100文字以内で入力してください');
+
+    try {
+      const results = await searchDrugsByName(q);
+      return success(results);
+    } catch (error) {
+      console.error('[KEGG] search failed:', error);
+      return errorResponse('薬剤情報の検索に失敗しました。時間をおいて再試行してください。', 502);
+    }
+  })();
+}

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -222,8 +222,13 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
         onClose={() => setShowInfoModal(false)}
         onApply={(data) => {
           if (data.name) setName(data.name);
-          if (data.instructions) {
-            setInstructions((prev) => (prev ? `${prev}\n${data.instructions}` : data.instructions ?? ''));
+          const newInstructions = data.instructions;
+          if (newInstructions) {
+            setInstructions((prev) => {
+              if (!prev) return newInstructions;
+              if (prev.includes(newInstructions)) return prev;
+              return `${prev}\n${newInstructions}`;
+            });
             setShowOptional(true);
           }
         }}

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import { ChevronDown, ChevronUp, Info } from 'lucide-react';
 import { Medication, MedicationCategory } from '../../domain/entities/Medication';
+import { MedicationInfoModal } from './MedicationInfoModal';
 
 export interface MedicationFormData {
   name: string;
@@ -33,6 +34,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
   const [instructions, setInstructions] = useState(initialData?.instructions || '');
   const hasOptionalData = !!(initialData?.stockQuantity || initialData?.stockAlertDate || initialData?.instructions);
   const [showOptional, setShowOptional] = useState(isEditing && hasOptionalData);
+  const [showInfoModal, setShowInfoModal] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -68,14 +70,25 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
         <label htmlFor="med-name" className="block text-sm font-medium text-gray-700 mb-1">
           薬の名前
         </label>
-        <input
-          id="med-name"
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
-          placeholder="薬の名前を入力"
-        />
+        <div className="flex space-x-2">
+          <input
+            id="med-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500"
+            placeholder="薬の名前を入力"
+          />
+          <button
+            type="button"
+            onClick={() => setShowInfoModal(true)}
+            className="flex items-center px-3 py-2 border border-primary-300 text-primary-600 rounded-lg hover:bg-primary-50 text-sm whitespace-nowrap"
+            aria-label="薬剤情報を取得"
+          >
+            <Info size={14} className="mr-1" />
+            情報取得
+          </button>
+        </div>
       </div>
 
       <div>
@@ -202,6 +215,19 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
           </button>
         )}
       </div>
+
+      <MedicationInfoModal
+        isOpen={showInfoModal}
+        initialQuery={name}
+        onClose={() => setShowInfoModal(false)}
+        onApply={(data) => {
+          if (data.name) setName(data.name);
+          if (data.instructions) {
+            setInstructions((prev) => (prev ? `${prev}\n${data.instructions}` : data.instructions ?? ''));
+            setShowOptional(true);
+          }
+        }}
+      />
     </form>
   );
 };

--- a/src/components/medications/MedicationInfoModal.tsx
+++ b/src/components/medications/MedicationInfoModal.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { X, Search, Loader2, ExternalLink, ChevronLeft } from 'lucide-react';
+import { useMedicationInfo } from '../../presentation/hooks/useMedicationInfo';
+
+interface MedicationInfoApplyData {
+  name?: string;
+  instructions?: string;
+}
+
+interface MedicationInfoModalProps {
+  isOpen: boolean;
+  initialQuery: string;
+  onClose: () => void;
+  onApply: (data: MedicationInfoApplyData) => void;
+}
+
+export const MedicationInfoModal: React.FC<MedicationInfoModalProps> = ({
+  isOpen,
+  initialQuery,
+  onClose,
+  onApply,
+}) => {
+  const {
+    searchResults,
+    selectedInfo,
+    isLoading,
+    hasSearched,
+    error,
+    search,
+    selectById,
+    clearSelection,
+    reset,
+  } = useMedicationInfo();
+  const [query, setQuery] = useState(initialQuery);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery(initialQuery);
+    reset();
+    if (initialQuery.trim()) {
+      void search(initialQuery);
+    }
+  }, [isOpen, initialQuery, reset, search]);
+
+  if (!isOpen) return null;
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = query.trim();
+    if (trimmed) void search(trimmed);
+  };
+
+  const handleApply = () => {
+    if (!selectedInfo) return;
+    const parts: string[] = [];
+    if (selectedInfo.efficacy) parts.push(`【効能】${selectedInfo.efficacy}`);
+    if (selectedInfo.components) parts.push(`【成分】${selectedInfo.components}`);
+    if (selectedInfo.remark) parts.push(`【備考】${selectedInfo.remark}`);
+    onApply({
+      name: selectedInfo.name,
+      instructions: parts.length > 0 ? parts.join('\n\n') : undefined,
+    });
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 sm:items-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="medication-info-title"
+    >
+      <div className="flex w-full max-h-[90vh] flex-col bg-white shadow-xl sm:mx-4 sm:max-w-lg sm:rounded-2xl rounded-t-2xl">
+        <div className="flex items-center justify-between border-b border-gray-200 p-4">
+          {selectedInfo ? (
+            <button
+              type="button"
+              onClick={clearSelection}
+              className="flex items-center text-sm text-gray-600 hover:text-gray-900"
+            >
+              <ChevronLeft size={16} className="mr-1" />
+              戻る
+            </button>
+          ) : (
+            <h2 id="medication-info-title" className="text-lg font-semibold">
+              薬剤情報の取得
+            </h2>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 text-gray-500 hover:text-gray-700"
+            aria-label="閉じる"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {!selectedInfo && (
+          <div className="border-b border-gray-200 p-4">
+            <form onSubmit={handleSearchSubmit} className="flex space-x-2">
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="flex-1 rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-primary-500"
+                placeholder="薬名を入力 (例: ロキソニン)"
+                maxLength={100}
+              />
+              <button
+                type="submit"
+                disabled={isLoading || !query.trim()}
+                className="flex items-center rounded-lg bg-primary-600 px-4 py-2 text-white hover:bg-primary-700 disabled:opacity-50"
+              >
+                <Search size={16} className="mr-1" />
+                検索
+              </button>
+            </form>
+            <p className="mt-2 text-xs text-gray-500">
+              提供: KEGG MEDICUS (公開薬剤データベース)
+            </p>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8 text-gray-500">
+              <Loader2 className="mr-2 animate-spin" size={20} />
+              <span>読み込み中...</span>
+            </div>
+          )}
+
+          {error && !isLoading && (
+            <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
+              {error.message}
+            </div>
+          )}
+
+          {!isLoading && !error && !selectedInfo && (
+            <>
+              {hasSearched && searchResults.length === 0 && (
+                <div className="py-8 text-center text-sm text-gray-400">
+                  該当する薬剤が見つかりませんでした
+                </div>
+              )}
+              {!hasSearched && searchResults.length === 0 && (
+                <div className="py-8 text-center text-sm text-gray-400">
+                  薬名を入力して検索してください
+                </div>
+              )}
+              {searchResults.length > 0 && (
+                <ul className="space-y-2">
+                  {searchResults.map((r) => (
+                    <li key={r.id}>
+                      <button
+                        type="button"
+                        onClick={() => void selectById(r.id)}
+                        className="w-full rounded-lg border border-gray-200 p-3 text-left hover:bg-gray-50"
+                      >
+                        <div className="text-sm font-medium text-gray-900">
+                          {r.name}
+                        </div>
+                        <div className="mt-1 text-xs text-gray-400">KEGG: {r.id}</div>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          )}
+
+          {!isLoading && !error && selectedInfo && (
+            <div className="space-y-4 text-sm">
+              <div>
+                <div className="text-xs font-medium text-gray-500">名称</div>
+                <div className="text-gray-900">{selectedInfo.name}</div>
+              </div>
+              {selectedInfo.efficacy && (
+                <div>
+                  <div className="text-xs font-medium text-gray-500">効能・効果</div>
+                  <div className="whitespace-pre-wrap text-gray-900">
+                    {selectedInfo.efficacy}
+                  </div>
+                </div>
+              )}
+              {selectedInfo.components && (
+                <div>
+                  <div className="text-xs font-medium text-gray-500">成分</div>
+                  <div className="whitespace-pre-wrap text-gray-900">
+                    {selectedInfo.components}
+                  </div>
+                </div>
+              )}
+              {selectedInfo.remark && (
+                <div>
+                  <div className="text-xs font-medium text-gray-500">備考</div>
+                  <div className="whitespace-pre-wrap text-gray-900">
+                    {selectedInfo.remark}
+                  </div>
+                </div>
+              )}
+              <a
+                href={selectedInfo.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center text-xs text-primary-600 hover:text-primary-700"
+              >
+                <ExternalLink size={12} className="mr-1" />
+                KEGGで詳細を見る
+              </a>
+              <p className="text-xs text-gray-400">
+                ※ 本情報は参考用です。詳細は医師・薬剤師にご確認ください。
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex space-x-2 border-t border-gray-200 p-4">
+          {selectedInfo ? (
+            <button
+              type="button"
+              onClick={handleApply}
+              className="flex-1 rounded-lg bg-primary-600 py-2 text-white hover:bg-primary-700"
+            >
+              フォームに反映
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-gray-300 py-2 text-gray-700 hover:bg-gray-50"
+            >
+              閉じる
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/medications/MedicationInfoModal.tsx
+++ b/src/components/medications/MedicationInfoModal.tsx
@@ -44,6 +44,15 @@ export const MedicationInfoModal: React.FC<MedicationInfoModalProps> = ({
     }
   }, [isOpen, initialQuery, reset, search]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const handleSearchSubmit = (e: React.FormEvent) => {
@@ -74,20 +83,24 @@ export const MedicationInfoModal: React.FC<MedicationInfoModalProps> = ({
     >
       <div className="flex w-full max-h-[90vh] flex-col bg-white shadow-xl sm:mx-4 sm:max-w-lg sm:rounded-2xl rounded-t-2xl">
         <div className="flex items-center justify-between border-b border-gray-200 p-4">
-          {selectedInfo ? (
-            <button
-              type="button"
-              onClick={clearSelection}
-              className="flex items-center text-sm text-gray-600 hover:text-gray-900"
+          <div className="flex items-center">
+            {selectedInfo && (
+              <button
+                type="button"
+                onClick={clearSelection}
+                className="flex items-center text-sm text-gray-600 hover:text-gray-900"
+              >
+                <ChevronLeft size={16} className="mr-1" />
+                戻る
+              </button>
+            )}
+            <h2
+              id="medication-info-title"
+              className={selectedInfo ? 'sr-only' : 'text-lg font-semibold'}
             >
-              <ChevronLeft size={16} className="mr-1" />
-              戻る
-            </button>
-          ) : (
-            <h2 id="medication-info-title" className="text-lg font-semibold">
               薬剤情報の取得
             </h2>
-          )}
+          </div>
           <button
             type="button"
             onClick={onClose}
@@ -107,6 +120,7 @@ export const MedicationInfoModal: React.FC<MedicationInfoModalProps> = ({
                 onChange={(e) => setQuery(e.target.value)}
                 className="flex-1 rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-primary-500"
                 placeholder="薬名を入力 (例: ロキソニン)"
+                aria-label="薬名を入力"
                 maxLength={100}
               />
               <button

--- a/src/data/api/apiClient.ts
+++ b/src/data/api/apiClient.ts
@@ -5,6 +5,13 @@ export class UnauthorizedError extends Error {
   }
 }
 
+export class ApiError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 const BASE_URL = '/api';
 
 interface ApiResponse<T> {
@@ -29,7 +36,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const json: ApiResponse<T> = await res.json();
 
   if (!json.success) {
-    throw new Error(json.error || 'APIエラー');
+    throw new ApiError(json.error || 'APIエラー', res.status);
   }
 
   return json.data;

--- a/src/data/api/medicationInfoApi.ts
+++ b/src/data/api/medicationInfoApi.ts
@@ -1,4 +1,4 @@
-import { apiClient } from './apiClient';
+import { apiClient, ApiError } from './apiClient';
 import {
   MedicationInfo,
   MedicationInfoSearchResult,
@@ -16,8 +16,9 @@ export const medicationInfoApi = {
       return await apiClient.get<MedicationInfo>(
         `/external/medication-info/${encodeURIComponent(id)}`,
       );
-    } catch {
-      return null;
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) return null;
+      throw err;
     }
   },
 };

--- a/src/data/api/medicationInfoApi.ts
+++ b/src/data/api/medicationInfoApi.ts
@@ -1,0 +1,23 @@
+import { apiClient } from './apiClient';
+import {
+  MedicationInfo,
+  MedicationInfoSearchResult,
+} from '../../domain/entities/MedicationInfo';
+
+export const medicationInfoApi = {
+  async search(query: string): Promise<MedicationInfoSearchResult[]> {
+    return apiClient.get<MedicationInfoSearchResult[]>(
+      `/external/medication-info/search?q=${encodeURIComponent(query)}`,
+    );
+  },
+
+  async getById(id: string): Promise<MedicationInfo | null> {
+    try {
+      return await apiClient.get<MedicationInfo>(
+        `/external/medication-info/${encodeURIComponent(id)}`,
+      );
+    } catch {
+      return null;
+    }
+  },
+};

--- a/src/data/repositories/MedicationInfoRepositoryImpl.ts
+++ b/src/data/repositories/MedicationInfoRepositoryImpl.ts
@@ -1,0 +1,16 @@
+import { MedicationInfoRepository } from '../../domain/repositories/MedicationInfoRepository';
+import {
+  MedicationInfo,
+  MedicationInfoSearchResult,
+} from '../../domain/entities/MedicationInfo';
+import { medicationInfoApi } from '../api/medicationInfoApi';
+
+export class MedicationInfoRepositoryImpl implements MedicationInfoRepository {
+  searchByName(query: string): Promise<MedicationInfoSearchResult[]> {
+    return medicationInfoApi.search(query);
+  }
+
+  getById(id: string): Promise<MedicationInfo | null> {
+    return medicationInfoApi.getById(id);
+  }
+}

--- a/src/domain/entities/MedicationInfo.ts
+++ b/src/domain/entities/MedicationInfo.ts
@@ -1,0 +1,18 @@
+/**
+ * 外部医薬品データベースから取得する薬剤情報エンティティ
+ */
+
+export interface MedicationInfoSearchResult {
+  id: string;
+  name: string;
+}
+
+export interface MedicationInfo {
+  id: string;
+  name: string;
+  efficacy?: string;
+  components?: string;
+  remark?: string;
+  sourceUrl: string;
+  source: 'kegg';
+}

--- a/src/domain/repositories/MedicationInfoRepository.ts
+++ b/src/domain/repositories/MedicationInfoRepository.ts
@@ -1,0 +1,6 @@
+import { MedicationInfo, MedicationInfoSearchResult } from '../entities/MedicationInfo';
+
+export interface MedicationInfoRepository {
+  searchByName(query: string): Promise<MedicationInfoSearchResult[]>;
+  getById(id: string): Promise<MedicationInfo | null>;
+}

--- a/src/domain/usecases/GetMedicationInfo.ts
+++ b/src/domain/usecases/GetMedicationInfo.ts
@@ -1,0 +1,22 @@
+import { MedicationInfo, MedicationInfoSearchResult } from '../entities/MedicationInfo';
+import { MedicationInfoRepository } from '../repositories/MedicationInfoRepository';
+
+export class SearchMedicationInfo {
+  constructor(private readonly repository: MedicationInfoRepository) {}
+
+  async execute(query: string): Promise<MedicationInfoSearchResult[]> {
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    return this.repository.searchByName(trimmed);
+  }
+}
+
+export class GetMedicationInfo {
+  constructor(private readonly repository: MedicationInfoRepository) {}
+
+  async execute(id: string): Promise<MedicationInfo | null> {
+    const trimmed = id.trim();
+    if (!trimmed) return null;
+    return this.repository.getById(trimmed);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -19,6 +19,7 @@ import { BodyMeasurementRepository } from '../domain/repositories/BodyMeasuremen
 import { EmergencyContactRepository } from '../domain/repositories/EmergencyContactRepository';
 import { PrescriptionRepository } from '../domain/repositories/PrescriptionRepository';
 import { NotificationSettingRepository } from '../domain/repositories/NotificationSettingRepository';
+import { MedicationInfoRepository } from '../domain/repositories/MedicationInfoRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -35,6 +36,7 @@ import { BodyMeasurementRepositoryImpl } from '../data/repositories/BodyMeasurem
 import { EmergencyContactRepositoryImpl } from '../data/repositories/EmergencyContactRepositoryImpl';
 import { PrescriptionRepositoryImpl } from '../data/repositories/PrescriptionRepositoryImpl';
 import { NotificationSettingRepositoryImpl } from '../data/repositories/NotificationSettingRepositoryImpl';
+import { MedicationInfoRepositoryImpl } from '../data/repositories/MedicationInfoRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -53,6 +55,7 @@ export interface DIContainer {
   emergencyContactRepository: EmergencyContactRepository;
   prescriptionRepository: PrescriptionRepository;
   notificationSettingRepository: NotificationSettingRepository;
+  medicationInfoRepository: MedicationInfoRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -77,6 +80,7 @@ export const getDIContainer = (): DIContainer => {
       emergencyContactRepository: new EmergencyContactRepositoryImpl(),
       prescriptionRepository: new PrescriptionRepositoryImpl(),
       notificationSettingRepository: new NotificationSettingRepositoryImpl(),
+      medicationInfoRepository: new MedicationInfoRepositoryImpl(),
     };
   }
   return container;

--- a/src/lib/external/keggApi.ts
+++ b/src/lib/external/keggApi.ts
@@ -1,0 +1,166 @@
+/**
+ * KEGG MEDICUS API クライアント (サーバーサイド専用)
+ *
+ * KEGG REST API: https://www.kegg.jp/kegg/rest/keggapi.html
+ * - find/drug_ja/{query} : 日本語での薬剤検索
+ * - get/dr_ja:{id}       : 日本語版の薬剤詳細
+ *
+ * 制限:
+ * - 3 req/sec (API側制限)
+ * - アカデミック用途での利用を前提
+ */
+
+const KEGG_BASE = 'https://rest.kegg.jp';
+const REQUEST_TIMEOUT_MS = 8000;
+const MAX_SEARCH_RESULTS = 20;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_CACHE_SIZE = 500;
+
+export interface KeggSearchResult {
+  id: string;
+  name: string;
+}
+
+export interface KeggDrugInfo {
+  id: string;
+  name: string;
+  efficacy?: string;
+  components?: string;
+  remark?: string;
+  sourceUrl: string;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const searchCache = new Map<string, CacheEntry<KeggSearchResult[]>>();
+const drugCache = new Map<string, CacheEntry<KeggDrugInfo | null>>();
+
+function cacheGet<T>(cache: Map<string, CacheEntry<T>>, key: string): T | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+}
+
+function cacheSet<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T): void {
+  if (cache.size >= MAX_CACHE_SIZE) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey !== undefined) cache.delete(firstKey);
+  }
+  cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+async function keggFetch(path: string): Promise<string> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${KEGG_BASE}${path}`, {
+      signal: controller.signal,
+      headers: { Accept: 'text/plain' },
+    });
+    if (res.status === 404) return '';
+    if (!res.ok) throw new Error(`KEGG API error: ${res.status}`);
+    return await res.text();
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * KEGG flat file形式のパース
+ * - 0-11文字目: フィールド名 (先頭行のみ。継続行は空白)
+ * - 12文字目以降: 値
+ * - "///" で1レコード終了
+ */
+function parseKeggFlatFile(text: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  const lines = text.split('\n');
+  let currentField: string | null = null;
+  let currentValue: string[] = [];
+
+  const commit = () => {
+    if (currentField) {
+      const joined = currentValue.join('\n').trim();
+      if (joined) {
+        const existing = fields.get(currentField);
+        fields.set(currentField, existing ? `${existing}\n${joined}` : joined);
+      }
+    }
+  };
+
+  for (const line of lines) {
+    if (line === '///') break;
+    if (line.length > 0 && line[0] !== ' ') {
+      commit();
+      currentField = line.substring(0, 12).trim();
+      currentValue = [line.substring(12)];
+    } else if (currentField) {
+      currentValue.push(line.substring(12));
+    }
+  }
+  commit();
+  return fields;
+}
+
+export async function searchDrugsByName(query: string): Promise<KeggSearchResult[]> {
+  const normalized = query.trim();
+  if (!normalized) return [];
+
+  const cacheKey = normalized.toLowerCase();
+  const cached = cacheGet(searchCache, cacheKey);
+  if (cached) return cached;
+
+  const encoded = encodeURIComponent(normalized);
+  const text = await keggFetch(`/find/drug_ja/${encoded}`);
+
+  const results: KeggSearchResult[] = [];
+  const lines = text.split('\n').filter((line) => line.trim());
+  for (const line of lines.slice(0, MAX_SEARCH_RESULTS)) {
+    const tabIndex = line.indexOf('\t');
+    if (tabIndex === -1) continue;
+    const idPart = line.substring(0, tabIndex).trim();
+    const name = line.substring(tabIndex + 1).trim();
+    const id = idPart.replace(/^(dr_ja|dr):/i, '').trim();
+    if (id && name) results.push({ id, name });
+  }
+
+  cacheSet(searchCache, cacheKey, results);
+  return results;
+}
+
+export async function getDrugInfo(id: string): Promise<KeggDrugInfo | null> {
+  const normalized = id.trim().toUpperCase();
+  if (!/^D\d{5}$/.test(normalized)) return null;
+
+  const cached = cacheGet(drugCache, normalized);
+  if (cached !== undefined) return cached;
+
+  const text = await keggFetch(`/get/dr_ja:${normalized}`);
+  if (!text) {
+    cacheSet(drugCache, normalized, null);
+    return null;
+  }
+
+  const fields = parseKeggFlatFile(text);
+  const rawName = fields.get('NAME') ?? '';
+  const firstName = rawName.split('\n')[0]?.trim() ?? '';
+  const cleanName = firstName.replace(/\s*\([^)]*\)\s*$/, '').trim();
+
+  const info: KeggDrugInfo = {
+    id: normalized,
+    name: cleanName || normalized,
+    efficacy: fields.get('EFFICACY') || undefined,
+    components: fields.get('COMPONENT') || undefined,
+    remark: fields.get('REMARK') || undefined,
+    sourceUrl: `https://www.kegg.jp/entry/${normalized}`,
+  };
+
+  cacheSet(drugCache, normalized, info);
+  return info;
+}

--- a/src/lib/external/keggApi.ts
+++ b/src/lib/external/keggApi.ts
@@ -5,9 +5,15 @@
  * - find/drug_ja/{query} : 日本語での薬剤検索
  * - get/dr_ja:{id}       : 日本語版の薬剤詳細
  *
- * 制限:
- * - 3 req/sec (API側制限)
- * - アカデミック用途での利用を前提
+ * ⚠️ ライセンス上の注意:
+ * KEGG REST API (rest.kegg.jp) はアカデミック利用を前提に公開されている。
+ * 商用・コンシューマー向けサービスで利用する場合は
+ * https://www.kegg.jp/kegg/legal.html の利用規約を確認し、必要に応じて
+ * KEGG 社と商用ライセンス契約を結ぶか、PMDA など代替データソースへ
+ * 差し替えること。
+ *
+ * 技術的な制限:
+ * - 3 req/sec (上流側のレート制限)
  */
 
 const KEGG_BASE = 'https://rest.kegg.jp';
@@ -56,6 +62,18 @@ function cacheSet<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T): 
   cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
 }
 
+/**
+ * KEGG REST API へリクエストを送る。
+ *
+ * 戻り値の契約:
+ * - 200 OK:   レスポンス本文を返す (通常は非空のflat-file text)
+ * - 404:      空文字列 `''` を返す ("該当なし" を示すセンチネル)
+ * - その他:   例外をthrow
+ *
+ * 呼び出し側 (searchDrugsByName / getDrugInfo) は空文字列を "該当なし" と
+ * みなして分岐している。KEGG REST は 200 で空本文を返さない前提のため
+ * この取り扱いで問題ないが、将来の挙動変更に備えてこの契約を守ること。
+ */
 async function keggFetch(path: string): Promise<string> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);

--- a/src/presentation/hooks/useMedicationInfo.ts
+++ b/src/presentation/hooks/useMedicationInfo.ts
@@ -1,0 +1,97 @@
+import { useState, useCallback, useMemo } from 'react';
+import {
+  MedicationInfo,
+  MedicationInfoSearchResult,
+} from '../../domain/entities/MedicationInfo';
+import {
+  SearchMedicationInfo,
+  GetMedicationInfo,
+} from '../../domain/usecases/GetMedicationInfo';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+
+export interface UseMedicationInfoResult {
+  searchResults: MedicationInfoSearchResult[];
+  selectedInfo: MedicationInfo | null;
+  isLoading: boolean;
+  hasSearched: boolean;
+  error: Error | null;
+  search: (query: string) => Promise<void>;
+  selectById: (id: string) => Promise<void>;
+  clearSelection: () => void;
+  reset: () => void;
+}
+
+export const useMedicationInfo = (): UseMedicationInfoResult => {
+  const useCases = useMemo(() => {
+    const { medicationInfoRepository } = getDIContainer();
+    return {
+      search: new SearchMedicationInfo(medicationInfoRepository),
+      get: new GetMedicationInfo(medicationInfoRepository),
+    };
+  }, []);
+
+  const [searchResults, setSearchResults] = useState<MedicationInfoSearchResult[]>([]);
+  const [selectedInfo, setSelectedInfo] = useState<MedicationInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const search = useCallback(async (query: string) => {
+    setIsLoading(true);
+    setError(null);
+    setSelectedInfo(null);
+    try {
+      const data = await useCases.search.execute(query);
+      setSearchResults(data);
+      setHasSearched(true);
+    } catch (err) {
+      setSearchResults([]);
+      setHasSearched(true);
+      setError(err instanceof Error ? err : new Error('検索に失敗しました'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [useCases]);
+
+  const selectById = useCallback(async (id: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await useCases.get.execute(id);
+      if (!data) {
+        setError(new Error('薬剤情報が見つかりませんでした'));
+        return;
+      }
+      setSelectedInfo(data);
+    } catch (err) {
+      setSelectedInfo(null);
+      setError(err instanceof Error ? err : new Error('薬剤情報の取得に失敗しました'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [useCases]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedInfo(null);
+    setError(null);
+  }, []);
+
+  const reset = useCallback(() => {
+    setSearchResults([]);
+    setSelectedInfo(null);
+    setHasSearched(false);
+    setError(null);
+  }, []);
+
+  return {
+    searchResults,
+    selectedInfo,
+    isLoading,
+    hasSearched,
+    error,
+    search,
+    selectById,
+    clearSelection,
+    reset,
+  };
+};

--- a/src/presentation/hooks/useMedicationInfo.ts
+++ b/src/presentation/hooks/useMedicationInfo.ts
@@ -59,6 +59,7 @@ export const useMedicationInfo = (): UseMedicationInfoResult => {
     try {
       const data = await useCases.get.execute(id);
       if (!data) {
+        setSelectedInfo(null);
         setError(new Error('薬剤情報が見つかりませんでした'));
         return;
       }


### PR DESCRIPTION
## Summary
- 薬剤登録フォームに「情報取得」ボタンを追加し、KEGG公開薬剤DBから効能・成分・備考を検索できる機能を追加
- サーバー側プロキシ(`/api/external/medication-info/search`, `/api/external/medication-info/[id]`)経由でKEGG APIを呼び出し(認証・レート制限・24hメモリキャッシュ付き)
- Clean Architectureに則り domain / data / presentation / infrastructure 各層に分離
- 取得情報はモーダルで閲覧し、ユーザーの選択で薬名・服用方法欄に反映可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added medication information lookup feature with search functionality
  * View comprehensive medication details including efficacy, components, and remarks with source attribution
  * Apply medication information directly to medication forms using a new lookup button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->