### PR TITLE
feat: 飲み忘れアラートに直接記録ボタンを追加

### DIFF
--- a/src/app/api/schedules/missed/route.ts
+++ b/src/app/api/schedules/missed/route.ts
@@ -108,6 +108,7 @@ export const GET = withAuth(async (userId) => {
   interface MissedDose {
     date: string;
     scheduleId: string;
+    medicationId: string;
     medicationName: string;
     memberName: string;
     memberId: string;
@@ -147,6 +148,7 @@ export const GET = withAuth(async (userId) => {
         missed.push({
           date: dateKey,
           scheduleId: s.id,
+          medicationId: s.medicationId,
           medicationName: s.medication.name,
           memberName: memberMap.get(s.memberId) || '',
           memberId: s.memberId,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useTodaySchedules } from '@/presentation/hooks/useTodaySchedules';
 import { useAppointments } from '@/presentation/hooks/useAppointments';
@@ -8,7 +8,8 @@ import { useAdherenceStats } from '@/presentation/hooks/useAdherenceStats';
 import { useStockAlerts } from '@/presentation/hooks/useStockAlerts';
 import { useMembers } from '@/presentation/hooks/useMembers';
 import { useUserProfile } from '@/presentation/hooks/useUserProfile';
-import { useMissedDoses } from '@/presentation/hooks/useMissedDoses';
+import { useMissedDoses, MissedDose } from '@/presentation/hooks/useMissedDoses';
+import { useMedicationRecordActions } from '@/presentation/hooks/useMedicationRecordActions';
 import { TodayScheduleList } from '@/components/dashboard/TodayScheduleList';
 import { MissedDosesAlert } from '@/components/dashboard/MissedDosesAlert';
 import { UpcomingAppointments } from '@/components/dashboard/UpcomingAppointments';
@@ -19,16 +20,43 @@ import { GreetingCard } from '@/components/dashboard/GreetingCard';
 import { MemberFilter } from '@/components/shared/MemberFilter';
 import { BottomNavigation } from '@/components/shared/BottomNavigation';
 
+function buildTakenAtISO(date: string, scheduledTime: string): string {
+  return new Date(`${date}T${scheduledTime}:00+09:00`).toISOString();
+}
+
 export default function Dashboard() {
   const { userId } = useAuth();
-  const { schedules, isLoading, markAsCompleted, markMultipleCompleted } = useTodaySchedules(userId);
+  const { schedules, isLoading, markAsCompleted, markMultipleCompleted, refetch: refetchToday } = useTodaySchedules(userId);
   const { appointments, isLoading: appointmentsLoading } = useAppointments();
-  const { stats, isLoading: statsLoading } = useAdherenceStats();
+  const { stats, isLoading: statsLoading, refetch: refetchStats } = useAdherenceStats();
   const { alerts, isLoading: alertsLoading } = useStockAlerts();
   const { members } = useMembers(userId);
   const { profile } = useUserProfile();
-  const { missedDoses, isLoading: missedLoading } = useMissedDoses();
+  const { missedDoses, isLoading: missedLoading, refetch: refetchMissed } = useMissedDoses();
+  const { markScheduleAsTakenAt } = useMedicationRecordActions();
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+
+  const handleMarkMissedAsTaken = useCallback(async (dose: MissedDose) => {
+    const takenAt = buildTakenAtISO(dose.date, dose.scheduledTime);
+    await markScheduleAsTakenAt(dose.memberId, dose.medicationId, dose.scheduleId, takenAt);
+    await Promise.all([refetchMissed(), refetchToday(), refetchStats()]);
+  }, [markScheduleAsTakenAt, refetchMissed, refetchToday, refetchStats]);
+
+  const handleMarkMultipleMissedAsTaken = useCallback(async (doses: MissedDose[]) => {
+    let failed = 0;
+    for (const dose of doses) {
+      try {
+        const takenAt = buildTakenAtISO(dose.date, dose.scheduledTime);
+        await markScheduleAsTakenAt(dose.memberId, dose.medicationId, dose.scheduleId, takenAt);
+      } catch {
+        failed++;
+      }
+    }
+    await Promise.all([refetchMissed(), refetchToday(), refetchStats()]);
+    if (failed > 0) {
+      throw new Error(`${failed}件の記録に失敗しました`);
+    }
+  }, [markScheduleAsTakenAt, refetchMissed, refetchToday, refetchStats]);
 
   const filteredSchedules = useMemo(
     () => selectedMemberId ? schedules.filter((s) => s.memberId === selectedMemberId) : schedules,
@@ -53,7 +81,12 @@ export default function Dashboard() {
 
         <WeeklySummaryCard schedules={schedules} isLoading={isLoading} />
 
-        <MissedDosesAlert missedDoses={missedDoses} isLoading={missedLoading} />
+        <MissedDosesAlert
+          missedDoses={missedDoses}
+          isLoading={missedLoading}
+          onMarkAsTaken={handleMarkMissedAsTaken}
+          onMarkMultipleAsTaken={handleMarkMultipleMissedAsTaken}
+        />
 
         <h2 className="text-lg font-semibold text-gray-800 mb-3">今日の予定</h2>
         <div className="mb-4">

--- a/src/components/dashboard/MissedDosesAlert.tsx
+++ b/src/components/dashboard/MissedDosesAlert.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import React, { useMemo } from 'react';
-import Link from 'next/link';
-import { AlertTriangle } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { AlertTriangle, Check, Loader2 } from 'lucide-react';
 import { MissedDose } from '../../presentation/hooks/useMissedDoses';
 
 interface MissedDosesAlertProps {
   missedDoses: MissedDose[];
   isLoading: boolean;
+  onMarkAsTaken?: (dose: MissedDose) => Promise<void>;
+  onMarkMultipleAsTaken?: (doses: MissedDose[]) => Promise<void>;
 }
 
 interface DateGroup {
@@ -33,7 +34,15 @@ function formatDateLabel(dateKey: string): string {
   return `${m}月${d}日（${dow}）`;
 }
 
-export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({ missedDoses, isLoading }) => {
+export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({
+  missedDoses,
+  isLoading,
+  onMarkAsTaken,
+  onMarkMultipleAsTaken,
+}) => {
+  const [recordingId, setRecordingId] = useState<string | null>(null);
+  const [bulkTarget, setBulkTarget] = useState<string | null>(null);
+
   const dateGroups = useMemo(() => {
     if (missedDoses.length === 0) return [];
     const map = new Map<string, MissedDose[]>();
@@ -52,44 +61,111 @@ export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({ missedDoses,
 
   if (isLoading || missedDoses.length === 0) return null;
 
+  const handleMarkOne = async (dose: MissedDose) => {
+    if (!onMarkAsTaken) return;
+    const key = `${dose.date}-${dose.scheduleId}`;
+    setRecordingId(key);
+    try {
+      await onMarkAsTaken(dose);
+    } finally {
+      setRecordingId(null);
+    }
+  };
+
+  const handleMarkAllForDate = async (group: DateGroup) => {
+    if (!onMarkMultipleAsTaken) return;
+    setBulkTarget(group.date);
+    try {
+      await onMarkMultipleAsTaken(group.items);
+    } finally {
+      setBulkTarget(null);
+    }
+  };
+
+  const handleMarkAll = async () => {
+    if (!onMarkMultipleAsTaken) return;
+    setBulkTarget('all');
+    try {
+      await onMarkMultipleAsTaken(missedDoses);
+    } finally {
+      setBulkTarget(null);
+    }
+  };
+
   return (
     <div className="mb-4">
       <div className="bg-red-50 border border-red-200 rounded-lg overflow-hidden">
-        <div className="flex items-center gap-2 px-4 py-2.5 bg-red-100">
-          <AlertTriangle size={18} className="text-red-600 flex-shrink-0" />
-          <h3 className="text-sm font-bold text-red-800">
-            飲み忘れがあります（{missedDoses.length}件）
-          </h3>
+        <div className="flex items-center justify-between gap-2 px-4 py-2.5 bg-red-100">
+          <div className="flex items-center gap-2 min-w-0">
+            <AlertTriangle size={18} className="text-red-600 flex-shrink-0" />
+            <h3 className="text-sm font-bold text-red-800 truncate">
+              飲み忘れがあります（{missedDoses.length}件）
+            </h3>
+          </div>
+          {onMarkMultipleAsTaken && (
+            <button
+              type="button"
+              onClick={handleMarkAll}
+              disabled={bulkTarget !== null || recordingId !== null}
+              className="flex items-center gap-1 text-xs text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 px-2 py-1 rounded font-medium flex-shrink-0"
+            >
+              {bulkTarget === 'all' ? <Loader2 size={12} className="animate-spin" /> : <Check size={12} />}
+              <span>全て記録</span>
+            </button>
+          )}
         </div>
         <div className="px-4 py-3 space-y-3">
           {dateGroups.map((group) => (
             <div key={group.date}>
-              <p className="text-xs font-semibold text-red-700 mb-1">{group.dateLabel}</p>
-              <div className="space-y-1">
-                {group.items.map((dose) => (
-                  <div
-                    key={`${dose.date}-${dose.scheduleId}`}
-                    className="flex items-center justify-between text-sm"
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-xs font-semibold text-red-700">{group.dateLabel}</p>
+                {onMarkMultipleAsTaken && group.items.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => handleMarkAllForDate(group)}
+                    disabled={bulkTarget !== null || recordingId !== null}
+                    className="text-xs text-red-600 hover:text-red-800 disabled:opacity-50 font-medium flex items-center gap-1"
                   >
-                    <span className="text-gray-800">
-                      <span className="text-gray-500">{dose.memberName}</span>
-                      {' '}
-                      <span className="font-medium">{dose.medicationName}</span>
-                    </span>
-                    <span className="text-xs text-gray-500">{dose.scheduledTime}</span>
-                  </div>
-                ))}
+                    {bulkTarget === group.date ? <Loader2 size={11} className="animate-spin" /> : null}
+                    <span>この日全て記録</span>
+                  </button>
+                )}
+              </div>
+              <div className="space-y-1">
+                {group.items.map((dose) => {
+                  const key = `${dose.date}-${dose.scheduleId}`;
+                  const isRecording = recordingId === key;
+                  return (
+                    <div
+                      key={key}
+                      className="flex items-center justify-between gap-2 text-sm"
+                    >
+                      <span className="text-gray-800 min-w-0 truncate">
+                        <span className="text-gray-500">{dose.memberName}</span>
+                        {' '}
+                        <span className="font-medium">{dose.medicationName}</span>
+                      </span>
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        <span className="text-xs text-gray-500">{dose.scheduledTime}</span>
+                        {onMarkAsTaken && (
+                          <button
+                            type="button"
+                            onClick={() => handleMarkOne(dose)}
+                            disabled={isRecording || bulkTarget !== null}
+                            aria-label="記録する"
+                            className="flex items-center gap-1 text-xs text-red-700 hover:text-white hover:bg-red-600 disabled:opacity-50 border border-red-300 hover:border-red-600 px-2 py-0.5 rounded transition-colors"
+                          >
+                            {isRecording ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
+                            <span>記録</span>
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           ))}
-        </div>
-        <div className="px-4 pb-3">
-          <Link
-            href="/history"
-            className="block text-center text-xs text-red-600 hover:text-red-700 font-medium py-1.5 rounded-md bg-red-100 hover:bg-red-200 transition-colors"
-          >
-            履歴から記録を追加
-          </Link>
         </div>
       </div>
     </div>

--- a/src/domain/repositories/ScheduleRepository.ts
+++ b/src/domain/repositories/ScheduleRepository.ts
@@ -28,6 +28,7 @@ export interface ScheduleWithDetails {
 export interface MissedDose {
   date: string;
   scheduleId: string;
+  medicationId: string;
   medicationName: string;
   memberName: string;
   memberId: string;

--- a/src/presentation/hooks/useMedicationRecordActions.ts
+++ b/src/presentation/hooks/useMedicationRecordActions.ts
@@ -10,6 +10,13 @@ import { getDIContainer } from '../../infrastructure/DIContainer';
 export interface UseMedicationRecordActionsResult {
   markAsTaken: (memberId: string, medicationId: string, notes?: string) => Promise<void>;
   markAsTakenAt: (memberId: string, medicationId: string, takenAt: string, notes?: string) => Promise<void>;
+  markScheduleAsTakenAt: (
+    memberId: string,
+    medicationId: string,
+    scheduleId: string,
+    takenAt: string,
+    notes?: string,
+  ) => Promise<void>;
   isLoading: boolean;
   error: Error | null;
 }
@@ -51,5 +58,25 @@ export const useMedicationRecordActions = (): UseMedicationRecordActionsResult =
     }
   }, [useCase]);
 
-  return { markAsTaken, markAsTakenAt, isLoading, error };
+  const markScheduleAsTakenAt = useCallback(async (
+    memberId: string,
+    medicationId: string,
+    scheduleId: string,
+    takenAt: string,
+    notes?: string,
+  ) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await useCase.execute({ memberId, medicationId, scheduleId, takenAt, notes });
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error('記録に失敗しました');
+      setError(e);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [useCase]);
+
+  return { markAsTaken, markAsTakenAt, markScheduleAsTakenAt, isLoading, error };
 };


### PR DESCRIPTION
## Summary

- 飲み忘れアラート内の各項目から直接「記録」できるボタンを追加（scheduleId 指定で確実にマッチ）
- 日付ごとの「この日全て記録」と全件まとめて消化する「全て記録」ボタンを追加
- 記録後は missed-doses / today-schedules / adherence-stats を同時 refetch
- `MissedDose` に `medicationId` を追加（API応答にも追加）
- `useMedicationRecordActions` に `markScheduleAsTakenAt` を追加

これまで飲み忘れは「履歴から記録を追加」フォームを開いて手動記録するしかなく、件数が多いと記録しても消えにくかった問題を解消します。