### PR TITLE
fix: 今日の予定が空表示になるバグを修正

### DIFF
--- a/src/data/repositories/server/PrismaScheduleRepository.ts
+++ b/src/data/repositories/server/PrismaScheduleRepository.ts
@@ -131,12 +131,11 @@ export class PrismaScheduleRepository implements ScheduleRepository {
     const jstToday = getJSTDate();
     const { todayStart, todayEnd } = getJSTDayBoundaries();
 
-    const [schedules, todayRecords, members] = await Promise.all([
+    const [schedulesRaw, todayRecords, members] = await Promise.all([
       prisma.schedule.findMany({
         where: {
           userId: this.userId,
           isEnabled: true,
-          medication: { is: { status: 'active' } },
         },
         include: {
           medication: { select: { id: true, name: true, displayOrder: true } },
@@ -160,6 +159,19 @@ export class PrismaScheduleRepository implements ScheduleRepository {
     const completedScheduleIds = new Set(
       todayRecords.filter((r) => r.scheduleId).map((r) => r.scheduleId as string)
     );
+
+    let inactiveMedicationIds = new Set<string>();
+    try {
+      const inactiveMeds = await prisma.medication.findMany({
+        where: { userId: this.userId, status: { not: 'active' } },
+        select: { id: true },
+      });
+      inactiveMedicationIds = new Set(inactiveMeds.map((m) => m.id));
+    } catch {
+      // status カラム未マイグレーション時は全件 active として扱う（フォールバック）
+    }
+
+    const schedules = schedulesRaw.filter((s) => !inactiveMedicationIds.has(s.medicationId));
 
     const activeSchedules = schedules.filter((s) =>
       isScheduleActiveToday(s, jstToday)


### PR DESCRIPTION
## Summary

- PR #1102 で追加した `getTodaySchedules` の SQL 条件 `medication: { is: { status: 'active' } }` を JS 側フィルタに変更
- production DB で `Medication.status` カラムがマイグレーション未適用だった場合に、今日の予定一覧が空になる事象を防ぐため
- inactive な薬の取得に失敗した場合は全件 active として扱うフォールバックを実装
- これにより一括チェック（まとめて服薬記録）も再表示されるようになる