### PR TITLE
chore: ビルド時に prisma migrate deploy を自動実行

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- `build` スクリプトを `prisma migrate deploy && next build` に変更
- Vercelデプロイ時に未適用のPrismaマイグレーションを本番Supabase DBに自動適用
- マイグレーション忘れによるランタイムエラー（table does not exist 等）を防止
- 直近のTemperatureRecord追加(#1094)も次のVercelデプロイで自動適用される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the build process to apply database migrations before building the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->