### PR TITLE
chore: vercel.json で Tokyo (hnd1) リージョンと関数設定を明示

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["hnd1"],
+  "functions": {
+    "src/app/api/**/route.ts": {
+      "memory": 1024,
+      "maxDuration": 10
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Vercel を Tokyo リージョンに移設したことを受け、設定をダッシュボード依存ではなくリポジトリにコミットして固定化します。

- `regions: ['hnd1']` で全 Vercel Functions を東京リージョンに固定
- `functions[src/app/api/**/route.ts]`: `memory: 1024` / `maxDuration: 10` を明示

DB が東京リージョンの場合、関数も東京に置くと内部 LAN 経由になり、API のレイテンシが大きく短縮されます。

## 補足: 完全 Edge Runtime 化について

「Node Edge にして高速化」のご要望ですが、現状そのまま Edge にすると以下の理由で動かないため、本PRでは Tokyo Node 関数の最適化に留めています:

- **Prisma**: Edge Runtime 未対応。`@prisma/adapter-neon` 等の Driver Adapter 導入が必要 (Neon/Supabase の使用前提)
- **bcryptjs**: Node API依存。`@noble/hashes` 等のEdge互換ライブラリへ置換が必要
- **`lib/auth.ts`**: 上記2つを import しているため、Edge ルートからの間接 import で全体が落ちる

完全移行は別タスクとして検討しましょう (お薬一覧APIなど主要ルートを 50ms 以下にできる可能性)。Tokyo Node でも実用上は十分速いので、緊急度は低めです。