### PR TITLE
fix(frontend): PWA廃止 + 旧Service Workerのkill-switch

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,39 @@
+// 自己解除する Service Worker（kill-switch）
+// 旧 Next.js PWA が登録した /sw.js を全クライアントから確実に取り除くためのもの。
+// React Router(SPA)版は Service Worker を使わないため、この SW は登録解除と
+// キャッシュ全削除だけを行い、開いているタブをリロードする。
+self.addEventListener('install', () => {
+  // 直ちに新しい SW を有効化
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      try {
+        // 旧 PWA のキャッシュをすべて削除
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+      } catch {
+        /* noop */
+      }
+      // 自身を登録解除
+      try {
+        await self.registration.unregister();
+      } catch {
+        /* noop */
+      }
+      // 開いている全タブを再読み込みして、SW なしの状態に戻す
+      const clients = await self.clients.matchAll({ type: 'window' });
+      for (const client of clients) {
+        try {
+          client.navigate(client.url);
+        } catch {
+          /* noop */
+        }
+      }
+    })(),
+  );
+});
+
+// fetch は一切横取りしない（旧 SW のような介入をしない）

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -3,5 +3,14 @@
   "buildCommand": "npm run build",
   "outputDirectory": "build/client",
   "framework": null,
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
+        { "key": "Service-Worker-Allowed", "value": "/" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- React Router(SPA)版は **完全web（PWA無し）**
- 旧 Next.js PWA が登録した `/sw.js` がブラウザに残存し `ERR_FAILED`（redirect mode）を誘発していたため、同一パス `/sw.js` に **自己解除(kill-switch) Service Worker** を配信（登録解除＋全キャッシュ削除＋開いているタブをリロード）
- `/sw.js` は `Cache-Control: no-store` で更新を確実に配布

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **新機能**
  * Service Workerのキャッシュ自動クリーンアップ機能を追加しました。古いキャッシュを自動的に削除し、クライアントを再ロードします。

* **改善**
  * Service Worker配信時のキャッシュ制御を強化しました。常に最新版を取得できるようにレスポンスヘッダを設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->