### PR TITLE
fix: まとめて服薬記録が反映されないバグを修正

### DIFF
--- a/src/presentation/hooks/useTodaySchedules.ts
+++ b/src/presentation/hooks/useTodaySchedules.ts
@@ -45,12 +45,18 @@ export const useTodaySchedules = (userId: string): UseTodaySchedulesResult => {
   }, [scheduleRepository, refetch]);
 
   const markMultipleCompleted = useCallback(async (scheduleIds: string[]) => {
-    try {
-      const now = new Date();
-      await Promise.all(scheduleIds.map((id) => scheduleRepository.markAsCompleted(id, now)));
-      await refetch();
-    } catch (err) {
-      setMarkError(err instanceof Error ? err : new Error('Unknown error'));
+    const now = new Date();
+    let failedCount = 0;
+    for (const id of scheduleIds) {
+      try {
+        await scheduleRepository.markAsCompleted(id, now);
+      } catch {
+        failedCount++;
+      }
+    }
+    await refetch();
+    if (failedCount > 0) {
+      setMarkError(new Error(`${failedCount}件の記録に失敗しました`));
     }
   }, [scheduleRepository, refetch]);
 


### PR DESCRIPTION
## Summary

- `markMultipleCompleted` で `Promise.all` を使って並列リクエストしていたため、1件でも失敗すると `refetch()` が呼ばれずUIが更新されない問題を修正
- 逐次処理（for ループ）に変更し、個別失敗があっても最後に必ず `refetch()` を呼ぶよう修正
- 失敗件数がある場合はエラーメッセージを表示するよう対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when completing multiple schedule items. The system now attempts to complete all selected items even if some fail, and provides clearer error feedback after processing all requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->