### PR TITLE
fix(backend): 生SQLを既存Prisma管理スキーマ(PascalCase/camelCase)に整合

### DIFF
--- a/backend/internal/domain/entity/entities.go
+++ b/backend/internal/domain/entity/entities.go
@@ -4,20 +4,20 @@ import "time"
 
 // User はアカウント
 type User struct {
-	ID                  string     `json:"id"`
-	Email               string     `json:"email"`
-	Password            string     `json:"-"`
-	DisplayName         *string    `json:"displayName"`
-	CharacterType       string     `json:"characterType"`
-	CharacterName       *string    `json:"characterName"`
-	EmailVerified       bool       `json:"emailVerified"`
-	VerificationCode    *string    `json:"-"`
-	VerificationExpiry  *time.Time `json:"-"`
-	VerificationAttempts int       `json:"-"`
-	ResetCode           *string    `json:"-"`
-	ResetCodeExpiry     *time.Time `json:"-"`
-	CreatedAt           time.Time  `json:"createdAt"`
-	UpdatedAt           time.Time  `json:"updatedAt"`
+	ID                   string     `json:"id"`
+	Email                string     `json:"email"`
+	Password             string     `json:"-"`
+	DisplayName          *string    `json:"displayName"`
+	CharacterType        string     `json:"characterType"`
+	CharacterName        *string    `json:"characterName"`
+	EmailVerified        bool       `json:"emailVerified"`
+	VerificationCode     *string    `json:"-"`
+	VerificationExpiry   *time.Time `json:"-"`
+	VerificationAttempts int        `json:"-"`
+	ResetCode            *string    `json:"-"`
+	ResetCodeExpiry      *time.Time `json:"-"`
+	CreatedAt            time.Time  `json:"createdAt"`
+	UpdatedAt            time.Time  `json:"updatedAt"`
 }
 
 // Member は家族・ペットのメンバー

--- a/backend/internal/domain/entity/entities_ext.go
+++ b/backend/internal/domain/entity/entities_ext.go
@@ -131,23 +131,29 @@ type EmergencyContact struct {
 
 // Prescription は処方箋
 type Prescription struct {
-	ID           string     `json:"id"`
-	UserID       string     `json:"userId"`
-	MemberID     string     `json:"memberId"`
-	Name         string     `json:"name"`
-	ImageData    *string    `json:"imageData"`
-	Notes        *string    `json:"notes"`
-	PrescribedAt *time.Time `json:"prescribedAt"`
-	CreatedAt    time.Time  `json:"createdAt"`
+	ID               string     `json:"id"`
+	UserID           string     `json:"userId"`
+	MemberID         string     `json:"memberId"`
+	PrescriptionName string     `json:"prescriptionName"`
+	PrescribedBy     *string    `json:"prescribedBy"`
+	PrescribedAt     time.Time  `json:"prescribedAt"`
+	ExpiresAt        *time.Time `json:"expiresAt"`
+	PharmacyName     *string    `json:"pharmacyName"`
+	Notes            *string    `json:"notes"`
+	CreatedAt        time.Time  `json:"createdAt"`
 }
 
 // NotificationSetting は通知設定（user スコープ・UNIQUE）
 type NotificationSetting struct {
-	ID              string    `json:"id"`
-	UserID          string    `json:"userId"`
-	PushEnabled     bool      `json:"pushEnabled"`
-	EmailEnabled    bool      `json:"emailEnabled"`
-	ReminderEnabled bool      `json:"reminderEnabled"`
-	CreatedAt       time.Time `json:"createdAt"`
-	UpdatedAt       time.Time `json:"updatedAt"`
+	ID                                   string    `json:"id"`
+	UserID                               string    `json:"userId"`
+	MedicationReminderEnabled            bool      `json:"medicationReminderEnabled"`
+	MissedMedicationEnabled              bool      `json:"missedMedicationEnabled"`
+	AppointmentReminderEnabled           bool      `json:"appointmentReminderEnabled"`
+	LowStockAlertEnabled                 bool      `json:"lowStockAlertEnabled"`
+	DefaultReminderMinutesBefore         int       `json:"defaultReminderMinutesBefore"`
+	DefaultAppointmentReminderDaysBefore int       `json:"defaultAppointmentReminderDaysBefore"`
+	EmailNotificationEnabled             bool      `json:"emailNotificationEnabled"`
+	CreatedAt                            time.Time `json:"createdAt"`
+	UpdatedAt                            time.Time `json:"updatedAt"`
 }

--- a/backend/internal/domain/repository/repository_ext.go
+++ b/backend/internal/domain/repository/repository_ext.go
@@ -288,19 +288,23 @@ type EmergencyContactRepository interface {
 // ---- Prescription ----
 
 type CreatePrescriptionInput struct {
-	UserID       string
-	MemberID     string
-	Name         string
-	ImageData    *string
-	Notes        *string
-	PrescribedAt *time.Time
+	UserID           string
+	MemberID         string
+	PrescriptionName string
+	PrescribedBy     *string
+	PrescribedAt     time.Time
+	ExpiresAt        *time.Time
+	PharmacyName     *string
+	Notes            *string
 }
 
 type UpdatePrescriptionInput struct {
-	Name         *string
-	ImageData    *string
-	Notes        *string
-	PrescribedAt *time.Time
+	PrescriptionName *string
+	PrescribedBy     *string
+	PrescribedAt     *time.Time
+	ExpiresAt        *time.Time
+	PharmacyName     *string
+	Notes            *string
 }
 
 type PrescriptionRepository interface {
@@ -314,10 +318,14 @@ type PrescriptionRepository interface {
 // ---- NotificationSetting ----
 
 type UpsertNotificationSettingInput struct {
-	UserID          string
-	PushEnabled     *bool
-	EmailEnabled    *bool
-	ReminderEnabled *bool
+	UserID                               string
+	MedicationReminderEnabled            *bool
+	MissedMedicationEnabled              *bool
+	AppointmentReminderEnabled           *bool
+	LowStockAlertEnabled                 *bool
+	DefaultReminderMinutesBefore         *int
+	DefaultAppointmentReminderDaysBefore *int
+	EmailNotificationEnabled             *bool
 }
 
 type NotificationSettingRepository interface {

--- a/backend/internal/infrastructure/persistence/allergy_repository.go
+++ b/backend/internal/infrastructure/persistence/allergy_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// AllergyRepository は allergies テーブルの生SQL実装
+// AllergyRepository は "Allergy" テーブルの生SQL実装
 type AllergyRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewAllergyRepository(db *database.DB) *AllergyRepository {
 	return &AllergyRepository{db: db}
 }
 
-const allergyColumns = `id, user_id, member_id, allergen_name, allergy_type, severity, symptoms, diagnosed_at, notes, created_at`
+const allergyColumns = `"id", "userId", "memberId", "allergenName", "allergyType", "severity", "symptoms", "diagnosedAt", "notes", "createdAt"`
 
 func scanAllergy(row pgx.Row) (*entity.Allergy, error) {
 	var a entity.Allergy
@@ -36,7 +36,7 @@ func scanAllergy(row pgx.Row) (*entity.Allergy, error) {
 
 func (r *AllergyRepository) List(ctx context.Context, userID string) ([]entity.Allergy, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+allergyColumns+` FROM allergies WHERE user_id=$1 ORDER BY created_at DESC`, userID)
+		`SELECT `+allergyColumns+` FROM "Allergy" WHERE "userId"=$1 ORDER BY "createdAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func (r *AllergyRepository) List(ctx context.Context, userID string) ([]entity.A
 }
 
 func (r *AllergyRepository) FindByID(ctx context.Context, id string) (*entity.Allergy, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+allergyColumns+` FROM allergies WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+allergyColumns+` FROM "Allergy" WHERE "id"=$1`, id)
 	return scanAllergy(row)
 }
 
 func (r *AllergyRepository) Create(ctx context.Context, in repository.CreateAllergyInput) (*entity.Allergy, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO allergies (id, user_id, member_id, allergen_name, allergy_type, severity, symptoms, diagnosed_at, notes, created_at)
+		`INSERT INTO "Allergy" ("id", "userId", "memberId", "allergenName", "allergyType", "severity", "symptoms", "diagnosedAt", "notes", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())
 		 RETURNING `+allergyColumns,
 		id, in.UserID, in.MemberID, in.AllergenName, in.AllergyType, in.Severity, in.Symptoms, in.DiagnosedAt, in.Notes)
@@ -69,20 +69,20 @@ func (r *AllergyRepository) Create(ctx context.Context, in repository.CreateAlle
 
 func (r *AllergyRepository) Update(ctx context.Context, id string, in repository.UpdateAllergyInput) (*entity.Allergy, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE allergies SET
-			allergen_name = COALESCE($2, allergen_name),
-			allergy_type = COALESCE($3, allergy_type),
-			severity = COALESCE($4, severity),
-			symptoms = COALESCE($5, symptoms),
-			diagnosed_at = COALESCE($6, diagnosed_at),
-			notes = COALESCE($7, notes)
-		 WHERE id=$1
+		`UPDATE "Allergy" SET
+			"allergenName" = COALESCE($2, "allergenName"),
+			"allergyType" = COALESCE($3, "allergyType"),
+			"severity" = COALESCE($4, "severity"),
+			"symptoms" = COALESCE($5, "symptoms"),
+			"diagnosedAt" = COALESCE($6, "diagnosedAt"),
+			"notes" = COALESCE($7, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+allergyColumns,
 		id, in.AllergenName, in.AllergyType, in.Severity, in.Symptoms, in.DiagnosedAt, in.Notes)
 	return scanAllergy(row)
 }
 
 func (r *AllergyRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM allergies WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Allergy" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/appointment_repository.go
+++ b/backend/internal/infrastructure/persistence/appointment_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// AppointmentRepository は appointments テーブルの生SQL実装
+// AppointmentRepository は "Appointment" テーブルの生SQL実装
 type AppointmentRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewAppointmentRepository(db *database.DB) *AppointmentRepository {
 	return &AppointmentRepository{db: db}
 }
 
-const appointmentColumns = `id, user_id, member_id, hospital_id, appointment_type, appointment_date, description, test_results, cost, reminder_enabled, reminder_days_before, created_at`
+const appointmentColumns = `"id", "userId", "memberId", "hospitalId", "appointmentType", "appointmentDate", "description", "testResults", "cost", "reminderEnabled", "reminderDaysBefore", "createdAt"`
 
 func scanAppointment(row pgx.Row) (*entity.Appointment, error) {
 	var a entity.Appointment
@@ -37,7 +37,7 @@ func scanAppointment(row pgx.Row) (*entity.Appointment, error) {
 
 func (r *AppointmentRepository) List(ctx context.Context, userID string) ([]entity.Appointment, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+appointmentColumns+` FROM appointments WHERE user_id=$1 ORDER BY appointment_date DESC`, userID)
+		`SELECT `+appointmentColumns+` FROM "Appointment" WHERE "userId"=$1 ORDER BY "appointmentDate" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -55,14 +55,14 @@ func (r *AppointmentRepository) List(ctx context.Context, userID string) ([]enti
 }
 
 func (r *AppointmentRepository) FindByID(ctx context.Context, id string) (*entity.Appointment, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+appointmentColumns+` FROM appointments WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+appointmentColumns+` FROM "Appointment" WHERE "id"=$1`, id)
 	return scanAppointment(row)
 }
 
 func (r *AppointmentRepository) Create(ctx context.Context, in repository.CreateAppointmentInput) (*entity.Appointment, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO appointments (id, user_id, member_id, hospital_id, appointment_type, appointment_date, description, test_results, cost, reminder_enabled, reminder_days_before, created_at)
+		`INSERT INTO "Appointment" ("id", "userId", "memberId", "hospitalId", "appointmentType", "appointmentDate", "description", "testResults", "cost", "reminderEnabled", "reminderDaysBefore", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, COALESCE($10, TRUE), COALESCE($11, 1), now())
 		 RETURNING `+appointmentColumns,
 		id, in.UserID, in.MemberID, in.HospitalID, in.AppointmentType, in.AppointmentDate, in.Description,
@@ -72,16 +72,16 @@ func (r *AppointmentRepository) Create(ctx context.Context, in repository.Create
 
 func (r *AppointmentRepository) Update(ctx context.Context, id string, in repository.UpdateAppointmentInput) (*entity.Appointment, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE appointments SET
-			hospital_id = COALESCE($2, hospital_id),
-			appointment_type = COALESCE($3, appointment_type),
-			appointment_date = COALESCE($4, appointment_date),
-			description = COALESCE($5, description),
-			test_results = COALESCE($6, test_results),
-			cost = COALESCE($7, cost),
-			reminder_enabled = COALESCE($8, reminder_enabled),
-			reminder_days_before = COALESCE($9, reminder_days_before)
-		 WHERE id=$1
+		`UPDATE "Appointment" SET
+			"hospitalId" = COALESCE($2, "hospitalId"),
+			"appointmentType" = COALESCE($3, "appointmentType"),
+			"appointmentDate" = COALESCE($4, "appointmentDate"),
+			"description" = COALESCE($5, "description"),
+			"testResults" = COALESCE($6, "testResults"),
+			"cost" = COALESCE($7, "cost"),
+			"reminderEnabled" = COALESCE($8, "reminderEnabled"),
+			"reminderDaysBefore" = COALESCE($9, "reminderDaysBefore")
+		 WHERE "id"=$1
 		 RETURNING `+appointmentColumns,
 		id, in.HospitalID, in.AppointmentType, in.AppointmentDate, in.Description, in.TestResults,
 		in.Cost, in.ReminderEnabled, in.ReminderDaysBefore)
@@ -89,6 +89,6 @@ func (r *AppointmentRepository) Update(ctx context.Context, id string, in reposi
 }
 
 func (r *AppointmentRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM appointments WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Appointment" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/body_measurement_repository.go
+++ b/backend/internal/infrastructure/persistence/body_measurement_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// BodyMeasurementRepository は body_measurements テーブルの生SQL実装
+// BodyMeasurementRepository は "BodyMeasurement" テーブルの生SQL実装
 type BodyMeasurementRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewBodyMeasurementRepository(db *database.DB) *BodyMeasurementRepository {
 	return &BodyMeasurementRepository{db: db}
 }
 
-const bodyMeasurementColumns = `id, user_id, member_id, weight, height, recorded_at, notes, created_at`
+const bodyMeasurementColumns = `"id", "userId", "memberId", "weight", "height", "recordedAt", "notes", "createdAt"`
 
 func scanBodyMeasurement(row pgx.Row) (*entity.BodyMeasurement, error) {
 	var b entity.BodyMeasurement
@@ -36,7 +36,7 @@ func scanBodyMeasurement(row pgx.Row) (*entity.BodyMeasurement, error) {
 
 func (r *BodyMeasurementRepository) List(ctx context.Context, userID string) ([]entity.BodyMeasurement, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+bodyMeasurementColumns+` FROM body_measurements WHERE user_id=$1 ORDER BY recorded_at DESC`, userID)
+		`SELECT `+bodyMeasurementColumns+` FROM "BodyMeasurement" WHERE "userId"=$1 ORDER BY "recordedAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func (r *BodyMeasurementRepository) List(ctx context.Context, userID string) ([]
 }
 
 func (r *BodyMeasurementRepository) FindByID(ctx context.Context, id string) (*entity.BodyMeasurement, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+bodyMeasurementColumns+` FROM body_measurements WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+bodyMeasurementColumns+` FROM "BodyMeasurement" WHERE "id"=$1`, id)
 	return scanBodyMeasurement(row)
 }
 
 func (r *BodyMeasurementRepository) Create(ctx context.Context, in repository.CreateBodyMeasurementInput) (*entity.BodyMeasurement, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO body_measurements (id, user_id, member_id, weight, height, recorded_at, notes, created_at)
+		`INSERT INTO "BodyMeasurement" ("id", "userId", "memberId", "weight", "height", "recordedAt", "notes", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7, now())
 		 RETURNING `+bodyMeasurementColumns,
 		id, in.UserID, in.MemberID, in.Weight, in.Height, in.RecordedAt, in.Notes)
@@ -69,18 +69,18 @@ func (r *BodyMeasurementRepository) Create(ctx context.Context, in repository.Cr
 
 func (r *BodyMeasurementRepository) Update(ctx context.Context, id string, in repository.UpdateBodyMeasurementInput) (*entity.BodyMeasurement, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE body_measurements SET
-			weight = COALESCE($2, weight),
-			height = COALESCE($3, height),
-			recorded_at = COALESCE($4, recorded_at),
-			notes = COALESCE($5, notes)
-		 WHERE id=$1
+		`UPDATE "BodyMeasurement" SET
+			"weight" = COALESCE($2, "weight"),
+			"height" = COALESCE($3, "height"),
+			"recordedAt" = COALESCE($4, "recordedAt"),
+			"notes" = COALESCE($5, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+bodyMeasurementColumns,
 		id, in.Weight, in.Height, in.RecordedAt, in.Notes)
 	return scanBodyMeasurement(row)
 }
 
 func (r *BodyMeasurementRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM body_measurements WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "BodyMeasurement" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/emergency_contact_repository.go
+++ b/backend/internal/infrastructure/persistence/emergency_contact_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// EmergencyContactRepository は emergency_contacts テーブルの生SQL実装
+// EmergencyContactRepository は "EmergencyContact" テーブルの生SQL実装
 type EmergencyContactRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewEmergencyContactRepository(db *database.DB) *EmergencyContactRepository 
 	return &EmergencyContactRepository{db: db}
 }
 
-const emergencyContactColumns = `id, user_id, member_id, contact_name, phone_number, relationship, notes, created_at`
+const emergencyContactColumns = `"id", "userId", "memberId", "contactName", "phoneNumber", "relationship", "notes", "createdAt"`
 
 func scanEmergencyContact(row pgx.Row) (*entity.EmergencyContact, error) {
 	var e entity.EmergencyContact
@@ -36,7 +36,7 @@ func scanEmergencyContact(row pgx.Row) (*entity.EmergencyContact, error) {
 
 func (r *EmergencyContactRepository) List(ctx context.Context, userID string) ([]entity.EmergencyContact, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+emergencyContactColumns+` FROM emergency_contacts WHERE user_id=$1 ORDER BY created_at DESC`, userID)
+		`SELECT `+emergencyContactColumns+` FROM "EmergencyContact" WHERE "userId"=$1 ORDER BY "createdAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func (r *EmergencyContactRepository) List(ctx context.Context, userID string) ([
 }
 
 func (r *EmergencyContactRepository) FindByID(ctx context.Context, id string) (*entity.EmergencyContact, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+emergencyContactColumns+` FROM emergency_contacts WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+emergencyContactColumns+` FROM "EmergencyContact" WHERE "id"=$1`, id)
 	return scanEmergencyContact(row)
 }
 
 func (r *EmergencyContactRepository) Create(ctx context.Context, in repository.CreateEmergencyContactInput) (*entity.EmergencyContact, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO emergency_contacts (id, user_id, member_id, contact_name, phone_number, relationship, notes, created_at)
+		`INSERT INTO "EmergencyContact" ("id", "userId", "memberId", "contactName", "phoneNumber", "relationship", "notes", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7, now())
 		 RETURNING `+emergencyContactColumns,
 		id, in.UserID, in.MemberID, in.ContactName, in.PhoneNumber, in.Relationship, in.Notes)
@@ -69,18 +69,18 @@ func (r *EmergencyContactRepository) Create(ctx context.Context, in repository.C
 
 func (r *EmergencyContactRepository) Update(ctx context.Context, id string, in repository.UpdateEmergencyContactInput) (*entity.EmergencyContact, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE emergency_contacts SET
-			contact_name = COALESCE($2, contact_name),
-			phone_number = COALESCE($3, phone_number),
-			relationship = COALESCE($4, relationship),
-			notes = COALESCE($5, notes)
-		 WHERE id=$1
+		`UPDATE "EmergencyContact" SET
+			"contactName" = COALESCE($2, "contactName"),
+			"phoneNumber" = COALESCE($3, "phoneNumber"),
+			"relationship" = COALESCE($4, "relationship"),
+			"notes" = COALESCE($5, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+emergencyContactColumns,
 		id, in.ContactName, in.PhoneNumber, in.Relationship, in.Notes)
 	return scanEmergencyContact(row)
 }
 
 func (r *EmergencyContactRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM emergency_contacts WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "EmergencyContact" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/examination_repository.go
+++ b/backend/internal/infrastructure/persistence/examination_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// ExaminationRepository は examinations テーブルの生SQL実装
+// ExaminationRepository は "Examination" テーブルの生SQL実装
 type ExaminationRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewExaminationRepository(db *database.DB) *ExaminationRepository {
 	return &ExaminationRepository{db: db}
 }
 
-const examinationColumns = `id, user_id, member_id, examination_type, examined_at, next_scheduled_date, notes, image_data, created_at`
+const examinationColumns = `"id", "userId", "memberId", "examinationType", "examinedAt", "nextScheduledDate", "notes", "imageData", "createdAt"`
 
 func scanExamination(row pgx.Row) (*entity.Examination, error) {
 	var e entity.Examination
@@ -36,7 +36,7 @@ func scanExamination(row pgx.Row) (*entity.Examination, error) {
 
 func (r *ExaminationRepository) List(ctx context.Context, userID string) ([]entity.Examination, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+examinationColumns+` FROM examinations WHERE user_id=$1 ORDER BY examined_at DESC`, userID)
+		`SELECT `+examinationColumns+` FROM "Examination" WHERE "userId"=$1 ORDER BY "examinedAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func (r *ExaminationRepository) List(ctx context.Context, userID string) ([]enti
 }
 
 func (r *ExaminationRepository) FindByID(ctx context.Context, id string) (*entity.Examination, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+examinationColumns+` FROM examinations WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+examinationColumns+` FROM "Examination" WHERE "id"=$1`, id)
 	return scanExamination(row)
 }
 
 func (r *ExaminationRepository) Create(ctx context.Context, in repository.CreateExaminationInput) (*entity.Examination, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO examinations (id, user_id, member_id, examination_type, examined_at, next_scheduled_date, notes, image_data, created_at)
+		`INSERT INTO "Examination" ("id", "userId", "memberId", "examinationType", "examinedAt", "nextScheduledDate", "notes", "imageData", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8, now())
 		 RETURNING `+examinationColumns,
 		id, in.UserID, in.MemberID, in.ExaminationType, in.ExaminedAt, in.NextScheduledDate, in.Notes, in.ImageData)
@@ -69,19 +69,19 @@ func (r *ExaminationRepository) Create(ctx context.Context, in repository.Create
 
 func (r *ExaminationRepository) Update(ctx context.Context, id string, in repository.UpdateExaminationInput) (*entity.Examination, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE examinations SET
-			examination_type = COALESCE($2, examination_type),
-			examined_at = COALESCE($3, examined_at),
-			next_scheduled_date = COALESCE($4, next_scheduled_date),
-			notes = COALESCE($5, notes),
-			image_data = COALESCE($6, image_data)
-		 WHERE id=$1
+		`UPDATE "Examination" SET
+			"examinationType" = COALESCE($2, "examinationType"),
+			"examinedAt" = COALESCE($3, "examinedAt"),
+			"nextScheduledDate" = COALESCE($4, "nextScheduledDate"),
+			"notes" = COALESCE($5, "notes"),
+			"imageData" = COALESCE($6, "imageData")
+		 WHERE "id"=$1
 		 RETURNING `+examinationColumns,
 		id, in.ExaminationType, in.ExaminedAt, in.NextScheduledDate, in.Notes, in.ImageData)
 	return scanExamination(row)
 }
 
 func (r *ExaminationRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM examinations WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Examination" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/health_log_repository.go
+++ b/backend/internal/infrastructure/persistence/health_log_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// HealthLogRepository は health_logs テーブルの生SQL実装
+// HealthLogRepository は "HealthLog" テーブルの生SQL実装
 type HealthLogRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewHealthLogRepository(db *database.DB) *HealthLogRepository {
 	return &HealthLogRepository{db: db}
 }
 
-const healthLogColumns = `id, user_id, member_id, condition_level, symptoms, notes, recorded_at`
+const healthLogColumns = `"id", "userId", "memberId", "conditionLevel", "symptoms", "notes", "recordedAt"`
 
 func scanHealthLog(row pgx.Row) (*entity.HealthLog, error) {
 	var h entity.HealthLog
@@ -36,7 +36,7 @@ func scanHealthLog(row pgx.Row) (*entity.HealthLog, error) {
 
 func (r *HealthLogRepository) List(ctx context.Context, userID string) ([]entity.HealthLog, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+healthLogColumns+` FROM health_logs WHERE user_id=$1 ORDER BY recorded_at DESC`, userID)
+		`SELECT `+healthLogColumns+` FROM "HealthLog" WHERE "userId"=$1 ORDER BY "recordedAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (r *HealthLogRepository) List(ctx context.Context, userID string) ([]entity
 }
 
 func (r *HealthLogRepository) FindByID(ctx context.Context, id string) (*entity.HealthLog, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+healthLogColumns+` FROM health_logs WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+healthLogColumns+` FROM "HealthLog" WHERE "id"=$1`, id)
 	return scanHealthLog(row)
 }
 
@@ -64,7 +64,7 @@ func (r *HealthLogRepository) Create(ctx context.Context, in repository.CreateHe
 		symptoms = []string{}
 	}
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO health_logs (id, user_id, member_id, condition_level, symptoms, notes, recorded_at)
+		`INSERT INTO "HealthLog" ("id", "userId", "memberId", "conditionLevel", "symptoms", "notes", "recordedAt")
 		 VALUES ($1,$2,$3,$4,$5,$6, COALESCE($7, now()))
 		 RETURNING `+healthLogColumns,
 		id, in.UserID, in.MemberID, in.ConditionLevel, symptoms, in.Notes, in.RecordedAt)
@@ -73,18 +73,18 @@ func (r *HealthLogRepository) Create(ctx context.Context, in repository.CreateHe
 
 func (r *HealthLogRepository) Update(ctx context.Context, id string, in repository.UpdateHealthLogInput) (*entity.HealthLog, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE health_logs SET
-			condition_level = COALESCE($2, condition_level),
-			symptoms = COALESCE($3, symptoms),
-			notes = COALESCE($4, notes),
-			recorded_at = COALESCE($5, recorded_at)
-		 WHERE id=$1
+		`UPDATE "HealthLog" SET
+			"conditionLevel" = COALESCE($2, "conditionLevel"),
+			"symptoms" = COALESCE($3, "symptoms"),
+			"notes" = COALESCE($4, "notes"),
+			"recordedAt" = COALESCE($5, "recordedAt")
+		 WHERE "id"=$1
 		 RETURNING `+healthLogColumns,
 		id, in.ConditionLevel, in.Symptoms, in.Notes, in.RecordedAt)
 	return scanHealthLog(row)
 }
 
 func (r *HealthLogRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM health_logs WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "HealthLog" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/hospital_repository.go
+++ b/backend/internal/infrastructure/persistence/hospital_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// HospitalRepository は hospitals テーブルの生SQL実装
+// HospitalRepository は "Hospital" テーブルの生SQL実装
 type HospitalRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewHospitalRepository(db *database.DB) *HospitalRepository {
 	return &HospitalRepository{db: db}
 }
 
-const hospitalColumns = `id, user_id, name, hospital_type, address, phone_number, department, doctor_name, notes, created_at`
+const hospitalColumns = `"id", "userId", "name", "hospitalType", "address", "phoneNumber", "department", "doctorName", "notes", "createdAt"`
 
 func scanHospital(row pgx.Row) (*entity.Hospital, error) {
 	var h entity.Hospital
@@ -37,7 +37,7 @@ func scanHospital(row pgx.Row) (*entity.Hospital, error) {
 
 func (r *HospitalRepository) List(ctx context.Context, userID string) ([]entity.Hospital, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+hospitalColumns+` FROM hospitals WHERE user_id=$1 ORDER BY created_at DESC`, userID)
+		`SELECT `+hospitalColumns+` FROM "Hospital" WHERE "userId"=$1 ORDER BY "createdAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -55,14 +55,14 @@ func (r *HospitalRepository) List(ctx context.Context, userID string) ([]entity.
 }
 
 func (r *HospitalRepository) FindByID(ctx context.Context, id string) (*entity.Hospital, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+hospitalColumns+` FROM hospitals WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+hospitalColumns+` FROM "Hospital" WHERE "id"=$1`, id)
 	return scanHospital(row)
 }
 
 func (r *HospitalRepository) Create(ctx context.Context, in repository.CreateHospitalInput) (*entity.Hospital, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO hospitals (id, user_id, name, hospital_type, address, phone_number, department, doctor_name, notes, created_at)
+		`INSERT INTO "Hospital" ("id", "userId", "name", "hospitalType", "address", "phoneNumber", "department", "doctorName", "notes", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())
 		 RETURNING `+hospitalColumns,
 		id, in.UserID, in.Name, in.HospitalType, in.Address, in.PhoneNumber, in.Department, in.DoctorName, in.Notes)
@@ -71,21 +71,21 @@ func (r *HospitalRepository) Create(ctx context.Context, in repository.CreateHos
 
 func (r *HospitalRepository) Update(ctx context.Context, id string, in repository.UpdateHospitalInput) (*entity.Hospital, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE hospitals SET
-			name = COALESCE($2, name),
-			hospital_type = COALESCE($3, hospital_type),
-			address = COALESCE($4, address),
-			phone_number = COALESCE($5, phone_number),
-			department = COALESCE($6, department),
-			doctor_name = COALESCE($7, doctor_name),
-			notes = COALESCE($8, notes)
-		 WHERE id=$1
+		`UPDATE "Hospital" SET
+			"name" = COALESCE($2, "name"),
+			"hospitalType" = COALESCE($3, "hospitalType"),
+			"address" = COALESCE($4, "address"),
+			"phoneNumber" = COALESCE($5, "phoneNumber"),
+			"department" = COALESCE($6, "department"),
+			"doctorName" = COALESCE($7, "doctorName"),
+			"notes" = COALESCE($8, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+hospitalColumns,
 		id, in.Name, in.HospitalType, in.Address, in.PhoneNumber, in.Department, in.DoctorName, in.Notes)
 	return scanHospital(row)
 }
 
 func (r *HospitalRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM hospitals WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Hospital" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/insurance_repository.go
+++ b/backend/internal/infrastructure/persistence/insurance_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// InsuranceRepository は insurances テーブルの生SQL実装
+// InsuranceRepository は "Insurance" テーブルの生SQL実装
 type InsuranceRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewInsuranceRepository(db *database.DB) *InsuranceRepository {
 	return &InsuranceRepository{db: db}
 }
 
-const insuranceColumns = `id, user_id, member_id, insurance_type, provider_name, policy_number, notes, created_at`
+const insuranceColumns = `"id", "userId", "memberId", "insuranceType", "providerName", "policyNumber", "notes", "createdAt"`
 
 func scanInsurance(row pgx.Row) (*entity.Insurance, error) {
 	var i entity.Insurance
@@ -36,7 +36,7 @@ func scanInsurance(row pgx.Row) (*entity.Insurance, error) {
 
 func (r *InsuranceRepository) List(ctx context.Context, userID string) ([]entity.Insurance, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+insuranceColumns+` FROM insurances WHERE user_id=$1 ORDER BY created_at DESC`, userID)
+		`SELECT `+insuranceColumns+` FROM "Insurance" WHERE "userId"=$1 ORDER BY "createdAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func (r *InsuranceRepository) List(ctx context.Context, userID string) ([]entity
 }
 
 func (r *InsuranceRepository) FindByID(ctx context.Context, id string) (*entity.Insurance, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+insuranceColumns+` FROM insurances WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+insuranceColumns+` FROM "Insurance" WHERE "id"=$1`, id)
 	return scanInsurance(row)
 }
 
 func (r *InsuranceRepository) Create(ctx context.Context, in repository.CreateInsuranceInput) (*entity.Insurance, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO insurances (id, user_id, member_id, insurance_type, provider_name, policy_number, notes, created_at)
+		`INSERT INTO "Insurance" ("id", "userId", "memberId", "insuranceType", "providerName", "policyNumber", "notes", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7, now())
 		 RETURNING `+insuranceColumns,
 		id, in.UserID, in.MemberID, in.InsuranceType, in.ProviderName, in.PolicyNumber, in.Notes)
@@ -69,18 +69,18 @@ func (r *InsuranceRepository) Create(ctx context.Context, in repository.CreateIn
 
 func (r *InsuranceRepository) Update(ctx context.Context, id string, in repository.UpdateInsuranceInput) (*entity.Insurance, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE insurances SET
-			insurance_type = COALESCE($2, insurance_type),
-			provider_name = COALESCE($3, provider_name),
-			policy_number = COALESCE($4, policy_number),
-			notes = COALESCE($5, notes)
-		 WHERE id=$1
+		`UPDATE "Insurance" SET
+			"insuranceType" = COALESCE($2, "insuranceType"),
+			"providerName" = COALESCE($3, "providerName"),
+			"policyNumber" = COALESCE($4, "policyNumber"),
+			"notes" = COALESCE($5, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+insuranceColumns,
 		id, in.InsuranceType, in.ProviderName, in.PolicyNumber, in.Notes)
 	return scanInsurance(row)
 }
 
 func (r *InsuranceRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM insurances WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Insurance" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/medication_record_repository.go
+++ b/backend/internal/infrastructure/persistence/medication_record_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// MedicationRecordRepository は medication_records テーブルの生SQL実装
+// MedicationRecordRepository は "MedicationRecord" テーブルの生SQL実装
 type MedicationRecordRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewMedicationRecordRepository(db *database.DB) *MedicationRecordRepository 
 	return &MedicationRecordRepository{db: db}
 }
 
-const recordColumns = `id, member_id, medication_id, user_id, schedule_id, taken_at, notes, dosage_amount`
+const recordColumns = `"id", "memberId", "medicationId", "userId", "scheduleId", "takenAt", "notes", "dosageAmount"`
 
 func scanRecord(row pgx.Row) (*entity.MedicationRecord, error) {
 	var r entity.MedicationRecord
@@ -37,7 +37,7 @@ func scanRecord(row pgx.Row) (*entity.MedicationRecord, error) {
 
 func (r *MedicationRecordRepository) queryList(ctx context.Context, where, arg string) ([]entity.MedicationRecord, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+recordColumns+` FROM medication_records WHERE `+where+` ORDER BY taken_at DESC`, arg)
+		`SELECT `+recordColumns+` FROM "MedicationRecord" WHERE `+where+` ORDER BY "takenAt" DESC`, arg)
 	if err != nil {
 		return nil, err
 	}
@@ -55,22 +55,22 @@ func (r *MedicationRecordRepository) queryList(ctx context.Context, where, arg s
 }
 
 func (r *MedicationRecordRepository) ListByUser(ctx context.Context, userID string) ([]entity.MedicationRecord, error) {
-	return r.queryList(ctx, "user_id=$1", userID)
+	return r.queryList(ctx, `"userId"=$1`, userID)
 }
 
 func (r *MedicationRecordRepository) ListByMember(ctx context.Context, memberID string) ([]entity.MedicationRecord, error) {
-	return r.queryList(ctx, "member_id=$1", memberID)
+	return r.queryList(ctx, `"memberId"=$1`, memberID)
 }
 
 func (r *MedicationRecordRepository) FindByID(ctx context.Context, id string) (*entity.MedicationRecord, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+recordColumns+` FROM medication_records WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+recordColumns+` FROM "MedicationRecord" WHERE "id"=$1`, id)
 	return scanRecord(row)
 }
 
 func (r *MedicationRecordRepository) Create(ctx context.Context, in repository.CreateRecordInput) (*entity.MedicationRecord, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO medication_records (id, member_id, medication_id, user_id, schedule_id, taken_at, notes, dosage_amount)
+		`INSERT INTO "MedicationRecord" ("id", "memberId", "medicationId", "userId", "scheduleId", "takenAt", "notes", "dosageAmount")
 		 VALUES ($1,$2,$3,$4,$5, COALESCE($6, now()), $7, $8)
 		 RETURNING `+recordColumns,
 		id, in.MemberID, in.MedicationID, in.UserID, in.ScheduleID, in.TakenAt, in.Notes, in.DosageAmount)
@@ -78,6 +78,6 @@ func (r *MedicationRecordRepository) Create(ctx context.Context, in repository.C
 }
 
 func (r *MedicationRecordRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM medication_records WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "MedicationRecord" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/medication_repository.go
+++ b/backend/internal/infrastructure/persistence/medication_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// MedicationRepository は medications テーブルの生SQL実装
+// MedicationRepository は "Medication" テーブルの生SQL実装
 type MedicationRepository struct {
 	db *database.DB
 }
@@ -20,9 +20,9 @@ func NewMedicationRepository(db *database.DB) *MedicationRepository {
 	return &MedicationRepository{db: db}
 }
 
-const medColumns = `id, member_id, user_id, name, category, dosage_amount, frequency,
-	stock_quantity, stock_alert_date, interval_hours, instructions, display_order,
-	is_active, status, created_at, updated_at`
+const medColumns = `"id", "memberId", "userId", "name", "category", "dosageAmount", "frequency",
+	"stockQuantity", "stockAlertDate", "intervalHours", "instructions", "displayOrder",
+	"isActive", "status", "createdAt", "updatedAt"`
 
 func scanMedication(row pgx.Row) (*entity.Medication, error) {
 	var m entity.Medication
@@ -40,7 +40,7 @@ func scanMedication(row pgx.Row) (*entity.Medication, error) {
 
 func (r *MedicationRepository) queryList(ctx context.Context, where string, arg string) ([]entity.Medication, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+medColumns+` FROM medications WHERE `+where+` ORDER BY display_order ASC, created_at ASC`, arg)
+		`SELECT `+medColumns+` FROM "Medication" WHERE `+where+` ORDER BY "displayOrder" ASC, "createdAt" ASC`, arg)
 	if err != nil {
 		return nil, err
 	}
@@ -59,23 +59,23 @@ func (r *MedicationRepository) queryList(ctx context.Context, where string, arg 
 }
 
 func (r *MedicationRepository) ListByMember(ctx context.Context, memberID string) ([]entity.Medication, error) {
-	return r.queryList(ctx, "member_id=$1", memberID)
+	return r.queryList(ctx, `"memberId"=$1`, memberID)
 }
 
 func (r *MedicationRepository) ListByUser(ctx context.Context, userID string) ([]entity.Medication, error) {
-	return r.queryList(ctx, "user_id=$1", userID)
+	return r.queryList(ctx, `"userId"=$1`, userID)
 }
 
 func (r *MedicationRepository) FindByID(ctx context.Context, id string) (*entity.Medication, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+medColumns+` FROM medications WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+medColumns+` FROM "Medication" WHERE "id"=$1`, id)
 	return scanMedication(row)
 }
 
 func (r *MedicationRepository) Create(ctx context.Context, in repository.CreateMedicationInput) (*entity.Medication, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO medications (id, member_id, user_id, name, category, dosage_amount, frequency,
-			stock_quantity, stock_alert_date, instructions, created_at, updated_at)
+		`INSERT INTO "Medication" ("id", "memberId", "userId", "name", "category", "dosageAmount", "frequency",
+			"stockQuantity", "stockAlertDate", "instructions", "createdAt", "updatedAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, now(), now())
 		 RETURNING `+medColumns,
 		id, in.MemberID, in.UserID, in.Name, in.Category, in.DosageAmount, in.Frequency,
@@ -85,18 +85,18 @@ func (r *MedicationRepository) Create(ctx context.Context, in repository.CreateM
 
 func (r *MedicationRepository) Update(ctx context.Context, id string, in repository.UpdateMedicationInput) (*entity.Medication, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE medications SET
-			name = COALESCE($2, name),
-			category = COALESCE($3, category),
-			dosage_amount = COALESCE($4, dosage_amount),
-			frequency = COALESCE($5, frequency),
-			stock_quantity = COALESCE($6, stock_quantity),
-			stock_alert_date = COALESCE($7, stock_alert_date),
-			instructions = COALESCE($8, instructions),
-			is_active = COALESCE($9, is_active),
-			status = COALESCE($10, status),
-			updated_at = now()
-		 WHERE id=$1
+		`UPDATE "Medication" SET
+			"name" = COALESCE($2, "name"),
+			"category" = COALESCE($3, "category"),
+			"dosageAmount" = COALESCE($4, "dosageAmount"),
+			"frequency" = COALESCE($5, "frequency"),
+			"stockQuantity" = COALESCE($6, "stockQuantity"),
+			"stockAlertDate" = COALESCE($7, "stockAlertDate"),
+			"instructions" = COALESCE($8, "instructions"),
+			"isActive" = COALESCE($9, "isActive"),
+			"status" = COALESCE($10, "status"),
+			"updatedAt" = now()
+		 WHERE "id"=$1
 		 RETURNING `+medColumns,
 		id, in.Name, in.Category, in.DosageAmount, in.Frequency, in.StockQuantity,
 		in.StockAlertDate, in.Instructions, in.IsActive, in.Status)
@@ -105,7 +105,7 @@ func (r *MedicationRepository) Update(ctx context.Context, id string, in reposit
 
 func (r *MedicationRepository) UpdateStock(ctx context.Context, id string, quantity int) (*entity.Medication, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE medications SET stock_quantity=$2, updated_at=now() WHERE id=$1 RETURNING `+medColumns,
+		`UPDATE "Medication" SET "stockQuantity"=$2, "updatedAt"=now() WHERE "id"=$1 RETURNING `+medColumns,
 		id, quantity)
 	return scanMedication(row)
 }
@@ -118,7 +118,7 @@ func (r *MedicationRepository) Reorder(ctx context.Context, userID string, order
 	defer tx.Rollback(ctx) //nolint:errcheck
 	for i, id := range orderedIDs {
 		if _, err := tx.Exec(ctx,
-			`UPDATE medications SET display_order=$1, updated_at=now() WHERE id=$2 AND user_id=$3`,
+			`UPDATE "Medication" SET "displayOrder"=$1, "updatedAt"=now() WHERE "id"=$2 AND "userId"=$3`,
 			i, id, userID); err != nil {
 			return err
 		}
@@ -127,6 +127,6 @@ func (r *MedicationRepository) Reorder(ctx context.Context, userID string, order
 }
 
 func (r *MedicationRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM medications WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Medication" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/member_repository.go
+++ b/backend/internal/infrastructure/persistence/member_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// MemberRepository は members テーブルの生SQL実装
+// MemberRepository は "Member" テーブルの生SQL実装
 type MemberRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewMemberRepository(db *database.DB) *MemberRepository {
 	return &MemberRepository{db: db}
 }
 
-const memberColumns = `id, user_id, member_type, name, pet_type, photo_url, birth_date, notes, created_at, updated_at`
+const memberColumns = `"id", "userId", "memberType", "name", "petType", "photoUrl", "birthDate", "notes", "createdAt", "updatedAt"`
 
 func scanMember(row pgx.Row) (*entity.Member, error) {
 	var m entity.Member
@@ -37,7 +37,7 @@ func scanMember(row pgx.Row) (*entity.Member, error) {
 
 func (r *MemberRepository) List(ctx context.Context, userID string) ([]entity.Member, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+memberColumns+` FROM members WHERE user_id=$1 ORDER BY created_at ASC`, userID)
+		`SELECT `+memberColumns+` FROM "Member" WHERE "userId"=$1 ORDER BY "createdAt" ASC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -56,14 +56,14 @@ func (r *MemberRepository) List(ctx context.Context, userID string) ([]entity.Me
 }
 
 func (r *MemberRepository) FindByID(ctx context.Context, id string) (*entity.Member, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+memberColumns+` FROM members WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+memberColumns+` FROM "Member" WHERE "id"=$1`, id)
 	return scanMember(row)
 }
 
 func (r *MemberRepository) Create(ctx context.Context, in repository.CreateMemberInput) (*entity.Member, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO members (id, user_id, member_type, name, pet_type, birth_date, notes, created_at, updated_at)
+		`INSERT INTO "Member" ("id", "userId", "memberType", "name", "petType", "birthDate", "notes", "createdAt", "updatedAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7, now(), now())
 		 RETURNING `+memberColumns,
 		id, in.UserID, in.MemberType, in.Name, in.PetType, in.BirthDate, in.Notes)
@@ -72,19 +72,19 @@ func (r *MemberRepository) Create(ctx context.Context, in repository.CreateMembe
 
 func (r *MemberRepository) Update(ctx context.Context, id string, in repository.UpdateMemberInput) (*entity.Member, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE members SET
-			name = COALESCE($2, name),
-			pet_type = COALESCE($3, pet_type),
-			birth_date = COALESCE($4, birth_date),
-			notes = COALESCE($5, notes),
-			updated_at = now()
-		 WHERE id=$1
+		`UPDATE "Member" SET
+			"name" = COALESCE($2, "name"),
+			"petType" = COALESCE($3, "petType"),
+			"birthDate" = COALESCE($4, "birthDate"),
+			"notes" = COALESCE($5, "notes"),
+			"updatedAt" = now()
+		 WHERE "id"=$1
 		 RETURNING `+memberColumns,
 		id, in.Name, in.PetType, in.BirthDate, in.Notes)
 	return scanMember(row)
 }
 
 func (r *MemberRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM members WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Member" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/notification_setting_repository.go
+++ b/backend/internal/infrastructure/persistence/notification_setting_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// NotificationSettingRepository は notification_settings テーブルの生SQL実装
+// NotificationSettingRepository は "NotificationSetting" テーブルの生SQL実装
 type NotificationSettingRepository struct {
 	db *database.DB
 }
@@ -20,11 +20,15 @@ func NewNotificationSettingRepository(db *database.DB) *NotificationSettingRepos
 	return &NotificationSettingRepository{db: db}
 }
 
-const notificationSettingColumns = `id, user_id, push_enabled, email_enabled, reminder_enabled, created_at, updated_at`
+const notificationSettingColumns = `"id", "userId", "medicationReminderEnabled", "missedMedicationEnabled",
+	"appointmentReminderEnabled", "lowStockAlertEnabled", "defaultReminderMinutesBefore",
+	"defaultAppointmentReminderDaysBefore", "emailNotificationEnabled", "createdAt", "updatedAt"`
 
 func scanNotificationSetting(row pgx.Row) (*entity.NotificationSetting, error) {
 	var n entity.NotificationSetting
-	err := row.Scan(&n.ID, &n.UserID, &n.PushEnabled, &n.EmailEnabled, &n.ReminderEnabled, &n.CreatedAt, &n.UpdatedAt)
+	err := row.Scan(&n.ID, &n.UserID, &n.MedicationReminderEnabled, &n.MissedMedicationEnabled,
+		&n.AppointmentReminderEnabled, &n.LowStockAlertEnabled, &n.DefaultReminderMinutesBefore,
+		&n.DefaultAppointmentReminderDaysBefore, &n.EmailNotificationEnabled, &n.CreatedAt, &n.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -35,21 +39,30 @@ func scanNotificationSetting(row pgx.Row) (*entity.NotificationSetting, error) {
 }
 
 func (r *NotificationSettingRepository) FindByUserID(ctx context.Context, userID string) (*entity.NotificationSetting, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+notificationSettingColumns+` FROM notification_settings WHERE user_id=$1`, userID)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+notificationSettingColumns+` FROM "NotificationSetting" WHERE "userId"=$1`, userID)
 	return scanNotificationSetting(row)
 }
 
 func (r *NotificationSettingRepository) Upsert(ctx context.Context, in repository.UpsertNotificationSettingInput) (*entity.NotificationSetting, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO notification_settings (id, user_id, push_enabled, email_enabled, reminder_enabled, created_at, updated_at)
-		 VALUES ($1, $2, COALESCE($3, FALSE), COALESCE($4, FALSE), COALESCE($5, TRUE), now(), now())
-		 ON CONFLICT (user_id) DO UPDATE SET
-			push_enabled = COALESCE($3, notification_settings.push_enabled),
-			email_enabled = COALESCE($4, notification_settings.email_enabled),
-			reminder_enabled = COALESCE($5, notification_settings.reminder_enabled),
-			updated_at = now()
+		`INSERT INTO "NotificationSetting" ("id", "userId", "medicationReminderEnabled", "missedMedicationEnabled",
+			"appointmentReminderEnabled", "lowStockAlertEnabled", "defaultReminderMinutesBefore",
+			"defaultAppointmentReminderDaysBefore", "emailNotificationEnabled", "createdAt", "updatedAt")
+		 VALUES ($1, $2, COALESCE($3, TRUE), COALESCE($4, TRUE), COALESCE($5, TRUE), COALESCE($6, TRUE),
+			COALESCE($7, 5), COALESCE($8, 1), COALESCE($9, TRUE), now(), now())
+		 ON CONFLICT ("userId") DO UPDATE SET
+			"medicationReminderEnabled" = COALESCE($3, "NotificationSetting"."medicationReminderEnabled"),
+			"missedMedicationEnabled" = COALESCE($4, "NotificationSetting"."missedMedicationEnabled"),
+			"appointmentReminderEnabled" = COALESCE($5, "NotificationSetting"."appointmentReminderEnabled"),
+			"lowStockAlertEnabled" = COALESCE($6, "NotificationSetting"."lowStockAlertEnabled"),
+			"defaultReminderMinutesBefore" = COALESCE($7, "NotificationSetting"."defaultReminderMinutesBefore"),
+			"defaultAppointmentReminderDaysBefore" = COALESCE($8, "NotificationSetting"."defaultAppointmentReminderDaysBefore"),
+			"emailNotificationEnabled" = COALESCE($9, "NotificationSetting"."emailNotificationEnabled"),
+			"updatedAt" = now()
 		 RETURNING `+notificationSettingColumns,
-		id, in.UserID, in.PushEnabled, in.EmailEnabled, in.ReminderEnabled)
+		id, in.UserID, in.MedicationReminderEnabled, in.MissedMedicationEnabled,
+		in.AppointmentReminderEnabled, in.LowStockAlertEnabled, in.DefaultReminderMinutesBefore,
+		in.DefaultAppointmentReminderDaysBefore, in.EmailNotificationEnabled)
 	return scanNotificationSetting(row)
 }

--- a/backend/internal/infrastructure/persistence/prescription_repository.go
+++ b/backend/internal/infrastructure/persistence/prescription_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// PrescriptionRepository は prescriptions テーブルの生SQL実装
+// PrescriptionRepository は "Prescription" テーブルの生SQL実装
 type PrescriptionRepository struct {
 	db *database.DB
 }
@@ -20,11 +20,11 @@ func NewPrescriptionRepository(db *database.DB) *PrescriptionRepository {
 	return &PrescriptionRepository{db: db}
 }
 
-const prescriptionColumns = `id, user_id, member_id, name, image_data, notes, prescribed_at, created_at`
+const prescriptionColumns = `"id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt", "expiresAt", "pharmacyName", "notes", "createdAt"`
 
 func scanPrescription(row pgx.Row) (*entity.Prescription, error) {
 	var p entity.Prescription
-	err := row.Scan(&p.ID, &p.UserID, &p.MemberID, &p.Name, &p.ImageData, &p.Notes, &p.PrescribedAt, &p.CreatedAt)
+	err := row.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.Notes, &p.CreatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -36,7 +36,7 @@ func scanPrescription(row pgx.Row) (*entity.Prescription, error) {
 
 func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]entity.Prescription, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+prescriptionColumns+` FROM prescriptions WHERE user_id=$1 ORDER BY created_at DESC`, userID)
+		`SELECT `+prescriptionColumns+` FROM "Prescription" WHERE "userId"=$1 ORDER BY "createdAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]ent
 	list := make([]entity.Prescription, 0)
 	for rows.Next() {
 		var p entity.Prescription
-		if err := rows.Scan(&p.ID, &p.UserID, &p.MemberID, &p.Name, &p.ImageData, &p.Notes, &p.PrescribedAt, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.Notes, &p.CreatedAt); err != nil {
 			return nil, err
 		}
 		list = append(list, p)
@@ -53,34 +53,36 @@ func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]ent
 }
 
 func (r *PrescriptionRepository) FindByID(ctx context.Context, id string) (*entity.Prescription, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+prescriptionColumns+` FROM prescriptions WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+prescriptionColumns+` FROM "Prescription" WHERE "id"=$1`, id)
 	return scanPrescription(row)
 }
 
 func (r *PrescriptionRepository) Create(ctx context.Context, in repository.CreatePrescriptionInput) (*entity.Prescription, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO prescriptions (id, user_id, member_id, name, image_data, notes, prescribed_at, created_at)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7, now())
+		`INSERT INTO "Prescription" ("id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt", "expiresAt", "pharmacyName", "notes", "createdAt")
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())
 		 RETURNING `+prescriptionColumns,
-		id, in.UserID, in.MemberID, in.Name, in.ImageData, in.Notes, in.PrescribedAt)
+		id, in.UserID, in.MemberID, in.PrescriptionName, in.PrescribedBy, in.PrescribedAt, in.ExpiresAt, in.PharmacyName, in.Notes)
 	return scanPrescription(row)
 }
 
 func (r *PrescriptionRepository) Update(ctx context.Context, id string, in repository.UpdatePrescriptionInput) (*entity.Prescription, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE prescriptions SET
-			name = COALESCE($2, name),
-			image_data = COALESCE($3, image_data),
-			notes = COALESCE($4, notes),
-			prescribed_at = COALESCE($5, prescribed_at)
-		 WHERE id=$1
+		`UPDATE "Prescription" SET
+			"prescriptionName" = COALESCE($2, "prescriptionName"),
+			"prescribedBy" = COALESCE($3, "prescribedBy"),
+			"prescribedAt" = COALESCE($4, "prescribedAt"),
+			"expiresAt" = COALESCE($5, "expiresAt"),
+			"pharmacyName" = COALESCE($6, "pharmacyName"),
+			"notes" = COALESCE($7, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+prescriptionColumns,
-		id, in.Name, in.ImageData, in.Notes, in.PrescribedAt)
+		id, in.PrescriptionName, in.PrescribedBy, in.PrescribedAt, in.ExpiresAt, in.PharmacyName, in.Notes)
 	return scanPrescription(row)
 }
 
 func (r *PrescriptionRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM prescriptions WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Prescription" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/schedule_repository.go
+++ b/backend/internal/infrastructure/persistence/schedule_repository.go
@@ -13,7 +13,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// ScheduleRepository は schedules テーブルの生SQL実装
+// ScheduleRepository は "Schedule" テーブルの生SQL実装
 type ScheduleRepository struct {
 	db *database.DB
 }
@@ -22,8 +22,8 @@ func NewScheduleRepository(db *database.DB) *ScheduleRepository {
 	return &ScheduleRepository{db: db}
 }
 
-const scheduleColumns = `id, medication_id, user_id, member_id, scheduled_time, days_of_week,
-	interval_days, start_date, is_enabled, reminder_minutes_before, created_at`
+const scheduleColumns = `"id", "medicationId", "userId", "memberId", "scheduledTime", "daysOfWeek",
+	"intervalDays", "startDate", "isEnabled", "reminderMinutesBefore", "createdAt"`
 
 func scanSchedule(row pgx.Row) (*entity.Schedule, error) {
 	var s entity.Schedule
@@ -40,7 +40,7 @@ func scanSchedule(row pgx.Row) (*entity.Schedule, error) {
 
 func (r *ScheduleRepository) ListByUser(ctx context.Context, userID string) ([]entity.Schedule, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+scheduleColumns+` FROM schedules WHERE user_id=$1 ORDER BY scheduled_time ASC`, userID)
+		`SELECT `+scheduleColumns+` FROM "Schedule" WHERE "userId"=$1 ORDER BY "scheduledTime" ASC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (r *ScheduleRepository) ListByUser(ctx context.Context, userID string) ([]e
 }
 
 func (r *ScheduleRepository) FindByID(ctx context.Context, id string) (*entity.Schedule, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+scheduleColumns+` FROM schedules WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+scheduleColumns+` FROM "Schedule" WHERE "id"=$1`, id)
 	return scanSchedule(row)
 }
 
@@ -69,8 +69,8 @@ func (r *ScheduleRepository) Create(ctx context.Context, in repository.CreateSch
 		days = []string{}
 	}
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO schedules (id, medication_id, user_id, member_id, scheduled_time, days_of_week,
-			interval_days, start_date, is_enabled, reminder_minutes_before, created_at)
+		`INSERT INTO "Schedule" ("id", "medicationId", "userId", "memberId", "scheduledTime", "daysOfWeek",
+			"intervalDays", "startDate", "isEnabled", "reminderMinutesBefore", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, now())
 		 RETURNING `+scheduleColumns,
 		id, in.MedicationID, in.UserID, in.MemberID, in.ScheduledTime, days,
@@ -80,21 +80,21 @@ func (r *ScheduleRepository) Create(ctx context.Context, in repository.CreateSch
 
 func (r *ScheduleRepository) Update(ctx context.Context, id string, in repository.UpdateScheduleInput) (*entity.Schedule, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE schedules SET
-			scheduled_time = COALESCE($2, scheduled_time),
-			days_of_week = COALESCE($3, days_of_week),
-			interval_days = COALESCE($4, interval_days),
-			start_date = COALESCE($5, start_date),
-			is_enabled = COALESCE($6, is_enabled),
-			reminder_minutes_before = COALESCE($7, reminder_minutes_before)
-		 WHERE id=$1
+		`UPDATE "Schedule" SET
+			"scheduledTime" = COALESCE($2, "scheduledTime"),
+			"daysOfWeek" = COALESCE($3, "daysOfWeek"),
+			"intervalDays" = COALESCE($4, "intervalDays"),
+			"startDate" = COALESCE($5, "startDate"),
+			"isEnabled" = COALESCE($6, "isEnabled"),
+			"reminderMinutesBefore" = COALESCE($7, "reminderMinutesBefore")
+		 WHERE "id"=$1
 		 RETURNING `+scheduleColumns,
 		id, in.ScheduledTime, in.DaysOfWeek, in.IntervalDays, in.StartDate, in.IsEnabled, in.ReminderMinutesBefore)
 	return scanSchedule(row)
 }
 
 func (r *ScheduleRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM schedules WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Schedule" WHERE "id"=$1`, id)
 	return err
 }
 
@@ -107,18 +107,18 @@ func (r *ScheduleRepository) GetTodaySchedules(ctx context.Context, userID strin
 
 	rows, err := r.db.Pool.Query(ctx,
 		`SELECT `+prefixCols("s", scheduleColumns)+`,
-			m.name, mem.name, mem.member_type, m.display_order,
+			m."name", mem."name", mem."memberType", m."displayOrder",
 			EXISTS(
-				SELECT 1 FROM medication_records r
-				WHERE r.schedule_id = s.id AND r.taken_at >= $3 AND r.taken_at < $4
+				SELECT 1 FROM "MedicationRecord" r
+				WHERE r."scheduleId" = s."id" AND r."takenAt" >= $3 AND r."takenAt" < $4
 			) AS is_completed
-		 FROM schedules s
-		 JOIN medications m ON m.id = s.medication_id
-		 JOIN members mem ON mem.id = s.member_id
-		 WHERE s.user_id = $1
-		   AND s.is_enabled = TRUE
-		   AND (array_length(s.days_of_week, 1) IS NULL OR $2 = ANY(s.days_of_week))
-		 ORDER BY s.scheduled_time ASC`,
+		 FROM "Schedule" s
+		 JOIN "Medication" m ON m."id" = s."medicationId"
+		 JOIN "Member" mem ON mem."id" = s."memberId"
+		 WHERE s."userId" = $1
+		   AND s."isEnabled" = TRUE
+		   AND (array_length(s."daysOfWeek", 1) IS NULL OR $2 = ANY(s."daysOfWeek"))
+		 ORDER BY s."scheduledTime" ASC`,
 		userID, weekday, dayStart, dayEnd)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,8 @@ func (r *ScheduleRepository) GetTodaySchedules(ctx context.Context, userID strin
 	return list, rows.Err()
 }
 
-// prefixCols は "id, name" を "s.id, s.name" の形に変換する
+// prefixCols は `"id", "name"` を `s."id", s."name"` の形に変換する。
+// 引用済みの camelCase カラム名をエイリアスで前置する。
 func prefixCols(alias, cols string) string {
 	parts := strings.Split(cols, ",")
 	out := make([]string, 0, len(parts))

--- a/backend/internal/infrastructure/persistence/temperature_record_repository.go
+++ b/backend/internal/infrastructure/persistence/temperature_record_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// TemperatureRecordRepository は temperature_records テーブルの生SQL実装
+// TemperatureRecordRepository は "TemperatureRecord" テーブルの生SQL実装
 type TemperatureRecordRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewTemperatureRecordRepository(db *database.DB) *TemperatureRecordRepositor
 	return &TemperatureRecordRepository{db: db}
 }
 
-const temperatureColumns = `id, user_id, member_id, temperature, measured_at, notes, created_at`
+const temperatureColumns = `"id", "userId", "memberId", "temperature", "measuredAt", "notes", "createdAt"`
 
 func scanTemperature(row pgx.Row) (*entity.TemperatureRecord, error) {
 	var t entity.TemperatureRecord
@@ -36,7 +36,7 @@ func scanTemperature(row pgx.Row) (*entity.TemperatureRecord, error) {
 
 func (r *TemperatureRecordRepository) queryList(ctx context.Context, where, arg string) ([]entity.TemperatureRecord, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+temperatureColumns+` FROM temperature_records WHERE `+where+` ORDER BY measured_at DESC`, arg)
+		`SELECT `+temperatureColumns+` FROM "TemperatureRecord" WHERE `+where+` ORDER BY "measuredAt" DESC`, arg)
 	if err != nil {
 		return nil, err
 	}
@@ -53,22 +53,22 @@ func (r *TemperatureRecordRepository) queryList(ctx context.Context, where, arg 
 }
 
 func (r *TemperatureRecordRepository) List(ctx context.Context, userID string) ([]entity.TemperatureRecord, error) {
-	return r.queryList(ctx, "user_id=$1", userID)
+	return r.queryList(ctx, `"userId"=$1`, userID)
 }
 
 func (r *TemperatureRecordRepository) ListByMember(ctx context.Context, memberID string) ([]entity.TemperatureRecord, error) {
-	return r.queryList(ctx, "member_id=$1", memberID)
+	return r.queryList(ctx, `"memberId"=$1`, memberID)
 }
 
 func (r *TemperatureRecordRepository) FindByID(ctx context.Context, id string) (*entity.TemperatureRecord, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+temperatureColumns+` FROM temperature_records WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+temperatureColumns+` FROM "TemperatureRecord" WHERE "id"=$1`, id)
 	return scanTemperature(row)
 }
 
 func (r *TemperatureRecordRepository) Create(ctx context.Context, in repository.CreateTemperatureRecordInput) (*entity.TemperatureRecord, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO temperature_records (id, user_id, member_id, temperature, measured_at, notes, created_at)
+		`INSERT INTO "TemperatureRecord" ("id", "userId", "memberId", "temperature", "measuredAt", "notes", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6, now())
 		 RETURNING `+temperatureColumns,
 		id, in.UserID, in.MemberID, in.Temperature, in.MeasuredAt, in.Notes)
@@ -77,17 +77,17 @@ func (r *TemperatureRecordRepository) Create(ctx context.Context, in repository.
 
 func (r *TemperatureRecordRepository) Update(ctx context.Context, id string, in repository.UpdateTemperatureRecordInput) (*entity.TemperatureRecord, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE temperature_records SET
-			temperature = COALESCE($2, temperature),
-			measured_at = COALESCE($3, measured_at),
-			notes = COALESCE($4, notes)
-		 WHERE id=$1
+		`UPDATE "TemperatureRecord" SET
+			"temperature" = COALESCE($2, "temperature"),
+			"measuredAt" = COALESCE($3, "measuredAt"),
+			"notes" = COALESCE($4, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+temperatureColumns,
 		id, in.Temperature, in.MeasuredAt, in.Notes)
 	return scanTemperature(row)
 }
 
 func (r *TemperatureRecordRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM temperature_records WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "TemperatureRecord" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/infrastructure/persistence/user_repository.go
+++ b/backend/internal/infrastructure/persistence/user_repository.go
@@ -9,7 +9,7 @@ import (
 	"healthfamily/internal/infrastructure/database"
 )
 
-// UserRepository は users テーブルの生SQL実装
+// UserRepository は "User" テーブルの生SQL実装
 type UserRepository struct {
 	db *database.DB
 }
@@ -18,9 +18,9 @@ func NewUserRepository(db *database.DB) *UserRepository {
 	return &UserRepository{db: db}
 }
 
-const userColumns = `id, email, password, display_name, character_type, character_name,
-	email_verified, verification_code, verification_expiry, verification_attempts,
-	reset_code, reset_code_expiry, created_at, updated_at`
+const userColumns = `"id", "email", "password", "displayName", "characterType", "characterName",
+	"emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",
+	"resetCode", "resetCodeExpiry", "createdAt", "updatedAt"`
 
 func scanUser(row pgx.Row) (*entity.User, error) {
 	var u entity.User
@@ -39,19 +39,19 @@ func scanUser(row pgx.Row) (*entity.User, error) {
 }
 
 func (r *UserRepository) FindByEmail(ctx context.Context, email string) (*entity.User, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+userColumns+` FROM users WHERE email = $1`, email)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+userColumns+` FROM "User" WHERE "email" = $1`, email)
 	return scanUser(row)
 }
 
 func (r *UserRepository) FindByID(ctx context.Context, id string) (*entity.User, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+userColumns+` FROM users WHERE id = $1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+userColumns+` FROM "User" WHERE "id" = $1`, id)
 	return scanUser(row)
 }
 
 func (r *UserRepository) Create(ctx context.Context, u *entity.User) error {
 	_, err := r.db.Pool.Exec(ctx,
-		`INSERT INTO users (id, email, password, display_name, character_type, email_verified,
-			verification_code, verification_expiry, created_at, updated_at)
+		`INSERT INTO "User" ("id", "email", "password", "displayName", "characterType", "emailVerified",
+			"verificationCode", "verificationExpiry", "createdAt", "updatedAt")
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), now())`,
 		u.ID, u.Email, u.Password, u.DisplayName, u.CharacterType, u.EmailVerified,
 		u.VerificationCode, u.VerificationExpiry,
@@ -61,10 +61,10 @@ func (r *UserRepository) Create(ctx context.Context, u *entity.User) error {
 
 func (r *UserRepository) Update(ctx context.Context, u *entity.User) error {
 	_, err := r.db.Pool.Exec(ctx,
-		`UPDATE users SET email=$2, password=$3, display_name=$4, character_type=$5, character_name=$6,
-			email_verified=$7, verification_code=$8, verification_expiry=$9, verification_attempts=$10,
-			reset_code=$11, reset_code_expiry=$12, updated_at=now()
-		 WHERE id=$1`,
+		`UPDATE "User" SET "email"=$2, "password"=$3, "displayName"=$4, "characterType"=$5, "characterName"=$6,
+			"emailVerified"=$7, "verificationCode"=$8, "verificationExpiry"=$9, "verificationAttempts"=$10,
+			"resetCode"=$11, "resetCodeExpiry"=$12, "updatedAt"=now()
+		 WHERE "id"=$1`,
 		u.ID, u.Email, u.Password, u.DisplayName, u.CharacterType, u.CharacterName,
 		u.EmailVerified, u.VerificationCode, u.VerificationExpiry, u.VerificationAttempts,
 		u.ResetCode, u.ResetCodeExpiry,

--- a/backend/internal/infrastructure/persistence/vaccination_repository.go
+++ b/backend/internal/infrastructure/persistence/vaccination_repository.go
@@ -11,7 +11,7 @@ import (
 	"healthfamily/internal/pkg/auth"
 )
 
-// VaccinationRepository は vaccinations テーブルの生SQL実装
+// VaccinationRepository は "Vaccination" テーブルの生SQL実装
 type VaccinationRepository struct {
 	db *database.DB
 }
@@ -20,7 +20,7 @@ func NewVaccinationRepository(db *database.DB) *VaccinationRepository {
 	return &VaccinationRepository{db: db}
 }
 
-const vaccinationColumns = `id, user_id, member_id, vaccine_name, vaccinated_at, next_scheduled_date, notes, created_at`
+const vaccinationColumns = `"id", "userId", "memberId", "vaccineName", "vaccinatedAt", "nextScheduledDate", "notes", "createdAt"`
 
 func scanVaccination(row pgx.Row) (*entity.Vaccination, error) {
 	var v entity.Vaccination
@@ -36,7 +36,7 @@ func scanVaccination(row pgx.Row) (*entity.Vaccination, error) {
 
 func (r *VaccinationRepository) List(ctx context.Context, userID string) ([]entity.Vaccination, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT `+vaccinationColumns+` FROM vaccinations WHERE user_id=$1 ORDER BY vaccinated_at DESC`, userID)
+		`SELECT `+vaccinationColumns+` FROM "Vaccination" WHERE "userId"=$1 ORDER BY "vaccinatedAt" DESC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,14 +53,14 @@ func (r *VaccinationRepository) List(ctx context.Context, userID string) ([]enti
 }
 
 func (r *VaccinationRepository) FindByID(ctx context.Context, id string) (*entity.Vaccination, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+vaccinationColumns+` FROM vaccinations WHERE id=$1`, id)
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+vaccinationColumns+` FROM "Vaccination" WHERE "id"=$1`, id)
 	return scanVaccination(row)
 }
 
 func (r *VaccinationRepository) Create(ctx context.Context, in repository.CreateVaccinationInput) (*entity.Vaccination, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO vaccinations (id, user_id, member_id, vaccine_name, vaccinated_at, next_scheduled_date, notes, created_at)
+		`INSERT INTO "Vaccination" ("id", "userId", "memberId", "vaccineName", "vaccinatedAt", "nextScheduledDate", "notes", "createdAt")
 		 VALUES ($1,$2,$3,$4,$5,$6,$7, now())
 		 RETURNING `+vaccinationColumns,
 		id, in.UserID, in.MemberID, in.VaccineName, in.VaccinatedAt, in.NextScheduledDate, in.Notes)
@@ -69,18 +69,18 @@ func (r *VaccinationRepository) Create(ctx context.Context, in repository.Create
 
 func (r *VaccinationRepository) Update(ctx context.Context, id string, in repository.UpdateVaccinationInput) (*entity.Vaccination, error) {
 	row := r.db.Pool.QueryRow(ctx,
-		`UPDATE vaccinations SET
-			vaccine_name = COALESCE($2, vaccine_name),
-			vaccinated_at = COALESCE($3, vaccinated_at),
-			next_scheduled_date = COALESCE($4, next_scheduled_date),
-			notes = COALESCE($5, notes)
-		 WHERE id=$1
+		`UPDATE "Vaccination" SET
+			"vaccineName" = COALESCE($2, "vaccineName"),
+			"vaccinatedAt" = COALESCE($3, "vaccinatedAt"),
+			"nextScheduledDate" = COALESCE($4, "nextScheduledDate"),
+			"notes" = COALESCE($5, "notes")
+		 WHERE "id"=$1
 		 RETURNING `+vaccinationColumns,
 		id, in.VaccineName, in.VaccinatedAt, in.NextScheduledDate, in.Notes)
 	return scanVaccination(row)
 }
 
 func (r *VaccinationRepository) Delete(ctx context.Context, id string) error {
-	_, err := r.db.Pool.Exec(ctx, `DELETE FROM vaccinations WHERE id=$1`, id)
+	_, err := r.db.Pool.Exec(ctx, `DELETE FROM "Vaccination" WHERE "id"=$1`, id)
 	return err
 }

--- a/backend/internal/interface/handler/notification_setting_handler.go
+++ b/backend/internal/interface/handler/notification_setting_handler.go
@@ -28,9 +28,13 @@ func (h *NotificationSettingHandler) Get(c *gin.Context) {
 }
 
 type upsertNotificationSettingRequest struct {
-	PushEnabled     *bool `json:"pushEnabled"`
-	EmailEnabled    *bool `json:"emailEnabled"`
-	ReminderEnabled *bool `json:"reminderEnabled"`
+	MedicationReminderEnabled            *bool `json:"medicationReminderEnabled"`
+	MissedMedicationEnabled              *bool `json:"missedMedicationEnabled"`
+	AppointmentReminderEnabled           *bool `json:"appointmentReminderEnabled"`
+	LowStockAlertEnabled                 *bool `json:"lowStockAlertEnabled"`
+	DefaultReminderMinutesBefore         *int  `json:"defaultReminderMinutesBefore"`
+	DefaultAppointmentReminderDaysBefore *int  `json:"defaultAppointmentReminderDaysBefore"`
+	EmailNotificationEnabled             *bool `json:"emailNotificationEnabled"`
 }
 
 func (h *NotificationSettingHandler) Upsert(c *gin.Context) {
@@ -41,10 +45,14 @@ func (h *NotificationSettingHandler) Upsert(c *gin.Context) {
 		return
 	}
 	v, err := h.uc.Upsert(c.Request.Context(), repository.UpsertNotificationSettingInput{
-		UserID:          userID,
-		PushEnabled:     req.PushEnabled,
-		EmailEnabled:    req.EmailEnabled,
-		ReminderEnabled: req.ReminderEnabled,
+		UserID:                               userID,
+		MedicationReminderEnabled:            req.MedicationReminderEnabled,
+		MissedMedicationEnabled:              req.MissedMedicationEnabled,
+		AppointmentReminderEnabled:           req.AppointmentReminderEnabled,
+		LowStockAlertEnabled:                 req.LowStockAlertEnabled,
+		DefaultReminderMinutesBefore:         req.DefaultReminderMinutesBefore,
+		DefaultAppointmentReminderDaysBefore: req.DefaultAppointmentReminderDaysBefore,
+		EmailNotificationEnabled:             req.EmailNotificationEnabled,
 	})
 	if err != nil {
 		response.HandleDomainError(c, err)

--- a/backend/internal/interface/handler/prescription_handler.go
+++ b/backend/internal/interface/handler/prescription_handler.go
@@ -38,27 +38,36 @@ func (h *PrescriptionHandler) Get(c *gin.Context) {
 }
 
 type createPrescriptionRequest struct {
-	MemberID     string  `json:"memberId" binding:"required"`
-	Name         string  `json:"name" binding:"required"`
-	ImageData    *string `json:"imageData"`
-	Notes        *string `json:"notes"`
-	PrescribedAt *string `json:"prescribedAt"`
+	MemberID         string  `json:"memberId" binding:"required"`
+	PrescriptionName string  `json:"prescriptionName" binding:"required"`
+	PrescribedBy     *string `json:"prescribedBy"`
+	PrescribedAt     *string `json:"prescribedAt" binding:"required"`
+	ExpiresAt        *string `json:"expiresAt"`
+	PharmacyName     *string `json:"pharmacyName"`
+	Notes            *string `json:"notes"`
 }
 
 func (h *PrescriptionHandler) Create(c *gin.Context) {
 	userID := middleware.UserID(c)
 	var req createPrescriptionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, 400, "メンバーIDと名称は必須です")
+		response.Error(c, 400, "メンバーID・名称・処方日は必須です")
+		return
+	}
+	prescribedAt := parseDate(req.PrescribedAt)
+	if prescribedAt == nil {
+		response.Error(c, 400, "処方日の形式が正しくありません")
 		return
 	}
 	v, err := h.uc.Create(c.Request.Context(), repository.CreatePrescriptionInput{
-		UserID:       userID,
-		MemberID:     req.MemberID,
-		Name:         req.Name,
-		ImageData:    req.ImageData,
-		Notes:        req.Notes,
-		PrescribedAt: parseDate(req.PrescribedAt),
+		UserID:           userID,
+		MemberID:         req.MemberID,
+		PrescriptionName: req.PrescriptionName,
+		PrescribedBy:     req.PrescribedBy,
+		PrescribedAt:     *prescribedAt,
+		ExpiresAt:        parseDate(req.ExpiresAt),
+		PharmacyName:     req.PharmacyName,
+		Notes:            req.Notes,
 	})
 	if err != nil {
 		response.HandleDomainError(c, err)
@@ -68,10 +77,12 @@ func (h *PrescriptionHandler) Create(c *gin.Context) {
 }
 
 type updatePrescriptionRequest struct {
-	Name         *string `json:"name"`
-	ImageData    *string `json:"imageData"`
-	Notes        *string `json:"notes"`
-	PrescribedAt *string `json:"prescribedAt"`
+	PrescriptionName *string `json:"prescriptionName"`
+	PrescribedBy     *string `json:"prescribedBy"`
+	PrescribedAt     *string `json:"prescribedAt"`
+	ExpiresAt        *string `json:"expiresAt"`
+	PharmacyName     *string `json:"pharmacyName"`
+	Notes            *string `json:"notes"`
 }
 
 func (h *PrescriptionHandler) Update(c *gin.Context) {
@@ -82,10 +93,12 @@ func (h *PrescriptionHandler) Update(c *gin.Context) {
 		return
 	}
 	v, err := h.uc.Update(c.Request.Context(), userID, c.Param("prescriptionId"), repository.UpdatePrescriptionInput{
-		Name:         req.Name,
-		ImageData:    req.ImageData,
-		Notes:        req.Notes,
-		PrescribedAt: parseDate(req.PrescribedAt),
+		PrescriptionName: req.PrescriptionName,
+		PrescribedBy:     req.PrescribedBy,
+		PrescribedAt:     parseDate(req.PrescribedAt),
+		ExpiresAt:        parseDate(req.ExpiresAt),
+		PharmacyName:     req.PharmacyName,
+		Notes:            req.Notes,
 	})
 	if err != nil {
 		response.HandleDomainError(c, err)

--- a/backend/internal/interface/middleware/ratelimit.go
+++ b/backend/internal/interface/middleware/ratelimit.go
@@ -16,10 +16,10 @@ type rateEntry struct {
 }
 
 type rateLimiter struct {
-	mu      sync.Mutex
-	store   map[string]*rateEntry
-	max     int
-	window  time.Duration
+	mu     sync.Mutex
+	store  map[string]*rateEntry
+	max    int
+	window time.Duration
 }
 
 var limiters sync.Map // name -> *rateLimiter

--- a/backend/internal/usecase/notification_setting_usecase.go
+++ b/backend/internal/usecase/notification_setting_usecase.go
@@ -24,10 +24,14 @@ func (uc *NotificationSettingUsecase) Get(ctx context.Context, userID string) (*
 	}
 	if s == nil {
 		return &entity.NotificationSetting{
-			UserID:          userID,
-			PushEnabled:     false,
-			EmailEnabled:    false,
-			ReminderEnabled: true,
+			UserID:                               userID,
+			MedicationReminderEnabled:            true,
+			MissedMedicationEnabled:              true,
+			AppointmentReminderEnabled:           true,
+			LowStockAlertEnabled:                 true,
+			DefaultReminderMinutesBefore:         5,
+			DefaultAppointmentReminderDaysBefore: 1,
+			EmailNotificationEnabled:             true,
 		}, nil
 	}
 	return s, nil

--- a/backend/migrations/0001_init.sql
+++ b/backend/migrations/0001_init.sql
@@ -1,243 +1,252 @@
 -- HealthFamily 初期スキーマ (生SQL / PostgreSQL)
--- Prisma schema.prisma と同等のテーブル構成。ID は text(UUID), 配列は text[]。
+-- Prisma schema.prisma と完全に一致するテーブル構成。
+-- テーブル名は PascalCase、カラム名は camelCase でダブルクォート必須（Prisma が大文字小文字を保持して作成しているため）。
+-- ID は TEXT(cuid, アプリ生成), 配列は TEXT[]。
+-- 既存DB(Supabase)に対して安全に no-op となるよう CREATE TABLE IF NOT EXISTS を使用する。
 
-CREATE TABLE IF NOT EXISTS users (
-    id                    TEXT PRIMARY KEY,
-    email                 TEXT NOT NULL UNIQUE,
-    password              TEXT NOT NULL,
-    display_name          TEXT,
-    character_type        TEXT NOT NULL DEFAULT 'cat',
-    character_name        TEXT,
-    email_verified        BOOLEAN NOT NULL DEFAULT FALSE,
-    verification_code     TEXT,
-    verification_expiry   TIMESTAMPTZ,
-    verification_attempts INTEGER NOT NULL DEFAULT 0,
-    reset_code            TEXT,
-    reset_code_expiry     TIMESTAMPTZ,
-    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "User" (
+    "id"                   TEXT PRIMARY KEY,
+    "email"                TEXT NOT NULL UNIQUE,
+    "password"             TEXT NOT NULL,
+    "displayName"          TEXT,
+    "characterType"        TEXT NOT NULL DEFAULT 'cat',
+    "characterName"        TEXT,
+    "emailVerified"        BOOLEAN NOT NULL DEFAULT FALSE,
+    "verificationCode"     TEXT,
+    "verificationExpiry"   TIMESTAMPTZ,
+    "verificationAttempts" INTEGER NOT NULL DEFAULT 0,
+    "resetCode"            TEXT,
+    "resetCodeExpiry"      TIMESTAMPTZ,
+    "createdAt"            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updatedAt"            TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE TABLE IF NOT EXISTS members (
-    id          TEXT PRIMARY KEY,
-    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_type TEXT NOT NULL DEFAULT 'human',
-    name        TEXT NOT NULL,
-    pet_type    TEXT,
-    photo_url   TEXT,
-    birth_date  TIMESTAMPTZ,
-    notes       TEXT,
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Member" (
+    "id"         TEXT PRIMARY KEY,
+    "userId"     TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberType" TEXT NOT NULL DEFAULT 'human',
+    "name"       TEXT NOT NULL,
+    "petType"    TEXT,
+    "photoUrl"   TEXT,
+    "birthDate"  TIMESTAMPTZ,
+    "notes"      TEXT,
+    "createdAt"  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updatedAt"  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_members_user_id ON members(user_id);
+CREATE INDEX IF NOT EXISTS "Member_userId_idx" ON "Member"("userId");
 
-CREATE TABLE IF NOT EXISTS medications (
-    id               TEXT PRIMARY KEY,
-    member_id        TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    user_id          TEXT NOT NULL,
-    name             TEXT NOT NULL,
-    category         TEXT NOT NULL DEFAULT 'regular',
-    dosage_amount    TEXT,
-    frequency        TEXT,
-    stock_quantity   INTEGER,
-    stock_alert_date TIMESTAMPTZ,
-    interval_hours   INTEGER,
-    instructions     TEXT,
-    display_order    INTEGER NOT NULL DEFAULT 0,
-    is_active        BOOLEAN NOT NULL DEFAULT TRUE,
-    status           TEXT NOT NULL DEFAULT 'active',
-    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Medication" (
+    "id"             TEXT PRIMARY KEY,
+    "memberId"       TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "userId"         TEXT NOT NULL,
+    "name"           TEXT NOT NULL,
+    "category"       TEXT NOT NULL DEFAULT 'regular',
+    "dosageAmount"   TEXT,
+    "frequency"      TEXT,
+    "stockQuantity"  INTEGER,
+    "stockAlertDate" TIMESTAMPTZ,
+    "intervalHours"  INTEGER,
+    "instructions"   TEXT,
+    "displayOrder"   INTEGER NOT NULL DEFAULT 0,
+    "isActive"       BOOLEAN NOT NULL DEFAULT TRUE,
+    "status"         TEXT NOT NULL DEFAULT 'active',
+    "createdAt"      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updatedAt"      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_medications_member_id ON medications(member_id);
-CREATE INDEX IF NOT EXISTS idx_medications_user_id ON medications(user_id);
+CREATE INDEX IF NOT EXISTS "Medication_memberId_idx" ON "Medication"("memberId");
+CREATE INDEX IF NOT EXISTS "Medication_userId_idx" ON "Medication"("userId");
 
-CREATE TABLE IF NOT EXISTS schedules (
-    id                      TEXT PRIMARY KEY,
-    medication_id           TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
-    user_id                 TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id               TEXT NOT NULL,
-    scheduled_time          TEXT NOT NULL,
-    days_of_week            TEXT[] NOT NULL DEFAULT '{}',
-    interval_days           INTEGER,
-    start_date              TIMESTAMPTZ,
-    is_enabled              BOOLEAN NOT NULL DEFAULT TRUE,
-    reminder_minutes_before INTEGER NOT NULL DEFAULT 5,
-    created_at              TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Schedule" (
+    "id"                    TEXT PRIMARY KEY,
+    "medicationId"          TEXT NOT NULL REFERENCES "Medication"("id") ON DELETE CASCADE,
+    "userId"                TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"              TEXT NOT NULL,
+    "scheduledTime"         TEXT NOT NULL,
+    "daysOfWeek"            TEXT[] NOT NULL DEFAULT '{}',
+    "intervalDays"          INTEGER,
+    "startDate"             TIMESTAMPTZ,
+    "isEnabled"             BOOLEAN NOT NULL DEFAULT TRUE,
+    "reminderMinutesBefore" INTEGER NOT NULL DEFAULT 5,
+    "createdAt"             TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_schedules_user_id ON schedules(user_id);
-CREATE INDEX IF NOT EXISTS idx_schedules_medication_id ON schedules(medication_id);
+CREATE INDEX IF NOT EXISTS "Schedule_userId_idx" ON "Schedule"("userId");
+CREATE INDEX IF NOT EXISTS "Schedule_medicationId_idx" ON "Schedule"("medicationId");
 
-CREATE TABLE IF NOT EXISTS medication_records (
-    id            TEXT PRIMARY KEY,
-    member_id     TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    medication_id TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
-    user_id       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    schedule_id   TEXT,
-    taken_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    notes         TEXT,
-    dosage_amount TEXT
+CREATE TABLE IF NOT EXISTS "MedicationRecord" (
+    "id"           TEXT PRIMARY KEY,
+    "memberId"     TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "medicationId" TEXT NOT NULL REFERENCES "Medication"("id") ON DELETE CASCADE,
+    "userId"       TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "scheduleId"   TEXT,
+    "takenAt"      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "notes"        TEXT,
+    "dosageAmount" TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_medication_records_user_id ON medication_records(user_id);
-CREATE INDEX IF NOT EXISTS idx_medication_records_member_id ON medication_records(member_id);
+CREATE INDEX IF NOT EXISTS "MedicationRecord_userId_idx" ON "MedicationRecord"("userId");
+CREATE INDEX IF NOT EXISTS "MedicationRecord_memberId_idx" ON "MedicationRecord"("memberId");
 
-CREATE TABLE IF NOT EXISTS hospitals (
-    id            TEXT PRIMARY KEY,
-    user_id       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    name          TEXT NOT NULL,
-    hospital_type TEXT,
-    address       TEXT,
-    phone_number  TEXT,
-    department    TEXT,
-    doctor_name   TEXT,
-    notes         TEXT,
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Hospital" (
+    "id"           TEXT PRIMARY KEY,
+    "userId"       TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "name"         TEXT NOT NULL,
+    "hospitalType" TEXT,
+    "address"      TEXT,
+    "phoneNumber"  TEXT,
+    "department"   TEXT,
+    "doctorName"   TEXT,
+    "notes"        TEXT,
+    "createdAt"    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_hospitals_user_id ON hospitals(user_id);
+CREATE INDEX IF NOT EXISTS "Hospital_userId_idx" ON "Hospital"("userId");
 
-CREATE TABLE IF NOT EXISTS health_logs (
-    id              TEXT PRIMARY KEY,
-    member_id       TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    condition_level INTEGER NOT NULL,
-    symptoms        TEXT[] NOT NULL DEFAULT '{}',
-    notes           TEXT,
-    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "HealthLog" (
+    "id"             TEXT PRIMARY KEY,
+    "memberId"       TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "userId"         TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "conditionLevel" INTEGER NOT NULL,
+    "symptoms"       TEXT[] NOT NULL DEFAULT '{}',
+    "notes"          TEXT,
+    "recordedAt"     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_health_logs_user_id ON health_logs(user_id);
-CREATE INDEX IF NOT EXISTS idx_health_logs_member_id ON health_logs(member_id);
+CREATE INDEX IF NOT EXISTS "HealthLog_userId_idx" ON "HealthLog"("userId");
+CREATE INDEX IF NOT EXISTS "HealthLog_memberId_idx" ON "HealthLog"("memberId");
 
-CREATE TABLE IF NOT EXISTS appointments (
-    id                   TEXT PRIMARY KEY,
-    user_id              TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id            TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    hospital_id          TEXT REFERENCES hospitals(id),
-    appointment_type     TEXT,
-    appointment_date     TIMESTAMPTZ NOT NULL,
-    description          TEXT,
-    test_results         TEXT,
-    cost                 DOUBLE PRECISION,
-    reminder_enabled     BOOLEAN NOT NULL DEFAULT TRUE,
-    reminder_days_before INTEGER NOT NULL DEFAULT 1,
-    created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Appointment" (
+    "id"                 TEXT PRIMARY KEY,
+    "userId"             TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"           TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "hospitalId"         TEXT REFERENCES "Hospital"("id"),
+    "appointmentType"    TEXT,
+    "appointmentDate"    TIMESTAMPTZ NOT NULL,
+    "description"        TEXT,
+    "testResults"        TEXT,
+    "cost"               DOUBLE PRECISION,
+    "reminderEnabled"    BOOLEAN NOT NULL DEFAULT TRUE,
+    "reminderDaysBefore" INTEGER NOT NULL DEFAULT 1,
+    "createdAt"          TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_appointments_user_id ON appointments(user_id);
-CREATE INDEX IF NOT EXISTS idx_appointments_member_id ON appointments(member_id);
+CREATE INDEX IF NOT EXISTS "Appointment_userId_idx" ON "Appointment"("userId");
+CREATE INDEX IF NOT EXISTS "Appointment_memberId_idx" ON "Appointment"("memberId");
 
-CREATE TABLE IF NOT EXISTS vaccinations (
-    id                  TEXT PRIMARY KEY,
-    user_id             TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id           TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    vaccine_name        TEXT NOT NULL,
-    vaccinated_at       TIMESTAMPTZ NOT NULL,
-    next_scheduled_date TIMESTAMPTZ,
-    notes               TEXT,
-    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Vaccination" (
+    "id"                TEXT PRIMARY KEY,
+    "userId"            TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"          TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "vaccineName"       TEXT NOT NULL,
+    "vaccinatedAt"      TIMESTAMPTZ NOT NULL,
+    "nextScheduledDate" TIMESTAMPTZ,
+    "notes"             TEXT,
+    "createdAt"         TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_vaccinations_user_id ON vaccinations(user_id);
-CREATE INDEX IF NOT EXISTS idx_vaccinations_member_id ON vaccinations(member_id);
+CREATE INDEX IF NOT EXISTS "Vaccination_userId_idx" ON "Vaccination"("userId");
+CREATE INDEX IF NOT EXISTS "Vaccination_memberId_idx" ON "Vaccination"("memberId");
 
-CREATE TABLE IF NOT EXISTS examinations (
-    id                  TEXT PRIMARY KEY,
-    user_id             TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id           TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    examination_type    TEXT NOT NULL,
-    examined_at         TIMESTAMPTZ NOT NULL,
-    next_scheduled_date TIMESTAMPTZ,
-    notes               TEXT,
-    image_data          TEXT,
-    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Examination" (
+    "id"                TEXT PRIMARY KEY,
+    "userId"            TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"          TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "examinationType"   TEXT NOT NULL,
+    "examinedAt"        TIMESTAMPTZ NOT NULL,
+    "nextScheduledDate" TIMESTAMPTZ,
+    "notes"             TEXT,
+    "imageData"         TEXT,
+    "createdAt"         TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_examinations_user_id ON examinations(user_id);
-CREATE INDEX IF NOT EXISTS idx_examinations_member_id ON examinations(member_id);
+CREATE INDEX IF NOT EXISTS "Examination_userId_idx" ON "Examination"("userId");
+CREATE INDEX IF NOT EXISTS "Examination_memberId_idx" ON "Examination"("memberId");
 
-CREATE TABLE IF NOT EXISTS insurances (
-    id             TEXT PRIMARY KEY,
-    user_id        TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id      TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    insurance_type TEXT NOT NULL,
-    provider_name  TEXT,
-    policy_number  TEXT,
-    notes          TEXT,
-    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Insurance" (
+    "id"            TEXT PRIMARY KEY,
+    "userId"        TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"      TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "insuranceType" TEXT NOT NULL,
+    "providerName"  TEXT,
+    "policyNumber"  TEXT,
+    "notes"         TEXT,
+    "createdAt"     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_insurances_user_id ON insurances(user_id);
-CREATE INDEX IF NOT EXISTS idx_insurances_member_id ON insurances(member_id);
+CREATE INDEX IF NOT EXISTS "Insurance_userId_idx" ON "Insurance"("userId");
+CREATE INDEX IF NOT EXISTS "Insurance_memberId_idx" ON "Insurance"("memberId");
 
-CREATE TABLE IF NOT EXISTS allergies (
-    id            TEXT PRIMARY KEY,
-    user_id       TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id     TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    allergen_name TEXT NOT NULL,
-    allergy_type  TEXT NOT NULL,
-    severity      TEXT NOT NULL,
-    symptoms      TEXT,
-    diagnosed_at  TIMESTAMPTZ,
-    notes         TEXT,
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Allergy" (
+    "id"           TEXT PRIMARY KEY,
+    "userId"       TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"     TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "allergenName" TEXT NOT NULL,
+    "allergyType"  TEXT NOT NULL,
+    "severity"     TEXT NOT NULL,
+    "symptoms"     TEXT,
+    "diagnosedAt"  TIMESTAMPTZ,
+    "notes"        TEXT,
+    "createdAt"    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_allergies_user_id ON allergies(user_id);
-CREATE INDEX IF NOT EXISTS idx_allergies_member_id ON allergies(member_id);
+CREATE INDEX IF NOT EXISTS "Allergy_userId_idx" ON "Allergy"("userId");
+CREATE INDEX IF NOT EXISTS "Allergy_memberId_idx" ON "Allergy"("memberId");
 
-CREATE TABLE IF NOT EXISTS body_measurements (
-    id          TEXT PRIMARY KEY,
-    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id   TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    weight      DOUBLE PRECISION,
-    height      DOUBLE PRECISION,
-    recorded_at TIMESTAMPTZ NOT NULL,
-    notes       TEXT,
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "BodyMeasurement" (
+    "id"         TEXT PRIMARY KEY,
+    "userId"     TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"   TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "weight"     DOUBLE PRECISION,
+    "height"     DOUBLE PRECISION,
+    "recordedAt" TIMESTAMPTZ NOT NULL,
+    "notes"      TEXT,
+    "createdAt"  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_body_measurements_user_id ON body_measurements(user_id);
-CREATE INDEX IF NOT EXISTS idx_body_measurements_member_id ON body_measurements(member_id);
+CREATE INDEX IF NOT EXISTS "BodyMeasurement_userId_idx" ON "BodyMeasurement"("userId");
+CREATE INDEX IF NOT EXISTS "BodyMeasurement_memberId_idx" ON "BodyMeasurement"("memberId");
 
-CREATE TABLE IF NOT EXISTS temperature_records (
-    id          TEXT PRIMARY KEY,
-    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id   TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    temperature DOUBLE PRECISION NOT NULL,
-    measured_at TIMESTAMPTZ NOT NULL,
-    notes       TEXT,
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "TemperatureRecord" (
+    "id"          TEXT PRIMARY KEY,
+    "userId"      TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"    TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "temperature" DOUBLE PRECISION NOT NULL,
+    "measuredAt"  TIMESTAMPTZ NOT NULL,
+    "notes"       TEXT,
+    "createdAt"   TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_temperature_records_user_id ON temperature_records(user_id);
-CREATE INDEX IF NOT EXISTS idx_temperature_records_member_id ON temperature_records(member_id);
-CREATE INDEX IF NOT EXISTS idx_temperature_records_member_measured ON temperature_records(member_id, measured_at);
+CREATE INDEX IF NOT EXISTS "TemperatureRecord_userId_idx" ON "TemperatureRecord"("userId");
+CREATE INDEX IF NOT EXISTS "TemperatureRecord_memberId_idx" ON "TemperatureRecord"("memberId");
+CREATE INDEX IF NOT EXISTS "TemperatureRecord_memberId_measuredAt_idx" ON "TemperatureRecord"("memberId", "measuredAt");
 
-CREATE TABLE IF NOT EXISTS emergency_contacts (
-    id           TEXT PRIMARY KEY,
-    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id    TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    contact_name TEXT NOT NULL,
-    phone_number TEXT NOT NULL,
-    relationship TEXT,
-    notes        TEXT,
-    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "EmergencyContact" (
+    "id"           TEXT PRIMARY KEY,
+    "userId"       TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"     TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "contactName"  TEXT NOT NULL,
+    "phoneNumber"  TEXT NOT NULL,
+    "relationship" TEXT,
+    "notes"        TEXT,
+    "createdAt"    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_emergency_contacts_user_id ON emergency_contacts(user_id);
-CREATE INDEX IF NOT EXISTS idx_emergency_contacts_member_id ON emergency_contacts(member_id);
+CREATE INDEX IF NOT EXISTS "EmergencyContact_userId_idx" ON "EmergencyContact"("userId");
+CREATE INDEX IF NOT EXISTS "EmergencyContact_memberId_idx" ON "EmergencyContact"("memberId");
 
-CREATE TABLE IF NOT EXISTS prescriptions (
-    id          TEXT PRIMARY KEY,
-    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    member_id   TEXT NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-    name        TEXT NOT NULL,
-    image_data  TEXT,
-    notes       TEXT,
-    prescribed_at TIMESTAMPTZ,
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "Prescription" (
+    "id"               TEXT PRIMARY KEY,
+    "userId"           TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "memberId"         TEXT NOT NULL REFERENCES "Member"("id") ON DELETE CASCADE,
+    "prescriptionName" TEXT NOT NULL,
+    "prescribedBy"     TEXT,
+    "prescribedAt"     TIMESTAMPTZ NOT NULL,
+    "expiresAt"        TIMESTAMPTZ,
+    "pharmacyName"     TEXT,
+    "notes"            TEXT,
+    "createdAt"        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-CREATE INDEX IF NOT EXISTS idx_prescriptions_user_id ON prescriptions(user_id);
-CREATE INDEX IF NOT EXISTS idx_prescriptions_member_id ON prescriptions(member_id);
+CREATE INDEX IF NOT EXISTS "Prescription_userId_idx" ON "Prescription"("userId");
+CREATE INDEX IF NOT EXISTS "Prescription_memberId_idx" ON "Prescription"("memberId");
 
-CREATE TABLE IF NOT EXISTS notification_settings (
-    id                    TEXT PRIMARY KEY,
-    user_id               TEXT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
-    push_enabled          BOOLEAN NOT NULL DEFAULT FALSE,
-    email_enabled         BOOLEAN NOT NULL DEFAULT FALSE,
-    reminder_enabled      BOOLEAN NOT NULL DEFAULT TRUE,
-    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE IF NOT EXISTS "NotificationSetting" (
+    "id"                                   TEXT PRIMARY KEY,
+    "userId"                               TEXT NOT NULL UNIQUE REFERENCES "User"("id") ON DELETE CASCADE,
+    "medicationReminderEnabled"            BOOLEAN NOT NULL DEFAULT TRUE,
+    "missedMedicationEnabled"              BOOLEAN NOT NULL DEFAULT TRUE,
+    "appointmentReminderEnabled"           BOOLEAN NOT NULL DEFAULT TRUE,
+    "lowStockAlertEnabled"                 BOOLEAN NOT NULL DEFAULT TRUE,
+    "defaultReminderMinutesBefore"         INTEGER NOT NULL DEFAULT 5,
+    "defaultAppointmentReminderDaysBefore" INTEGER NOT NULL DEFAULT 1,
+    "emailNotificationEnabled"             BOOLEAN NOT NULL DEFAULT TRUE,
+    "createdAt"                            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updatedAt"                            TIMESTAMPTZ NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## Summary
- バックエンドは **Prisma不使用・生SQL(pgx)** のまま。既存 Supabase のテーブルが Prisma 生成のため、SQL識別子を `"User"."displayName"` 形式（ダブルクォート付きPascalCase/camelCase）に統一し既存データを引き継ぐ
- `backend/migrations/0001_init.sql` を既存スキーマに一致（`CREATE TABLE IF NOT EXISTS`、既存DBにはno-op）
- 全リポジトリ(16)のSQL識別子を修正（スキャン順・Goコードは不変）
- `NotificationSetting`/`Prescription` を実スキーマのフィールドに修正
- `go build`/`go vet`/`go test`・ルート登録スモークテスト通過