### PR TITLE
feat: 検査記録に画像添付機能を追加

### DIFF
--- a/prisma/migrations/20260503_add_examination_image/migration.sql
+++ b/prisma/migrations/20260503_add_examination_image/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Examination" ADD COLUMN "imageData" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,6 +211,7 @@ model Examination {
   examinedAt        DateTime
   nextScheduledDate DateTime?
   notes             String?
+  imageData         String?   @db.Text
   createdAt         DateTime  @default(now())
 
   @@index([userId])

--- a/src/components/examinations/ExaminationForm.tsx
+++ b/src/components/examinations/ExaminationForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { X, ImagePlus } from 'lucide-react';
 import { Member } from '../../domain/entities/Member';
 
 export interface ExaminationFormData {
@@ -9,6 +10,7 @@ export interface ExaminationFormData {
   examinedAt: string;
   nextScheduledDate?: string;
   notes?: string;
+  imageData?: string;
 }
 
 interface ExaminationFormProps {
@@ -21,7 +23,41 @@ interface ExaminationFormProps {
     examinedAt: Date;
     nextScheduledDate?: Date;
     notes?: string;
+    imageData?: string;
   };
+}
+
+async function compressImage(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onerror = reject;
+      img.onload = () => {
+        const MAX_DIM = 1200;
+        let { width, height } = img;
+        if (width > MAX_DIM || height > MAX_DIM) {
+          if (width >= height) {
+            height = Math.round((height / width) * MAX_DIM);
+            width = MAX_DIM;
+          } else {
+            width = Math.round((width / height) * MAX_DIM);
+            height = MAX_DIM;
+          }
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) { reject(new Error('Canvas not available')); return; }
+        ctx.drawImage(img, 0, 0, width, height);
+        resolve(canvas.toDataURL('image/jpeg', 0.82));
+      };
+      img.src = e.target?.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
@@ -34,6 +70,29 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
     initialData?.nextScheduledDate ? initialData.nextScheduledDate.toISOString().split('T')[0] : '',
   );
   const [notes, setNotes] = useState(initialData?.notes || '');
+  const [imageData, setImageData] = useState<string | null>(initialData?.imageData ?? null);
+  const [imageError, setImageError] = useState('');
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      setImageError('10MB以下の画像を選択してください');
+      return;
+    }
+    setImageError('');
+    try {
+      const compressed = await compressImage(file);
+      if (compressed.length > 1_500_000) {
+        setImageError('画像を圧縮できませんでした。より小さい画像を選択してください');
+        return;
+      }
+      setImageData(compressed);
+    } catch {
+      setImageError('画像の読み込みに失敗しました');
+    }
+    e.target.value = '';
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -45,6 +104,7 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
       examinedAt: new Date(examinedAt).toISOString(),
       nextScheduledDate: nextScheduledDate ? new Date(nextScheduledDate).toISOString() : undefined,
       notes: notes.trim() || undefined,
+      imageData: imageData ?? undefined,
     });
 
     if (!initialData) {
@@ -52,6 +112,7 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
       setExaminedAt(new Date().toISOString().split('T')[0]);
       setNextScheduledDate('');
       setNotes('');
+      setImageData(null);
     }
   };
 
@@ -86,7 +147,7 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
           onChange={(e) => setExaminationType(e.target.value)}
           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
           required
-          placeholder="例: 健康診断、血液検査、歯科検診"
+          placeholder="例: 健康診断、血液検査、耐性検査"
         />
       </div>
 
@@ -127,8 +188,43 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
           onChange={(e) => setNotes(e.target.value)}
           className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
           rows={2}
-          placeholder="メモを入力"
+          placeholder="例: 耐性あり ベンジルペニシリン / 異常なし"
         />
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-gray-700 mb-1">
+          検査結果の画像（任意）
+        </span>
+        {imageData ? (
+          <div className="relative">
+            <img
+              src={imageData}
+              alt="検査結果"
+              className="w-full rounded-lg border border-gray-200 max-h-52 object-contain bg-gray-50"
+            />
+            <button
+              type="button"
+              onClick={() => setImageData(null)}
+              className="absolute top-1.5 right-1.5 bg-white rounded-full p-0.5 text-gray-500 hover:text-red-500 shadow transition-colors"
+              aria-label="画像を削除"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        ) : (
+          <label className="flex items-center justify-center gap-2 w-full py-3 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-primary-400 transition-colors text-sm text-gray-500">
+            <ImagePlus size={16} className="text-gray-400" />
+            <span>画像を追加</span>
+            <input
+              type="file"
+              accept="image/*"
+              className="sr-only"
+              onChange={handleImageChange}
+            />
+          </label>
+        )}
+        {imageError && <p className="text-xs text-red-500 mt-1">{imageError}</p>}
       </div>
 
       <div className="flex space-x-2">

--- a/src/components/examinations/ExaminationList.tsx
+++ b/src/components/examinations/ExaminationList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Pencil, Trash2, Check, X, Calendar } from 'lucide-react';
+import { Pencil, Trash2, Check, X, Calendar, ImagePlus } from 'lucide-react';
 import { Examination } from '../../domain/entities/Examination';
 import { UpdateExaminationInput } from '../../domain/repositories/ExaminationRepository';
 import { formatDateJP } from '../../domain/entities/DateFormat';
@@ -38,6 +38,39 @@ export const ExaminationList: React.FC<ExaminationListProps> = ({ examinations, 
   );
 };
 
+async function compressImage(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onerror = reject;
+      img.onload = () => {
+        const MAX_DIM = 1200;
+        let { width, height } = img;
+        if (width > MAX_DIM || height > MAX_DIM) {
+          if (width >= height) {
+            height = Math.round((height / width) * MAX_DIM);
+            width = MAX_DIM;
+          } else {
+            width = Math.round((width / height) * MAX_DIM);
+            height = MAX_DIM;
+          }
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) { reject(new Error('Canvas not available')); return; }
+        ctx.drawImage(img, 0, 0, width, height);
+        resolve(canvas.toDataURL('image/jpeg', 0.82));
+      };
+      img.src = e.target?.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
 interface ExaminationCardProps {
   examination: Examination;
   onUpdate: (id: string, input: UpdateExaminationInput) => Promise<void>;
@@ -47,12 +80,36 @@ interface ExaminationCardProps {
 const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examination, onUpdate, onDelete }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [showFullImage, setShowFullImage] = useState(false);
   const [editType, setEditType] = useState(examination.examinationType);
   const [editDate, setEditDate] = useState(examination.examinedAt.toISOString().split('T')[0]);
   const [editNextDate, setEditNextDate] = useState(
     examination.nextScheduledDate ? examination.nextScheduledDate.toISOString().split('T')[0] : '',
   );
   const [editNotes, setEditNotes] = useState(examination.notes || '');
+  const [editImageData, setEditImageData] = useState<string | null>(examination.imageData ?? null);
+  const [editImageError, setEditImageError] = useState('');
+
+  const handleEditImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      setEditImageError('10MB以下の画像を選択してください');
+      return;
+    }
+    setEditImageError('');
+    try {
+      const compressed = await compressImage(file);
+      if (compressed.length > 1_500_000) {
+        setEditImageError('画像を圧縮できませんでした。より小さい画像を選択してください');
+        return;
+      }
+      setEditImageData(compressed);
+    } catch {
+      setEditImageError('画像の読み込みに失敗しました');
+    }
+    e.target.value = '';
+  };
 
   const handleSave = async () => {
     if (!editType.trim() || !editDate) return;
@@ -61,6 +118,7 @@ const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examinatio
       examinedAt: new Date(editDate).toISOString(),
       nextScheduledDate: editNextDate ? new Date(editNextDate).toISOString() : null,
       notes: editNotes.trim() || null,
+      imageData: editImageData,
     });
     setIsEditing(false);
   };
@@ -70,6 +128,8 @@ const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examinatio
     setEditDate(examination.examinedAt.toISOString().split('T')[0]);
     setEditNextDate(examination.nextScheduledDate ? examination.nextScheduledDate.toISOString().split('T')[0] : '');
     setEditNotes(examination.notes || '');
+    setEditImageData(examination.imageData ?? null);
+    setEditImageError('');
     setIsEditing(false);
   };
 
@@ -117,6 +177,33 @@ const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examinatio
             rows={2}
           />
         </div>
+        <div>
+          <span className="block text-xs text-gray-500 mb-1">検査結果の画像</span>
+          {editImageData ? (
+            <div className="relative">
+              <img
+                src={editImageData}
+                alt="検査結果"
+                className="w-full rounded border border-gray-200 max-h-40 object-contain bg-gray-50"
+              />
+              <button
+                type="button"
+                onClick={() => setEditImageData(null)}
+                className="absolute top-1 right-1 bg-white rounded-full p-0.5 text-gray-500 hover:text-red-500 shadow"
+                aria-label="画像を削除"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          ) : (
+            <label className="flex items-center gap-2 py-2 px-3 border border-dashed border-gray-300 rounded cursor-pointer hover:border-primary-400 text-xs text-gray-500">
+              <ImagePlus size={14} className="text-gray-400" />
+              <span>画像を追加</span>
+              <input type="file" accept="image/*" className="sr-only" onChange={handleEditImageChange} />
+            </label>
+          )}
+          {editImageError && <p className="text-xs text-red-500 mt-1">{editImageError}</p>}
+        </div>
         <div className="flex space-x-2">
           <button
             onClick={handleSave}
@@ -160,7 +247,7 @@ const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examinatio
                 {isNextDatePast && <span>(期限切れ)</span>}
               </p>
             )}
-            {examination.notes && <p className="text-gray-400">{examination.notes}</p>}
+            {examination.notes && <p className="text-gray-400 whitespace-pre-wrap">{examination.notes}</p>}
           </div>
         </div>
         <div className="flex items-center space-x-1 flex-shrink-0">
@@ -180,6 +267,21 @@ const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examinatio
           </button>
         </div>
       </div>
+
+      {examination.imageData && (
+        <div className="mt-2">
+          <img
+            src={examination.imageData}
+            alt="検査結果画像"
+            className={`w-full rounded border border-gray-200 object-contain bg-gray-50 cursor-pointer transition-all ${
+              showFullImage ? 'max-h-none' : 'max-h-32'
+            }`}
+            onClick={() => setShowFullImage((v) => !v)}
+            title={showFullImage ? 'タップで縮小' : 'タップで拡大'}
+          />
+        </div>
+      )}
+
       <ConfirmationDialog
         title="検査記録の削除"
         message={`「${examination.examinationType}」を削除しますか？この操作は取り消せません。`}

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -232,6 +232,7 @@ export function toExamination(b: BackendExamination): Examination {
     examinedAt: new Date(b.examinedAt),
     nextScheduledDate: b.nextScheduledDate ? new Date(b.nextScheduledDate) : undefined,
     notes: b.notes,
+    imageData: b.imageData,
     createdAt: new Date(b.createdAt),
   };
 }

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -178,6 +178,7 @@ export interface BackendExamination {
   examinedAt: string;
   nextScheduledDate?: string;
   notes?: string;
+  imageData?: string;
   createdAt: string;
 }
 

--- a/src/data/repositories/server/PrismaExaminationRepository.ts
+++ b/src/data/repositories/server/PrismaExaminationRepository.ts
@@ -19,6 +19,7 @@ function toExamination(row: {
   examinedAt: Date;
   nextScheduledDate: Date | null;
   notes: string | null;
+  imageData: string | null;
   createdAt: Date;
   member?: { name: string };
 }): Examination {
@@ -31,6 +32,7 @@ function toExamination(row: {
     examinedAt: row.examinedAt,
     nextScheduledDate: row.nextScheduledDate ?? undefined,
     notes: row.notes ?? undefined,
+    imageData: row.imageData ?? undefined,
     createdAt: row.createdAt,
   };
 }
@@ -64,6 +66,7 @@ export class PrismaExaminationRepository implements ExaminationRepository {
         examinedAt: new Date(input.examinedAt),
         nextScheduledDate: input.nextScheduledDate ? new Date(input.nextScheduledDate) : undefined,
         notes: input.notes,
+        imageData: input.imageData ?? undefined,
       },
       include: { member: { select: { name: true } } },
     });
@@ -85,6 +88,7 @@ export class PrismaExaminationRepository implements ExaminationRepository {
       data.nextScheduledDate = input.nextScheduledDate ? new Date(input.nextScheduledDate) : null;
     }
     if (input.notes !== undefined) data.notes = input.notes;
+    if (input.imageData !== undefined) data.imageData = input.imageData;
 
     const row = await prisma.examination.update({
       where: { id },

--- a/src/domain/entities/Examination.ts
+++ b/src/domain/entities/Examination.ts
@@ -7,5 +7,6 @@ export interface Examination {
   readonly examinedAt: Date;
   readonly nextScheduledDate?: Date;
   readonly notes?: string;
+  readonly imageData?: string;
   readonly createdAt: Date;
 }

--- a/src/domain/repositories/ExaminationRepository.ts
+++ b/src/domain/repositories/ExaminationRepository.ts
@@ -6,6 +6,7 @@ export interface CreateExaminationInput {
   examinedAt: string;
   nextScheduledDate?: string;
   notes?: string;
+  imageData?: string;
 }
 
 export interface UpdateExaminationInput {
@@ -13,6 +14,7 @@ export interface UpdateExaminationInput {
   examinedAt?: string;
   nextScheduledDate?: string | null;
   notes?: string | null;
+  imageData?: string | null;
 }
 
 export interface ExaminationRepository {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -180,12 +180,15 @@ export const updateVaccinationSchema = z.object({
 });
 
 // ===== Examinations =====
+const imageDataField = z.string().max(1_500_000).optional().nullable();
+
 export const createExaminationSchema = z.object({
   memberId: idField,
   examinationType: z.string({ required_error: '検査の種類は必須です' }).trim().min(1, '検査の種類は必須です').max(200),
   examinedAt: dateString,
   nextScheduledDate: dateString.optional(),
   notes: z.string().trim().max(500).optional(),
+  imageData: imageDataField,
 });
 
 export const updateExaminationSchema = z.object({
@@ -193,6 +196,7 @@ export const updateExaminationSchema = z.object({
   examinedAt: dateString.optional(),
   nextScheduledDate: dateString.optional().nullable(),
   notes: z.string().trim().max(500).optional().nullable(),
+  imageData: imageDataField,
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
 });


### PR DESCRIPTION
## Summary

- 検査記録（ExaminationForm）に画像アップロードフィールドを追加
- クライアント側で最大1200pxにリサイズ＋JPEG圧縮（82%品質）してから Base64 でDBに保存
- 画像サイズ上限：元ファイル10MB以内、圧縮後1.5MB以内
- カード表示でサムネイル表示、タップで拡大/縮小切り替え
- 編集モードでも画像の追加・差し替え・削除が可能
- Prismaスキーマに `imageData String? @db.Text` を追加し、マイグレーション作成
- メモ欄のプレースホルダーに耐性検査の例（「耐性あり ベンジルペニシリン」）を追加