### PR TITLE
feat: LINE通知機能を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Test
         run: npx vitest run --coverage
       - name: Build
-        run: npm run build
+        run: npx next build

--- a/prisma/migrations/20260428_add_line_notification/migration.sql
+++ b/prisma/migrations/20260428_add_line_notification/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "lineUserId" TEXT,
+ADD COLUMN "lineLinkCode" TEXT,
+ADD COLUMN "lineLinkCodeExpiry" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_lineUserId_key" ON "User"("lineUserId");
+
+-- AlterTable
+ALTER TABLE "NotificationSetting" ADD COLUMN "lineNotificationEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,9 @@ model User {
   verificationAttempts Int       @default(0)
   resetCode            String?
   resetCodeExpiry      DateTime?
+  lineUserId           String?   @unique
+  lineLinkCode         String?
+  lineLinkCodeExpiry   DateTime?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
 
@@ -310,6 +313,7 @@ model NotificationSetting {
   defaultReminderMinutesBefore        Int      @default(5)
   defaultAppointmentReminderDaysBefore Int     @default(1)
   emailNotificationEnabled            Boolean  @default(true)
+  lineNotificationEnabled             Boolean  @default(false)
   createdAt                           DateTime @default(now())
   updatedAt                           DateTime @updatedAt
 }

--- a/src/app/api/line/link/route.ts
+++ b/src/app/api/line/link/route.ts
@@ -1,0 +1,81 @@
+import { prisma } from '@/lib/prisma';
+import { generateLineLinkCode } from '@/lib/line';
+import { success, errorResponse } from '@/lib/auth-helpers';
+import { withAuth } from '@/lib/api-helpers';
+import { checkRateLimit } from '@/lib/security';
+
+const LINK_CODE_TTL_MS = 10 * 60 * 1000;
+
+interface LinkStatus {
+  linked: boolean;
+  pendingCode: string | null;
+  pendingExpiresAt: string | null;
+  friendAddUrl: string | null;
+}
+
+function getFriendAddUrl(): string | null {
+  return process.env.LINE_FRIEND_ADD_URL || null;
+}
+
+export const GET = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`line-link-get:${userId}`, { maxAttempts: 30, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { lineUserId: true, lineLinkCode: true, lineLinkCodeExpiry: true },
+  });
+  if (!user) return errorResponse('ユーザーが見つかりません', 404);
+
+  const now = new Date();
+  const codeValid = user.lineLinkCode && user.lineLinkCodeExpiry && user.lineLinkCodeExpiry > now;
+
+  const status: LinkStatus = {
+    linked: Boolean(user.lineUserId),
+    pendingCode: codeValid ? user.lineLinkCode : null,
+    pendingExpiresAt: codeValid ? user.lineLinkCodeExpiry!.toISOString() : null,
+    friendAddUrl: getFriendAddUrl(),
+  };
+  return success(status);
+});
+
+export const POST = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`line-link-post:${userId}`, { maxAttempts: 5, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+  const code = generateLineLinkCode();
+  const expiry = new Date(Date.now() + LINK_CODE_TTL_MS);
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      lineLinkCode: code,
+      lineLinkCodeExpiry: expiry,
+    },
+  });
+
+  return success({
+    code,
+    expiresAt: expiry.toISOString(),
+    friendAddUrl: getFriendAddUrl(),
+  });
+});
+
+export const DELETE = withAuth(async (userId) => {
+  const { allowed } = checkRateLimit(`line-link-delete:${userId}`, { maxAttempts: 10, windowMs: 60000 });
+  if (!allowed) return errorResponse('リクエストが多すぎます。しばらくしてから再試行してください。', 429);
+
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id: userId },
+      data: { lineUserId: null, lineLinkCode: null, lineLinkCodeExpiry: null },
+    }),
+    prisma.notificationSetting.upsert({
+      where: { userId },
+      create: { userId, lineNotificationEnabled: false },
+      update: { lineNotificationEnabled: false },
+    }),
+  ]);
+
+  return success({ unlinked: true });
+});

--- a/src/app/api/line/webhook/route.ts
+++ b/src/app/api/line/webhook/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import {
+  verifyLineSignature,
+  sendLineReplyMessage,
+  lineMessageTemplates,
+} from '@/lib/line';
+
+interface LineMessageEvent {
+  type: 'message';
+  replyToken: string;
+  source: { type: string; userId?: string };
+  message: { type: string; text?: string };
+}
+
+interface LineFollowEvent {
+  type: 'follow';
+  replyToken: string;
+  source: { type: string; userId?: string };
+}
+
+interface LineUnfollowEvent {
+  type: 'unfollow';
+  source: { type: string; userId?: string };
+}
+
+type LineEvent = LineMessageEvent | LineFollowEvent | LineUnfollowEvent | { type: string };
+
+function ok() {
+  return NextResponse.json({ success: true });
+}
+
+async function handleFollowEvent(event: LineFollowEvent): Promise<void> {
+  if (!event.replyToken) return;
+  await sendLineReplyMessage(event.replyToken, lineMessageTemplates.linkInstruction()).catch(() => {});
+}
+
+async function handleUnfollowEvent(event: LineUnfollowEvent): Promise<void> {
+  const lineUserId = event.source.userId;
+  if (!lineUserId) return;
+  await prisma.user.updateMany({
+    where: { lineUserId },
+    data: { lineUserId: null, lineLinkCode: null, lineLinkCodeExpiry: null },
+  });
+}
+
+async function handleMessageEvent(event: LineMessageEvent): Promise<void> {
+  const lineUserId = event.source.userId;
+  const text = event.message.text?.trim();
+  if (!lineUserId || !text) return;
+
+  const codeMatch = text.match(/^\d{6}$/);
+  if (!codeMatch) {
+    await sendLineReplyMessage(event.replyToken, lineMessageTemplates.linkInstruction()).catch(() => {});
+    return;
+  }
+
+  const code = codeMatch[0];
+  const now = new Date();
+  const user = await prisma.user.findFirst({
+    where: {
+      lineLinkCode: code,
+      lineLinkCodeExpiry: { gt: now },
+    },
+    select: { id: true, displayName: true, lineUserId: true },
+  });
+
+  if (!user) {
+    await sendLineReplyMessage(event.replyToken, lineMessageTemplates.linkInvalid()).catch(() => {});
+    return;
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.user.updateMany({
+      where: { lineUserId, NOT: { id: user.id } },
+      data: { lineUserId: null },
+    });
+    await tx.user.update({
+      where: { id: user.id },
+      data: {
+        lineUserId,
+        lineLinkCode: null,
+        lineLinkCodeExpiry: null,
+      },
+    });
+    await tx.notificationSetting.upsert({
+      where: { userId: user.id },
+      create: { userId: user.id, lineNotificationEnabled: true },
+      update: { lineNotificationEnabled: true },
+    });
+  });
+
+  await sendLineReplyMessage(
+    event.replyToken,
+    lineMessageTemplates.linkSuccess(user.displayName),
+  ).catch(() => {});
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+  const signature = request.headers.get('x-line-signature');
+
+  if (!verifyLineSignature(rawBody, signature)) {
+    return NextResponse.json({ success: false, error: 'Invalid signature' }, { status: 401 });
+  }
+
+  let payload: { events?: LineEvent[] };
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const events = payload.events ?? [];
+  for (const event of events) {
+    try {
+      if (event.type === 'follow') {
+        await handleFollowEvent(event as LineFollowEvent);
+      } else if (event.type === 'unfollow') {
+        await handleUnfollowEvent(event as LineUnfollowEvent);
+      } else if (event.type === 'message' && (event as LineMessageEvent).message.type === 'text') {
+        await handleMessageEvent(event as LineMessageEvent);
+      }
+    } catch (error) {
+      console.error('LINE webhook event handler failed', error);
+    }
+  }
+
+  return ok();
+}

--- a/src/app/appointments/page.tsx
+++ b/src/app/appointments/page.tsx
@@ -50,6 +50,7 @@ export default function AppointmentsPage() {
   const [showPrescriptionForm, setShowPrescriptionForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>('upcoming');
+  const [createError, setCreateError] = useState<string | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
   const editFormRef = useRef<HTMLDivElement>(null);
 
@@ -61,8 +62,13 @@ export default function AppointmentsPage() {
   ], [counts]);
 
   const handleCreate = async (data: AppointmentFormData) => {
-    await createAppointment(data);
-    setShowForm(false);
+    setCreateError(null);
+    try {
+      await createAppointment(data);
+      setShowForm(false);
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : '予約の追加に失敗しました。もう一度お試しください。');
+    }
   };
 
   const handleEdit = (appointment: Appointment) => {
@@ -155,8 +161,10 @@ export default function AppointmentsPage() {
   const handleToggleForm = () => {
     if (showForm) {
       setShowForm(false);
+      setCreateError(null);
     } else {
       setEditingAppointment(null);
+      setCreateError(null);
       setShowForm(true);
     }
   };
@@ -180,6 +188,9 @@ export default function AppointmentsPage() {
         {showForm && membersReady && members.length > 0 && (
           <div className="mb-6 bg-white rounded-lg shadow-md p-4 border border-gray-200">
             <h2 className="text-sm font-semibold text-gray-700 mb-3">通院予約の追加</h2>
+            {createError && (
+              <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2 mb-3">{createError}</p>
+            )}
             <AppointmentForm
               members={members}
               hospitals={hospitals}

--- a/src/components/appointments/AppointmentForm.tsx
+++ b/src/components/appointments/AppointmentForm.tsx
@@ -17,7 +17,7 @@ export interface AppointmentFormData {
 interface AppointmentFormProps {
   members: Member[];
   hospitals: Hospital[];
-  onSubmit: (data: AppointmentFormData) => void;
+  onSubmit: (data: AppointmentFormData) => Promise<void> | void;
   initialData?: Appointment;
   onCancel?: () => void;
 }
@@ -39,23 +39,29 @@ export const AppointmentForm: React.FC<AppointmentFormProps> = ({ members, hospi
   );
   const [type, setType] = useState(initialData?.appointmentType || '');
   const [notes, setNotes] = useState(initialData?.description || '');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!memberId || !appointmentDate) return;
+    if (!memberId || !appointmentDate || isSubmitting) return;
 
-    onSubmit({
-      memberId,
-      hospitalId: hospitalId || undefined,
-      appointmentDate,
-      type: type || undefined,
-      notes: notes.trim() || undefined,
-    });
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        memberId,
+        hospitalId: hospitalId || undefined,
+        appointmentDate,
+        type: type || undefined,
+        notes: notes.trim() || undefined,
+      });
 
-    if (!isEditing) {
-      setAppointmentDate('');
-      setType('');
-      setNotes('');
+      if (!isEditing) {
+        setAppointmentDate('');
+        setType('');
+        setNotes('');
+      }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -157,9 +163,10 @@ export const AppointmentForm: React.FC<AppointmentFormProps> = ({ members, hospi
       <div className={isEditing ? 'flex space-x-2' : ''}>
         <button
           type="submit"
-          className={`${isEditing ? 'flex-1' : 'w-full'} bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium`}
+          disabled={isSubmitting}
+          className={`${isEditing ? 'flex-1' : 'w-full'} bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium disabled:opacity-60 disabled:cursor-not-allowed`}
         >
-          {isEditing ? '更新する' : '追加する'}
+          {isSubmitting ? '送信中...' : isEditing ? '更新する' : '追加する'}
         </button>
         {isEditing && onCancel && (
           <button

--- a/src/data/api/notificationSettingApi.ts
+++ b/src/data/api/notificationSettingApi.ts
@@ -12,6 +12,7 @@ interface BackendNotificationSetting {
   defaultReminderMinutesBefore: number;
   defaultAppointmentReminderDaysBefore: number;
   emailNotificationEnabled: boolean;
+  lineNotificationEnabled: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -27,6 +28,7 @@ function toNotificationSetting(raw: BackendNotificationSetting): NotificationSet
     defaultReminderMinutesBefore: raw.defaultReminderMinutesBefore,
     defaultAppointmentReminderDaysBefore: raw.defaultAppointmentReminderDaysBefore,
     emailNotificationEnabled: raw.emailNotificationEnabled,
+    lineNotificationEnabled: raw.lineNotificationEnabled,
     createdAt: new Date(raw.createdAt),
     updatedAt: new Date(raw.updatedAt),
   };

--- a/src/data/repositories/server/PrismaNotificationSettingRepository.ts
+++ b/src/data/repositories/server/PrismaNotificationSettingRepository.ts
@@ -19,6 +19,7 @@ function toNotificationSetting(row: {
   defaultReminderMinutesBefore: number;
   defaultAppointmentReminderDaysBefore: number;
   emailNotificationEnabled: boolean;
+  lineNotificationEnabled: boolean;
   createdAt: Date;
   updatedAt: Date;
 }): NotificationSetting {
@@ -32,6 +33,7 @@ function toNotificationSetting(row: {
     defaultReminderMinutesBefore: row.defaultReminderMinutesBefore,
     defaultAppointmentReminderDaysBefore: row.defaultAppointmentReminderDaysBefore,
     emailNotificationEnabled: row.emailNotificationEnabled,
+    lineNotificationEnabled: row.lineNotificationEnabled,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -57,6 +59,7 @@ export class PrismaNotificationSettingRepository implements NotificationSettingR
     if (input.defaultReminderMinutesBefore !== undefined) data.defaultReminderMinutesBefore = input.defaultReminderMinutesBefore;
     if (input.defaultAppointmentReminderDaysBefore !== undefined) data.defaultAppointmentReminderDaysBefore = input.defaultAppointmentReminderDaysBefore;
     if (input.emailNotificationEnabled !== undefined) data.emailNotificationEnabled = input.emailNotificationEnabled;
+    if (input.lineNotificationEnabled !== undefined) data.lineNotificationEnabled = input.lineNotificationEnabled;
 
     const row = await prisma.notificationSetting.upsert({
       where: { userId: this.userId },

--- a/src/domain/entities/NotificationSetting.ts
+++ b/src/domain/entities/NotificationSetting.ts
@@ -14,6 +14,7 @@ export interface NotificationSetting {
   readonly defaultReminderMinutesBefore: number;
   readonly defaultAppointmentReminderDaysBefore: number;
   readonly emailNotificationEnabled: boolean;
+  readonly lineNotificationEnabled: boolean;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
@@ -26,6 +27,7 @@ export const DEFAULT_NOTIFICATION_SETTING: Omit<NotificationSetting, 'id' | 'use
   defaultReminderMinutesBefore: 5,
   defaultAppointmentReminderDaysBefore: 1,
   emailNotificationEnabled: true,
+  lineNotificationEnabled: false,
 };
 
 export function createNotificationSetting(
@@ -39,12 +41,12 @@ export function createNotificationSetting(
   };
 }
 
-export function isNotificationEnabled(
+export type NotificationChannel = 'email' | 'line';
+
+export function isNotificationTypeEnabled(
   setting: NotificationSetting,
   type: NotificationType,
 ): boolean {
-  if (!setting.emailNotificationEnabled) return false;
-
   switch (type) {
     case 'medication_reminder':
       return setting.medicationReminderEnabled;
@@ -55,6 +57,26 @@ export function isNotificationEnabled(
     case 'low_stock':
       return setting.lowStockAlertEnabled;
   }
+}
+
+export function isChannelEnabled(
+  setting: NotificationSetting,
+  channel: NotificationChannel,
+): boolean {
+  switch (channel) {
+    case 'email':
+      return setting.emailNotificationEnabled;
+    case 'line':
+      return setting.lineNotificationEnabled;
+  }
+}
+
+export function isNotificationEnabled(
+  setting: NotificationSetting,
+  type: NotificationType,
+  channel: NotificationChannel = 'email',
+): boolean {
+  return isChannelEnabled(setting, channel) && isNotificationTypeEnabled(setting, type);
 }
 
 export function getDefaultReminderMinutes(setting: NotificationSetting): number {

--- a/src/domain/repositories/NotificationSettingRepository.ts
+++ b/src/domain/repositories/NotificationSettingRepository.ts
@@ -8,6 +8,7 @@ export interface UpdateNotificationSettingInput {
   defaultReminderMinutesBefore?: number;
   defaultAppointmentReminderDaysBefore?: number;
   emailNotificationEnabled?: boolean;
+  lineNotificationEnabled?: boolean;
 }
 
 export interface NotificationSettingRepository {

--- a/src/lib/line.ts
+++ b/src/lib/line.ts
@@ -1,0 +1,193 @@
+import crypto from 'crypto';
+
+const LINE_PUSH_API = 'https://api.line.me/v2/bot/message/push';
+const LINE_REPLY_API = 'https://api.line.me/v2/bot/message/reply';
+
+function getChannelAccessToken(): string {
+  const token = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+  if (!token) {
+    throw new Error('LINE_CHANNEL_ACCESS_TOKEN is not set');
+  }
+  return token;
+}
+
+function getChannelSecret(): string {
+  const secret = process.env.LINE_CHANNEL_SECRET;
+  if (!secret) {
+    throw new Error('LINE_CHANNEL_SECRET is not set');
+  }
+  return secret;
+}
+
+export interface LineTextMessage {
+  type: 'text';
+  text: string;
+}
+
+export async function sendLinePushMessage(lineUserId: string, text: string): Promise<void> {
+  const message: LineTextMessage = { type: 'text', text };
+  const res = await fetch(LINE_PUSH_API, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getChannelAccessToken()}`,
+    },
+    body: JSON.stringify({ to: lineUserId, messages: [message] }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => '');
+    throw new Error(`Failed to send LINE message: ${res.status} ${errorText}`);
+  }
+}
+
+export async function sendLineReplyMessage(replyToken: string, text: string): Promise<void> {
+  const message: LineTextMessage = { type: 'text', text };
+  const res = await fetch(LINE_REPLY_API, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getChannelAccessToken()}`,
+    },
+    body: JSON.stringify({ replyToken, messages: [message] }),
+  });
+  if (!res.ok) {
+    const errorText = await res.text().catch(() => '');
+    throw new Error(`Failed to send LINE reply: ${res.status} ${errorText}`);
+  }
+}
+
+export function verifyLineSignature(rawBody: string, signature: string | null): boolean {
+  if (!signature) return false;
+  const hmac = crypto.createHmac('sha256', getChannelSecret());
+  hmac.update(rawBody);
+  const expected = hmac.digest('base64');
+  if (expected.length !== signature.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
+
+export function generateLineLinkCode(): string {
+  const bytes = crypto.randomBytes(4);
+  const num = bytes.readUInt32BE(0);
+  return (100000 + (num % 900000)).toString();
+}
+
+export const lineMessageTemplates = {
+  medicationReminder({
+    memberName,
+    medicationName,
+    scheduledTime,
+  }: {
+    memberName: string;
+    medicationName: string;
+    scheduledTime: string;
+  }): string {
+    return [
+      'お薬の時間です',
+      '',
+      `${memberName}さん`,
+      `お薬: ${medicationName}`,
+      `予定時刻: ${scheduledTime}`,
+      '',
+      'HealthFamily',
+    ].join('\n');
+  },
+
+  missedMedication({
+    memberName,
+    medicationName,
+    scheduledTime,
+  }: {
+    memberName: string;
+    medicationName: string;
+    scheduledTime: string;
+  }): string {
+    return [
+      'お薬の飲み忘れ',
+      '',
+      `${memberName}さん`,
+      `お薬: ${medicationName}`,
+      `予定時刻: ${scheduledTime}`,
+      '',
+      'まだお薬を服用していないようです。忘れずに服用してください。',
+      '',
+      'HealthFamily',
+    ].join('\n');
+  },
+
+  appointmentReminder({
+    memberName,
+    hospitalName,
+    appointmentDate,
+    description,
+  }: {
+    memberName: string;
+    hospitalName: string;
+    appointmentDate: string;
+    description?: string;
+  }): string {
+    const lines = [
+      '通院リマインダー',
+      '',
+      `${memberName}さん`,
+      `病院: ${hospitalName}`,
+      `日時: ${appointmentDate}`,
+    ];
+    if (description) lines.push(`内容: ${description}`);
+    lines.push('', 'HealthFamily');
+    return lines.join('\n');
+  },
+
+  lowStockAlert({
+    memberName,
+    medicationName,
+    currentStock,
+    alertDate,
+    daysUntilAlert,
+  }: {
+    memberName: string;
+    medicationName: string;
+    currentStock: number;
+    alertDate: string;
+    daysUntilAlert: number;
+  }): string {
+    return [
+      'お薬の在庫アラート',
+      '',
+      `${memberName}さん`,
+      `お薬: ${medicationName}`,
+      `現在の在庫: ${currentStock}日分`,
+      `警告日: ${alertDate} (あと${daysUntilAlert}日)`,
+      '',
+      '在庫が警告日までに不足する見込みです。早めにかかりつけ医に相談し、処方を受けてください。',
+      '',
+      'HealthFamily',
+    ].join('\n');
+  },
+
+  linkSuccess(displayName: string | null): string {
+    const name = displayName ? `${displayName}さん、` : '';
+    return [
+      'LINE連携が完了しました',
+      '',
+      `${name}HealthFamilyからの通知をこのトークルームでお届けします。`,
+      '通知の種類は設定画面から変更できます。',
+    ].join('\n');
+  },
+
+  linkInvalid(): string {
+    return [
+      '連携コードが無効です',
+      '',
+      '6桁のコードを正しく入力するか、設定画面でコードを再生成してください。',
+      'コードの有効期限は10分です。',
+    ].join('\n');
+  },
+
+  linkInstruction(): string {
+    return [
+      'HealthFamilyへようこそ',
+      '',
+      'アプリの「設定 > 通知設定 > LINE連携」で6桁のコードを発行し、このトークに送信してください。',
+    ].join('\n');
+  },
+};

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -328,6 +328,7 @@ export const updateNotificationSettingSchema = z.object({
   defaultReminderMinutesBefore: z.number().int().min(0, 'リマインダー時間は0以上で指定してください').max(120).optional(),
   defaultAppointmentReminderDaysBefore: z.number().int().min(0, 'リマインダー日数は0以上で指定してください').max(30).optional(),
   emailNotificationEnabled: z.boolean().optional(),
+  lineNotificationEnabled: z.boolean().optional(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
 });


### PR DESCRIPTION
## Summary

- LINEボット連携機能を追加（`/api/line/link`, `/api/line/webhook` ルート）
- `NotificationSetting` に `lineNotificationEnabled` フィールドを追加
- `User` モデルに `lineUserId`, `lineLinkCode`, `lineLinkCodeExpiry` を追加
- Prismaマイグレーション `20260428_add_line_notification` を追加
- 通院予約追加フォームのバグを修正：エラーが無音で飲み込まれ追加できない問題を解消
  - `AppointmentForm` の `onSubmit` を async 対応に変更、成功後のみフォームリセット・送信中は二重送信ガード
  - `appointments/page.tsx` に `try-catch` を追加してエラーメッセージを表示
- CI ワークフローのビルドステップを `npx next build` に変更（`prisma migrate deploy` がCI環境のダミーDBに接続しようとして失敗するため）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LINE account linking and linking management functionality.
  * Enabled LINE as a notification channel for reminders and updates.
  * Appointment creation now displays error messages when submissions fail.

* **Improvements**
  * Enhanced form submission feedback with loading states and disabled buttons during processing.

* **Chores**
  * Updated CI build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->