### PR TITLE
fix: ホーム画面の薬欠落とログイン画面アイコン非表示を修正

### DIFF
--- a/src/data/repositories/server/PrismaScheduleRepository.ts
+++ b/src/data/repositories/server/PrismaScheduleRepository.ts
@@ -162,8 +162,11 @@ export class PrismaScheduleRepository implements ScheduleRepository {
 
     let inactiveMedicationIds = new Set<string>();
     try {
+      // 明示的に paused / discontinued を指定するホワイトリスト方式。
+      // status が NULL / 空文字 / 想定外の値だった場合も active として扱われ、
+      // 「お薬一覧に出ているのに今日の予定に出ない」事故を防ぐ。
       const inactiveMeds = await prisma.medication.findMany({
-        where: { userId: this.userId, status: { not: 'active' } },
+        where: { userId: this.userId, status: { in: ['paused', 'discontinued'] } },
         select: { id: true },
       });
       inactiveMedicationIds = new Set(inactiveMeds.map((m) => m.id));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,5 +4,5 @@ import { authConfig } from '@/lib/auth.config';
 export const { auth: middleware } = NextAuth(authConfig);
 
 export const config = {
-  matcher: ['/((?!login|signup|verify|forgot-password|reset-password|api/auth|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!login|signup|verify|forgot-password|reset-password|api/auth|_next/static|_next/image|favicon.ico|icon.svg|icon.png|apple-icon.png|manifest.webmanifest|sw.js).*)'],
 };


### PR DESCRIPTION
## Summary

### 1. お薬一覧にあるのにホーム画面に出ない薬がある問題
- `PrismaScheduleRepository.getTodaySchedules` で `status != 'active'` フィルタを使っていたため、status が NULL や想定外の値の薬まで「今日の予定」から除外されていた
- フィルタを `status: { in: ['paused', 'discontinued'] }` のホワイトリスト方式に変更し、未知の値・NULL は active として扱うようにした

### 2. ログイン・パスワード再設定画面でアイコンが壊れて表示される問題
- middleware の `matcher` が `/icon.svg` `/icon.png` `/apple-icon.png` `/manifest.webmanifest` `/sw.js` を除外していなかったため、未ログイン時に NextAuth が /login へリダイレクトし画像 GET が壊れていた
- 静的アセットのパスを matcher の除外リストに追加して素通しさせる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 薬剤ステータスの検出ロジックを改善し、スキーマ移行時の互換性と信頼性を向上させました。

* **Chores**
  * 静的アセットの読み込み処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->