### PR TITLE
chore: 認証画面のアイコンに rounded-2xl で角丸を適用

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -42,7 +42,7 @@ export default function ForgotPassword() {
     <div className="min-h-screen flex items-center justify-center bg-pink-50/30 px-4">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
-          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2" unoptimized />
+          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2 rounded-2xl" unoptimized />
           <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
           <p className="mt-2 text-gray-500">パスワードの再設定</p>
         </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -43,7 +43,7 @@ export default function Login() {
     <div className="min-h-screen flex items-center justify-center bg-pink-50/30 px-4">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
-          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2" unoptimized />
+          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2 rounded-2xl" unoptimized />
           <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
           <p className="mt-2 text-gray-500">ログイン</p>
         </div>

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -71,7 +71,7 @@ function ResetPasswordContent() {
     <div className="min-h-screen flex items-center justify-center bg-pink-50/30 px-4">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
-          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2" unoptimized />
+          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2 rounded-2xl" unoptimized />
           <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
           <p className="mt-2 text-gray-500">新しいパスワードの設定</p>
         </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -46,7 +46,7 @@ export default function SignUp() {
     <div className="min-h-screen flex items-center justify-center bg-pink-50/30 px-4">
       <div className="max-w-md w-full space-y-8">
         <div className="text-center">
-          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2" unoptimized />
+          <Image src="/icon.svg" alt="HealthFamily" width={80} height={80} className="mx-auto mb-2 rounded-2xl" unoptimized />
           <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
           <p className="mt-2 text-gray-500">新規登録</p>
         </div>


### PR DESCRIPTION
## Summary

- ログイン / サインアップ / パスワードを忘れた方 / パスワード再設定 の 4画面のアイコン `<Image>` に `rounded-2xl` (border-radius: 1rem) を追加
- SVG の外周の四隅が丸く表示されるようになる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
  * 認証ページ全体のアイコン画像に対して、ビジュアルデザインの向上のためのスタイリング更新を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->