### PR TITLE
design: フェミニン風のタブピル＆カード調整

### DIFF
--- a/src/components/dashboard/GreetingCard.tsx
+++ b/src/components/dashboard/GreetingCard.tsx
@@ -16,14 +16,16 @@ export const GreetingCard: React.FC<GreetingCardProps> = ({ displayName, weeklyR
   const summaryMessage = GreetingMessageEntity.getWeeklySummaryMessage(weeklyRate ?? null);
 
   return (
-    <div className="bg-gradient-greeting rounded-2xl p-4 mb-6 flex items-center space-x-3 shadow-soft">
-      <CharacterIcon type={config.type} size={40} />
+    <div className="bg-white rounded-2xl p-4 mb-6 flex items-center space-x-3 shadow-soft border border-pink-100">
+      <div className="bg-pink-50 rounded-2xl p-1.5">
+        <CharacterIcon type={config.type} size={36} />
+      </div>
       <div>
-        <p className="text-sm font-semibold text-primary-800">
+        <p className="text-sm font-semibold text-navy-800">
           {greeting}、{displayName}さん
         </p>
-        <p className="text-xs text-primary-600 mt-0.5">{summaryMessage}{config.suffix}</p>
-        <p className="text-xs text-primary-400 mt-0.5">{config.name}より</p>
+        <p className="text-xs text-navy-600 mt-0.5">{summaryMessage}{config.suffix}</p>
+        <p className="text-xs text-gray-400 mt-0.5">{config.name}より</p>
       </div>
     </div>
   );

--- a/src/components/dashboard/WeeklySummaryCard.tsx
+++ b/src/components/dashboard/WeeklySummaryCard.tsx
@@ -26,8 +26,8 @@ export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = React.memo(({
   const completionRate = Math.round((completed / total) * 100);
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-4 mb-4 border border-gray-200">
-      <h3 className="text-sm font-semibold text-gray-700 mb-3">今日のまとめ</h3>
+    <div className="bg-white rounded-2xl shadow-soft p-4 mb-4 border border-gray-100">
+      <h3 className="text-sm font-semibold text-navy-800 mb-3">今日のまとめ</h3>
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-1">
           <CheckCircle2 size={16} className="text-green-500" />

--- a/src/components/shared/BottomNavigation.tsx
+++ b/src/components/shared/BottomNavigation.tsx
@@ -32,7 +32,7 @@ export const BottomNavigation: React.FC<BottomNavigationProps> = ({ activePath }
               href={path}
               {...(isActive && { 'aria-current': 'page' as const })}
               className={`flex flex-col items-center text-xs transition-colors ${
-                isActive ? 'text-primary-600 font-semibold' : 'text-gray-500 hover:text-navy-700'
+                isActive ? 'text-navy-700 font-semibold' : 'text-gray-400 hover:text-navy-600'
               }`}
             >
               {React.createElement(icon, { size: 20, className: 'mb-0.5' })}

--- a/src/components/shared/CategoryFilter.tsx
+++ b/src/components/shared/CategoryFilter.tsx
@@ -27,8 +27,8 @@ export const CategoryFilter: React.FC<CategoryFilterProps> = ({
         onClick={() => onSelect(null)}
         className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
           selectedCategory === null
-            ? 'bg-primary-600 text-white'
-            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            ? 'bg-navy-700 text-white border border-navy-700'
+            : 'bg-white text-navy-700 border border-gray-300 hover:bg-gray-50'
         }`}
       >
         すべて
@@ -41,8 +41,8 @@ export const CategoryFilter: React.FC<CategoryFilterProps> = ({
           onClick={() => onSelect(cat.id)}
           className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
             selectedCategory === cat.id
-              ? 'bg-primary-600 text-white'
-              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              ? 'bg-navy-700 text-white border border-navy-700'
+              : 'bg-white text-navy-700 border border-gray-300 hover:bg-gray-50'
           }`}
         >
           {cat.label}

--- a/src/components/shared/MemberFilter.tsx
+++ b/src/components/shared/MemberFilter.tsx
@@ -20,8 +20,8 @@ export const MemberFilter: React.FC<MemberFilterProps> = ({ members, selectedMem
         onClick={() => onSelect(null)}
         className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
           selectedMemberId === null
-            ? 'bg-primary-600 text-white'
-            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            ? 'bg-navy-700 text-white border border-navy-700'
+            : 'bg-white text-navy-700 border border-gray-300 hover:bg-gray-50'
         }`}
         role="tab"
         aria-selected={selectedMemberId === null}
@@ -34,8 +34,8 @@ export const MemberFilter: React.FC<MemberFilterProps> = ({ members, selectedMem
           onClick={() => onSelect(member.id)}
           className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
             selectedMemberId === member.id
-              ? 'bg-primary-600 text-white'
-              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              ? 'bg-navy-700 text-white border border-navy-700'
+              : 'bg-white text-navy-700 border border-gray-300 hover:bg-gray-50'
           }`}
           role="tab"
           aria-selected={selectedMemberId === member.id}


### PR DESCRIPTION
## Summary

スクリーンショットの参考実物に近づけるための見た目調整:
- `CategoryFilter` / `MemberFilter` のアクティブ状態をネイビー塗り(navy-700)＋ 非アクティブをアウトライン(白bg + ネイビー文字 + グレー枠) に変更
- `BottomNavigation` のアクティブ色をピンクからネイビーへ変更
- `GreetingCard` を白カード + ピンク淡背景のキャラ枠 + ネイビー文字に刷新
- `WeeklySummaryCard` を rounded-2xl + shadow-soft に統一

機能変更はありません。
