### PR TITLE
feat: お薬に休薬・中止ステータスと並び替えUX改善を追加

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ja-JP"
+tone_instructions: "必ず日本語で回答してください。コードレビューコメント・要約・提案・walkthrough など、すべての出力を日本語で記述してください。丁寧な日本語で、若手エンジニアに教えるようなトーンでお願いします。"
+reviews:
+  profile: "chill"
+  high_level_summary: true
+  poem: false
+  review_status: false
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "main"
+chat:
+  auto_reply: true

--- a/prisma/migrations/20260505_add_medication_status/migration.sql
+++ b/prisma/migrations/20260505_add_medication_status/migration.sql
@@ -1,0 +1,2 @@
+-- Add status column to Medication for 休薬/中止 display
+ALTER TABLE "Medication" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'active';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Medication {
   instructions      String?
   displayOrder      Int      @default(0)
   isActive          Boolean  @default(true)
+  status            String   @default("active")
   createdAt         DateTime @default(now())
   updatedAt         DateTime @updatedAt
 

--- a/src/app/api/medications/[medicationId]/route.ts
+++ b/src/app/api/medications/[medicationId]/route.ts
@@ -51,6 +51,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ medi
         stockAlertDate: parsed.data.stockAlertDate,
         instructions: parsed.data.instructions,
         isActive: parsed.data.isActive,
+        status: parsed.data.status,
       });
       return success(updated);
     } catch (error) {

--- a/src/app/medications/page.tsx
+++ b/src/app/medications/page.tsx
@@ -97,6 +97,7 @@ function MemberMedications({ member, userId, categoryFilter }: { member: Member;
       stockQuantity: data.stockQuantity,
       stockAlertDate: data.stockAlertDate,
       instructions: data.instructions,
+      status: data.status,
     });
     setEditingMed(null);
   };

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -129,6 +129,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
                 key={opt.id}
                 type="button"
                 onClick={() => setStatus(opt.id)}
+                aria-pressed={status === opt.id}
                 className={`px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${
                   status === opt.id ? opt.activeClass : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
                 }`}

--- a/src/components/medications/MedicationForm.tsx
+++ b/src/components/medications/MedicationForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ChevronDown, ChevronUp, Info } from 'lucide-react';
-import { Medication, MedicationCategory } from '../../domain/entities/Medication';
+import { Medication, MedicationCategory, MedicationStatus } from '../../domain/entities/Medication';
 import { MedicationInfoModal } from './MedicationInfoModal';
 
 export interface MedicationFormData {
@@ -11,6 +11,7 @@ export interface MedicationFormData {
   stockQuantity?: number;
   stockAlertDate?: string;
   instructions?: string;
+  status?: MedicationStatus;
 }
 
 interface MedicationFormProps {
@@ -32,6 +33,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
     initialData?.stockAlertDate ? new Date(initialData.stockAlertDate).toISOString().split('T')[0] : ''
   );
   const [instructions, setInstructions] = useState(initialData?.instructions || '');
+  const [status, setStatus] = useState<MedicationStatus>(initialData?.status || 'active');
   const hasOptionalData = !!(initialData?.stockQuantity || initialData?.stockAlertDate || initialData?.instructions);
   const [showOptional, setShowOptional] = useState(isEditing && hasOptionalData);
   const [showInfoModal, setShowInfoModal] = useState(false);
@@ -49,6 +51,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
       ...(stockQuantity ? { stockQuantity: parseInt(stockQuantity, 10) } : {}),
       ...(stockAlertDate ? { stockAlertDate } : {}),
       ...(instructions.trim() ? { instructions: instructions.trim() } : {}),
+      ...(isEditing ? { status } : {}),
     };
 
     onSubmit(data);
@@ -112,6 +115,31 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
           <option value="heartworm">フィラリア薬</option>
         </select>
       </div>
+
+      {isEditing && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">服用状況</label>
+          <div className="grid grid-cols-3 gap-2">
+            {([
+              { id: 'active', label: '服用中', activeClass: 'bg-primary-600 text-white border-primary-600' },
+              { id: 'paused', label: '休薬', activeClass: 'bg-red-100 text-red-700 border-red-300' },
+              { id: 'discontinued', label: '中止', activeClass: 'bg-red-600 text-white border-red-600' },
+            ] as Array<{ id: MedicationStatus; label: string; activeClass: string }>).map((opt) => (
+              <button
+                key={opt.id}
+                type="button"
+                onClick={() => setStatus(opt.id)}
+                className={`px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${
+                  status === opt.id ? opt.activeClass : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-gray-400 mt-1">休薬・中止にすると今日の予定からも除外されます</p>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-3">
         <div>

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Pill, Check, Pencil, Clock, ChevronUp, ChevronDown, AlertCircle } from 'lucide-react';
 import { Medication } from '../../domain/entities/Medication';
 import { MedicationViewModel } from '../../domain/usecases/ManageMedications';
@@ -29,6 +29,18 @@ interface MedicationListProps {
 }
 
 export const MedicationList: React.FC<MedicationListProps> = ({ medications, isLoading, onDelete, onMarkTaken, onMarkPastTaken, onEdit, onReorder, scheduleMap, scheduleEditUrl }) => {
+  // 並び替えの体感速度を上げるためにローカルで楽観的に更新する
+  const [localOrder, setLocalOrder] = useState<MedicationViewModel[]>(medications);
+  const reorderTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setLocalOrder(medications);
+  }, [medications]);
+
+  useEffect(() => () => {
+    if (reorderTimeoutRef.current) clearTimeout(reorderTimeoutRef.current);
+  }, []);
+
   if (isLoading) {
     return (
       <LoadingSpinner />
@@ -41,18 +53,24 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
     );
   }
 
-  const handleMove = async (index: number, direction: 'up' | 'down') => {
+  const handleMove = (index: number, direction: 'up' | 'down') => {
     if (!onReorder) return;
-    const newList = [...medications];
     const targetIndex = direction === 'up' ? index - 1 : index + 1;
-    if (targetIndex < 0 || targetIndex >= newList.length) return;
+    if (targetIndex < 0 || targetIndex >= localOrder.length) return;
+    const newList = [...localOrder];
     [newList[index], newList[targetIndex]] = [newList[targetIndex], newList[index]];
-    await onReorder(newList.map((vm) => vm.medication.id));
+    setLocalOrder(newList);
+    if (reorderTimeoutRef.current) clearTimeout(reorderTimeoutRef.current);
+    reorderTimeoutRef.current = setTimeout(() => {
+      onReorder(newList.map((vm) => vm.medication.id)).catch(() => {
+        setLocalOrder(medications);
+      });
+    }, 400);
   };
 
   return (
     <div className="space-y-3">
-      {medications.map((vm, index) => (
+      {localOrder.map((vm, index) => (
         <MedicationCard
           key={vm.medication.id}
           viewModel={vm}
@@ -61,7 +79,7 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
           onMarkPastTaken={onMarkPastTaken}
           onEdit={onEdit}
           onMoveUp={onReorder && index > 0 ? () => handleMove(index, 'up') : undefined}
-          onMoveDown={onReorder && index < medications.length - 1 ? () => handleMove(index, 'down') : undefined}
+          onMoveDown={onReorder && index < localOrder.length - 1 ? () => handleMove(index, 'down') : undefined}
           schedules={scheduleMap?.[vm.medication.id]}
           scheduleEditUrl={scheduleEditUrl}
         />
@@ -146,9 +164,19 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(({ viewModel, o
           </div>
         )}
         <div className="flex-1">
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center flex-wrap gap-x-2 gap-y-1">
             <Pill size={20} className="text-primary-600" />
             <p className="font-semibold text-gray-800">{displayInfo.name}</p>
+            {medication.status === 'paused' && (
+              <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-bold border border-red-300">
+                休薬
+              </span>
+            )}
+            {medication.status === 'discontinued' && (
+              <span className="px-2 py-0.5 bg-red-600 text-white text-xs rounded-full font-bold">
+                中止
+              </span>
+            )}
             {isLowStock && (
               <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-medium">
                 在庫少

--- a/src/components/medications/MedicationList.tsx
+++ b/src/components/medications/MedicationList.tsx
@@ -32,6 +32,8 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
   // 並び替えの体感速度を上げるためにローカルで楽観的に更新する
   const [localOrder, setLocalOrder] = useState<MedicationViewModel[]>(medications);
   const reorderTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(false);
+  const queuedOrderRef = useRef<string[] | null>(null);
 
   useEffect(() => {
     setLocalOrder(medications);
@@ -53,6 +55,23 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
     );
   }
 
+  const flushReorder = async () => {
+    if (!onReorder || inFlightRef.current) return;
+    const payload = queuedOrderRef.current;
+    if (!payload) return;
+    queuedOrderRef.current = null;
+    inFlightRef.current = true;
+    try {
+      await onReorder(payload);
+    } catch {
+      queuedOrderRef.current = null;
+      setLocalOrder(medications);
+    } finally {
+      inFlightRef.current = false;
+      if (queuedOrderRef.current) void flushReorder();
+    }
+  };
+
   const handleMove = (index: number, direction: 'up' | 'down') => {
     if (!onReorder) return;
     const targetIndex = direction === 'up' ? index - 1 : index + 1;
@@ -62,9 +81,8 @@ export const MedicationList: React.FC<MedicationListProps> = ({ medications, isL
     setLocalOrder(newList);
     if (reorderTimeoutRef.current) clearTimeout(reorderTimeoutRef.current);
     reorderTimeoutRef.current = setTimeout(() => {
-      onReorder(newList.map((vm) => vm.medication.id)).catch(() => {
-        setLocalOrder(medications);
-      });
+      queuedOrderRef.current = newList.map((vm) => vm.medication.id);
+      void flushReorder();
     }, 400);
   };
 

--- a/src/data/api/mappers.ts
+++ b/src/data/api/mappers.ts
@@ -1,7 +1,7 @@
 import { Appointment } from '../../domain/entities/Appointment';
 import { Hospital } from '../../domain/entities/Hospital';
 import { Member, MemberType, PetType } from '../../domain/entities/Member';
-import { Medication, MedicationCategory } from '../../domain/entities/Medication';
+import { Medication, MedicationCategory, MedicationStatus } from '../../domain/entities/Medication';
 import { MedicationRecord } from '../../domain/entities/MedicationRecord';
 import { Schedule, DayOfWeek } from '../../domain/entities/Schedule';
 import { HealthLog, ConditionLevel, SymptomType, SYMPTOM_OPTIONS } from '../../domain/entities/HealthLog';
@@ -19,6 +19,7 @@ const VALID_SYMPTOMS: readonly string[] = [...SYMPTOM_OPTIONS];
 
 const VALID_MEMBER_TYPES: readonly string[] = ['human', 'pet'];
 const VALID_MEDICATION_CATEGORIES: readonly string[] = ['regular', 'supplement', 'prn', 'inhaler', 'eye_drops', 'patch', 'topical', 'flea_tick', 'heartworm'];
+const VALID_MEDICATION_STATUSES: readonly string[] = ['active', 'paused', 'discontinued'];
 const VALID_DAYS_OF_WEEK: readonly string[] = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 const VALID_PET_TYPES: readonly string[] = ['dog', 'cat', 'rabbit', 'bird', 'other'];
 
@@ -50,6 +51,7 @@ export function toMedication(b: BackendMedication): Medication {
     instructions: b.instructions,
     displayOrder: b.displayOrder ?? 0,
     isActive: b.isActive ?? true,
+    status: b.status && VALID_MEDICATION_STATUSES.includes(b.status) ? (b.status as MedicationStatus) : 'active',
     createdAt: new Date(b.createdAt),
     updatedAt: new Date(b.updatedAt),
   };

--- a/src/data/api/types.ts
+++ b/src/data/api/types.ts
@@ -23,6 +23,7 @@ export interface BackendMedication {
   instructions?: string;
   displayOrder?: number;
   isActive?: boolean;
+  status?: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/data/repositories/server/PrismaMedicationRepository.ts
+++ b/src/data/repositories/server/PrismaMedicationRepository.ts
@@ -9,11 +9,19 @@ import {
   CreateMedicationInput,
   UpdateMedicationInput,
 } from '@/domain/repositories/MedicationRepository';
-import { Medication, MedicationCategory } from '@/domain/entities/Medication';
+import { Medication, MedicationCategory, MedicationStatus } from '@/domain/entities/Medication';
 import { MedicationSearchResult } from '@/domain/entities/MedicationSearchResult';
 import { StockAlert } from '@/domain/entities/StockAlert';
 import { StockAlertEntity } from '@/domain/entities/StockAlert';
 import { QUERY_LIMITS } from '@/lib/constants';
+
+const VALID_STATUSES: readonly MedicationStatus[] = ['active', 'paused', 'discontinued'];
+
+function toMedicationStatus(value: string | null | undefined): MedicationStatus {
+  return value && (VALID_STATUSES as readonly string[]).includes(value)
+    ? (value as MedicationStatus)
+    : 'active';
+}
 
 function toMedication(row: {
   id: string;
@@ -29,6 +37,7 @@ function toMedication(row: {
   instructions: string | null;
   displayOrder: number;
   isActive: boolean;
+  status?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }): Medication {
@@ -46,6 +55,7 @@ function toMedication(row: {
     instructions: row.instructions ?? undefined,
     displayOrder: row.displayOrder,
     isActive: row.isActive,
+    status: toMedicationStatus(row.status),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -101,6 +111,7 @@ export class PrismaMedicationRepository implements MedicationRepository {
     }
     if (input.instructions !== undefined) data.instructions = input.instructions;
     if (input.isActive !== undefined) data.isActive = input.isActive;
+    if (input.status !== undefined) data.status = input.status;
 
     const row = await prisma.medication.update({
       where: { id: medicationId },

--- a/src/data/repositories/server/PrismaScheduleRepository.ts
+++ b/src/data/repositories/server/PrismaScheduleRepository.ts
@@ -133,7 +133,11 @@ export class PrismaScheduleRepository implements ScheduleRepository {
 
     const [schedules, todayRecords, members] = await Promise.all([
       prisma.schedule.findMany({
-        where: { userId: this.userId, isEnabled: true },
+        where: {
+          userId: this.userId,
+          isEnabled: true,
+          medication: { is: { status: 'active' } },
+        },
         include: {
           medication: { select: { id: true, name: true, displayOrder: true } },
         },

--- a/src/domain/entities/Medication.ts
+++ b/src/domain/entities/Medication.ts
@@ -15,6 +15,8 @@ export type MedicationCategory =
   | 'flea_tick'
   | 'heartworm';
 
+export type MedicationStatus = 'active' | 'paused' | 'discontinued';
+
 export interface Medication {
   readonly id: string;
   readonly memberId: string;
@@ -29,6 +31,7 @@ export interface Medication {
   readonly instructions?: string;
   readonly displayOrder: number;
   readonly isActive: boolean;
+  readonly status: MedicationStatus;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
@@ -249,6 +252,23 @@ export class MedicationEntity {
    */
   static getActiveStatusLabel(isActive: boolean): string {
     return isActive ? '有効' : '無効';
+  }
+
+  private static readonly STATUS_LABELS: Record<MedicationStatus, string> = {
+    active: '服用中',
+    paused: '休薬',
+    discontinued: '中止',
+  };
+
+  static getStatusLabel(status: MedicationStatus): string {
+    return MedicationEntity.STATUS_LABELS[status] ?? status;
+  }
+
+  static getAllStatuses(): Array<{ id: MedicationStatus; label: string }> {
+    return Object.entries(MedicationEntity.STATUS_LABELS).map(([id, label]) => ({
+      id: id as MedicationStatus,
+      label,
+    }));
   }
 
   /**

--- a/src/domain/repositories/MedicationRepository.ts
+++ b/src/domain/repositories/MedicationRepository.ts
@@ -2,7 +2,7 @@
  * 薬リポジトリインターフェース
  */
 
-import { Medication, MedicationCategory } from '../entities/Medication';
+import { Medication, MedicationCategory, MedicationStatus } from '../entities/Medication';
 import { MedicationSearchResult } from '../entities/MedicationSearchResult';
 import { StockAlert } from '../entities/StockAlert';
 
@@ -27,6 +27,7 @@ export interface UpdateMedicationInput {
   stockAlertDate?: string | null;
   instructions?: string | null;
   isActive?: boolean;
+  status?: MedicationStatus;
 }
 
 export interface MedicationRepository {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -58,6 +58,7 @@ export const updateMedicationSchema = z.object({
   stockAlertDate: dateString.optional().nullable(),
   instructions: z.string().trim().max(1000).optional().nullable(),
   isActive: z.boolean().optional(),
+  status: z.enum(['active', 'paused', 'discontinued']).optional(),
 }).refine((data) => Object.keys(data).length > 0, {
   message: '更新するフィールドがありません',
 });


### PR DESCRIPTION
## Summary

- Medicationに `status` (active/paused/discontinued) を追加し、お薬一覧に「休薬」「中止」の赤バッジを表示
- 編集フォームから服用状況を切り替え可能（休薬・中止選択時は今日の予定から自動除外）
- お薬一覧の上下並び替えを楽観的UIに変更し、タップ即時に順序が反映されるよう改善（API呼び出しはデバウンス）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added medication status tracking with three states: Active, Paused, and Discontinued. Users can now manage and update the status of each medication during editing. The system automatically filters medication schedules to display only active medications, improving schedule accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->