### PR TITLE
fix: 体調記録の保存後リスト表示が壊れるバグを修正

### DIFF
--- a/src/app/api/health-logs/route.ts
+++ b/src/app/api/health-logs/route.ts
@@ -3,14 +3,13 @@ import { success, created, errorResponse } from '@/lib/auth-helpers';
 import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
 import { checkRateLimit } from '@/lib/security';
 import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
-import { GetHealthLogs, CreateHealthLog } from '@/domain/usecases/ManageHealthLogs';
+import { CreateHealthLog } from '@/domain/usecases/ManageHealthLogs';
 
 export const GET = withAuth(async (userId) => {
   const { allowed } = checkRateLimit(`health-logs-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
   if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
   const container = createServerDIContainer(userId);
-  const usecase = new GetHealthLogs(container.healthLogRepository);
-  const logs = await usecase.execute();
+  const logs = await container.healthLogRepository.getLogs();
   return success(logs);
 });
 


### PR DESCRIPTION
## Summary
- GET /api/health-logs が GetHealthLogs ユースケースを通してグループ化済み配列(DailyHealthLogGroup[])を返していたが、クライアントは生の HealthLog[] を期待していたため二重グループ化が発生
- 記録の作成自体は成功していたが、リスト取得結果が壊れて画面上に表示されない問題を修正
- API では repository.getLogs() を直接呼んで生データを返し、グループ化はクライアント側ユースケースに任せる