### PR TITLE
feat: 体温記録機能を追加（時系列グラフ付き）

### DIFF
--- a/prisma/migrations/20260426_add_temperature_records/migration.sql
+++ b/prisma/migrations/20260426_add_temperature_records/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "TemperatureRecord" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "memberId" TEXT NOT NULL,
+    "temperature" DOUBLE PRECISION NOT NULL,
+    "measuredAt" TIMESTAMP(3) NOT NULL,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TemperatureRecord_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TemperatureRecord_userId_idx" ON "TemperatureRecord"("userId");
+
+-- CreateIndex
+CREATE INDEX "TemperatureRecord_memberId_idx" ON "TemperatureRecord"("memberId");
+
+-- CreateIndex
+CREATE INDEX "TemperatureRecord_memberId_measuredAt_idx" ON "TemperatureRecord"("memberId", "measuredAt");
+
+-- AddForeignKey
+ALTER TABLE "TemperatureRecord" ADD CONSTRAINT "TemperatureRecord_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TemperatureRecord" ADD CONSTRAINT "TemperatureRecord_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES "Member"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   bodyMeasurements   BodyMeasurement[]
   emergencyContacts  EmergencyContact[]
   prescriptions          Prescription[]
+  temperatureRecords     TemperatureRecord[]
   notificationSetting    NotificationSetting?
 }
 
@@ -64,6 +65,7 @@ model Member {
   bodyMeasurements   BodyMeasurement[]
   emergencyContacts  EmergencyContact[]
   prescriptions      Prescription[]
+  temperatureRecords TemperatureRecord[]
 
   @@index([userId])
 }
@@ -263,6 +265,22 @@ model BodyMeasurement {
 
   @@index([userId])
   @@index([memberId])
+}
+
+model TemperatureRecord {
+  id          String   @id @default(cuid())
+  userId      String
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  memberId    String
+  member      Member   @relation(fields: [memberId], references: [id], onDelete: Cascade)
+  temperature Float
+  measuredAt  DateTime
+  notes       String?
+  createdAt   DateTime @default(now())
+
+  @@index([userId])
+  @@index([memberId])
+  @@index([memberId, measuredAt])
 }
 
 model EmergencyContact {

--- a/src/app/api/temperature-records/[recordId]/route.ts
+++ b/src/app/api/temperature-records/[recordId]/route.ts
@@ -1,0 +1,60 @@
+import { updateTemperatureRecordSchema } from '@/lib/schemas';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, withOwnershipCheck, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { UpdateTemperatureRecord, DeleteTemperatureRecord } from '@/domain/usecases/ManageTemperatureRecords';
+
+export async function PUT(request: Request, { params }: { params: Promise<{ recordId: string }> }) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`temperature-records-put:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const container = createServerDIContainer(userId);
+    const { recordId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: recordId,
+      finder: (id) => container.temperatureRecordRepository.findById(id),
+      resourceName: '体温記録',
+      handler: async () => {
+        const jsonResult = await safeParseJson(request);
+        if ('error' in jsonResult) return jsonResult.error;
+        const body = jsonResult.data;
+        const parsed = updateTemperatureRecordSchema.safeParse(body);
+        if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+        const usecase = new UpdateTemperatureRecord(container.temperatureRecordRepository);
+        const updated = await usecase.execute(recordId, {
+          temperature: parsed.data.temperature,
+          measuredAt: parsed.data.measuredAt,
+          notes: parsed.data.notes,
+        });
+        return success(updated);
+      },
+    });
+  })();
+}
+
+export async function DELETE(_request: Request, { params }: { params: Promise<{ recordId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`temperature-records-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+    const container = createServerDIContainer(userId);
+    const { recordId } = await params;
+    return withOwnershipCheck({
+      userId,
+      resourceId: recordId,
+      finder: (id) => container.temperatureRecordRepository.findById(id),
+      resourceName: '体温記録',
+      handler: async () => {
+        const usecase = new DeleteTemperatureRecord(container.temperatureRecordRepository);
+        await usecase.execute(recordId);
+        return success({ message: '削除しました' });
+      },
+    });
+  })();
+}

--- a/src/app/api/temperature-records/member/[memberId]/route.ts
+++ b/src/app/api/temperature-records/member/[memberId]/route.ts
@@ -1,0 +1,26 @@
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateParamId } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { GetTemperatureRecordsByMember } from '@/domain/usecases/ManageTemperatureRecords';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ memberId: string }> }) {
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`temperature-records-member-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const { memberId } = await params;
+    const idError = validateParamId(memberId);
+    if (idError) return idError;
+
+    const container = createServerDIContainer(userId);
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => container.memberRepository.getMemberById(memberId), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const usecase = new GetTemperatureRecordsByMember(container.temperatureRecordRepository);
+    const records = await usecase.execute(memberId);
+    return success(records);
+  })();
+}

--- a/src/app/api/temperature-records/route.ts
+++ b/src/app/api/temperature-records/route.ts
@@ -1,0 +1,45 @@
+import { createTemperatureRecordSchema } from '@/lib/schemas';
+import { success, created, errorResponse } from '@/lib/auth-helpers';
+import { withAuth, verifyResourceOwnership, validateBodySize, safeParseJson } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+import { createServerDIContainer } from '@/infrastructure/ServerDIContainer';
+import { CreateTemperatureRecord } from '@/domain/usecases/ManageTemperatureRecords';
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`temperature-records-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+  const container = createServerDIContainer(userId);
+  const records = await container.temperatureRecordRepository.getAll();
+  return success(records);
+});
+
+export async function POST(request: Request) {
+  const sizeError = validateBodySize(request);
+  if (sizeError) return sizeError;
+
+  return withAuth(async (userId) => {
+    const { allowed } = checkRateLimit(`temperature-records-post:${userId}`, { maxAttempts: 20, windowMs: 60000 });
+    if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+    const jsonResult = await safeParseJson(request);
+    if ('error' in jsonResult) return jsonResult.error;
+    const body = jsonResult.data;
+    const parsed = createTemperatureRecordSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message);
+
+    const container = createServerDIContainer(userId);
+    const ownershipError = await verifyResourceOwnership(userId, [
+      { finder: () => container.memberRepository.getMemberById(parsed.data.memberId), resourceName: 'メンバー' },
+    ]);
+    if (ownershipError) return ownershipError;
+
+    const usecase = new CreateTemperatureRecord(container.temperatureRecordRepository);
+    const record = await usecase.execute({
+      memberId: parsed.data.memberId,
+      temperature: parsed.data.temperature,
+      measuredAt: parsed.data.measuredAt,
+      notes: parsed.data.notes,
+    });
+    return created(record);
+  })();
+}

--- a/src/app/health-logs/page.tsx
+++ b/src/app/health-logs/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
-import { Plus, X, Activity, Ruler } from 'lucide-react';
+import { Plus, X, Activity, Ruler, Thermometer } from 'lucide-react';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 import { HealthLogList } from '@/components/health-logs/HealthLogList';
 import { HealthLogForm } from '@/components/health-logs/HealthLogForm';
@@ -10,19 +10,25 @@ import { HealthWeeklyTrend } from '@/components/health-logs/HealthWeeklyTrend';
 import { SymptomFrequencySummary } from '@/components/health-logs/SymptomFrequencySummary';
 import { useHealthLogs } from '@/presentation/hooks/useHealthLogs';
 import { useBodyMeasurements } from '@/presentation/hooks/useBodyMeasurements';
+import { useTemperatureRecords } from '@/presentation/hooks/useTemperatureRecords';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useAuth } from '@/hooks/useAuth';
 import { HealthLogEntity } from '@/domain/entities/HealthLog';
 import { BodyMeasurementForm, BodyMeasurementFormData } from '@/components/body-measurements/BodyMeasurementForm';
 import { BodyMeasurementList } from '@/components/body-measurements/BodyMeasurementList';
+import { TemperatureForm, TemperatureFormData } from '@/components/temperatures/TemperatureForm';
+import { TemperatureChart } from '@/components/temperatures/TemperatureChart';
+import { TemperatureRecordList } from '@/components/temperatures/TemperatureRecordList';
 
 export default function HealthLogsPage() {
   const { userId, isLoading: authLoading } = useAuth();
   const { groups, isLoading, createLog, deleteLog } = useHealthLogs();
   const { members, isLoading: membersLoading } = useMembers(userId ?? '');
   const { measurements, isLoading: measurementsLoading, createMeasurement, updateMeasurement, deleteMeasurement } = useBodyMeasurements();
+  const { records: temperatureRecords, isLoading: temperatureLoading, createRecord: createTemperature, deleteRecord: deleteTemperature } = useTemperatureRecords();
   const [showForm, setShowForm] = useState(false);
   const [showMeasurementForm, setShowMeasurementForm] = useState(false);
+  const [showTemperatureForm, setShowTemperatureForm] = useState(false);
 
   const allLogs = useMemo(
     () => groups.flatMap((g) => g.logs),
@@ -57,6 +63,16 @@ export default function HealthLogsPage() {
   const handleDeleteMeasurement = async (id: string) => {
     if (!window.confirm('この記録を削除しますか？')) return;
     await deleteMeasurement(id);
+  };
+
+  const handleCreateTemperature = async (data: TemperatureFormData) => {
+    await createTemperature(data);
+    setShowTemperatureForm(false);
+  };
+
+  const handleDeleteTemperature = async (id: string) => {
+    if (!window.confirm('この体温記録を削除しますか？')) return;
+    await deleteTemperature(id);
   };
 
   return (
@@ -133,6 +149,48 @@ export default function HealthLogsPage() {
             isLoading={measurementsLoading}
             onUpdate={updateMeasurement}
             onDelete={handleDeleteMeasurement}
+          />
+        </div>
+
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center space-x-2">
+              <Thermometer size={18} className="text-primary-600" />
+              <h2 className="text-base font-bold text-gray-800">体温記録</h2>
+            </div>
+            <button
+              onClick={() => setShowTemperatureForm(!showTemperatureForm)}
+              className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+              aria-label={showTemperatureForm ? '閉じる' : '体温を追加'}
+            >
+              {showTemperatureForm ? <X size={16} /> : <Plus size={16} />}
+            </button>
+          </div>
+
+          {showTemperatureForm && !authLoading && !membersLoading && members.length > 0 && (
+            <div className="mb-4">
+              <TemperatureForm
+                members={members}
+                onSubmit={handleCreateTemperature}
+                onCancel={() => setShowTemperatureForm(false)}
+              />
+            </div>
+          )}
+
+          {showTemperatureForm && !authLoading && !membersLoading && members.length === 0 && (
+            <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+              先に<Link href="/members" className="underline font-medium text-yellow-800 hover:text-yellow-900">メンバーページ</Link>でメンバーを登録してください。
+            </div>
+          )}
+
+          <div className="mb-3">
+            <TemperatureChart records={temperatureRecords} />
+          </div>
+
+          <TemperatureRecordList
+            records={temperatureRecords}
+            isLoading={temperatureLoading}
+            onDelete={handleDeleteTemperature}
           />
         </div>
       </main>

--- a/src/components/temperatures/TemperatureChart.tsx
+++ b/src/components/temperatures/TemperatureChart.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { TemperatureRecord } from '../../domain/entities/TemperatureRecord';
+
+interface TemperatureChartProps {
+  records: TemperatureRecord[];
+  /** 表示する直近日数 (デフォルト7日) */
+  days?: number;
+}
+
+const VIEWBOX_WIDTH = 320;
+const VIEWBOX_HEIGHT = 180;
+const PADDING_LEFT = 32;
+const PADDING_RIGHT = 12;
+const PADDING_TOP = 16;
+const PADDING_BOTTOM = 28;
+const PLOT_WIDTH = VIEWBOX_WIDTH - PADDING_LEFT - PADDING_RIGHT;
+const PLOT_HEIGHT = VIEWBOX_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+
+const Y_MIN = 35.0;
+const Y_MAX = 40.0;
+const Y_TICKS = [35, 36, 37, 38, 39, 40];
+const FEVER_LINE = 37.5;
+
+export const TemperatureChart: React.FC<TemperatureChartProps> = ({ records, days = 7 }) => {
+  const { points, xLabels, hasData } = useMemo(() => {
+    const now = new Date();
+    const endTs = now.getTime();
+    const startTs = endTs - days * 24 * 60 * 60 * 1000;
+
+    const inRange = records.filter((r) => {
+      const t = r.measuredAt.getTime();
+      return t >= startTs && t <= endTs;
+    });
+
+    const sorted = [...inRange].sort((a, b) => a.measuredAt.getTime() - b.measuredAt.getTime());
+
+    const xFromTs = (ts: number) =>
+      PADDING_LEFT + ((ts - startTs) / (endTs - startTs)) * PLOT_WIDTH;
+    const yFromTemp = (temp: number) => {
+      const clamped = Math.max(Y_MIN, Math.min(Y_MAX, temp));
+      return PADDING_TOP + (1 - (clamped - Y_MIN) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
+    };
+
+    const pts = sorted.map((r) => ({
+      x: xFromTs(r.measuredAt.getTime()),
+      y: yFromTemp(r.temperature),
+      record: r,
+    }));
+
+    const labels: { x: number; label: string }[] = [];
+    const labelCount = Math.min(days, 4);
+    for (let i = 0; i < labelCount; i++) {
+      const ts = startTs + ((endTs - startTs) * i) / (labelCount - 1 || 1);
+      const d = new Date(ts);
+      labels.push({
+        x: xFromTs(ts),
+        label: `${d.getMonth() + 1}/${d.getDate()}`,
+      });
+    }
+
+    return { points: pts, xLabels: labels, hasData: sorted.length > 0 };
+  }, [records, days]);
+
+  const pathD = useMemo(() => {
+    if (points.length === 0) return '';
+    return points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  }, [points]);
+
+  const feverY = PADDING_TOP + (1 - (FEVER_LINE - Y_MIN) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-gray-200">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold text-gray-700">体温推移（直近{days}日）</h3>
+        <span className="text-xs text-gray-400">単位: °C</span>
+      </div>
+      {!hasData ? (
+        <div className="py-8 text-center text-sm text-gray-400">この期間の体温記録はありません</div>
+      ) : (
+        <svg
+          viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+          className="w-full h-auto"
+          role="img"
+          aria-label="体温推移グラフ"
+        >
+          {Y_TICKS.map((t) => {
+            const y = PADDING_TOP + (1 - (t - Y_MIN) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
+            return (
+              <g key={t}>
+                <line
+                  x1={PADDING_LEFT}
+                  x2={VIEWBOX_WIDTH - PADDING_RIGHT}
+                  y1={y}
+                  y2={y}
+                  stroke="#e5e7eb"
+                  strokeWidth={1}
+                />
+                <text
+                  x={PADDING_LEFT - 4}
+                  y={y + 3}
+                  textAnchor="end"
+                  fontSize={9}
+                  fill="#9ca3af"
+                >
+                  {t}
+                </text>
+              </g>
+            );
+          })}
+
+          <line
+            x1={PADDING_LEFT}
+            x2={VIEWBOX_WIDTH - PADDING_RIGHT}
+            y1={feverY}
+            y2={feverY}
+            stroke="#fca5a5"
+            strokeWidth={1}
+            strokeDasharray="3 2"
+          />
+          <text x={VIEWBOX_WIDTH - PADDING_RIGHT} y={feverY - 2} textAnchor="end" fontSize={8} fill="#dc2626">
+            発熱境界 37.5
+          </text>
+
+          {xLabels.map((l, i) => (
+            <text
+              key={i}
+              x={l.x}
+              y={VIEWBOX_HEIGHT - PADDING_BOTTOM + 14}
+              textAnchor="middle"
+              fontSize={9}
+              fill="#9ca3af"
+            >
+              {l.label}
+            </text>
+          ))}
+
+          {pathD && (
+            <path d={pathD} fill="none" stroke="#16a34a" strokeWidth={1.5} strokeLinejoin="round" />
+          )}
+
+          {points.map((p) => (
+            <circle
+              key={p.record.id}
+              cx={p.x}
+              cy={p.y}
+              r={3}
+              fill={p.record.temperature >= FEVER_LINE ? '#dc2626' : '#16a34a'}
+            >
+              <title>
+                {p.record.measuredAt.toLocaleString('ja-JP')} - {p.record.temperature}°C
+              </title>
+            </circle>
+          ))}
+        </svg>
+      )}
+    </div>
+  );
+};

--- a/src/components/temperatures/TemperatureForm.tsx
+++ b/src/components/temperatures/TemperatureForm.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import React, { useState } from 'react';
+import { X } from 'lucide-react';
+
+export interface TemperatureFormData {
+  memberId: string;
+  temperature: number;
+  measuredAt: string;
+  notes?: string;
+}
+
+interface TemperatureFormProps {
+  members: { id: string; name: string }[];
+  onSubmit: (data: TemperatureFormData) => Promise<void>;
+  onCancel: () => void;
+}
+
+function getNowLocalIsoForInput(): string {
+  const now = new Date();
+  const tzOffsetMs = now.getTimezoneOffset() * 60_000;
+  return new Date(now.getTime() - tzOffsetMs).toISOString().slice(0, 16);
+}
+
+export const TemperatureForm: React.FC<TemperatureFormProps> = ({ members, onSubmit, onCancel }) => {
+  const [memberId, setMemberId] = useState(members[0]?.id ?? '');
+  const [temperature, setTemperature] = useState('36.5');
+  const [measuredAt, setMeasuredAt] = useState(getNowLocalIsoForInput());
+  const [notes, setNotes] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!memberId) {
+      setError('メンバーを選択してください');
+      return;
+    }
+
+    const tempNum = parseFloat(temperature);
+    if (!Number.isFinite(tempNum) || tempNum < 30 || tempNum > 45) {
+      setError('体温は30.0〜45.0の範囲で入力してください');
+      return;
+    }
+    if (!measuredAt) {
+      setError('計測時刻を選択してください');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        memberId,
+        temperature: tempNum,
+        measuredAt: new Date(measuredAt).toISOString(),
+        notes: notes.trim() || undefined,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '保存に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm p-4 border border-gray-200">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-800">体温を記録</h3>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-gray-400 hover:text-gray-600"
+          aria-label="閉じる"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="temp-member" className="block text-sm font-medium text-gray-700 mb-1">
+            メンバー
+          </label>
+          <select
+            id="temp-member"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+          >
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label htmlFor="temp-value" className="block text-sm font-medium text-gray-700 mb-1">
+              体温 (°C)
+            </label>
+            <input
+              id="temp-value"
+              type="number"
+              step="0.1"
+              min="30"
+              max="45"
+              value={temperature}
+              onChange={(e) => setTemperature(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              inputMode="decimal"
+            />
+          </div>
+          <div>
+            <label htmlFor="temp-time" className="block text-sm font-medium text-gray-700 mb-1">
+              計測時刻
+            </label>
+            <input
+              id="temp-time"
+              type="datetime-local"
+              value={measuredAt}
+              onChange={(e) => setMeasuredAt(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="temp-notes" className="block text-sm font-medium text-gray-700 mb-1">
+            メモ（任意）
+          </label>
+          <textarea
+            id="temp-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="例: 解熱剤服用後 / 朝起床時"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm resize-none"
+            rows={2}
+            maxLength={500}
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting || !memberId}
+          className="w-full py-2 bg-primary-600 text-white rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+        >
+          {isSubmitting ? '記録中...' : '記録する'}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/src/components/temperatures/TemperatureRecordList.tsx
+++ b/src/components/temperatures/TemperatureRecordList.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import React from 'react';
+import { Trash2, Thermometer } from 'lucide-react';
+import { TemperatureRecord, TemperatureRecordEntity } from '../../domain/entities/TemperatureRecord';
+
+interface TemperatureRecordListProps {
+  records: TemperatureRecord[];
+  isLoading: boolean;
+  onDelete: (id: string) => void;
+}
+
+function formatDateTime(d: Date): string {
+  const m = d.getMonth() + 1;
+  const day = d.getDate();
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${m}/${day} ${hh}:${mm}`;
+}
+
+export const TemperatureRecordList: React.FC<TemperatureRecordListProps> = ({
+  records,
+  isLoading,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return <div className="py-4 text-center text-sm text-gray-400">読み込み中...</div>;
+  }
+
+  if (records.length === 0) {
+    return <div className="py-4 text-center text-sm text-gray-400">体温の記録はまだありません</div>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {records.map((r) => {
+        const category = TemperatureRecordEntity.classify(r.temperature);
+        const colorClass = TemperatureRecordEntity.getCategoryColor(category);
+        const categoryLabel = TemperatureRecordEntity.getCategoryLabel(category);
+        return (
+          <li
+            key={r.id}
+            className="flex items-center justify-between rounded-lg border border-gray-200 bg-white p-3"
+          >
+            <div className="flex items-center space-x-3">
+              <Thermometer size={18} className={colorClass} />
+              <div>
+                <div className="flex items-baseline space-x-2">
+                  <span className={`text-base font-semibold ${colorClass}`}>
+                    {r.temperature.toFixed(1)}°C
+                  </span>
+                  <span className="text-xs text-gray-500">{categoryLabel}</span>
+                </div>
+                <div className="text-xs text-gray-500">
+                  {r.memberName ? `${r.memberName}・` : ''}{formatDateTime(r.measuredAt)}
+                </div>
+                {r.notes && <div className="mt-1 text-xs text-gray-600">{r.notes}</div>}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => onDelete(r.id)}
+              className="p-1 text-gray-400 hover:text-red-600"
+              aria-label="削除"
+            >
+              <Trash2 size={16} />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -9,10 +9,11 @@ import { Vaccination } from '../../domain/entities/Vaccination';
 import { Examination } from '../../domain/entities/Examination';
 import { Allergy } from '../../domain/entities/Allergy';
 import { BodyMeasurement } from '../../domain/entities/BodyMeasurement';
+import { TemperatureRecord } from '../../domain/entities/TemperatureRecord';
 import { EmergencyContact } from '../../domain/entities/EmergencyContact';
 import { Prescription } from '../../domain/entities/Prescription';
 import { Insurance } from '../../domain/entities/Insurance';
-import { BackendAllergy, BackendBodyMeasurement, BackendEmergencyContact, BackendPrescription, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendVaccination } from './types';
+import { BackendAllergy, BackendBodyMeasurement, BackendEmergencyContact, BackendPrescription, BackendAppointment, BackendExamination, BackendHealthLog, BackendHospital, BackendInsurance, BackendMember, BackendMedication, BackendRecord, BackendSchedule, BackendTemperatureRecord, BackendVaccination } from './types';
 
 const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
@@ -187,6 +188,19 @@ export function toBodyMeasurement(b: BackendBodyMeasurement): BodyMeasurement {
     weight: b.weight,
     height: b.height,
     recordedAt: new Date(b.recordedAt),
+    notes: b.notes,
+    createdAt: new Date(b.createdAt),
+  };
+}
+
+export function toTemperatureRecord(b: BackendTemperatureRecord): TemperatureRecord {
+  return {
+    id: b.id,
+    userId: b.userId,
+    memberId: b.memberId,
+    memberName: b.memberName,
+    temperature: b.temperature,
+    measuredAt: new Date(b.measuredAt),
     notes: b.notes,
     createdAt: new Date(b.createdAt),
   };

--- a/src/data/api/temperatureRecordApi.ts
+++ b/src/data/api/temperatureRecordApi.ts
@@ -1,0 +1,39 @@
+import { TemperatureRecord } from '../../domain/entities/TemperatureRecord';
+import {
+  CreateTemperatureRecordInput,
+  UpdateTemperatureRecordInput,
+} from '../../domain/repositories/TemperatureRecordRepository';
+import { apiClient } from './apiClient';
+import { toTemperatureRecord } from './mappers';
+import { BackendTemperatureRecord } from './types';
+
+export const temperatureRecordApi = {
+  async getAll(): Promise<TemperatureRecord[]> {
+    const data = await apiClient.get<BackendTemperatureRecord[]>('/temperature-records');
+    return data.map(toTemperatureRecord);
+  },
+
+  async getByMember(memberId: string): Promise<TemperatureRecord[]> {
+    const data = await apiClient.get<BackendTemperatureRecord[]>(
+      `/temperature-records/member/${encodeURIComponent(memberId)}`,
+    );
+    return data.map(toTemperatureRecord);
+  },
+
+  async create(input: CreateTemperatureRecordInput): Promise<TemperatureRecord> {
+    const data = await apiClient.post<BackendTemperatureRecord>('/temperature-records', input);
+    return toTemperatureRecord(data);
+  },
+
+  async update(id: string, input: UpdateTemperatureRecordInput): Promise<TemperatureRecord> {
+    const data = await apiClient.put<BackendTemperatureRecord>(
+      `/temperature-records/${encodeURIComponent(id)}`,
+      input,
+    );
+    return toTemperatureRecord(data);
+  },
+
+  async delete(id: string): Promise<void> {
+    await apiClient.del(`/temperature-records/${encodeURIComponent(id)}`);
+  },
+};

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -144,6 +144,17 @@ export interface BackendBodyMeasurement {
   createdAt: string;
 }
 
+export interface BackendTemperatureRecord {
+  id: string;
+  userId: string;
+  memberId: string;
+  memberName?: string;
+  temperature: number;
+  measuredAt: string;
+  notes?: string;
+  createdAt: string;
+}
+
 export interface BackendAllergy {
   id: string;
   userId: string;

--- a/src/data/repositories/TemperatureRecordRepositoryImpl.ts
+++ b/src/data/repositories/TemperatureRecordRepositoryImpl.ts
@@ -1,0 +1,33 @@
+import {
+  TemperatureRecordRepository,
+  CreateTemperatureRecordInput,
+  UpdateTemperatureRecordInput,
+} from '../../domain/repositories/TemperatureRecordRepository';
+import { TemperatureRecord } from '../../domain/entities/TemperatureRecord';
+import { temperatureRecordApi } from '../api/temperatureRecordApi';
+
+export class TemperatureRecordRepositoryImpl implements TemperatureRecordRepository {
+  async findById(_id: string): Promise<{ userId: string } | null> {
+    throw new Error('findById はサーバーサイド専用です');
+  }
+
+  async getAll(): Promise<TemperatureRecord[]> {
+    return temperatureRecordApi.getAll();
+  }
+
+  async getByMember(memberId: string): Promise<TemperatureRecord[]> {
+    return temperatureRecordApi.getByMember(memberId);
+  }
+
+  async create(input: CreateTemperatureRecordInput): Promise<TemperatureRecord> {
+    return temperatureRecordApi.create(input);
+  }
+
+  async update(id: string, input: UpdateTemperatureRecordInput): Promise<TemperatureRecord> {
+    return temperatureRecordApi.update(id, input);
+  }
+
+  async delete(id: string): Promise<void> {
+    return temperatureRecordApi.delete(id);
+  }
+}

--- a/src/data/repositories/server/PrismaTemperatureRecordRepository.ts
+++ b/src/data/repositories/server/PrismaTemperatureRecordRepository.ts
@@ -1,0 +1,110 @@
+/**
+ * サーバーサイド用 体温記録リポジトリ実装（Prisma）
+ */
+
+import { prisma } from '@/lib/prisma';
+import {
+  TemperatureRecordRepository,
+  CreateTemperatureRecordInput,
+  UpdateTemperatureRecordInput,
+} from '@/domain/repositories/TemperatureRecordRepository';
+import { TemperatureRecord } from '@/domain/entities/TemperatureRecord';
+import { QUERY_LIMITS } from '@/lib/constants';
+
+function toTemperatureRecord(row: {
+  id: string;
+  userId: string;
+  memberId: string;
+  temperature: number;
+  measuredAt: Date;
+  notes: string | null;
+  createdAt: Date;
+  member?: { name: string };
+}): TemperatureRecord {
+  return {
+    id: row.id,
+    userId: row.userId,
+    memberId: row.memberId,
+    memberName: row.member?.name,
+    temperature: row.temperature,
+    measuredAt: row.measuredAt,
+    notes: row.notes ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class PrismaTemperatureRecordRepository implements TemperatureRecordRepository {
+  constructor(private readonly userId: string) {}
+
+  async findById(id: string): Promise<{ userId: string } | null> {
+    return prisma.temperatureRecord.findUnique({
+      where: { id },
+      select: { id: true, userId: true },
+    });
+  }
+
+  async getAll(): Promise<TemperatureRecord[]> {
+    const rows = await prisma.temperatureRecord.findMany({
+      where: { userId: this.userId },
+      include: { member: { select: { name: true } } },
+      orderBy: { measuredAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toTemperatureRecord);
+  }
+
+  async getByMember(memberId: string): Promise<TemperatureRecord[]> {
+    const rows = await prisma.temperatureRecord.findMany({
+      where: { userId: this.userId, memberId },
+      include: { member: { select: { name: true } } },
+      orderBy: { measuredAt: 'desc' },
+      take: QUERY_LIMITS.DEFAULT,
+    });
+    return rows.map(toTemperatureRecord);
+  }
+
+  async create(input: CreateTemperatureRecordInput): Promise<TemperatureRecord> {
+    const row = await prisma.temperatureRecord.create({
+      data: {
+        userId: this.userId,
+        memberId: input.memberId,
+        temperature: input.temperature,
+        measuredAt: new Date(input.measuredAt),
+        notes: input.notes,
+      },
+      include: { member: { select: { name: true } } },
+    });
+    return toTemperatureRecord(row);
+  }
+
+  async update(id: string, input: UpdateTemperatureRecordInput): Promise<TemperatureRecord> {
+    const existing = await prisma.temperatureRecord.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('体温記録が見つかりません');
+    }
+
+    const data: Record<string, unknown> = {};
+    if (input.temperature !== undefined) data.temperature = input.temperature;
+    if (input.measuredAt !== undefined) data.measuredAt = new Date(input.measuredAt);
+    if (input.notes !== undefined) data.notes = input.notes;
+
+    const row = await prisma.temperatureRecord.update({
+      where: { id },
+      data,
+      include: { member: { select: { name: true } } },
+    });
+    return toTemperatureRecord(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    const existing = await prisma.temperatureRecord.findFirst({
+      where: { id, userId: this.userId },
+    });
+    if (!existing) {
+      throw new Error('体温記録が見つかりません');
+    }
+    await prisma.temperatureRecord.delete({ where: { id } });
+  }
+}

--- a/src/domain/entities/TemperatureRecord.ts
+++ b/src/domain/entities/TemperatureRecord.ts
@@ -1,0 +1,65 @@
+/**
+ * 体温記録エンティティ
+ */
+
+export interface TemperatureRecord {
+  readonly id: string;
+  readonly userId: string;
+  readonly memberId: string;
+  readonly memberName?: string;
+  readonly temperature: number;
+  readonly measuredAt: Date;
+  readonly notes?: string;
+  readonly createdAt: Date;
+}
+
+export type TemperatureCategory = 'hypothermia' | 'normal' | 'low_fever' | 'fever' | 'high_fever';
+
+export class TemperatureRecordEntity {
+  private static readonly TEMP_HYPOTHERMIA = 35.0;
+  private static readonly TEMP_LOW_FEVER = 37.5;
+  private static readonly TEMP_FEVER = 38.0;
+  private static readonly TEMP_HIGH_FEVER = 39.0;
+  private static readonly TEMP_MIN_VALID = 30.0;
+  private static readonly TEMP_MAX_VALID = 45.0;
+
+  private static readonly CATEGORY_LABELS: Record<TemperatureCategory, string> = {
+    hypothermia: '低体温',
+    normal: '平熱',
+    low_fever: '微熱',
+    fever: '発熱',
+    high_fever: '高熱',
+  };
+
+  private static readonly CATEGORY_COLORS: Record<TemperatureCategory, string> = {
+    hypothermia: 'text-blue-600',
+    normal: 'text-green-600',
+    low_fever: 'text-yellow-600',
+    fever: 'text-orange-600',
+    high_fever: 'text-red-600',
+  };
+
+  static classify(temperature: number): TemperatureCategory {
+    if (temperature < TemperatureRecordEntity.TEMP_HYPOTHERMIA) return 'hypothermia';
+    if (temperature < TemperatureRecordEntity.TEMP_LOW_FEVER) return 'normal';
+    if (temperature < TemperatureRecordEntity.TEMP_FEVER) return 'low_fever';
+    if (temperature < TemperatureRecordEntity.TEMP_HIGH_FEVER) return 'fever';
+    return 'high_fever';
+  }
+
+  static getCategoryLabel(category: TemperatureCategory): string {
+    return TemperatureRecordEntity.CATEGORY_LABELS[category];
+  }
+
+  static getCategoryColor(category: TemperatureCategory): string {
+    return TemperatureRecordEntity.CATEGORY_COLORS[category];
+  }
+
+  static isValidTemperature(temperature: number): boolean {
+    return (
+      Number.isFinite(temperature) &&
+      temperature >= TemperatureRecordEntity.TEMP_MIN_VALID &&
+      temperature <= TemperatureRecordEntity.TEMP_MAX_VALID
+    );
+  }
+}

--- a/src/domain/repositories/TemperatureRecordRepository.ts
+++ b/src/domain/repositories/TemperatureRecordRepository.ts
@@ -1,0 +1,23 @@
+import { TemperatureRecord } from '../entities/TemperatureRecord';
+
+export interface CreateTemperatureRecordInput {
+  memberId: string;
+  temperature: number;
+  measuredAt: string;
+  notes?: string;
+}
+
+export interface UpdateTemperatureRecordInput {
+  temperature?: number;
+  measuredAt?: string;
+  notes?: string | null;
+}
+
+export interface TemperatureRecordRepository {
+  findById(id: string): Promise<{ userId: string } | null>;
+  getAll(): Promise<TemperatureRecord[]>;
+  getByMember(memberId: string): Promise<TemperatureRecord[]>;
+  create(input: CreateTemperatureRecordInput): Promise<TemperatureRecord>;
+  update(id: string, input: UpdateTemperatureRecordInput): Promise<TemperatureRecord>;
+  delete(id: string): Promise<void>;
+}

--- a/src/domain/usecases/ManageTemperatureRecords.ts
+++ b/src/domain/usecases/ManageTemperatureRecords.ts
@@ -1,0 +1,57 @@
+import { TemperatureRecord, TemperatureRecordEntity } from '../entities/TemperatureRecord';
+import {
+  TemperatureRecordRepository,
+  CreateTemperatureRecordInput,
+  UpdateTemperatureRecordInput,
+} from '../repositories/TemperatureRecordRepository';
+
+export class GetTemperatureRecords {
+  constructor(private readonly repository: TemperatureRecordRepository) {}
+
+  async execute(): Promise<TemperatureRecord[]> {
+    return this.repository.getAll();
+  }
+}
+
+export class GetTemperatureRecordsByMember {
+  constructor(private readonly repository: TemperatureRecordRepository) {}
+
+  async execute(memberId: string): Promise<TemperatureRecord[]> {
+    if (!memberId) throw new Error('メンバーIDは必須です');
+    return this.repository.getByMember(memberId);
+  }
+}
+
+export class CreateTemperatureRecord {
+  constructor(private readonly repository: TemperatureRecordRepository) {}
+
+  async execute(input: CreateTemperatureRecordInput): Promise<TemperatureRecord> {
+    if (!input.memberId) throw new Error('メンバーIDは必須です');
+    if (!input.measuredAt) throw new Error('計測時刻は必須です');
+    if (!TemperatureRecordEntity.isValidTemperature(input.temperature)) {
+      throw new Error('体温は30.0〜45.0の範囲で指定してください');
+    }
+    return this.repository.create(input);
+  }
+}
+
+export class UpdateTemperatureRecord {
+  constructor(private readonly repository: TemperatureRecordRepository) {}
+
+  async execute(id: string, input: UpdateTemperatureRecordInput): Promise<TemperatureRecord> {
+    if (!id) throw new Error('記録IDは必須です');
+    if (input.temperature !== undefined && !TemperatureRecordEntity.isValidTemperature(input.temperature)) {
+      throw new Error('体温は30.0〜45.0の範囲で指定してください');
+    }
+    return this.repository.update(id, input);
+  }
+}
+
+export class DeleteTemperatureRecord {
+  constructor(private readonly repository: TemperatureRecordRepository) {}
+
+  async execute(id: string): Promise<void> {
+    if (!id) throw new Error('記録IDは必須です');
+    return this.repository.delete(id);
+  }
+}

--- a/src/infrastructure/DIContainer.ts
+++ b/src/infrastructure/DIContainer.ts
@@ -20,6 +20,7 @@ import { EmergencyContactRepository } from '../domain/repositories/EmergencyCont
 import { PrescriptionRepository } from '../domain/repositories/PrescriptionRepository';
 import { NotificationSettingRepository } from '../domain/repositories/NotificationSettingRepository';
 import { MedicationInfoRepository } from '../domain/repositories/MedicationInfoRepository';
+import { TemperatureRecordRepository } from '../domain/repositories/TemperatureRecordRepository';
 import { MemberRepositoryImpl } from '../data/repositories/MemberRepositoryImpl';
 import { MedicationRepositoryImpl } from '../data/repositories/MedicationRepositoryImpl';
 import { ScheduleRepositoryImpl } from '../data/repositories/ScheduleRepositoryImpl';
@@ -37,6 +38,7 @@ import { EmergencyContactRepositoryImpl } from '../data/repositories/EmergencyCo
 import { PrescriptionRepositoryImpl } from '../data/repositories/PrescriptionRepositoryImpl';
 import { NotificationSettingRepositoryImpl } from '../data/repositories/NotificationSettingRepositoryImpl';
 import { MedicationInfoRepositoryImpl } from '../data/repositories/MedicationInfoRepositoryImpl';
+import { TemperatureRecordRepositoryImpl } from '../data/repositories/TemperatureRecordRepositoryImpl';
 
 export interface DIContainer {
   memberRepository: MemberRepository;
@@ -56,6 +58,7 @@ export interface DIContainer {
   prescriptionRepository: PrescriptionRepository;
   notificationSettingRepository: NotificationSettingRepository;
   medicationInfoRepository: MedicationInfoRepository;
+  temperatureRecordRepository: TemperatureRecordRepository;
 }
 
 // シングルトンコンテナ（テスト時にモックに差し替え可能）
@@ -81,6 +84,7 @@ export const getDIContainer = (): DIContainer => {
       prescriptionRepository: new PrescriptionRepositoryImpl(),
       notificationSettingRepository: new NotificationSettingRepositoryImpl(),
       medicationInfoRepository: new MedicationInfoRepositoryImpl(),
+      temperatureRecordRepository: new TemperatureRecordRepositoryImpl(),
     };
   }
   return container;

--- a/src/infrastructure/ServerDIContainer.ts
+++ b/src/infrastructure/ServerDIContainer.ts
@@ -20,6 +20,7 @@ import { MemberRepository } from '@/domain/repositories/MemberRepository';
 import { AppointmentRepository } from '@/domain/repositories/AppointmentRepository';
 import { UserProfileRepository } from '@/domain/repositories/UserProfileRepository';
 import { NotificationSettingRepository } from '@/domain/repositories/NotificationSettingRepository';
+import { TemperatureRecordRepository } from '@/domain/repositories/TemperatureRecordRepository';
 import { PrismaMedicationRepository } from '@/data/repositories/server/PrismaMedicationRepository';
 import { PrismaScheduleRepository } from '@/data/repositories/server/PrismaScheduleRepository';
 import { PrismaMedicationRecordRepository } from '@/data/repositories/server/PrismaMedicationRecordRepository';
@@ -36,6 +37,7 @@ import { PrismaMemberRepository } from '@/data/repositories/server/PrismaMemberR
 import { PrismaAppointmentRepository } from '@/data/repositories/server/PrismaAppointmentRepository';
 import { PrismaUserProfileRepository } from '@/data/repositories/server/PrismaUserProfileRepository';
 import { PrismaNotificationSettingRepository } from '@/data/repositories/server/PrismaNotificationSettingRepository';
+import { PrismaTemperatureRecordRepository } from '@/data/repositories/server/PrismaTemperatureRecordRepository';
 
 export interface ServerDIContainer {
   medicationRepository: MedicationRepository;
@@ -54,6 +56,7 @@ export interface ServerDIContainer {
   appointmentRepository: AppointmentRepository;
   userProfileRepository: UserProfileRepository;
   notificationSettingRepository: NotificationSettingRepository;
+  temperatureRecordRepository: TemperatureRecordRepository;
 }
 
 /**
@@ -78,5 +81,6 @@ export function createServerDIContainer(userId: string): ServerDIContainer {
     appointmentRepository: new PrismaAppointmentRepository(userId),
     userProfileRepository: new PrismaUserProfileRepository(userId),
     notificationSettingRepository: new PrismaNotificationSettingRepository(userId),
+    temperatureRecordRepository: new PrismaTemperatureRecordRepository(userId),
   };
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -275,6 +275,28 @@ export const updateBodyMeasurementSchema = z.object({
   message: '更新するフィールドがありません',
 });
 
+// ===== Temperature Records =====
+export const createTemperatureRecordSchema = z.object({
+  memberId: idField,
+  temperature: z.number().min(30, '体温は30.0以上を指定してください').max(45, '体温は45.0以下を指定してください'),
+  measuredAt: z.string().trim().refine(
+    (val) => !isNaN(Date.parse(val)),
+    { message: '計測時刻は有効な日時形式で入力してください' },
+  ),
+  notes: z.string().trim().max(500).optional(),
+});
+
+export const updateTemperatureRecordSchema = z.object({
+  temperature: z.number().min(30).max(45).optional(),
+  measuredAt: z.string().trim().refine(
+    (val) => !isNaN(Date.parse(val)),
+    { message: '計測時刻は有効な日時形式で入力してください' },
+  ).optional(),
+  notes: z.string().trim().max(500).optional().nullable(),
+}).refine((data) => Object.keys(data).length > 0, {
+  message: '更新するフィールドがありません',
+});
+
 // ===== Allergies =====
 export const createAllergySchema = z.object({
   memberId: idField,

--- a/src/presentation/hooks/useTemperatureRecords.ts
+++ b/src/presentation/hooks/useTemperatureRecords.ts
@@ -1,0 +1,68 @@
+import { useCallback, useMemo } from 'react';
+import { TemperatureRecord } from '../../domain/entities/TemperatureRecord';
+import {
+  GetTemperatureRecords,
+  CreateTemperatureRecord,
+  UpdateTemperatureRecord,
+  DeleteTemperatureRecord,
+} from '../../domain/usecases/ManageTemperatureRecords';
+import {
+  CreateTemperatureRecordInput,
+  UpdateTemperatureRecordInput,
+} from '../../domain/repositories/TemperatureRecordRepository';
+import { getDIContainer } from '../../infrastructure/DIContainer';
+import { useFetcher } from './useFetcher';
+
+export interface UseTemperatureRecordsResult {
+  records: TemperatureRecord[];
+  isLoading: boolean;
+  error: Error | null;
+  createRecord: (input: CreateTemperatureRecordInput) => Promise<void>;
+  updateRecord: (id: string, input: UpdateTemperatureRecordInput) => Promise<void>;
+  deleteRecord: (id: string) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export const useTemperatureRecords = (): UseTemperatureRecordsResult => {
+  const useCases = useMemo(() => {
+    const { temperatureRecordRepository } = getDIContainer();
+    return {
+      get: new GetTemperatureRecords(temperatureRecordRepository),
+      create: new CreateTemperatureRecord(temperatureRecordRepository),
+      update: new UpdateTemperatureRecord(temperatureRecordRepository),
+      delete: new DeleteTemperatureRecord(temperatureRecordRepository),
+    };
+  }, []);
+
+  const { data: records, isLoading, error, refetch } = useFetcher(
+    () => useCases.get.execute(),
+    [useCases],
+    [] as TemperatureRecord[],
+    'temperature-records',
+  );
+
+  const handleCreate = useCallback(async (input: CreateTemperatureRecordInput) => {
+    await useCases.create.execute(input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleUpdate = useCallback(async (id: string, input: UpdateTemperatureRecordInput) => {
+    await useCases.update.execute(id, input);
+    await refetch();
+  }, [useCases, refetch]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    await useCases.delete.execute(id);
+    await refetch();
+  }, [useCases, refetch]);
+
+  return {
+    records,
+    isLoading,
+    error,
+    createRecord: handleCreate,
+    updateRecord: handleUpdate,
+    deleteRecord: handleDelete,
+    refetch,
+  };
+};


### PR DESCRIPTION
## Summary
- 体調ページに体温記録セクションを追加（計測時刻 + 体温(°C) + メモ）
- 直近7日の体温推移をSVG折れ線グラフで可視化、発熱境界(37.5°C)を点線で表示
- TemperatureRecordモデル + マイグレーション追加 (Prisma)
- Clean Architectureに沿って domain / data / presentation / infrastructure を分離
- 既存依存のみで実装（recharts等の追加なし、自前SVG)
- 薬の副作用判定の参考情報として、服薬と体温推移を同じページで確認可能