### PR TITLE
feat(frontend): 旧Next.js全UIをReact Router版へ移植 + Maison Blanche配色

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -4,6 +4,7 @@
 
 html,
 body {
-  @apply bg-slate-50 text-slate-800 antialiased;
-  font-family: system-ui, -apple-system, "Hiragino Sans", "Noto Sans JP", sans-serif;
+  @apply text-ink-700 antialiased;
+  background-color: #f5f2f2;
+  font-family: "Noto Sans JP", system-ui, -apple-system, sans-serif;
 }

--- a/frontend/app/components/allergies/AllergyForm.tsx
+++ b/frontend/app/components/allergies/AllergyForm.tsx
@@ -1,0 +1,216 @@
+import React, { useState } from "react";
+import type { Member } from "@/lib/types";
+
+export interface AllergyFormData {
+  memberId: string;
+  allergenName: string;
+  allergyType: string;
+  severity: string;
+  symptoms?: string;
+  diagnosedAt?: string;
+  notes?: string;
+}
+
+interface AllergyFormProps {
+  members: Member[];
+  onSubmit: (data: AllergyFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    allergenName: string;
+    allergyType: string;
+    severity: string;
+    symptoms?: string;
+    diagnosedAt?: string;
+    notes?: string;
+  };
+}
+
+const ALLERGY_TYPES = [
+  { value: "food", label: "食物" },
+  { value: "medication", label: "薬物" },
+  { value: "environmental", label: "環境" },
+  { value: "pollen", label: "花粉" },
+  { value: "atopy", label: "アトピー" },
+  { value: "other", label: "その他" },
+];
+
+const SEVERITY_LEVELS = [
+  { value: "mild", label: "軽度" },
+  { value: "moderate", label: "中度" },
+  { value: "severe", label: "重度" },
+];
+
+export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
+  const [allergenName, setAllergenName] = useState(initialData?.allergenName || "");
+  const [allergyType, setAllergyType] = useState(initialData?.allergyType || "");
+  const [severity, setSeverity] = useState(initialData?.severity || "");
+  const [symptoms, setSymptoms] = useState(initialData?.symptoms || "");
+  const [diagnosedAt, setDiagnosedAt] = useState(initialData?.diagnosedAt || "");
+  const [notes, setNotes] = useState(initialData?.notes || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !allergenName.trim() || !allergyType || !severity) return;
+
+    onSubmit({
+      memberId,
+      allergenName: allergenName.trim(),
+      allergyType,
+      severity,
+      symptoms: symptoms.trim() || undefined,
+      diagnosedAt: diagnosedAt || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setAllergenName("");
+      setAllergyType("");
+      setSeverity("");
+      setSymptoms("");
+      setDiagnosedAt("");
+      setNotes("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="allergy-member" className="block text-sm font-medium text-ink-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="allergy-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="allergy-name" className="block text-sm font-medium text-ink-700 mb-1">
+          アレルゲン名
+        </label>
+        <input
+          id="allergy-name"
+          type="text"
+          value={allergenName}
+          onChange={(e) => setAllergenName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="例: ピーナッツ、ペニシリン、花粉"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="allergy-type" className="block text-sm font-medium text-ink-700 mb-1">
+          アレルギーの種類
+        </label>
+        <select
+          id="allergy-type"
+          value={allergyType}
+          onChange={(e) => setAllergyType(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {ALLERGY_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="allergy-severity" className="block text-sm font-medium text-ink-700 mb-1">
+          重症度
+        </label>
+        <select
+          id="allergy-severity"
+          value={severity}
+          onChange={(e) => setSeverity(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {SEVERITY_LEVELS.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="allergy-symptoms" className="block text-sm font-medium text-ink-700 mb-1">
+          症状（任意）
+        </label>
+        <textarea
+          id="allergy-symptoms"
+          value={symptoms}
+          onChange={(e) => setSymptoms(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="例: アナフィラキシー、じんましん、呼吸困難"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="allergy-diagnosed" className="block text-sm font-medium text-ink-700 mb-1">
+          診断日（任意）
+        </label>
+        <input
+          id="allergy-diagnosed"
+          type="text"
+          inputMode="numeric"
+          value={diagnosedAt}
+          onChange={(e) => setDiagnosedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="例: 2024-01-15"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="allergy-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="allergy-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="例: エピペン携帯必要"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
+        >
+          {initialData ? "更新する" : "登録する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-primary-50 text-ink-700 py-2 px-4 rounded-lg hover:bg-primary-100 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/allergies/AllergyList.tsx
+++ b/frontend/app/components/allergies/AllergyList.tsx
@@ -1,0 +1,241 @@
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X } from "lucide-react";
+import type { Allergy } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+export type AllergyWithMember = Allergy & { memberName?: string };
+
+export interface UpdateAllergyInput {
+  allergenName?: string;
+  allergyType?: string;
+  severity?: string;
+  symptoms?: string | null;
+  notes?: string | null;
+}
+
+const ALLERGY_TYPE_LABELS: Record<string, string> = {
+  food: "食物",
+  medication: "薬物",
+  environmental: "環境",
+  pollen: "花粉",
+  atopy: "アトピー",
+  other: "その他",
+};
+
+const SEVERITY_LABELS: Record<string, string> = {
+  mild: "軽度",
+  moderate: "中度",
+  severe: "重度",
+};
+
+const SEVERITY_COLORS: Record<string, string> = {
+  mild: "bg-green-100 text-green-700",
+  moderate: "bg-yellow-100 text-yellow-700",
+  severe: "bg-red-100 text-red-700",
+};
+
+interface AllergyListProps {
+  allergies: AllergyWithMember[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateAllergyInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const AllergyList: React.FC<AllergyListProps> = ({ allergies, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (allergies.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="アレルギーが登録されていません"
+        subMessage="上の＋ボタンからアレルギー情報を追加できます"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {allergies.map((allergy) => (
+        <AllergyCard key={allergy.id} allergy={allergy} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface AllergyCardProps {
+  allergy: AllergyWithMember;
+  onUpdate: (id: string, input: UpdateAllergyInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const AllergyCard: React.FC<AllergyCardProps> = React.memo(({ allergy, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editName, setEditName] = useState(allergy.allergenName);
+  const [editType, setEditType] = useState(allergy.allergyType);
+  const [editSeverity, setEditSeverity] = useState(allergy.severity);
+  const [editSymptoms, setEditSymptoms] = useState(allergy.symptoms || "");
+  const [editNotes, setEditNotes] = useState(allergy.notes || "");
+
+  const handleSave = async () => {
+    if (!editName.trim() || !editType || !editSeverity) return;
+    await onUpdate(allergy.id, {
+      allergenName: editName.trim(),
+      allergyType: editType,
+      severity: editSeverity,
+      symptoms: editSymptoms.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(allergy.allergenName);
+    setEditType(allergy.allergyType);
+    setEditSeverity(allergy.severity);
+    setEditSymptoms(allergy.symptoms || "");
+    setEditNotes(allergy.notes || "");
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200 space-y-3">
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">アレルゲン名</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">種類</label>
+          <select
+            value={editType}
+            onChange={(e) => setEditType(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          >
+            {Object.entries(ALLERGY_TYPE_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">重症度</label>
+          <select
+            value={editSeverity}
+            onChange={(e) => setEditSeverity(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          >
+            {Object.entries(SEVERITY_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">症状</label>
+          <textarea
+            value={editSymptoms}
+            onChange={(e) => setEditSymptoms(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim() || !editType || !editSeverity}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary text-white py-1.5 rounded-lg text-sm hover:bg-primary-dark transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-50 text-ink-700 py-1.5 rounded-lg text-sm hover:bg-primary-100 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+            <p className="font-medium text-ink-800 text-sm">{allergy.allergenName}</p>
+            <span
+              className={`text-xs px-1.5 py-0.5 rounded ${SEVERITY_COLORS[allergy.severity] || "bg-primary-50 text-ink-600"}`}
+            >
+              {SEVERITY_LABELS[allergy.severity] || allergy.severity}
+            </span>
+            <span className="text-xs bg-primary-50 text-primary-600 px-1.5 py-0.5 rounded">
+              {ALLERGY_TYPE_LABELS[allergy.allergyType] || allergy.allergyType}
+            </span>
+            {allergy.memberName && (
+              <span className="text-xs bg-primary-50 text-ink-600 px-1.5 py-0.5 rounded">{allergy.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-ink-500 mt-1 space-y-0.5">
+            {allergy.symptoms && <p>{allergy.symptoms}</p>}
+            {allergy.diagnosedAt && <p>診断日: {new Date(allergy.diagnosedAt).toLocaleDateString("ja-JP")}</p>}
+            {allergy.notes && <p className="text-ink-400">{allergy.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <ConfirmationDialog
+        title="アレルギーの削除"
+        message={`「${allergy.allergenName}」を削除しますか？この操作は取り消せません。`}
+        isOpen={isDeleteDialogOpen}
+        onConfirm={() => {
+          setIsDeleteDialogOpen(false);
+          onDelete(allergy.id);
+        }}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        isDangerous
+      />
+    </div>
+  );
+});
+
+AllergyCard.displayName = "AllergyCard";

--- a/frontend/app/components/appointments/AppointmentForm.tsx
+++ b/frontend/app/components/appointments/AppointmentForm.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from "react";
+import type { Appointment, Hospital, Member } from "@/lib/types";
+import { MemberIcon, type MemberType, type PetType } from "@/components/shared/MemberIcon";
+
+export interface AppointmentFormData {
+  memberId: string;
+  hospitalId?: string;
+  appointmentDate: string;
+  type?: string;
+  notes?: string;
+}
+
+interface AppointmentFormProps {
+  members: Member[];
+  hospitals: Hospital[];
+  onSubmit: (data: AppointmentFormData) => void;
+  initialData?: Appointment;
+  onCancel?: () => void;
+}
+
+export const APPOINTMENT_TYPE_LABELS: Record<string, string> = {
+  checkup: "定期検診",
+  treatment: "治療",
+  vaccination: "予防接種",
+  surgery: "手術",
+  consultation: "相談",
+  medication_pickup: "お薬",
+  examination: "検査",
+  flea_tick: "ノミ・ダニ薬",
+  heartworm: "フィラリア",
+  therapeutic_diet: "療養食",
+  grooming: "トリミング",
+  other: "その他",
+};
+
+const formatDateForInput = (date: string): string => {
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return "";
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const AppointmentForm: React.FC<AppointmentFormProps> = ({
+  members,
+  hospitals,
+  onSubmit,
+  initialData,
+  onCancel,
+}) => {
+  const isEditing = !!initialData;
+  const [memberId, setMemberId] = useState(initialData?.memberId || members[0]?.id || "");
+  const [hospitalId, setHospitalId] = useState(initialData?.hospitalId || "");
+  const [appointmentDate, setAppointmentDate] = useState(
+    initialData ? formatDateForInput(initialData.appointmentDate) : "",
+  );
+  const [type, setType] = useState(initialData?.appointmentType || "");
+  const [notes, setNotes] = useState(initialData?.description || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !appointmentDate) return;
+
+    onSubmit({
+      memberId,
+      hospitalId: hospitalId || undefined,
+      appointmentDate,
+      type: type || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!isEditing) {
+      setAppointmentDate("");
+      setType("");
+      setNotes("");
+    }
+  };
+
+  const typeOptions = Object.entries(APPOINTMENT_TYPE_LABELS);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="apt-member" className="block text-sm font-medium text-ink-700 mb-1">
+          メンバー
+        </label>
+        <div className="space-y-1">
+          {members.map((m) => {
+            const isSelected = memberId === m.id;
+            return (
+              <button
+                key={m.id}
+                type="button"
+                onClick={() => setMemberId(m.id)}
+                disabled={isEditing}
+                className={`w-full flex items-center space-x-2 px-3 py-2 rounded-lg border text-left transition-colors ${
+                  isSelected
+                    ? "border-primary-500 bg-primary-50"
+                    : "border-primary-100 hover:bg-primary-50"
+                } ${isEditing ? "opacity-60 cursor-not-allowed" : ""}`}
+              >
+                <MemberIcon
+                  memberType={m.memberType as MemberType}
+                  petType={(m.petType as PetType | null) ?? undefined}
+                  size={16}
+                  className="text-ink-600"
+                />
+                <span className="text-sm">{m.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="apt-date" className="block text-sm font-medium text-ink-700 mb-1">
+          予約日
+        </label>
+        <input
+          id="apt-date"
+          type="date"
+          value={appointmentDate}
+          onChange={(e) => setAppointmentDate(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        />
+      </div>
+
+      {hospitals.length > 0 && (
+        <div>
+          <label htmlFor="apt-hospital" className="block text-sm font-medium text-ink-700 mb-1">
+            病院（任意）
+          </label>
+          <select
+            id="apt-hospital"
+            value={hospitalId}
+            onChange={(e) => setHospitalId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="">選択しない</option>
+            {hospitals.map((h) => (
+              <option key={h.id} value={h.id}>
+                {h.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="apt-type" className="block text-sm font-medium text-ink-700 mb-1">
+          種別（任意）
+        </label>
+        <select
+          id="apt-type"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        >
+          <option value="">選択しない</option>
+          {typeOptions.map(([key, label]) => (
+            <option key={key} value={key}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="apt-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          {type === "vaccination" ? "ワクチン名" : "メモ"}（任意）
+        </label>
+        <textarea
+          id="apt-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder={type === "vaccination" ? "例: 混合ワクチン, 狂犬病ワクチン" : "メモを入力"}
+        />
+      </div>
+
+      <div className={isEditing ? "flex space-x-2" : ""}>
+        <button
+          type="submit"
+          className={`${isEditing ? "flex-1" : "w-full"} bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium`}
+        >
+          {isEditing ? "更新する" : "追加する"}
+        </button>
+        {isEditing && onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-primary-100 text-ink-700 py-2 px-4 rounded-lg hover:bg-primary-200 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/appointments/AppointmentList.tsx
+++ b/frontend/app/components/appointments/AppointmentList.tsx
@@ -1,0 +1,232 @@
+import React, { useMemo } from "react";
+import { Calendar, MapPin, Pencil, Trash2, User } from "lucide-react";
+import type { Appointment } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { APPOINTMENT_TYPE_LABELS } from "./AppointmentForm";
+
+export type AppointmentFilter = "upcoming" | "past";
+
+interface AppointmentListProps {
+  appointments: Appointment[];
+  isLoading: boolean;
+  filter?: AppointmentFilter;
+  memberNameOf: (memberId: string) => string;
+  hospitalNameOf: (hospitalId: string | null) => string;
+  onEdit: (appointment: Appointment) => void;
+  onDelete: (appointmentId: string) => void;
+}
+
+const DAY_OF_WEEK_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+function toStartOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function getAppointmentDate(appointment: Appointment): Date {
+  const d = new Date(appointment.appointmentDate);
+  if (!Number.isNaN(d.getTime())) return d;
+  const fallback = new Date(appointment.createdAt);
+  return !Number.isNaN(fallback.getTime()) ? fallback : new Date(0);
+}
+
+function isToday(appointment: Appointment): boolean {
+  return toStartOfDay(new Date()).getTime() === toStartOfDay(getAppointmentDate(appointment)).getTime();
+}
+
+function isPast(appointment: Appointment): boolean {
+  return toStartOfDay(getAppointmentDate(appointment)).getTime() < toStartOfDay(new Date()).getTime();
+}
+
+function daysUntil(appointment: Appointment): number {
+  const diffMs = toStartOfDay(getAppointmentDate(appointment)).getTime() - toStartOfDay(new Date()).getTime();
+  return Math.round(diffMs / (1000 * 60 * 60 * 24));
+}
+
+function formatDate(appointment: Appointment): string {
+  const d = getAppointmentDate(appointment);
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日(${DAY_OF_WEEK_LABELS[d.getDay()]})`;
+}
+
+function getTypeLabel(type: string | null): string {
+  if (!type) return "";
+  return APPOINTMENT_TYPE_LABELS[type] || type;
+}
+
+export function getAppointmentCounts(appointments: Appointment[]): { upcoming: number; past: number } {
+  let upcoming = 0;
+  let past = 0;
+  for (const a of appointments) {
+    if (isPast(a)) past++;
+    else upcoming++;
+  }
+  return { upcoming, past };
+}
+
+export const AppointmentList: React.FC<AppointmentListProps> = ({
+  appointments,
+  isLoading,
+  filter,
+  memberNameOf,
+  hospitalNameOf,
+  onEdit,
+  onDelete,
+}) => {
+  const { upcoming, past } = useMemo(() => {
+    const up: Appointment[] = [];
+    const pa: Appointment[] = [];
+    for (const a of appointments) {
+      if (isPast(a)) pa.push(a);
+      else up.push(a);
+    }
+    return { upcoming: up, past: pa };
+  }, [appointments]);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (appointments.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="通院予定がありません"
+        subMessage="上の＋ボタンから通院予定を追加できます"
+      />
+    );
+  }
+
+  const renderCard = (apt: Appointment) => (
+    <AppointmentCard
+      key={apt.id}
+      appointment={apt}
+      memberNameOf={memberNameOf}
+      hospitalNameOf={hospitalNameOf}
+      onEdit={onEdit}
+      onDelete={onDelete}
+    />
+  );
+
+  if (filter === "upcoming") {
+    return (
+      <div className="space-y-2">
+        {upcoming.length > 0 ? (
+          upcoming.map(renderCard)
+        ) : (
+          <p className="text-sm text-ink-500 text-center py-8">今後の予定はありません</p>
+        )}
+      </div>
+    );
+  }
+
+  if (filter === "past") {
+    return (
+      <div className="space-y-2">
+        {past.length > 0 ? (
+          past.map(renderCard)
+        ) : (
+          <p className="text-sm text-ink-500 text-center py-8">過去の予定はありません</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {upcoming.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-ink-600 mb-2 px-1">今後の予定</h3>
+          <div className="space-y-2">{upcoming.map(renderCard)}</div>
+        </div>
+      )}
+
+      {past.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-ink-400 mb-2 px-1">過去の予定</h3>
+          <div className="space-y-2 opacity-60">{past.map(renderCard)}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface AppointmentCardProps {
+  appointment: Appointment;
+  memberNameOf: (memberId: string) => string;
+  hospitalNameOf: (hospitalId: string | null) => string;
+  onEdit: (appointment: Appointment) => void;
+  onDelete: (appointmentId: string) => void;
+}
+
+const AppointmentCard: React.FC<AppointmentCardProps> = React.memo(
+  ({ appointment, memberNameOf, hospitalNameOf, onEdit, onDelete }) => {
+    const days = daysUntil(appointment);
+    const typeLabel = getTypeLabel(appointment.appointmentType);
+    const today = isToday(appointment);
+    const past = isPast(appointment);
+    const memberName = memberNameOf(appointment.memberId);
+    const hospitalName = hospitalNameOf(appointment.hospitalId);
+
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+        <div className="flex items-start justify-between">
+          <div className="flex items-start space-x-3 flex-1 min-w-0">
+            <div className="flex-shrink-0 mt-0.5">
+              <Calendar size={18} className={today ? "text-red-500" : "text-primary-600"} />
+            </div>
+            <div className="min-w-0">
+              <p className="font-medium text-ink-800 text-sm">
+                {formatDate(appointment)}
+                {today && (
+                  <span className="ml-2 px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-medium">
+                    今日
+                  </span>
+                )}
+                {!past && !today && days <= 7 && (
+                  <span className="ml-2 text-xs text-orange-600 font-medium">あと{days}日</span>
+                )}
+              </p>
+              <div className="flex flex-wrap items-center gap-2 text-xs text-ink-500 mt-1">
+                {memberName && (
+                  <span className="flex items-center space-x-1">
+                    <User size={12} />
+                    <span>{memberName}</span>
+                  </span>
+                )}
+                {hospitalName && (
+                  <span className="flex items-center space-x-1">
+                    <MapPin size={12} />
+                    <span>{hospitalName}</span>
+                  </span>
+                )}
+                {typeLabel && <span>{typeLabel}</span>}
+              </div>
+              {appointment.description && (
+                <p className="text-xs text-ink-400 mt-1">{appointment.description}</p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center space-x-1 flex-shrink-0">
+            <button
+              onClick={() => onEdit(appointment)}
+              className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+              aria-label="編集"
+            >
+              <Pencil size={14} />
+            </button>
+            <button
+              onClick={() => onDelete(appointment.id)}
+              className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+              aria-label="削除"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+AppointmentCard.displayName = "AppointmentCard";

--- a/frontend/app/components/appointments/MiniCalendar.tsx
+++ b/frontend/app/components/appointments/MiniCalendar.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface MiniCalendarProps {
+  appointmentDates: Date[];
+}
+
+const DAY_HEADERS = ["月", "火", "水", "木", "金", "土", "日"];
+
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export const MiniCalendar: React.FC<MiniCalendarProps> = ({ appointmentDates }) => {
+  const today = new Date();
+  const [viewMonth, setViewMonth] = useState(today.getMonth());
+  const [viewYear, setViewYear] = useState(today.getFullYear());
+
+  const firstDay = new Date(viewYear, viewMonth, 1);
+  const lastDay = new Date(viewYear, viewMonth + 1, 0);
+  const startDow = (firstDay.getDay() + 6) % 7; // Monday = 0
+
+  const days: (number | null)[] = [];
+  for (let i = 0; i < startDow; i++) days.push(null);
+  for (let d = 1; d <= lastDay.getDate(); d++) days.push(d);
+
+  const hasAppointment = (day: number) =>
+    appointmentDates.some((d) => isSameDay(d, new Date(viewYear, viewMonth, day)));
+
+  const isTodayCell = (day: number) => isSameDay(today, new Date(viewYear, viewMonth, day));
+
+  const prevMonth = () => {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear(viewYear - 1);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  };
+
+  const nextMonth = () => {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear(viewYear + 1);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100 mb-4">
+      <div className="flex items-center justify-between mb-2">
+        <button onClick={prevMonth} className="p-1 text-ink-500 hover:text-ink-700" aria-label="前の月">
+          <ChevronLeft size={16} />
+        </button>
+        <span className="text-sm font-semibold text-ink-700">
+          {viewYear}年{viewMonth + 1}月
+        </span>
+        <button onClick={nextMonth} className="p-1 text-ink-500 hover:text-ink-700" aria-label="次の月">
+          <ChevronRight size={16} />
+        </button>
+      </div>
+      <div className="grid grid-cols-7 gap-0.5 text-center">
+        {DAY_HEADERS.map((d) => (
+          <div key={d} className="text-xs text-ink-400 py-1">
+            {d}
+          </div>
+        ))}
+        {days.map((day, i) => (
+          <button
+            key={i}
+            disabled={day === null}
+            className={`relative text-xs py-1 rounded ${
+              day !== null && isTodayCell(day)
+                ? "bg-primary-600 text-white font-bold"
+                : day !== null
+                  ? "text-ink-700 hover:bg-primary-50"
+                  : ""
+            }`}
+          >
+            {day ?? ""}
+            {day !== null && hasAppointment(day) && (
+              <span
+                data-testid="dot-marker"
+                className="absolute bottom-0 left-1/2 -translate-x-1/2 w-1 h-1 bg-red-500 rounded-full"
+              />
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/app/components/body-measurements/BodyMeasurementForm.tsx
+++ b/frontend/app/components/body-measurements/BodyMeasurementForm.tsx
@@ -1,0 +1,180 @@
+import React, { useState } from "react";
+import type { Member } from "@/lib/types";
+
+export interface BodyMeasurementFormData {
+  memberId: string;
+  weight?: number;
+  height?: number;
+  recordedAt: string;
+  notes?: string;
+}
+
+interface BodyMeasurementFormProps {
+  members: Member[];
+  onSubmit: (data: BodyMeasurementFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    weight?: number;
+    height?: number;
+    recordedAt: string;
+    notes?: string;
+  };
+}
+
+export const BodyMeasurementForm: React.FC<BodyMeasurementFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+  initialData,
+}) => {
+  const [memberId, setMemberId] = useState(
+    initialData?.memberId || (members.length === 1 ? members[0].id : ""),
+  );
+  const [weight, setWeight] = useState(initialData?.weight?.toString() || "");
+  const [height, setHeight] = useState(initialData?.height?.toString() || "");
+  const [recordedAt, setRecordedAt] = useState(
+    initialData?.recordedAt || new Date().toISOString().split("T")[0],
+  );
+  const [notes, setNotes] = useState(initialData?.notes || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !recordedAt) return;
+    const w = weight ? parseFloat(weight) : undefined;
+    const h = height ? parseFloat(height) : undefined;
+    if (w == null && h == null) return;
+
+    onSubmit({
+      memberId,
+      weight: w,
+      height: h,
+      recordedAt,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setWeight("");
+      setHeight("");
+      setNotes("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label
+          htmlFor="bm-member"
+          className="block text-sm font-medium text-ink-700 mb-1"
+        >
+          メンバー
+        </label>
+        <select
+          id="bm-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-xl outline-none focus:border-primary"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label
+            htmlFor="bm-weight"
+            className="block text-sm font-medium text-ink-700 mb-1"
+          >
+            体重 (kg)
+          </label>
+          <input
+            id="bm-weight"
+            type="number"
+            step="0.1"
+            min="0.1"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-xl outline-none focus:border-primary"
+            placeholder="65.5"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="bm-height"
+            className="block text-sm font-medium text-ink-700 mb-1"
+          >
+            身長 (cm)
+          </label>
+          <input
+            id="bm-height"
+            type="number"
+            step="0.1"
+            min="0.1"
+            value={height}
+            onChange={(e) => setHeight(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-xl outline-none focus:border-primary"
+            placeholder="170.0"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label
+          htmlFor="bm-date"
+          className="block text-sm font-medium text-ink-700 mb-1"
+        >
+          記録日
+        </label>
+        <input
+          id="bm-date"
+          type="date"
+          value={recordedAt}
+          onChange={(e) => setRecordedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-xl outline-none focus:border-primary"
+          required
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="bm-notes"
+          className="block text-sm font-medium text-ink-700 mb-1"
+        >
+          メモ（任意）
+        </label>
+        <textarea
+          id="bm-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-xl outline-none focus:border-primary"
+          rows={2}
+          placeholder="朝食前に測定、など"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary text-white py-2 px-4 rounded-xl hover:bg-primary-dark transition-colors font-medium"
+        >
+          {initialData ? "更新する" : "記録する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-primary-50 text-ink-700 py-2 px-4 rounded-xl hover:bg-primary-100 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/body-measurements/BodyMeasurementList.tsx
+++ b/frontend/app/components/body-measurements/BodyMeasurementList.tsx
@@ -1,0 +1,212 @@
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X } from "lucide-react";
+import type {
+  BodyMeasurementView,
+  UpdateBodyMeasurementInput,
+} from "@/hooks/health-logs";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+interface BodyMeasurementListProps {
+  measurements: BodyMeasurementView[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateBodyMeasurementInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const BodyMeasurementList: React.FC<BodyMeasurementListProps> = ({
+  measurements,
+  isLoading,
+  onUpdate,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (measurements.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="記録がありません"
+        subMessage="上の＋ボタンから計測記録を追加できます"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {measurements.map((m) => (
+        <MeasurementCard
+          key={m.id}
+          measurement={m}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+};
+
+interface MeasurementCardProps {
+  measurement: BodyMeasurementView;
+  onUpdate: (id: string, input: UpdateBodyMeasurementInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const MeasurementCard: React.FC<MeasurementCardProps> = React.memo(
+  ({ measurement, onUpdate, onDelete }) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+    const [editWeight, setEditWeight] = useState(
+      measurement.weight?.toString() || "",
+    );
+    const [editHeight, setEditHeight] = useState(
+      measurement.height?.toString() || "",
+    );
+    const [editNotes, setEditNotes] = useState(measurement.notes || "");
+
+    const handleSave = async () => {
+      const w = editWeight ? parseFloat(editWeight) : null;
+      const h = editHeight ? parseFloat(editHeight) : null;
+      if (w == null && h == null) return;
+      await onUpdate(measurement.id, {
+        weight: w,
+        height: h,
+        notes: editNotes.trim() || null,
+      });
+      setIsEditing(false);
+    };
+
+    const handleCancel = () => {
+      setEditWeight(measurement.weight?.toString() || "");
+      setEditHeight(measurement.height?.toString() || "");
+      setEditNotes(measurement.notes || "");
+      setIsEditing(false);
+    };
+
+    if (isEditing) {
+      return (
+        <div className="bg-white rounded-2xl shadow-sm p-3 border border-primary-200 space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-ink-500 mb-1">
+                体重 (kg)
+              </label>
+              <input
+                type="number"
+                step="0.1"
+                min="0.1"
+                value={editWeight}
+                onChange={(e) => setEditWeight(e.target.value)}
+                className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm outline-none focus:border-primary"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-ink-500 mb-1">
+                身長 (cm)
+              </label>
+              <input
+                type="number"
+                step="0.1"
+                min="0.1"
+                value={editHeight}
+                onChange={(e) => setEditHeight(e.target.value)}
+                className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm outline-none focus:border-primary"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-ink-500 mb-1">メモ</label>
+            <textarea
+              value={editNotes}
+              onChange={(e) => setEditNotes(e.target.value)}
+              className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm outline-none focus:border-primary"
+              rows={2}
+            />
+          </div>
+          <div className="flex space-x-2">
+            <button
+              onClick={handleSave}
+              disabled={!editWeight && !editHeight}
+              className="flex-1 flex items-center justify-center space-x-1 bg-primary text-white py-1.5 rounded-xl text-sm hover:bg-primary-dark transition-colors disabled:opacity-50"
+            >
+              <Check size={14} />
+              <span>保存</span>
+            </button>
+            <button
+              onClick={handleCancel}
+              className="flex-1 flex items-center justify-center space-x-1 bg-primary-50 text-ink-700 py-1.5 rounded-xl text-sm hover:bg-primary-100 transition-colors"
+            >
+              <X size={14} />
+              <span>キャンセル</span>
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-3 border border-primary-100">
+        <div className="flex items-start justify-between">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+              <p className="text-xs text-ink-500">
+                {new Date(measurement.recordedAt).toLocaleDateString("ja-JP")}
+              </p>
+              {measurement.memberName && (
+                <span className="text-xs bg-primary-50 text-ink-600 px-1.5 py-0.5 rounded">
+                  {measurement.memberName}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center space-x-3 mt-1">
+              {measurement.weight != null && (
+                <p className="font-medium text-ink-800 text-sm">
+                  体重: {measurement.weight} kg
+                </p>
+              )}
+              {measurement.height != null && (
+                <p className="font-medium text-ink-800 text-sm">
+                  身長: {measurement.height} cm
+                </p>
+              )}
+            </div>
+            {measurement.notes && (
+              <p className="text-xs text-ink-400 mt-1">{measurement.notes}</p>
+            )}
+          </div>
+          <div className="flex items-center space-x-1 flex-shrink-0">
+            <button
+              onClick={() => setIsEditing(true)}
+              className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+              aria-label="編集"
+            >
+              <Pencil size={14} />
+            </button>
+            <button
+              onClick={() => setIsDeleteDialogOpen(true)}
+              className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+              aria-label="削除"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        </div>
+        <ConfirmationDialog
+          title="計測記録の削除"
+          message="この計測記録を削除しますか？この操作は取り消せません。"
+          isOpen={isDeleteDialogOpen}
+          onConfirm={() => {
+            setIsDeleteDialogOpen(false);
+            onDelete(measurement.id);
+          }}
+          onCancel={() => setIsDeleteDialogOpen(false)}
+          isDangerous
+        />
+      </div>
+    );
+  },
+);
+
+MeasurementCard.displayName = "MeasurementCard";

--- a/frontend/app/components/character/CharacterSelector.tsx
+++ b/frontend/app/components/character/CharacterSelector.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { CHARACTER_CONFIGS } from "@/lib/character";
+import type { CharacterType } from "@/lib/character";
+import { useCharacterStore } from "@/stores/characterStore";
+import { CharacterIcon } from "@/components/shared/CharacterIcon";
+
+const characterTypes: CharacterType[] = ["dog", "cat", "rabbit", "bird"];
+
+export const CharacterSelector: React.FC = () => {
+  const { selectedCharacter, setCharacter } = useCharacterStore();
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {characterTypes.map((type) => {
+        const config = CHARACTER_CONFIGS[type];
+        const isSelected = selectedCharacter === type;
+
+        return (
+          <button
+            key={type}
+            onClick={() => setCharacter(type)}
+            className={`flex flex-col items-center p-4 rounded-xl border-2 transition-all ${
+              isSelected
+                ? "border-primary-500 bg-primary-50 ring-2 ring-primary-200"
+                : "border-primary-100 bg-white hover:border-primary-300"
+            }`}
+          >
+            <CharacterIcon type={type} size={40} className="mb-2 text-ink-700" />
+            <span
+              className={`text-sm font-medium ${
+                isSelected ? "text-primary-700" : "text-ink-600"
+              }`}
+            >
+              {config.name}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/app/components/dashboard/AdherenceStatsCard.tsx
+++ b/frontend/app/components/dashboard/AdherenceStatsCard.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { TrendingUp } from "lucide-react";
+import { getRateLabel, getRateLevel, type AdherenceStats } from "@/hooks/dashboard";
+
+interface AdherenceStatsCardProps {
+  stats: AdherenceStats | null;
+  isLoading: boolean;
+}
+
+const levelColors = {
+  excellent: "text-green-600",
+  good: "text-blue-600",
+  warning: "text-yellow-600",
+  poor: "text-red-600",
+} as const;
+
+const levelBgColors = {
+  excellent: "bg-green-100",
+  good: "bg-blue-100",
+  warning: "bg-yellow-100",
+  poor: "bg-red-100",
+} as const;
+
+export const AdherenceStatsCard: React.FC<AdherenceStatsCardProps> = React.memo(
+  ({ stats, isLoading }) => {
+    if (isLoading || !stats) return null;
+
+    const weeklyLevel = getRateLevel(stats.overall.weeklyRate);
+    const monthlyLevel = getRateLevel(stats.overall.monthlyRate);
+
+    return (
+      <div className="mb-6">
+        <div className="flex items-center space-x-2 mb-3">
+          <TrendingUp size={18} className="text-primary" />
+          <h2 className="text-lg font-semibold text-ink-800">お薬の達成率</h2>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-sm p-4 border border-primary-100">
+          <div className="grid grid-cols-2 gap-4 mb-4">
+            <div className="text-center">
+              <p className="text-xs text-ink-500 mb-1">週間</p>
+              <p className={`text-2xl font-bold ${levelColors[weeklyLevel]}`}>
+                {stats.overall.weeklyRate}%
+              </p>
+              <span
+                className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${levelBgColors[weeklyLevel]} ${levelColors[weeklyLevel]}`}
+              >
+                {getRateLabel(stats.overall.weeklyRate)}
+              </span>
+            </div>
+            <div className="text-center">
+              <p className="text-xs text-ink-500 mb-1">月間</p>
+              <p className={`text-2xl font-bold ${levelColors[monthlyLevel]}`}>
+                {stats.overall.monthlyRate}%
+              </p>
+              <span
+                className={`inline-block mt-1 px-2 py-0.5 rounded-full text-xs font-medium ${levelBgColors[monthlyLevel]} ${levelColors[monthlyLevel]}`}
+              >
+                {getRateLabel(stats.overall.monthlyRate)}
+              </span>
+            </div>
+          </div>
+
+          {stats.members.length > 0 && (
+            <div className="border-t border-primary-100 pt-3">
+              <p className="text-xs text-ink-500 mb-2">メンバー別</p>
+              <div className="space-y-2">
+                {stats.members.map((member) => {
+                  const memberLevel = getRateLevel(member.weeklyRate);
+                  return (
+                    <div key={member.memberId} className="flex items-center justify-between">
+                      <span className="text-sm text-ink-700">{member.memberName}</span>
+                      <span className={`text-sm font-medium ${levelColors[memberLevel]}`}>
+                        {member.weeklyRate}%
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  },
+);
+
+AdherenceStatsCard.displayName = "AdherenceStatsCard";

--- a/frontend/app/components/dashboard/GreetingCard.tsx
+++ b/frontend/app/components/dashboard/GreetingCard.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useCharacterStore } from "@/stores/characterStore";
+import { CharacterIcon } from "@/components/shared/CharacterIcon";
+
+interface GreetingCardProps {
+  displayName: string;
+  weeklyRate?: number | null;
+}
+
+function getTimeGreeting(hour: number): string {
+  if (hour >= 5 && hour < 12) return "おはよう";
+  if (hour >= 12 && hour < 18) return "こんにちは";
+  return "こんばんは";
+}
+
+function getWeeklySummaryMessage(weeklyRate: number | null): string {
+  if (weeklyRate === null) return "今日もお薬を忘れずに";
+  if (weeklyRate >= 90) return "素晴らしい1週間です。この調子で続けましょう";
+  if (weeklyRate >= 70) return "順調にお薬を服用できています";
+  if (weeklyRate >= 50) return "少しずつ習慣にしていきましょう";
+  return "一緒に頑張りましょう。無理せず続けることが大切です";
+}
+
+export const GreetingCard: React.FC<GreetingCardProps> = ({ displayName, weeklyRate }) => {
+  // selectedCharacter を購読して、キャラクター変更時に再レンダリングさせる
+  useCharacterStore((s) => s.selectedCharacter);
+  const config = useCharacterStore((s) => s.getConfig)();
+  const now = new Date();
+  const greeting = getTimeGreeting(now.getHours());
+  const summaryMessage = getWeeklySummaryMessage(weeklyRate ?? null);
+
+  return (
+    <div className="bg-white rounded-2xl p-4 mb-6 flex items-center space-x-3 shadow-sm border border-primary-100">
+      <div className="bg-primary-50 rounded-2xl p-1.5">
+        <CharacterIcon type={config.type} size={36} className="text-ink-700" />
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-ink-800">
+          {greeting}、{displayName}さん
+        </p>
+        <p className="text-xs text-ink-600 mt-0.5">
+          {summaryMessage}
+          {config.suffix}
+        </p>
+        <p className="text-xs text-ink-400 mt-0.5">{config.name}より</p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/app/components/dashboard/MissedDoseIndicator.tsx
+++ b/frontend/app/components/dashboard/MissedDoseIndicator.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { AlertTriangle, Clock } from "lucide-react";
+import { getOverdueLevelStyle, type OverdueLevel } from "@/hooks/dashboard";
+
+interface MissedDoseIndicatorProps {
+  overdueLevel: OverdueLevel;
+  overdueMinutes: number;
+}
+
+export const MissedDoseIndicator: React.FC<MissedDoseIndicatorProps> = ({
+  overdueLevel,
+  overdueMinutes,
+}) => {
+  if (overdueLevel === "none") return null;
+
+  const style = getOverdueLevelStyle(overdueLevel);
+  const hours = Math.floor(overdueMinutes / 60);
+  const mins = overdueMinutes % 60;
+  const timeLabel = hours > 0 ? `${hours}時間${mins > 0 ? `${mins}分` : ""}` : `${mins}分`;
+
+  return (
+    <div className={`flex items-center space-x-1 text-xs ${style.text}`}>
+      {overdueLevel === "danger" ? <AlertTriangle size={14} /> : <Clock size={14} />}
+      <span>{timeLabel}経過</span>
+    </div>
+  );
+};

--- a/frontend/app/components/dashboard/MissedDosesAlert.tsx
+++ b/frontend/app/components/dashboard/MissedDosesAlert.tsx
@@ -1,0 +1,177 @@
+import React, { useMemo, useState } from "react";
+import { AlertTriangle, Check, Loader2 } from "lucide-react";
+import type { MissedDose } from "@/hooks/dashboard";
+
+interface MissedDosesAlertProps {
+  missedDoses: MissedDose[];
+  isLoading: boolean;
+  onMarkAsTaken?: (dose: MissedDose) => Promise<void>;
+  onMarkMultipleAsTaken?: (doses: MissedDose[]) => Promise<void>;
+}
+
+interface DateGroup {
+  date: string;
+  dateLabel: string;
+  items: MissedDose[];
+}
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+function formatDateLabel(dateKey: string): string {
+  const [y, m, d] = dateKey.split("-").map(Number);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return dateKey;
+  const date = new Date(y, m - 1, d);
+  if (isNaN(date.getTime())) return dateKey;
+  const dow = DAY_LABELS[date.getDay()] ?? "";
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const diffDays = Math.round((today.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 1) return `昨日（${m}/${d} ${dow}）`;
+  if (diffDays === 2) return `一昨日（${m}/${d} ${dow}）`;
+  return `${m}月${d}日（${dow}）`;
+}
+
+export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({
+  missedDoses,
+  isLoading,
+  onMarkAsTaken,
+  onMarkMultipleAsTaken,
+}) => {
+  const [recordingId, setRecordingId] = useState<string | null>(null);
+  const [bulkTarget, setBulkTarget] = useState<string | null>(null);
+
+  const dateGroups = useMemo(() => {
+    if (missedDoses.length === 0) return [];
+    const map = new Map<string, MissedDose[]>();
+    for (const dose of missedDoses) {
+      const group = map.get(dose.date) || [];
+      group.push(dose);
+      map.set(dose.date, group);
+    }
+    const groups: DateGroup[] = [];
+    for (const [date, items] of map) {
+      groups.push({ date, dateLabel: formatDateLabel(date), items });
+    }
+    groups.sort((a, b) => b.date.localeCompare(a.date));
+    return groups;
+  }, [missedDoses]);
+
+  if (isLoading || missedDoses.length === 0) return null;
+
+  const handleMarkOne = async (dose: MissedDose) => {
+    if (!onMarkAsTaken) return;
+    const key = `${dose.date}-${dose.scheduleId}`;
+    setRecordingId(key);
+    try {
+      await onMarkAsTaken(dose);
+    } finally {
+      setRecordingId(null);
+    }
+  };
+
+  const handleMarkAllForDate = async (group: DateGroup) => {
+    if (!onMarkMultipleAsTaken) return;
+    setBulkTarget(group.date);
+    try {
+      await onMarkMultipleAsTaken(group.items);
+    } finally {
+      setBulkTarget(null);
+    }
+  };
+
+  const handleMarkAll = async () => {
+    if (!onMarkMultipleAsTaken) return;
+    setBulkTarget("all");
+    try {
+      await onMarkMultipleAsTaken(missedDoses);
+    } finally {
+      setBulkTarget(null);
+    }
+  };
+
+  return (
+    <div className="mb-4">
+      <div className="bg-red-50 border border-red-200 rounded-2xl overflow-hidden">
+        <div className="flex items-center justify-between gap-2 px-4 py-2.5 bg-red-100">
+          <div className="flex items-center gap-2 min-w-0">
+            <AlertTriangle size={18} className="text-red-600 flex-shrink-0" />
+            <h3 className="text-sm font-bold text-red-800 truncate">
+              飲み忘れがあります（{missedDoses.length}件）
+            </h3>
+          </div>
+          {onMarkMultipleAsTaken && (
+            <button
+              type="button"
+              onClick={handleMarkAll}
+              disabled={bulkTarget !== null || recordingId !== null}
+              className="flex items-center gap-1 text-xs text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 px-2 py-1 rounded font-medium flex-shrink-0"
+            >
+              {bulkTarget === "all" ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Check size={12} />
+              )}
+              <span>全て記録</span>
+            </button>
+          )}
+        </div>
+        <div className="px-4 py-3 space-y-3">
+          {dateGroups.map((group) => (
+            <div key={group.date}>
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-xs font-semibold text-red-700">{group.dateLabel}</p>
+                {onMarkMultipleAsTaken && group.items.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => handleMarkAllForDate(group)}
+                    disabled={bulkTarget !== null || recordingId !== null}
+                    className="text-xs text-red-600 hover:text-red-800 disabled:opacity-50 font-medium flex items-center gap-1"
+                  >
+                    {bulkTarget === group.date ? (
+                      <Loader2 size={11} className="animate-spin" />
+                    ) : null}
+                    <span>この日全て記録</span>
+                  </button>
+                )}
+              </div>
+              <div className="space-y-1">
+                {group.items.map((dose) => {
+                  const key = `${dose.date}-${dose.scheduleId}`;
+                  const isRecording = recordingId === key;
+                  return (
+                    <div key={key} className="flex items-center justify-between gap-2 text-sm">
+                      <span className="text-ink-800 min-w-0 truncate">
+                        <span className="text-ink-500">{dose.memberName}</span>{" "}
+                        <span className="font-medium">{dose.medicationName}</span>
+                      </span>
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        <span className="text-xs text-ink-500">{dose.scheduledTime}</span>
+                        {onMarkAsTaken && (
+                          <button
+                            type="button"
+                            onClick={() => handleMarkOne(dose)}
+                            disabled={isRecording || bulkTarget !== null}
+                            aria-label="記録する"
+                            className="flex items-center gap-1 text-xs text-red-700 hover:text-white hover:bg-red-600 disabled:opacity-50 border border-red-300 hover:border-red-600 px-2 py-0.5 rounded transition-colors"
+                          >
+                            {isRecording ? (
+                              <Loader2 size={11} className="animate-spin" />
+                            ) : (
+                              <Check size={11} />
+                            )}
+                            <span>記録</span>
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/app/components/dashboard/StockAlertList.tsx
+++ b/frontend/app/components/dashboard/StockAlertList.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+import { getRemainingDaysLabel, type StockAlert } from "@/hooks/dashboard";
+
+interface StockAlertListProps {
+  alerts: StockAlert[];
+  isLoading: boolean;
+}
+
+export const StockAlertList: React.FC<StockAlertListProps> = ({ alerts, isLoading }) => {
+  if (isLoading || alerts.length === 0) return null;
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center space-x-2 mb-3">
+        <AlertTriangle size={18} className="text-yellow-600" />
+        <h2 className="text-lg font-semibold text-ink-800">在庫アラート</h2>
+      </div>
+      <div className="space-y-2">
+        {alerts.map((alert) => (
+          <StockAlertItem key={alert.medicationId} alert={alert} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+interface StockAlertItemProps {
+  alert: StockAlert;
+}
+
+const StockAlertItem: React.FC<StockAlertItemProps> = React.memo(({ alert }) => (
+  <div
+    className={`bg-white rounded-2xl shadow-sm p-3 border ${
+      alert.isOverdue ? "border-red-300 bg-red-50" : "border-yellow-300 bg-yellow-50"
+    }`}
+  >
+    <div className="flex items-center justify-between">
+      <div>
+        <p className="text-sm font-medium text-ink-800">{alert.medicationName}</p>
+        <p className="text-xs text-ink-500">{alert.memberName}</p>
+      </div>
+      <div className="text-right">
+        <p className="text-sm font-medium text-ink-700">
+          {getRemainingDaysLabel(alert.remainingDays ?? null)}
+        </p>
+        {alert.stockQuantity !== null && (
+          <p className="text-xs text-ink-400">残{alert.stockQuantity}錠</p>
+        )}
+        <p className={`text-xs font-medium ${alert.isOverdue ? "text-red-600" : "text-yellow-600"}`}>
+          {alert.isOverdue ? "期限超過" : `あと${alert.daysUntilAlert}日`}
+        </p>
+      </div>
+    </div>
+  </div>
+));
+
+StockAlertItem.displayName = "StockAlertItem";

--- a/frontend/app/components/dashboard/TodayScheduleList.tsx
+++ b/frontend/app/components/dashboard/TodayScheduleList.tsx
@@ -1,0 +1,375 @@
+import React, { useMemo, useState, useCallback } from "react";
+import { Link } from "react-router";
+import { Check, Users, Pill, Clock, X, ChevronDown, ChevronUp } from "lucide-react";
+import {
+  getOverdueLevel,
+  getOverdueLevelStyle,
+  getOverdueMinutes,
+  type TodayScheduleViewModel,
+} from "@/hooks/dashboard";
+import { MissedDoseIndicator } from "./MissedDoseIndicator";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+
+interface TodayScheduleListProps {
+  schedules: TodayScheduleViewModel[];
+  isLoading: boolean;
+  onMarkCompleted?: (
+    scheduleId: string,
+    options?: { takenAt?: string; notes?: string },
+  ) => Promise<void>;
+  onMarkMultipleCompleted?: (scheduleIds: string[]) => Promise<void>;
+  hasMembers?: boolean;
+}
+
+export const TodayScheduleList: React.FC<TodayScheduleListProps> = ({
+  schedules,
+  isLoading,
+  onMarkCompleted,
+  onMarkMultipleCompleted,
+  hasMembers,
+}) => {
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+  const [isBulkSubmitting, setIsBulkSubmitting] = useState(false);
+
+  const pendingIds = useMemo(
+    () => new Set(schedules.filter((s) => s.status !== "completed").map((s) => s.scheduleId)),
+    [schedules],
+  );
+
+  const handleToggleCheck = useCallback((scheduleId: string) => {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(scheduleId)) {
+        next.delete(scheduleId);
+      } else {
+        next.add(scheduleId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleToggleAll = useCallback(() => {
+    setCheckedIds((prev) => {
+      if (prev.size === pendingIds.size) return new Set();
+      return new Set(pendingIds);
+    });
+  }, [pendingIds]);
+
+  const handleBulkSubmit = async () => {
+    if (!onMarkMultipleCompleted || checkedIds.size === 0) return;
+    setIsBulkSubmitting(true);
+    try {
+      await onMarkMultipleCompleted([...checkedIds]);
+      setCheckedIds(new Set());
+    } finally {
+      setIsBulkSubmitting(false);
+    }
+  };
+
+  if (isLoading) return <LoadingSpinner />;
+
+  if (schedules.length === 0) {
+    if (!hasMembers) {
+      return (
+        <div className="bg-white rounded-2xl border border-primary-100 p-6">
+          <p className="text-sm font-medium text-ink-700 mb-4">はじめての方へ</p>
+          <div className="space-y-3">
+            <SetupStep icon={Users} label="メンバーを登録" to="/members" description="家族やペットを追加" step={1} />
+            <SetupStep icon={Pill} label="お薬を登録" to="/medications" description="メンバーごとに薬を追加" step={2} />
+            <SetupStep icon={Clock} label="スケジュールを設定" to="/medications" description="飲む時間と頻度を設定" step={3} />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="bg-white rounded-2xl border border-primary-100 p-6 text-center">
+        <p className="text-ink-500 mb-3">今日の服薬スケジュールはありません</p>
+        <Link
+          to="/medications"
+          className="inline-flex items-center space-x-1 text-sm text-primary hover:text-primary-dark font-medium"
+        >
+          <Pill size={14} />
+          <span>お薬ページでスケジュールを確認</span>
+        </Link>
+      </div>
+    );
+  }
+
+  const pendingCount = pendingIds.size;
+  const allChecked = checkedIds.size === pendingCount && pendingCount > 0;
+
+  return (
+    <div className="space-y-2">
+      {pendingCount > 1 && onMarkMultipleCompleted && (
+        <div className="flex items-center justify-between px-1 mb-1">
+          <span className="text-xs text-ink-500">{pendingCount}件が未服薬</span>
+          <button
+            type="button"
+            onClick={handleToggleAll}
+            className="text-xs text-primary font-medium hover:underline"
+          >
+            {allChecked ? "すべて解除" : "すべて選択"}
+          </button>
+        </div>
+      )}
+
+      {schedules.map((schedule) => (
+        <ScheduleCard
+          key={schedule.scheduleId}
+          schedule={schedule}
+          isChecked={checkedIds.has(schedule.scheduleId)}
+          onToggleCheck={handleToggleCheck}
+          onMarkCompleted={onMarkCompleted}
+          showCheckbox={!!onMarkMultipleCompleted && pendingCount > 0}
+        />
+      ))}
+
+      {checkedIds.size > 0 && onMarkMultipleCompleted && (
+        <div className="sticky bottom-20 z-10 pt-2">
+          <button
+            type="button"
+            onClick={handleBulkSubmit}
+            disabled={isBulkSubmitting}
+            className="w-full flex items-center justify-center space-x-2 bg-green-600 text-white rounded-xl py-3 font-semibold shadow-lg hover:bg-green-700 active:bg-green-800 disabled:opacity-60 transition-colors"
+          >
+            <Check size={18} />
+            <span>{isBulkSubmitting ? "記録中..." : `${checkedIds.size}件をまとめて服薬記録`}</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ScheduleCardProps {
+  schedule: TodayScheduleViewModel;
+  isChecked: boolean;
+  onToggleCheck: (id: string) => void;
+  onMarkCompleted?: (
+    scheduleId: string,
+    options?: { takenAt?: string; notes?: string },
+  ) => Promise<void>;
+  showCheckbox: boolean;
+}
+
+const ScheduleCard: React.FC<ScheduleCardProps> = React.memo(
+  ({ schedule, isChecked, onToggleCheck, onMarkCompleted, showCheckbox }) => {
+    const [showDetail, setShowDetail] = useState(false);
+    const [takenDate, setTakenDate] = useState("");
+    const [notes, setNotes] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const overdueInfo = useMemo(() => {
+      const now = new Date();
+      return {
+        level: getOverdueLevel(schedule.scheduledTime, now, schedule.status === "completed"),
+        minutes: getOverdueMinutes(schedule.scheduledTime, now),
+      };
+    }, [schedule.scheduledTime, schedule.status]);
+
+    const overdueStyle = getOverdueLevelStyle(overdueInfo.level);
+
+    const now = new Date();
+    const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+
+    const isPending = schedule.status !== "completed";
+
+    const handleDetailOpen = () => {
+      setTakenDate(todayStr);
+      setNotes("");
+      setShowDetail(true);
+    };
+
+    const handleDetailConfirm = async () => {
+      if (!onMarkCompleted) return;
+      setIsSubmitting(true);
+      try {
+        const options: { takenAt?: string; notes?: string } = {};
+        if (takenDate && takenDate !== todayStr) {
+          options.takenAt = new Date(`${takenDate}T${schedule.scheduledTime}:00`).toISOString();
+        }
+        if (notes.trim()) {
+          options.notes = notes.trim();
+        }
+        await onMarkCompleted(
+          schedule.scheduleId,
+          Object.keys(options).length > 0 ? options : undefined,
+        );
+        setShowDetail(false);
+      } finally {
+        setIsSubmitting(false);
+      }
+    };
+
+    const borderClass = isChecked
+      ? "border-green-400 bg-green-50"
+      : overdueInfo.level !== "none"
+        ? `${overdueStyle.bg} ${overdueStyle.border}`
+        : "border-primary-100 bg-white";
+
+    return (
+      <div
+        className={`rounded-2xl shadow-sm p-4 border transition-all ${borderClass}`}
+        data-testid="schedule-item"
+        role="article"
+        aria-label={`${schedule.scheduledTime}の服薬スケジュール - ${schedule.medicationName}`}
+      >
+        <div className="flex items-center gap-3">
+          {showCheckbox && isPending && (
+            <button
+              type="button"
+              onClick={() => onToggleCheck(schedule.scheduleId)}
+              aria-label={isChecked ? "チェックを外す" : "服薬済みとしてチェック"}
+              className={`flex-shrink-0 w-7 h-7 rounded-full border-2 flex items-center justify-center transition-colors ${
+                isChecked
+                  ? "bg-green-500 border-green-500 text-white"
+                  : "border-primary-200 bg-white hover:border-green-400"
+              }`}
+            >
+              {isChecked && <Check size={14} />}
+            </button>
+          )}
+
+          <div className="flex-1 flex items-center justify-between min-w-0">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="flex flex-col items-center flex-shrink-0">
+                <span className="text-2xl font-bold text-ink-800" data-testid="schedule-time">
+                  {schedule.scheduledTime}
+                </span>
+                <MissedDoseIndicator
+                  overdueLevel={overdueInfo.level}
+                  overdueMinutes={overdueInfo.minutes}
+                />
+              </div>
+              <div className="flex flex-col min-w-0">
+                <span className="text-sm font-medium text-ink-500">{schedule.memberName}</span>
+                <span className="text-base font-semibold text-ink-800 truncate">
+                  {schedule.medicationName}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+              {isPending && onMarkCompleted && (
+                <button
+                  type="button"
+                  onClick={showDetail ? () => setShowDetail(false) : handleDetailOpen}
+                  className="flex items-center gap-0.5 text-xs text-ink-400 hover:text-ink-600 transition-colors"
+                  aria-label="詳細入力"
+                >
+                  <span>詳細</span>
+                  {showDetail ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                </button>
+              )}
+              <StatusBadge status={schedule.status} />
+            </div>
+          </div>
+        </div>
+
+        {showDetail && isPending && (
+          <div className="mt-3 pt-3 border-t border-primary-100">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-medium text-ink-600">服薬記録（詳細）</span>
+              <button
+                onClick={() => setShowDetail(false)}
+                className="p-0.5 text-ink-400 hover:text-ink-600"
+                aria-label="閉じる"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <div className="space-y-2">
+              <div>
+                <label className="block text-xs text-ink-500 mb-0.5">服薬日</label>
+                <input
+                  type="date"
+                  value={takenDate}
+                  max={todayStr}
+                  onChange={(e) => setTakenDate(e.target.value)}
+                  className="w-full rounded-md border border-primary-200 px-2 py-1.5 text-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-ink-500 mb-0.5">メモ（任意）</label>
+                <input
+                  type="text"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="例: 飲み忘れ分"
+                  className="w-full rounded-md border border-primary-200 px-2 py-1.5 text-sm"
+                  maxLength={500}
+                />
+              </div>
+              <button
+                onClick={handleDetailConfirm}
+                disabled={isSubmitting || !takenDate}
+                className="w-full flex items-center justify-center space-x-1 bg-green-600 text-white rounded-md py-1.5 text-sm font-medium hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Check size={14} />
+                <span>
+                  {isSubmitting
+                    ? "記録中..."
+                    : takenDate !== todayStr
+                      ? `${takenDate.replace(/^\d{4}-/, "").replace("-", "/")}の服薬を記録`
+                      : "服薬を記録"}
+                </span>
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+ScheduleCard.displayName = "ScheduleCard";
+
+interface StatusBadgeProps {
+  status: "pending" | "completed" | "overdue";
+}
+
+const StatusBadge: React.FC<StatusBadgeProps> = React.memo(({ status }) => {
+  const styles = {
+    pending: { bg: "bg-yellow-100", text: "text-yellow-800", label: "未服薬" },
+    completed: { bg: "bg-green-100", text: "text-green-800", label: "服薬済み" },
+    overdue: { bg: "bg-red-100", text: "text-red-800", label: "時間超過" },
+  } as const;
+  const style = styles[status];
+  return (
+    <span
+      className={`px-2.5 py-0.5 rounded-full text-xs font-semibold ${style.bg} ${style.text}`}
+      role="status"
+      aria-label={`ステータス: ${style.label}`}
+    >
+      {style.label}
+    </span>
+  );
+});
+
+StatusBadge.displayName = "StatusBadge";
+
+interface SetupStepProps {
+  icon: React.FC<{ size?: number; className?: string }>;
+  label: string;
+  description: string;
+  to: string;
+  step: number;
+}
+
+const SetupStep: React.FC<SetupStepProps> = ({ icon: Icon, label, description, to, step }) => (
+  <Link
+    to={to}
+    className="flex items-center space-x-3 p-3 rounded-2xl border border-primary-100 hover:border-primary-200 hover:bg-primary-50/50 transition-colors"
+  >
+    <div className="flex-shrink-0 w-8 h-8 rounded-full bg-primary-100 text-primary flex items-center justify-center text-xs font-bold">
+      {step}
+    </div>
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center space-x-1.5">
+        <Icon size={14} className="text-primary" />
+        <span className="text-sm font-medium text-ink-800">{label}</span>
+      </div>
+      <p className="text-xs text-ink-500 mt-0.5">{description}</p>
+    </div>
+  </Link>
+);

--- a/frontend/app/components/dashboard/UpcomingAppointments.tsx
+++ b/frontend/app/components/dashboard/UpcomingAppointments.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { Link } from "react-router";
+import { Calendar, User, MapPin } from "lucide-react";
+import type { EnrichedAppointment } from "@/hooks/dashboard";
+
+interface UpcomingAppointmentsProps {
+  appointments: EnrichedAppointment[];
+  isLoading: boolean;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  checkup: "定期検診",
+  treatment: "治療",
+  vaccination: "予防接種",
+  surgery: "手術",
+  consultation: "相談",
+  medication_pickup: "お薬",
+  examination: "検査",
+  flea_tick: "ノミ・ダニ薬",
+  heartworm: "フィラリア",
+  therapeutic_diet: "療養食",
+  grooming: "トリミング",
+  other: "その他",
+};
+
+const DAY_OF_WEEK = ["日", "月", "火", "水", "木", "金", "土"];
+
+function toStartOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function diffDays(from: Date, to: Date): number {
+  const a = toStartOfDay(from).getTime();
+  const b = toStartOfDay(to).getTime();
+  return Math.round((b - a) / (1000 * 60 * 60 * 24));
+}
+
+function isToday(date: Date): boolean {
+  return toStartOfDay(new Date()).getTime() === toStartOfDay(date).getTime();
+}
+
+function isPast(date: Date): boolean {
+  return toStartOfDay(date).getTime() < toStartOfDay(new Date()).getTime();
+}
+
+function formatDate(date: Date): string {
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日(${DAY_OF_WEEK[date.getDay()]})`;
+}
+
+export const UpcomingAppointments: React.FC<UpcomingAppointmentsProps> = ({
+  appointments,
+  isLoading,
+}) => {
+  if (isLoading) return null;
+
+  const upcoming = appointments
+    .map((a) => ({ apt: a, date: new Date(a.appointmentDate) }))
+    .filter(({ date }) => !isPast(date) && diffDays(new Date(), date) <= 7)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+    .slice(0, 3);
+
+  if (upcoming.length === 0) return null;
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold text-ink-800">今後の通院予定</h2>
+        <Link to="/appointments" className="text-xs text-primary hover:underline">
+          すべて見る
+        </Link>
+      </div>
+      <div className="space-y-2">
+        {upcoming.map(({ apt, date }) => {
+          const daysUntil = diffDays(new Date(), date);
+          const today = isToday(date);
+          return (
+            <div key={apt.id} className="bg-white rounded-2xl shadow-sm p-3 border border-primary-100">
+              <div className="flex items-center space-x-3">
+                <Calendar size={16} className={today ? "text-red-500" : "text-primary"} />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-ink-800">
+                    {formatDate(date)}
+                    {today && (
+                      <span className="ml-2 px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-medium">
+                        今日
+                      </span>
+                    )}
+                    {!today && daysUntil <= 3 && (
+                      <span className="ml-2 text-xs text-orange-600 font-medium">
+                        あと{daysUntil}日
+                      </span>
+                    )}
+                  </p>
+                  <div className="flex items-center gap-2 text-xs text-ink-500 mt-0.5 flex-wrap">
+                    {apt.memberName && (
+                      <span className="flex items-center space-x-1">
+                        <User size={10} />
+                        <span>{apt.memberName}</span>
+                      </span>
+                    )}
+                    {apt.hospitalName && (
+                      <span className="flex items-center space-x-1">
+                        <MapPin size={10} />
+                        <span>{apt.hospitalName}</span>
+                      </span>
+                    )}
+                    {apt.appointmentType && TYPE_LABELS[apt.appointmentType] && (
+                      <span className="px-1.5 py-0.5 bg-primary-50 text-ink-600 rounded text-xs">
+                        {TYPE_LABELS[apt.appointmentType]}
+                      </span>
+                    )}
+                  </div>
+                  {apt.description && (
+                    <p className="text-xs text-ink-400 mt-0.5 truncate">{apt.description}</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/app/components/dashboard/WeeklySummaryCard.tsx
+++ b/frontend/app/components/dashboard/WeeklySummaryCard.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { CheckCircle2, Clock, AlertCircle } from "lucide-react";
+import type { TodayScheduleViewModel } from "@/hooks/dashboard";
+
+interface WeeklySummaryCardProps {
+  schedules: TodayScheduleViewModel[];
+  isLoading: boolean;
+}
+
+export const WeeklySummaryCard: React.FC<WeeklySummaryCardProps> = React.memo(
+  ({ schedules, isLoading }) => {
+    if (isLoading) {
+      return (
+        <div className="bg-white rounded-2xl shadow-sm p-4 mb-4 border border-primary-100">
+          <p className="text-ink-400 text-sm text-center py-2">読み込み中...</p>
+        </div>
+      );
+    }
+
+    const completed = schedules.filter((s) => s.status === "completed").length;
+    const pending = schedules.filter((s) => s.status === "pending").length;
+    const overdue = schedules.filter((s) => s.status === "overdue").length;
+    const total = schedules.length;
+
+    if (total === 0) return null;
+
+    const completionRate = Math.round((completed / total) * 100);
+
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-4 mb-4 border border-primary-100">
+        <h3 className="text-sm font-semibold text-ink-800 mb-3">今日のまとめ</h3>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-1">
+            <CheckCircle2 size={16} className="text-green-500" />
+            <span className="text-sm text-ink-700">{completed}件完了</span>
+          </div>
+          <div className="flex items-center space-x-1">
+            <Clock size={16} className="text-yellow-500" />
+            <span className="text-sm text-ink-700">{pending}件予定</span>
+          </div>
+          {overdue > 0 && (
+            <div className="flex items-center space-x-1">
+              <AlertCircle size={16} className="text-red-500" />
+              <span className="text-sm text-ink-700">{overdue}件超過</span>
+            </div>
+          )}
+        </div>
+        <div className="mt-3">
+          <div className="flex items-center justify-between text-xs text-ink-500 mb-1">
+            <span>達成率</span>
+            <span>{completionRate}%</span>
+          </div>
+          <div className="w-full bg-primary-100 rounded-full h-2">
+            <div
+              className="h-2 rounded-full transition-all"
+              style={{
+                width: `${completionRate}%`,
+                backgroundColor:
+                  completionRate >= 80 ? "#22c55e" : completionRate >= 50 ? "#f59e0b" : "#ef4444",
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+WeeklySummaryCard.displayName = "WeeklySummaryCard";

--- a/frontend/app/components/emergency-contacts/EmergencyContactForm.tsx
+++ b/frontend/app/components/emergency-contacts/EmergencyContactForm.tsx
@@ -1,0 +1,186 @@
+import React, { useState } from "react";
+import type { Member } from "@/lib/types";
+
+export interface EmergencyContactFormData {
+  memberId: string;
+  contactName: string;
+  phoneNumber: string;
+  relationship?: string;
+  notes?: string;
+}
+
+interface EmergencyContactFormProps {
+  members: Member[];
+  onSubmit: (data: EmergencyContactFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    contactName: string;
+    phoneNumber: string;
+    relationship?: string;
+    notes?: string;
+  };
+}
+
+const RELATIONSHIP_OPTIONS = ["父", "母", "配偶者", "兄弟姉妹", "祖父母", "子", "かかりつけ医", "友人", "職場"];
+
+export const EmergencyContactForm: React.FC<EmergencyContactFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+  initialData,
+}) => {
+  const [memberId, setMemberId] = useState(
+    initialData?.memberId || (members.length === 1 ? members[0].id : ""),
+  );
+  const [contactName, setContactName] = useState(initialData?.contactName || "");
+  const [phoneNumber, setPhoneNumber] = useState(initialData?.phoneNumber || "");
+  const [relationship, setRelationship] = useState(initialData?.relationship || "");
+  const [showCustomRelationship, setShowCustomRelationship] = useState(
+    !!initialData?.relationship && !RELATIONSHIP_OPTIONS.includes(initialData.relationship),
+  );
+  const [notes, setNotes] = useState(initialData?.notes || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !contactName.trim() || !phoneNumber.trim()) return;
+
+    onSubmit({
+      memberId,
+      contactName: contactName.trim(),
+      phoneNumber: phoneNumber.trim(),
+      relationship: relationship.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setContactName("");
+      setPhoneNumber("");
+      setRelationship("");
+      setNotes("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="ec-member" className="block text-sm font-medium text-ink-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="ec-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="ec-name" className="block text-sm font-medium text-ink-700 mb-1">
+          連絡先名
+        </label>
+        <input
+          id="ec-name"
+          type="text"
+          value={contactName}
+          onChange={(e) => setContactName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="例: 田中花子"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ec-phone" className="block text-sm font-medium text-ink-700 mb-1">
+          電話番号
+        </label>
+        <input
+          id="ec-phone"
+          type="tel"
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="例: 090-1234-5678"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ec-relationship" className="block text-sm font-medium text-ink-700 mb-1">
+          続柄（任意）
+        </label>
+        <select
+          id="ec-relationship"
+          value={RELATIONSHIP_OPTIONS.includes(relationship) ? relationship : relationship ? "other" : ""}
+          onChange={(e) => {
+            if (e.target.value === "other") {
+              setRelationship("");
+              setShowCustomRelationship(true);
+            } else {
+              setRelationship(e.target.value);
+              setShowCustomRelationship(false);
+            }
+          }}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        >
+          <option value="">選択してください</option>
+          {RELATIONSHIP_OPTIONS.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+          <option value="other">その他（自由入力）</option>
+        </select>
+        {showCustomRelationship && (
+          <input
+            type="text"
+            value={relationship}
+            onChange={(e) => setRelationship(e.target.value)}
+            className="w-full mt-2 px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            placeholder="続柄を入力してください"
+          />
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="ec-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="ec-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="日中連絡可、夜間のみ等"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium"
+        >
+          {initialData ? "更新する" : "登録する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-primary-100 text-ink-700 py-2 px-4 rounded-lg hover:bg-primary-200 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/emergency-contacts/EmergencyContactList.tsx
+++ b/frontend/app/components/emergency-contacts/EmergencyContactList.tsx
@@ -1,0 +1,206 @@
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X, Phone } from "lucide-react";
+import type { EmergencyContact } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+export interface UpdateEmergencyContactInput {
+  contactName?: string;
+  phoneNumber?: string;
+  relationship?: string | null;
+  notes?: string | null;
+}
+
+export interface EmergencyContactWithMember extends EmergencyContact {
+  memberName?: string;
+}
+
+interface EmergencyContactListProps {
+  contacts: EmergencyContactWithMember[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateEmergencyContactInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const EmergencyContactList: React.FC<EmergencyContactListProps> = ({
+  contacts,
+  isLoading,
+  onUpdate,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (contacts.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="緊急連絡先が登録されていません"
+        subMessage="上の＋ボタンから連絡先を追加できます"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {contacts.map((contact) => (
+        <ContactCard key={contact.id} contact={contact} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface ContactCardProps {
+  contact: EmergencyContactWithMember;
+  onUpdate: (id: string, input: UpdateEmergencyContactInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const ContactCard: React.FC<ContactCardProps> = React.memo(({ contact, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editName, setEditName] = useState(contact.contactName);
+  const [editPhone, setEditPhone] = useState(contact.phoneNumber);
+  const [editRelationship, setEditRelationship] = useState(contact.relationship || "");
+  const [editNotes, setEditNotes] = useState(contact.notes || "");
+
+  const handleSave = async () => {
+    if (!editName.trim() || !editPhone.trim()) return;
+    await onUpdate(contact.id, {
+      contactName: editName.trim(),
+      phoneNumber: editPhone.trim(),
+      relationship: editRelationship.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(contact.contactName);
+    setEditPhone(contact.phoneNumber);
+    setEditRelationship(contact.relationship || "");
+    setEditNotes(contact.notes || "");
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200 space-y-3">
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">連絡先名</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">電話番号</label>
+          <input
+            type="tel"
+            value={editPhone}
+            onChange={(e) => setEditPhone(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">続柄</label>
+          <input
+            type="text"
+            value={editRelationship}
+            onChange={(e) => setEditRelationship(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim() || !editPhone.trim()}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-600 text-white py-1.5 rounded-lg text-sm hover:bg-primary-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-100 text-ink-700 py-1.5 rounded-lg text-sm hover:bg-primary-200 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+            <p className="font-medium text-ink-800 text-sm">{contact.contactName}</p>
+            {contact.relationship && (
+              <span className="text-xs bg-primary-50 text-primary-600 px-1.5 py-0.5 rounded">
+                {contact.relationship}
+              </span>
+            )}
+            {contact.memberName && (
+              <span className="text-xs bg-primary-100 text-ink-600 px-1.5 py-0.5 rounded">
+                {contact.memberName}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center space-x-1 mt-1">
+            <Phone size={12} className="text-ink-400" />
+            <a href={`tel:${contact.phoneNumber}`} className="text-sm text-primary-600 hover:underline">
+              {contact.phoneNumber}
+            </a>
+          </div>
+          {contact.notes && <p className="text-xs text-ink-400 mt-1">{contact.notes}</p>}
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <ConfirmationDialog
+        title="緊急連絡先の削除"
+        message={`「${contact.contactName}」を削除しますか？この操作は取り消せません。`}
+        isOpen={isDeleteDialogOpen}
+        onConfirm={() => {
+          setIsDeleteDialogOpen(false);
+          onDelete(contact.id);
+        }}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        isDangerous
+      />
+    </div>
+  );
+});
+
+ContactCard.displayName = "ContactCard";

--- a/frontend/app/components/examinations/ExaminationForm.tsx
+++ b/frontend/app/components/examinations/ExaminationForm.tsx
@@ -1,0 +1,267 @@
+import React, { useState } from "react";
+import { X, ImagePlus } from "lucide-react";
+import type { Member } from "@/lib/types";
+
+export interface ExaminationFormData {
+  memberId: string;
+  examinationType: string;
+  examinedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+  imageData?: string;
+}
+
+interface ExaminationFormProps {
+  members: Member[];
+  onSubmit: (data: ExaminationFormData) => Promise<void> | void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    examinationType: string;
+    examinedAt: string;
+    nextScheduledDate?: string | null;
+    notes?: string | null;
+    imageData?: string | null;
+  };
+}
+
+const toDateInput = (value: string | null | undefined): string => {
+  if (!value) return "";
+  return new Date(value).toISOString().split("T")[0];
+};
+
+const todayInput = (): string => new Date().toISOString().split("T")[0];
+
+async function compressImage(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onerror = reject;
+      img.onload = () => {
+        const MAX_DIM = 1200;
+        let { width, height } = img;
+        if (width > MAX_DIM || height > MAX_DIM) {
+          if (width >= height) {
+            height = Math.round((height / width) * MAX_DIM);
+            width = MAX_DIM;
+          } else {
+            width = Math.round((width / height) * MAX_DIM);
+            height = MAX_DIM;
+          }
+        }
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Canvas not available"));
+          return;
+        }
+        ctx.drawImage(img, 0, 0, width, height);
+        resolve(canvas.toDataURL("image/jpeg", 0.82));
+      };
+      img.src = e.target?.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
+  const [examinationType, setExaminationType] = useState(initialData?.examinationType || "");
+  const [examinedAt, setExaminedAt] = useState(
+    initialData?.examinedAt ? toDateInput(initialData.examinedAt) : todayInput(),
+  );
+  const [nextScheduledDate, setNextScheduledDate] = useState(toDateInput(initialData?.nextScheduledDate));
+  const [notes, setNotes] = useState(initialData?.notes || "");
+  const [imageData, setImageData] = useState<string | null>(initialData?.imageData ?? null);
+  const [imageError, setImageError] = useState("");
+  const [submitError, setSubmitError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      setImageError("10MB以下の画像を選択してください");
+      return;
+    }
+    setImageError("");
+    try {
+      const compressed = await compressImage(file);
+      if (compressed.length > 1_500_000) {
+        setImageError("画像を圧縮できませんでした。より小さい画像を選択してください");
+        return;
+      }
+      setImageData(compressed);
+    } catch {
+      setImageError("画像の読み込みに失敗しました");
+    }
+    e.target.value = "";
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !examinationType.trim() || !examinedAt) return;
+    if (isSubmitting) return;
+
+    setSubmitError("");
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        memberId,
+        examinationType: examinationType.trim(),
+        examinedAt: new Date(examinedAt).toISOString(),
+        nextScheduledDate: nextScheduledDate ? new Date(nextScheduledDate).toISOString() : undefined,
+        notes: notes.trim() || undefined,
+        imageData: imageData ?? undefined,
+      });
+
+      if (!initialData) {
+        setExaminationType("");
+        setExaminedAt(todayInput());
+        setNextScheduledDate("");
+        setNotes("");
+        setImageData(null);
+      }
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "登録に失敗しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="exam-member" className="block text-sm font-medium text-ink-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="exam-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="exam-type" className="block text-sm font-medium text-ink-700 mb-1">
+          検査の種類
+        </label>
+        <input
+          id="exam-type"
+          type="text"
+          value={examinationType}
+          onChange={(e) => setExaminationType(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="例: 健康診断、血液検査、耐性検査"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="exam-date" className="block text-sm font-medium text-ink-700 mb-1">
+          検査日
+        </label>
+        <input
+          id="exam-date"
+          type="date"
+          value={examinedAt}
+          onChange={(e) => setExaminedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label htmlFor="exam-next" className="block text-sm font-medium text-ink-700 mb-1">
+          次回検査日（任意）
+        </label>
+        <input
+          id="exam-next"
+          type="date"
+          value={nextScheduledDate}
+          onChange={(e) => setNextScheduledDate(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="exam-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="exam-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="例: 耐性あり ベンジルペニシリン / 異常なし"
+        />
+      </div>
+
+      <div>
+        <span className="block text-sm font-medium text-ink-700 mb-1">検査結果の画像（任意）</span>
+        {imageData ? (
+          <div className="relative">
+            <img
+              src={imageData}
+              alt="検査結果"
+              className="w-full rounded-lg border border-primary-100 max-h-52 object-contain bg-primary-50"
+            />
+            <button
+              type="button"
+              onClick={() => setImageData(null)}
+              className="absolute top-1.5 right-1.5 bg-white rounded-full p-0.5 text-ink-500 hover:text-red-500 shadow transition-colors"
+              aria-label="画像を削除"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        ) : (
+          <label className="flex items-center justify-center gap-2 w-full py-3 border-2 border-dashed border-primary-200 rounded-lg cursor-pointer hover:border-primary-400 transition-colors text-sm text-ink-500">
+            <ImagePlus size={16} className="text-ink-400" />
+            <span>画像を追加</span>
+            <input type="file" accept="image/*" className="sr-only" onChange={handleImageChange} />
+          </label>
+        )}
+        {imageError && <p className="text-xs text-red-500 mt-1">{imageError}</p>}
+      </div>
+
+      {submitError && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">{submitError}</p>
+      )}
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {isSubmitting ? "送信中..." : initialData ? "更新する" : "登録する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="flex-1 bg-primary-50 text-ink-700 py-2 px-4 rounded-lg hover:bg-primary-100 transition-colors font-medium disabled:opacity-60"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/examinations/ExaminationList.tsx
+++ b/frontend/app/components/examinations/ExaminationList.tsx
@@ -1,0 +1,316 @@
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X, Calendar, ImagePlus } from "lucide-react";
+import type { Examination } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+export type ExaminationWithMember = Examination & { memberName?: string };
+
+export interface UpdateExaminationInput {
+  examinationType?: string;
+  examinedAt?: string;
+  nextScheduledDate?: string | null;
+  notes?: string | null;
+  imageData?: string | null;
+}
+
+const formatDateJP = (value: string): string =>
+  new Date(value).toLocaleDateString("ja-JP", { year: "numeric", month: "long", day: "numeric" });
+
+const toDateInput = (value: string | null | undefined): string => {
+  if (!value) return "";
+  return new Date(value).toISOString().split("T")[0];
+};
+
+interface ExaminationListProps {
+  examinations: ExaminationWithMember[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateExaminationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const ExaminationList: React.FC<ExaminationListProps> = ({ examinations, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (examinations.length === 0) {
+    return <EmptyStatePrompt message="検査記録がありません" subMessage="上の＋ボタンから記録を追加できます" />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {examinations.map((examination) => (
+        <ExaminationCard key={examination.id} examination={examination} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+async function compressImage(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = reject;
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onerror = reject;
+      img.onload = () => {
+        const MAX_DIM = 1200;
+        let { width, height } = img;
+        if (width > MAX_DIM || height > MAX_DIM) {
+          if (width >= height) {
+            height = Math.round((height / width) * MAX_DIM);
+            width = MAX_DIM;
+          } else {
+            width = Math.round((width / height) * MAX_DIM);
+            height = MAX_DIM;
+          }
+        }
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          reject(new Error("Canvas not available"));
+          return;
+        }
+        ctx.drawImage(img, 0, 0, width, height);
+        resolve(canvas.toDataURL("image/jpeg", 0.82));
+      };
+      img.src = e.target?.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+interface ExaminationCardProps {
+  examination: ExaminationWithMember;
+  onUpdate: (id: string, input: UpdateExaminationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const ExaminationCard: React.FC<ExaminationCardProps> = React.memo(({ examination, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [showFullImage, setShowFullImage] = useState(false);
+  const [editType, setEditType] = useState(examination.examinationType);
+  const [editDate, setEditDate] = useState(toDateInput(examination.examinedAt));
+  const [editNextDate, setEditNextDate] = useState(toDateInput(examination.nextScheduledDate));
+  const [editNotes, setEditNotes] = useState(examination.notes || "");
+  const [editImageData, setEditImageData] = useState<string | null>(examination.imageData ?? null);
+  const [editImageError, setEditImageError] = useState("");
+
+  const handleEditImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      setEditImageError("10MB以下の画像を選択してください");
+      return;
+    }
+    setEditImageError("");
+    try {
+      const compressed = await compressImage(file);
+      if (compressed.length > 1_500_000) {
+        setEditImageError("画像を圧縮できませんでした。より小さい画像を選択してください");
+        return;
+      }
+      setEditImageData(compressed);
+    } catch {
+      setEditImageError("画像の読み込みに失敗しました");
+    }
+    e.target.value = "";
+  };
+
+  const handleSave = async () => {
+    if (!editType.trim() || !editDate) return;
+    await onUpdate(examination.id, {
+      examinationType: editType.trim(),
+      examinedAt: new Date(editDate).toISOString(),
+      nextScheduledDate: editNextDate ? new Date(editNextDate).toISOString() : null,
+      notes: editNotes.trim() || null,
+      imageData: editImageData,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditType(examination.examinationType);
+    setEditDate(toDateInput(examination.examinedAt));
+    setEditNextDate(toDateInput(examination.nextScheduledDate));
+    setEditNotes(examination.notes || "");
+    setEditImageData(examination.imageData ?? null);
+    setEditImageError("");
+    setIsEditing(false);
+  };
+
+  const nextDate = examination.nextScheduledDate ? new Date(examination.nextScheduledDate) : null;
+  const isNextDateUpcoming = nextDate && nextDate > new Date();
+  const isNextDatePast = nextDate && nextDate <= new Date();
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200 space-y-3">
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">検査の種類</label>
+          <input
+            type="text"
+            value={editType}
+            onChange={(e) => setEditType(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">検査日</label>
+          <input
+            type="date"
+            value={editDate}
+            onChange={(e) => setEditDate(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">次回検査日</label>
+          <input
+            type="date"
+            value={editNextDate}
+            onChange={(e) => setEditNextDate(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+          />
+        </div>
+        <div>
+          <span className="block text-xs text-ink-500 mb-1">検査結果の画像</span>
+          {editImageData ? (
+            <div className="relative">
+              <img
+                src={editImageData}
+                alt="検査結果"
+                className="w-full rounded border border-primary-100 max-h-40 object-contain bg-primary-50"
+              />
+              <button
+                type="button"
+                onClick={() => setEditImageData(null)}
+                className="absolute top-1 right-1 bg-white rounded-full p-0.5 text-ink-500 hover:text-red-500 shadow"
+                aria-label="画像を削除"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          ) : (
+            <label className="flex items-center gap-2 py-2 px-3 border border-dashed border-primary-200 rounded cursor-pointer hover:border-primary-400 text-xs text-ink-500">
+              <ImagePlus size={14} className="text-ink-400" />
+              <span>画像を追加</span>
+              <input type="file" accept="image/*" className="sr-only" onChange={handleEditImageChange} />
+            </label>
+          )}
+          {editImageError && <p className="text-xs text-red-500 mt-1">{editImageError}</p>}
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editType.trim() || !editDate}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary text-white py-1.5 rounded-lg text-sm hover:bg-primary-dark transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-50 text-ink-700 py-1.5 rounded-lg text-sm hover:bg-primary-100 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2">
+            <p className="font-medium text-ink-800 text-sm">{examination.examinationType}</p>
+            {examination.memberName && (
+              <span className="text-xs bg-primary-50 text-ink-600 px-1.5 py-0.5 rounded">{examination.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-ink-500 mt-1 space-y-0.5">
+            <p className="flex items-center space-x-1">
+              <Calendar size={10} />
+              <span>検査日: {formatDateJP(examination.examinedAt)}</span>
+            </p>
+            {examination.nextScheduledDate && (
+              <p
+                className={`flex items-center space-x-1 ${
+                  isNextDatePast ? "text-red-500 font-medium" : isNextDateUpcoming ? "text-primary-500" : ""
+                }`}
+              >
+                <Calendar size={10} />
+                <span>次回予定: {formatDateJP(examination.nextScheduledDate)}</span>
+                {isNextDatePast && <span>(期限切れ)</span>}
+              </p>
+            )}
+            {examination.notes && <p className="text-ink-400 whitespace-pre-wrap">{examination.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+
+      {examination.imageData && (
+        <div className="mt-2">
+          <img
+            src={examination.imageData}
+            alt="検査結果画像"
+            className={`w-full rounded border border-primary-100 object-contain bg-primary-50 cursor-pointer transition-all ${
+              showFullImage ? "max-h-none" : "max-h-32"
+            }`}
+            onClick={() => setShowFullImage((v) => !v)}
+            title={showFullImage ? "タップで縮小" : "タップで拡大"}
+          />
+        </div>
+      )}
+
+      <ConfirmationDialog
+        title="検査記録の削除"
+        message={`「${examination.examinationType}」を削除しますか？この操作は取り消せません。`}
+        isOpen={isDeleteDialogOpen}
+        onConfirm={() => {
+          setIsDeleteDialogOpen(false);
+          onDelete(examination.id);
+        }}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        isDangerous
+      />
+    </div>
+  );
+});
+
+ExaminationCard.displayName = "ExaminationCard";

--- a/frontend/app/components/health-logs/HealthLogForm.tsx
+++ b/frontend/app/components/health-logs/HealthLogForm.tsx
@@ -1,0 +1,168 @@
+import React, { useState } from "react";
+import { X } from "lucide-react";
+import {
+  CONDITION_LEVELS,
+  SYMPTOM_OPTIONS,
+  getConditionColor,
+  getConditionLabel,
+  getSymptomLabel,
+  type ConditionLevel,
+  type SymptomType,
+} from "@/hooks/health-logs";
+
+interface HealthLogFormProps {
+  members: { id: string; name: string }[];
+  onSubmit: (input: {
+    memberId: string;
+    conditionLevel: number;
+    symptoms?: string[];
+    notes?: string;
+  }) => Promise<void>;
+  onCancel: () => void;
+}
+
+export const HealthLogForm: React.FC<HealthLogFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+}) => {
+  const [memberId, setMemberId] = useState(members[0]?.id ?? "");
+  const [conditionLevel, setConditionLevel] = useState<ConditionLevel>(3);
+  const [selectedSymptoms, setSelectedSymptoms] = useState<SymptomType[]>([]);
+  const [notes, setNotes] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const toggleSymptom = (symptom: SymptomType) => {
+    setSelectedSymptoms((prev) =>
+      prev.includes(symptom)
+        ? prev.filter((s) => s !== symptom)
+        : [...prev, symptom],
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId) return;
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        memberId,
+        conditionLevel,
+        symptoms: selectedSymptoms.length > 0 ? selectedSymptoms : undefined,
+        notes: notes.trim() || undefined,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white rounded-2xl shadow-sm p-4 border border-primary-100"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-ink-800">体調を記録</h3>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-ink-400 hover:text-ink-600"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-ink-700 mb-1">
+            メンバー
+          </label>
+          <select
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm outline-none focus:border-primary"
+          >
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-ink-700 mb-2">
+            体調レベル
+          </label>
+          <div className="flex justify-between">
+            {CONDITION_LEVELS.map((level) => (
+              <button
+                key={level}
+                type="button"
+                onClick={() => setConditionLevel(level)}
+                className={`flex flex-col items-center px-3 py-2 rounded-xl border transition-colors ${
+                  conditionLevel === level
+                    ? "border-primary-500 bg-primary-50"
+                    : "border-primary-100 hover:border-primary-300"
+                }`}
+              >
+                <span
+                  className={`text-lg font-bold ${getConditionColor(level)}`}
+                >
+                  {level}
+                </span>
+                <span className="text-xs text-ink-500 mt-0.5">
+                  {getConditionLabel(level)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-ink-700 mb-2">
+            症状（複数選択可）
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {SYMPTOM_OPTIONS.map((symptom) => (
+              <button
+                key={symptom}
+                type="button"
+                onClick={() => toggleSymptom(symptom)}
+                className={`px-3 py-1 text-sm rounded-full border transition-colors ${
+                  selectedSymptoms.includes(symptom)
+                    ? "border-primary-500 bg-primary-50 text-primary-700"
+                    : "border-primary-100 text-ink-600 hover:border-primary-300"
+                }`}
+              >
+                {getSymptomLabel(symptom)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-ink-700 mb-1">
+            メモ（任意）
+          </label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="体調に関するメモ..."
+            className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm resize-none outline-none focus:border-primary"
+            rows={3}
+            maxLength={500}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting || !memberId}
+          className="w-full py-2 bg-primary text-white rounded-xl font-medium hover:bg-primary-dark disabled:opacity-50 transition-colors"
+        >
+          {isSubmitting ? "記録中..." : "記録する"}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/health-logs/HealthLogList.tsx
+++ b/frontend/app/components/health-logs/HealthLogList.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { User, Trash2 } from "lucide-react";
+import {
+  formatDate,
+  getConditionColor,
+  getConditionLabel,
+  getSymptomLabel,
+  type DailyHealthLogGroup,
+} from "@/hooks/health-logs";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+
+interface HealthLogListProps {
+  groups: DailyHealthLogGroup[];
+  isLoading: boolean;
+  onDelete?: (logId: string) => void;
+}
+
+export const HealthLogList: React.FC<HealthLogListProps> = ({
+  groups,
+  isLoading,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (groups.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="体調記録がありません"
+        subMessage="上のボタンから記録を追加してください"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <div key={group.date}>
+          <h3 className="text-sm font-semibold text-ink-600 mb-2 px-1">
+            {formatDate(group.date)}
+          </h3>
+          <div className="space-y-2">
+            {group.logs.map((log) => (
+              <div
+                key={log.id}
+                className="bg-white rounded-2xl shadow-sm p-3 border border-primary-100"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-3 flex-1 min-w-0">
+                    <div className="flex-shrink-0">
+                      <span
+                        className={`text-xl font-bold ${getConditionColor(log.conditionLevel)}`}
+                      >
+                        {log.conditionLevel}
+                      </span>
+                    </div>
+                    <div className="min-w-0">
+                      <p className="font-medium text-ink-800">
+                        {getConditionLabel(log.conditionLevel)}
+                      </p>
+                      <div className="flex items-center space-x-1 text-xs text-ink-500 mt-0.5">
+                        <User size={12} />
+                        <span>{log.memberName}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-2 flex-shrink-0 ml-2">
+                    <span className="text-sm text-ink-500">
+                      {log.recordedAt.getHours().toString().padStart(2, "0")}:
+                      {log.recordedAt.getMinutes().toString().padStart(2, "0")}
+                    </span>
+                    {onDelete && (
+                      <button
+                        onClick={() => onDelete(log.id)}
+                        className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+                        aria-label="削除"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {log.symptoms.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-2 pl-8">
+                    {log.symptoms.map((symptom) => (
+                      <span
+                        key={symptom}
+                        className="px-2 py-0.5 text-xs bg-primary-50 text-ink-600 rounded-full"
+                      >
+                        {getSymptomLabel(symptom)}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {log.notes && (
+                  <p className="text-xs text-ink-400 mt-1 pl-8">{log.notes}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/frontend/app/components/health-logs/HealthWeeklyTrend.tsx
+++ b/frontend/app/components/health-logs/HealthWeeklyTrend.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Activity } from "lucide-react";
+import type { DailyAverage } from "@/hooks/health-logs";
+
+interface HealthWeeklyTrendProps {
+  averages: DailyAverage[];
+}
+
+const BAR_COLORS: Record<number, string> = {
+  1: "bg-red-400",
+  2: "bg-orange-400",
+  3: "bg-yellow-400",
+  4: "bg-green-400",
+  5: "bg-green-500",
+};
+
+export const HealthWeeklyTrend: React.FC<HealthWeeklyTrendProps> = React.memo(
+  ({ averages }) => {
+    if (averages.length === 0) return null;
+
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-4 border border-primary-100 mb-4">
+        <div className="flex items-center space-x-2 mb-3">
+          <Activity size={16} className="text-primary-600" />
+          <h3 className="text-sm font-semibold text-ink-700">週間体調トレンド</h3>
+        </div>
+
+        <div
+          className="flex items-end justify-between space-x-1"
+          style={{ height: "80px" }}
+        >
+          {averages.map((day) => (
+            <div key={day.date} className="flex flex-col items-center flex-1">
+              <div
+                className="w-full flex flex-col items-center justify-end"
+                style={{ height: "60px" }}
+              >
+                {day.average !== null ? (
+                  <div
+                    className={`w-full max-w-[24px] rounded-t ${BAR_COLORS[day.average] ?? "bg-ink-200"}`}
+                    style={{ height: `${(day.average / 5) * 100}%` }}
+                  />
+                ) : (
+                  <div className="w-full max-w-[24px] h-1 bg-ink-100 rounded" />
+                )}
+              </div>
+              <span className="text-xs text-ink-400 mt-1">{day.dayLabel}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
+
+HealthWeeklyTrend.displayName = "HealthWeeklyTrend";

--- a/frontend/app/components/health-logs/SymptomFrequencySummary.tsx
+++ b/frontend/app/components/health-logs/SymptomFrequencySummary.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Thermometer } from "lucide-react";
+import { SYMPTOM_LABELS, type SymptomFrequency } from "@/hooks/health-logs";
+
+interface SymptomFrequencySummaryProps {
+  symptoms: SymptomFrequency[];
+}
+
+export const SymptomFrequencySummary: React.FC<SymptomFrequencySummaryProps> =
+  React.memo(({ symptoms }) => {
+    if (symptoms.length === 0) return null;
+
+    const maxCount = Math.max(...symptoms.map((s) => s.count));
+
+    return (
+      <div className="bg-white rounded-2xl shadow-sm p-4 border border-primary-100 mb-4">
+        <div className="flex items-center space-x-2 mb-3">
+          <Thermometer size={16} className="text-primary-600" />
+          <h3 className="text-sm font-semibold text-ink-700">
+            よく記録された症状
+          </h3>
+        </div>
+
+        <div className="space-y-2">
+          {symptoms.map((item) => (
+            <div key={item.symptom} className="flex items-center space-x-2">
+              <span className="text-xs text-ink-600 w-12 shrink-0">
+                {SYMPTOM_LABELS[item.symptom]}
+              </span>
+              <div className="flex-1 bg-primary-50 rounded-full h-4">
+                <div
+                  data-testid="symptom-bar"
+                  className="bg-primary-400 rounded-full h-4"
+                  style={{ width: `${(item.count / maxCount) * 100}%` }}
+                />
+              </div>
+              <span className="text-xs text-ink-500 w-8 text-right shrink-0">
+                {item.count}回
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  });
+
+SymptomFrequencySummary.displayName = "SymptomFrequencySummary";

--- a/frontend/app/components/history/AddPastRecordForm.tsx
+++ b/frontend/app/components/history/AddPastRecordForm.tsx
@@ -1,0 +1,191 @@
+import React, { useState, useEffect } from "react";
+import { Plus, X } from "lucide-react";
+import type { CreateRecordInput } from "@/hooks/history";
+
+interface MedicationOption {
+  id: string;
+  name: string;
+  memberId: string;
+}
+
+interface MemberOption {
+  id: string;
+  name: string;
+}
+
+interface AddPastRecordFormProps {
+  selectedDate: string;
+  members: MemberOption[];
+  fetchMedicationsByMember: (memberId: string) => Promise<MedicationOption[]>;
+  onSubmit: (input: CreateRecordInput) => Promise<void>;
+  onClose: () => void;
+}
+
+export const AddPastRecordForm: React.FC<AddPastRecordFormProps> = ({
+  selectedDate,
+  members,
+  fetchMedicationsByMember,
+  onSubmit,
+  onClose,
+}) => {
+  const [selectedMemberId, setSelectedMemberId] = useState("");
+  const [selectedMedicationIds, setSelectedMedicationIds] = useState<string[]>([]);
+  const [notes, setNotes] = useState("");
+  const [medications, setMedications] = useState<MedicationOption[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedMemberId) {
+      setMedications([]);
+      setSelectedMedicationIds([]);
+      return;
+    }
+    fetchMedicationsByMember(selectedMemberId)
+      .then((data) => {
+        setMedications(data);
+        setSelectedMedicationIds([]);
+      })
+      .catch(() => {
+        setMedications([]);
+      });
+  }, [selectedMemberId, fetchMedicationsByMember]);
+
+  const toggleMedication = (medicationId: string) => {
+    setSelectedMedicationIds((prev) =>
+      prev.includes(medicationId) ? prev.filter((id) => id !== medicationId) : [...prev, medicationId],
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedMemberId || selectedMedicationIds.length === 0) return;
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const takenAt = new Date(`${selectedDate}T12:00:00`).toISOString();
+      const results = await Promise.allSettled(
+        selectedMedicationIds.map((medicationId) =>
+          onSubmit({
+            memberId: selectedMemberId,
+            medicationId,
+            takenAt,
+            notes: notes.trim() || undefined,
+          }),
+        ),
+      );
+      const failedCount = results.filter((r) => r.status === "rejected").length;
+      if (failedCount > 0) {
+        const successCount = results.length - failedCount;
+        if (successCount > 0) {
+          setError(`${successCount}件追加、${failedCount}件失敗しました`);
+        } else {
+          setError("記録の追加に失敗しました");
+        }
+        return;
+      }
+      onClose();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const formatDisplayDate = (dateKey: string) => {
+    const [y, m, d] = dateKey.split("-").map(Number);
+    return `${y}年${m}月${d}日`;
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-primary-100 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold text-ink-700">{formatDisplayDate(selectedDate)} の記録を追加</h4>
+        <button onClick={onClose} className="p-1 text-ink-400 hover:text-ink-600" aria-label="閉じる">
+          <X size={18} />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label htmlFor="past-record-member" className="block text-xs font-medium text-ink-600 mb-1">
+            メンバー
+          </label>
+          <select
+            id="past-record-member"
+            value={selectedMemberId}
+            onChange={(e) => setSelectedMemberId(e.target.value)}
+            className="w-full rounded-md border border-primary-200 px-3 py-2 text-sm"
+            required
+          >
+            <option value="">選択してください</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-ink-600 mb-1">お薬（複数選択可）</label>
+          {!selectedMemberId ? (
+            <p className="text-sm text-ink-400 py-2">メンバーを先に選択</p>
+          ) : medications.length === 0 ? (
+            <p className="text-sm text-ink-400 py-2">登録されたお薬がありません</p>
+          ) : (
+            <div className="space-y-1 max-h-40 overflow-y-auto rounded-md border border-primary-200 p-2">
+              {medications.map((med) => (
+                <label
+                  key={med.id}
+                  className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-sm cursor-pointer transition-colors ${
+                    selectedMedicationIds.includes(med.id) ? "bg-primary-50 text-primary-700" : "hover:bg-primary-50"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedMedicationIds.includes(med.id)}
+                    onChange={() => toggleMedication(med.id)}
+                    className="rounded border-primary-300 text-primary-600 focus:ring-primary-500"
+                  />
+                  {med.name}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="past-record-notes" className="block text-xs font-medium text-ink-600 mb-1">
+            メモ（任意）
+          </label>
+          <input
+            id="past-record-notes"
+            type="text"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            className="w-full rounded-md border border-primary-200 px-3 py-2 text-sm"
+            placeholder="メモを入力"
+            maxLength={500}
+          />
+        </div>
+
+        {error && <p className="text-xs text-red-600">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={isSubmitting || !selectedMemberId || selectedMedicationIds.length === 0}
+          className="w-full flex items-center justify-center space-x-1 bg-primary text-white rounded-md py-2 text-sm font-medium hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Plus size={16} />
+          <span>
+            {isSubmitting
+              ? "追加中..."
+              : selectedMedicationIds.length > 1
+                ? `${selectedMedicationIds.length}件の記録を追加`
+                : "記録を追加"}
+          </span>
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/frontend/app/components/history/MedicationCalendar.tsx
+++ b/frontend/app/components/history/MedicationCalendar.tsx
@@ -1,0 +1,209 @@
+import React, { useState, useMemo } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { HealthLog } from "@/lib/types";
+import { toDateKey, type EnrichedRecord } from "@/hooks/history";
+
+interface CalendarDay {
+  date: Date;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  recordCount: number;
+  averageCondition: number | null;
+}
+
+const WEEKDAY_HEADERS = ["日", "月", "火", "水", "木", "金", "土"];
+
+function isSameDay(a: Date, b: Date): boolean {
+  return toDateKey(a) === toDateKey(b);
+}
+
+/** 指定月のカレンダー（6週分）を生成 */
+function generateMonth(year: number, month: number, today: Date): CalendarDay[] {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const startOffset = firstDay.getDay();
+  const days: CalendarDay[] = [];
+
+  for (let i = startOffset - 1; i >= 0; i--) {
+    const date = new Date(year, month, -i);
+    days.push({ date, isCurrentMonth: false, isToday: isSameDay(date, today), recordCount: 0, averageCondition: null });
+  }
+  for (let d = 1; d <= lastDay.getDate(); d++) {
+    const date = new Date(year, month, d);
+    days.push({ date, isCurrentMonth: true, isToday: isSameDay(date, today), recordCount: 0, averageCondition: null });
+  }
+  const remaining = 42 - days.length;
+  for (let i = 1; i <= remaining; i++) {
+    const date = new Date(year, month + 1, i);
+    days.push({ date, isCurrentMonth: false, isToday: isSameDay(date, today), recordCount: 0, averageCondition: null });
+  }
+  return days;
+}
+
+function getMonthLabel(year: number, month: number): string {
+  return `${year}年${month + 1}月`;
+}
+
+function getRecordCountColor(count: number): string {
+  if (count === 0) return "";
+  if (count <= 2) return "bg-green-100";
+  if (count <= 5) return "bg-green-200";
+  return "bg-green-300";
+}
+
+interface MedicationCalendarProps {
+  records: EnrichedRecord[];
+  healthLogs: HealthLog[];
+  onSelectDate: (dateKey: string) => void;
+  selectedDate: string | null;
+}
+
+export const MedicationCalendar: React.FC<MedicationCalendarProps> = ({
+  records,
+  healthLogs,
+  onSelectDate,
+  selectedDate,
+}) => {
+  const today = useMemo(() => new Date(), []);
+  const [year, setYear] = useState(() => new Date().getFullYear());
+  const [month, setMonth] = useState(() => new Date().getMonth());
+
+  const days = useMemo(() => {
+    const baseDays = generateMonth(year, month, today);
+
+    const recordCounts = new Map<string, number>();
+    for (const record of records) {
+      const key = toDateKey(record.takenAt);
+      recordCounts.set(key, (recordCounts.get(key) || 0) + 1);
+    }
+
+    const conditionMap = new Map<string, number[]>();
+    for (const log of healthLogs) {
+      const key = toDateKey(new Date(log.recordedAt));
+      if (!conditionMap.has(key)) conditionMap.set(key, []);
+      conditionMap.get(key)!.push(log.conditionLevel);
+    }
+
+    return baseDays.map((day) => {
+      const key = toDateKey(day.date);
+      const conditions = conditionMap.get(key);
+      return {
+        ...day,
+        recordCount: recordCounts.get(key) || 0,
+        averageCondition: conditions
+          ? Math.round((conditions.reduce((a, b) => a + b, 0) / conditions.length) * 10) / 10
+          : null,
+      };
+    });
+  }, [year, month, records, healthLogs, today]);
+
+  const handlePrevMonth = () => {
+    if (month === 0) {
+      setYear((y) => y - 1);
+      setMonth(11);
+    } else {
+      setMonth((m) => m - 1);
+    }
+  };
+
+  const handleNextMonth = () => {
+    if (month === 11) {
+      setYear((y) => y + 1);
+      setMonth(0);
+    } else {
+      setMonth((m) => m + 1);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-primary-100 p-4">
+      <div className="flex items-center justify-between mb-4">
+        <button
+          onClick={handlePrevMonth}
+          className="p-1 text-ink-500 hover:text-ink-700 transition-colors"
+          aria-label="前月"
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <h3 className="text-base font-semibold text-ink-800">{getMonthLabel(year, month)}</h3>
+        <button
+          onClick={handleNextMonth}
+          className="p-1 text-ink-500 hover:text-ink-700 transition-colors"
+          aria-label="翌月"
+        >
+          <ChevronRight size={20} />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-7 gap-0.5 mb-1">
+        {WEEKDAY_HEADERS.map((day, i) => (
+          <div
+            key={day}
+            className={`text-center text-xs font-medium py-1 ${
+              i === 0 ? "text-red-400" : i === 6 ? "text-blue-400" : "text-ink-500"
+            }`}
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-0.5">
+        {days.map((day, index) => (
+          <CalendarDayCell
+            key={index}
+            day={day}
+            isSelected={selectedDate === toDateKey(day.date)}
+            onClick={() => onSelectDate(toDateKey(day.date))}
+          />
+        ))}
+      </div>
+
+      <div className="flex items-center justify-center space-x-4 mt-3 text-xs text-ink-500">
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-sm bg-green-100" />
+          <span>1-2件</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-sm bg-green-200" />
+          <span>3-5件</span>
+        </div>
+        <div className="flex items-center space-x-1">
+          <div className="w-3 h-3 rounded-sm bg-green-300" />
+          <span>6件+</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface CalendarDayCellProps {
+  day: CalendarDay;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+const CalendarDayCell: React.FC<CalendarDayCellProps> = ({ day, isSelected, onClick }) => {
+  const bgColor = getRecordCountColor(day.recordCount);
+  const dayOfWeek = day.date.getDay();
+
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        relative aspect-square flex flex-col items-center justify-center
+        text-sm rounded-md transition-colors
+        ${day.isCurrentMonth ? "text-ink-800" : "text-ink-300"}
+        ${day.isToday ? "ring-2 ring-primary-500" : ""}
+        ${isSelected ? "bg-primary-100 ring-2 ring-primary-600" : bgColor || "hover:bg-primary-50"}
+        ${dayOfWeek === 0 && day.isCurrentMonth ? "text-red-500" : ""}
+        ${dayOfWeek === 6 && day.isCurrentMonth ? "text-blue-500" : ""}
+      `}
+    >
+      <span className="leading-none">{day.date.getDate()}</span>
+      {day.recordCount > 0 && day.isCurrentMonth && (
+        <span className="text-[10px] text-ink-500 leading-none mt-0.5">{day.recordCount}</span>
+      )}
+    </button>
+  );
+};

--- a/frontend/app/components/history/MedicationHistoryList.tsx
+++ b/frontend/app/components/history/MedicationHistoryList.tsx
@@ -1,0 +1,189 @@
+import React, { useMemo, useState } from "react";
+import { Clock, Pill, User, Trash2, Pencil, Check, X } from "lucide-react";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import type { DailyRecordGroup, EnrichedRecord } from "@/hooks/history";
+import { formatRecordDate, formatRecordTime } from "@/hooks/history";
+
+interface MemberRecordGroup {
+  memberId: string;
+  memberName: string;
+  records: EnrichedRecord[];
+}
+
+function groupByMember(records: EnrichedRecord[]): MemberRecordGroup[] {
+  const map = new Map<string, MemberRecordGroup>();
+  for (const record of records) {
+    let group = map.get(record.memberId);
+    if (!group) {
+      group = { memberId: record.memberId, memberName: record.memberName, records: [] };
+      map.set(record.memberId, group);
+    }
+    group.records.push(record);
+  }
+  return Array.from(map.values());
+}
+
+interface MedicationHistoryListProps {
+  groups: DailyRecordGroup[];
+  isLoading: boolean;
+  onDelete?: (recordId: string) => void;
+  onUpdateNotes?: (recordId: string, notes: string | null) => Promise<void>;
+}
+
+export const MedicationHistoryList: React.FC<MedicationHistoryListProps> = ({
+  groups,
+  isLoading,
+  onDelete,
+  onUpdateNotes,
+}) => {
+  const groupedByMember = useMemo(() => {
+    return groups.map((group) => ({
+      date: group.date,
+      memberGroups: groupByMember(group.records),
+    }));
+  }, [groups]);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (groups.length === 0) {
+    return <EmptyStatePrompt message="服薬履歴がありません" subMessage="服薬を記録すると履歴が表示されます" />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {groupedByMember.map((dayGroup) => (
+        <div key={dayGroup.date}>
+          <h3 className="text-sm font-semibold text-ink-600 mb-2 px-1">{formatRecordDate(dayGroup.date)}</h3>
+          <div className="space-y-4">
+            {dayGroup.memberGroups.map((memberGroup) => (
+              <div key={memberGroup.memberId}>
+                <div className="flex items-center space-x-1.5 mb-1.5 px-1">
+                  <User size={14} className="text-ink-400" />
+                  <span className="text-xs font-medium text-ink-500">{memberGroup.memberName}</span>
+                </div>
+                <div className="space-y-2">
+                  {memberGroup.records.map((record) => (
+                    <RecordCard key={record.id} record={record} onDelete={onDelete} onUpdateNotes={onUpdateNotes} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+interface RecordCardProps {
+  record: EnrichedRecord;
+  onDelete?: (recordId: string) => void;
+  onUpdateNotes?: (recordId: string, notes: string | null) => Promise<void>;
+}
+
+const RecordCard: React.FC<RecordCardProps> = ({ record, onDelete, onUpdateNotes }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editNotes, setEditNotes] = useState(record.notes || "");
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const handleStartEdit = () => {
+    setEditNotes(record.notes || "");
+    setSaveError(null);
+    setIsEditing(true);
+  };
+
+  const handleSave = async () => {
+    if (!onUpdateNotes) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await onUpdateNotes(record.id, editNotes.trim() || null);
+      setIsEditing(false);
+    } catch {
+      setSaveError("保存に失敗しました");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3 flex-1 min-w-0">
+          <div className="flex-shrink-0">
+            <Pill size={18} className="text-primary-600" />
+          </div>
+          <div className="min-w-0">
+            <p className="font-medium text-ink-800 truncate">{record.medicationName}</p>
+            {record.dosageAmount && <p className="text-xs text-ink-500 mt-0.5">{record.dosageAmount}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-2 flex-shrink-0 ml-2">
+          <div className="flex items-center space-x-1 text-sm text-ink-500">
+            <Clock size={14} />
+            <span>{formatRecordTime(record.takenAt)}</span>
+          </div>
+          {onDelete && (
+            <button
+              onClick={() => onDelete(record.id)}
+              className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+              aria-label="削除"
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+      {isEditing ? (
+        <div className="mt-2 pl-8">
+          <div className="flex items-center gap-1.5">
+            <input
+              type="text"
+              value={editNotes}
+              onChange={(e) => setEditNotes(e.target.value)}
+              className="flex-1 rounded border border-primary-200 px-2 py-1 text-xs"
+              placeholder="メモを入力"
+              maxLength={500}
+              autoFocus
+              disabled={isSaving}
+            />
+            <button
+              onClick={handleSave}
+              disabled={isSaving}
+              className="p-1 text-green-600 hover:text-green-700 disabled:opacity-50"
+              aria-label="保存"
+            >
+              <Check size={14} />
+            </button>
+            <button
+              onClick={() => setIsEditing(false)}
+              disabled={isSaving}
+              className="p-1 text-ink-400 hover:text-ink-600 disabled:opacity-50"
+              aria-label="キャンセル"
+            >
+              <X size={14} />
+            </button>
+          </div>
+          {saveError && <p className="text-xs text-red-500 mt-1">{saveError}</p>}
+        </div>
+      ) : (
+        <div className="mt-1 pl-8 flex items-center gap-1">
+          {record.notes ? <p className="text-xs text-ink-400">{record.notes}</p> : null}
+          {onUpdateNotes && (
+            <button
+              onClick={handleStartEdit}
+              className="p-0.5 text-ink-300 hover:text-ink-500 transition-colors"
+              aria-label="メモを編集"
+            >
+              <Pencil size={12} />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/app/components/hospitals/HospitalForm.tsx
+++ b/frontend/app/components/hospitals/HospitalForm.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from "react";
+
+export interface HospitalFormData {
+  name: string;
+  address?: string;
+  phone?: string;
+  department?: string;
+  doctorName?: string;
+  notes?: string;
+}
+
+interface HospitalFormProps {
+  onSubmit: (data: HospitalFormData) => void;
+}
+
+export const HospitalForm: React.FC<HospitalFormProps> = ({ onSubmit }) => {
+  const [name, setName] = useState("");
+  const [address, setAddress] = useState("");
+  const [phone, setPhone] = useState("");
+  const [department, setDepartment] = useState("");
+  const [doctorName, setDoctorName] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    onSubmit({
+      name: name.trim(),
+      address: address.trim() || undefined,
+      phone: phone.trim() || undefined,
+      department: department.trim() || undefined,
+      doctorName: doctorName.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    setName("");
+    setAddress("");
+    setPhone("");
+    setDepartment("");
+    setDoctorName("");
+    setNotes("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="hosp-name" className="block text-sm font-medium text-ink-700 mb-1">
+          病院名
+        </label>
+        <input
+          id="hosp-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="病院名を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="hosp-address" className="block text-sm font-medium text-ink-700 mb-1">
+          住所（任意）
+        </label>
+        <input
+          id="hosp-address"
+          type="text"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="住所を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="hosp-phone" className="block text-sm font-medium text-ink-700 mb-1">
+          電話番号（任意）
+        </label>
+        <input
+          id="hosp-phone"
+          type="tel"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="電話番号を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="hosp-department" className="block text-sm font-medium text-ink-700 mb-1">
+          診療科（任意）
+        </label>
+        <input
+          id="hosp-department"
+          type="text"
+          value={department}
+          onChange={(e) => setDepartment(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="例: 内科、外科、小児科"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="hosp-doctorName" className="block text-sm font-medium text-ink-700 mb-1">
+          担当医（任意）
+        </label>
+        <input
+          id="hosp-doctorName"
+          type="text"
+          value={doctorName}
+          onChange={(e) => setDoctorName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="担当医の名前を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="hosp-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="hosp-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="メモを入力"
+        />
+      </div>
+
+      <button
+        type="submit"
+        className="w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium"
+      >
+        追加する
+      </button>
+    </form>
+  );
+};

--- a/frontend/app/components/hospitals/HospitalList.tsx
+++ b/frontend/app/components/hospitals/HospitalList.tsx
@@ -1,0 +1,230 @@
+import React, { useState } from "react";
+import { Check, MapPin, Pencil, Phone, Trash2, X } from "lucide-react";
+import type { Hospital } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+export interface UpdateHospitalInput {
+  name?: string;
+  address?: string;
+  phone?: string;
+  department?: string;
+  doctorName?: string;
+  notes?: string;
+}
+
+interface HospitalListProps {
+  hospitals: Hospital[];
+  isLoading: boolean;
+  onUpdate: (hospitalId: string, input: UpdateHospitalInput) => Promise<void>;
+  onDelete: (hospitalId: string) => void;
+}
+
+export const HospitalList: React.FC<HospitalListProps> = ({
+  hospitals,
+  isLoading,
+  onUpdate,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (hospitals.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="病院が登録されていません"
+        subMessage="上のフォームから病院を追加してください"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {hospitals.map((hospital) => (
+        <HospitalCard key={hospital.id} hospital={hospital} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface HospitalCardProps {
+  hospital: Hospital;
+  onUpdate: (hospitalId: string, input: UpdateHospitalInput) => Promise<void>;
+  onDelete: (hospitalId: string) => void;
+}
+
+const HospitalCard: React.FC<HospitalCardProps> = React.memo(({ hospital, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editName, setEditName] = useState(hospital.name);
+  const [editAddress, setEditAddress] = useState(hospital.address || "");
+  const [editPhone, setEditPhone] = useState(hospital.phoneNumber || "");
+  const [editDepartment, setEditDepartment] = useState(hospital.department || "");
+  const [editDoctorName, setEditDoctorName] = useState(hospital.doctorName || "");
+  const [editNotes, setEditNotes] = useState(hospital.notes || "");
+
+  const handleSave = async () => {
+    if (!editName.trim()) return;
+    await onUpdate(hospital.id, {
+      name: editName.trim(),
+      address: editAddress.trim() || undefined,
+      phone: editPhone.trim() || undefined,
+      department: editDepartment.trim() || undefined,
+      doctorName: editDoctorName.trim() || undefined,
+      notes: editNotes.trim() || undefined,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(hospital.name);
+    setEditAddress(hospital.address || "");
+    setEditPhone(hospital.phoneNumber || "");
+    setEditDepartment(hospital.department || "");
+    setEditDoctorName(hospital.doctorName || "");
+    setEditNotes(hospital.notes || "");
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200 space-y-3">
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">病院名</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">住所</label>
+          <input
+            type="text"
+            value={editAddress}
+            onChange={(e) => setEditAddress(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            placeholder="住所を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">電話番号</label>
+          <input
+            type="tel"
+            value={editPhone}
+            onChange={(e) => setEditPhone(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            placeholder="電話番号を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">診療科</label>
+          <input
+            type="text"
+            value={editDepartment}
+            onChange={(e) => setEditDepartment(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            placeholder="例: 内科、外科、小児科"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">担当医</label>
+          <input
+            type="text"
+            value={editDoctorName}
+            onChange={(e) => setEditDoctorName(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            placeholder="担当医の名前を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+            placeholder="メモを入力"
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim()}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-600 text-white py-1.5 rounded-lg text-sm hover:bg-primary-700 transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-100 text-ink-700 py-1.5 rounded-lg text-sm hover:bg-primary-200 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-start justify-between">
+        <div className="flex items-start space-x-3 flex-1 min-w-0">
+          <div className="flex-shrink-0 mt-0.5">
+            <MapPin size={18} className="text-primary-600" />
+          </div>
+          <div className="min-w-0">
+            <p className="font-medium text-ink-800 text-sm">{hospital.name}</p>
+            <div className="text-xs text-ink-500 mt-1 space-y-0.5">
+              {hospital.address && <p>{hospital.address}</p>}
+              {hospital.phoneNumber && (
+                <p className="flex items-center space-x-1">
+                  <Phone size={10} />
+                  <span>{hospital.phoneNumber}</span>
+                </p>
+              )}
+              {hospital.department && <p>{hospital.department}</p>}
+              {hospital.doctorName && <p>担当医: {hospital.doctorName}</p>}
+              {hospital.notes && <p className="text-ink-400">{hospital.notes}</p>}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <ConfirmationDialog
+        title="病院の削除"
+        message={`「${hospital.name}」を削除しますか？この操作は取り消せません。`}
+        isOpen={isDeleteDialogOpen}
+        onConfirm={() => {
+          setIsDeleteDialogOpen(false);
+          onDelete(hospital.id);
+        }}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        isDangerous
+      />
+    </div>
+  );
+});
+
+HospitalCard.displayName = "HospitalCard";

--- a/frontend/app/components/insurances/InsuranceForm.tsx
+++ b/frontend/app/components/insurances/InsuranceForm.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from "react";
+import type { Member } from "@/lib/types";
+
+export interface InsuranceFormData {
+  memberId: string;
+  insuranceType: string;
+  providerName?: string;
+  policyNumber?: string;
+  notes?: string;
+}
+
+interface InsuranceFormProps {
+  members: Member[];
+  onSubmit: (data: InsuranceFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    insuranceType: string;
+    providerName?: string;
+    policyNumber?: string;
+    notes?: string;
+  };
+}
+
+export const InsuranceForm: React.FC<InsuranceFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
+  const [insuranceType, setInsuranceType] = useState(initialData?.insuranceType || "");
+  const [providerName, setProviderName] = useState(initialData?.providerName || "");
+  const [policyNumber, setPolicyNumber] = useState(initialData?.policyNumber || "");
+  const [notes, setNotes] = useState(initialData?.notes || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !insuranceType.trim()) return;
+
+    onSubmit({
+      memberId,
+      insuranceType: insuranceType.trim(),
+      providerName: providerName.trim() || undefined,
+      policyNumber: policyNumber.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setInsuranceType("");
+      setProviderName("");
+      setPolicyNumber("");
+      setNotes("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="ins-member" className="block text-sm font-medium text-ink-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="ins-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="ins-type" className="block text-sm font-medium text-ink-700 mb-1">
+          保険の種類
+        </label>
+        <input
+          id="ins-type"
+          type="text"
+          value={insuranceType}
+          onChange={(e) => setInsuranceType(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="例: ガン保険、生命保険、医療保険"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ins-provider" className="block text-sm font-medium text-ink-700 mb-1">
+          保険会社名（任意）
+        </label>
+        <input
+          id="ins-provider"
+          type="text"
+          value={providerName}
+          onChange={(e) => setProviderName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="保険会社名を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ins-policy" className="block text-sm font-medium text-ink-700 mb-1">
+          証券番号（任意）
+        </label>
+        <input
+          id="ins-policy"
+          type="text"
+          value={policyNumber}
+          onChange={(e) => setPolicyNumber(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="証券番号を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="ins-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="ins-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="メモを入力"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
+        >
+          {initialData ? "更新する" : "登録する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-primary-50 text-ink-700 py-2 px-4 rounded-lg hover:bg-primary-100 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/insurances/InsuranceList.tsx
+++ b/frontend/app/components/insurances/InsuranceList.tsx
@@ -1,0 +1,186 @@
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X } from "lucide-react";
+import type { Insurance } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+export type InsuranceWithMember = Insurance & { memberName?: string };
+
+export interface UpdateInsuranceInput {
+  insuranceType?: string;
+  providerName?: string | null;
+  policyNumber?: string | null;
+  notes?: string | null;
+}
+
+interface InsuranceListProps {
+  insurances: InsuranceWithMember[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateInsuranceInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const InsuranceList: React.FC<InsuranceListProps> = ({ insurances, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (insurances.length === 0) {
+    return <EmptyStatePrompt message="保険が登録されていません" subMessage="上の＋ボタンから保険情報を追加できます" />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {insurances.map((insurance) => (
+        <InsuranceCard key={insurance.id} insurance={insurance} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface InsuranceCardProps {
+  insurance: InsuranceWithMember;
+  onUpdate: (id: string, input: UpdateInsuranceInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const InsuranceCard: React.FC<InsuranceCardProps> = React.memo(({ insurance, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editType, setEditType] = useState(insurance.insuranceType);
+  const [editProvider, setEditProvider] = useState(insurance.providerName || "");
+  const [editPolicy, setEditPolicy] = useState(insurance.policyNumber || "");
+  const [editNotes, setEditNotes] = useState(insurance.notes || "");
+
+  const handleSave = async () => {
+    if (!editType.trim()) return;
+    await onUpdate(insurance.id, {
+      insuranceType: editType.trim(),
+      providerName: editProvider.trim() || null,
+      policyNumber: editPolicy.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditType(insurance.insuranceType);
+    setEditProvider(insurance.providerName || "");
+    setEditPolicy(insurance.policyNumber || "");
+    setEditNotes(insurance.notes || "");
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200 space-y-3">
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">保険の種類</label>
+          <input
+            type="text"
+            value={editType}
+            onChange={(e) => setEditType(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">保険会社名</label>
+          <input
+            type="text"
+            value={editProvider}
+            onChange={(e) => setEditProvider(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            placeholder="保険会社名を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">証券番号</label>
+          <input
+            type="text"
+            value={editPolicy}
+            onChange={(e) => setEditPolicy(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            placeholder="証券番号を入力"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editType.trim()}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary text-white py-1.5 rounded-lg text-sm hover:bg-primary-dark transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-50 text-ink-700 py-1.5 rounded-lg text-sm hover:bg-primary-100 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2">
+            <p className="font-medium text-ink-800 text-sm">{insurance.insuranceType}</p>
+            {insurance.memberName && (
+              <span className="text-xs bg-primary-50 text-ink-600 px-1.5 py-0.5 rounded">{insurance.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-ink-500 mt-1 space-y-0.5">
+            {insurance.providerName && <p>{insurance.providerName}</p>}
+            {insurance.policyNumber && <p>証券番号: {insurance.policyNumber}</p>}
+            {insurance.notes && <p className="text-ink-400">{insurance.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <ConfirmationDialog
+        title="保険の削除"
+        message={`「${insurance.insuranceType}」を削除しますか？この操作は取り消せません。`}
+        isOpen={isDeleteDialogOpen}
+        onConfirm={() => {
+          setIsDeleteDialogOpen(false);
+          onDelete(insurance.id);
+        }}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        isDangerous
+      />
+    </div>
+  );
+});
+
+InsuranceCard.displayName = "InsuranceCard";

--- a/frontend/app/components/medications/MedicationForm.tsx
+++ b/frontend/app/components/medications/MedicationForm.tsx
@@ -1,0 +1,263 @@
+import React, { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import type { Medication } from "@/lib/types";
+
+export type MedicationCategory =
+  | "regular"
+  | "supplement"
+  | "prn"
+  | "inhaler"
+  | "eye_drops"
+  | "patch"
+  | "topical"
+  | "flea_tick"
+  | "heartworm";
+
+export type MedicationStatus = "active" | "paused" | "discontinued";
+
+export interface MedicationFormData {
+  name: string;
+  category: MedicationCategory;
+  dosage: string;
+  frequency: string;
+  stockQuantity?: number;
+  stockAlertDate?: string;
+  instructions?: string;
+  status?: MedicationStatus;
+}
+
+interface MedicationFormProps {
+  onSubmit: (data: MedicationFormData) => void;
+  initialData?: Medication;
+  onCancel?: () => void;
+}
+
+export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initialData, onCancel }) => {
+  const isEditing = !!initialData;
+  const [name, setName] = useState(initialData?.name || "");
+  const [category, setCategory] = useState<MedicationCategory>(
+    (initialData?.category as MedicationCategory) || "regular",
+  );
+  const [dosage, setDosage] = useState(initialData?.dosageAmount || "");
+  const [frequency, setFrequency] = useState(initialData?.frequency || "");
+  const [stockQuantity, setStockQuantity] = useState(
+    initialData?.stockQuantity !== undefined && initialData?.stockQuantity !== null
+      ? String(initialData.stockQuantity)
+      : "",
+  );
+  const [stockAlertDate, setStockAlertDate] = useState(
+    initialData?.stockAlertDate ? new Date(initialData.stockAlertDate).toISOString().split("T")[0] : "",
+  );
+  const [instructions, setInstructions] = useState(initialData?.instructions || "");
+  const [status, setStatus] = useState<MedicationStatus>(
+    (initialData?.status as MedicationStatus) || "active",
+  );
+  const hasOptionalData = !!(
+    initialData?.stockQuantity ||
+    initialData?.stockAlertDate ||
+    initialData?.instructions
+  );
+  const [showOptional, setShowOptional] = useState(isEditing && hasOptionalData);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) return;
+
+    const data: MedicationFormData = {
+      name: name.trim(),
+      category,
+      dosage: dosage.trim(),
+      frequency: frequency.trim(),
+      ...(stockQuantity ? { stockQuantity: parseInt(stockQuantity, 10) } : {}),
+      ...(stockAlertDate ? { stockAlertDate } : {}),
+      ...(instructions.trim() ? { instructions: instructions.trim() } : {}),
+      ...(isEditing ? { status } : {}),
+    };
+
+    onSubmit(data);
+
+    if (!isEditing) {
+      setName("");
+      setCategory("regular");
+      setDosage("");
+      setFrequency("");
+      setStockQuantity("");
+      setStockAlertDate("");
+      setInstructions("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="med-name" className="block text-sm font-medium text-ink-700 mb-1">
+          薬の名前
+        </label>
+        <input
+          id="med-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+          placeholder="薬の名前を入力"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="med-category" className="block text-sm font-medium text-ink-700 mb-1">
+          カテゴリ
+        </label>
+        <select
+          id="med-category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value as MedicationCategory)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+        >
+          <option value="regular">常用薬</option>
+          <option value="supplement">サプリメント</option>
+          <option value="prn">頓服薬</option>
+          <option value="inhaler">吸入薬</option>
+          <option value="eye_drops">目薬</option>
+          <option value="patch">湿布</option>
+          <option value="topical">塗り薬</option>
+          <option value="flea_tick">ノミ・ダニ薬</option>
+          <option value="heartworm">フィラリア薬</option>
+        </select>
+      </div>
+
+      {isEditing && (
+        <div>
+          <label className="block text-sm font-medium text-ink-700 mb-1">服用状況</label>
+          <div className="grid grid-cols-3 gap-2">
+            {(
+              [
+                { id: "active", label: "服用中", activeClass: "bg-primary-600 text-white border-primary-600" },
+                { id: "paused", label: "休薬", activeClass: "bg-red-100 text-red-700 border-red-300" },
+                { id: "discontinued", label: "中止", activeClass: "bg-red-600 text-white border-red-600" },
+              ] as Array<{ id: MedicationStatus; label: string; activeClass: string }>
+            ).map((opt) => (
+              <button
+                key={opt.id}
+                type="button"
+                onClick={() => setStatus(opt.id)}
+                aria-pressed={status === opt.id}
+                className={`px-3 py-2 rounded-lg border text-sm font-medium transition-colors ${
+                  status === opt.id
+                    ? opt.activeClass
+                    : "bg-white text-ink-600 border-primary-200 hover:bg-primary-50"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-ink-400 mt-1">休薬・中止にすると今日の予定からも除外されます</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="med-dosage" className="block text-sm font-medium text-ink-700 mb-1">
+            用量 <span className="text-xs text-ink-400 font-normal">任意</span>
+          </label>
+          <input
+            id="med-dosage"
+            type="text"
+            value={dosage}
+            onChange={(e) => setDosage(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+            placeholder="例: 1錠"
+          />
+        </div>
+        <div>
+          <label htmlFor="med-frequency" className="block text-sm font-medium text-ink-700 mb-1">
+            頻度 <span className="text-xs text-ink-400 font-normal">任意</span>
+          </label>
+          <input
+            id="med-frequency"
+            type="text"
+            value={frequency}
+            onChange={(e) => setFrequency(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+            placeholder="例: 1日1回"
+          />
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setShowOptional(!showOptional)}
+        className="flex items-center space-x-1 text-sm text-ink-500 hover:text-ink-700 transition-colors"
+      >
+        {showOptional ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        <span>詳細設定（在庫・服用方法など）</span>
+      </button>
+
+      {showOptional && (
+        <div className="space-y-4 pt-1">
+          <div>
+            <label htmlFor="med-stock" className="block text-sm font-medium text-ink-700 mb-1">
+              在庫数(何日分)
+            </label>
+            <input
+              id="med-stock"
+              type="number"
+              min="0"
+              value={stockQuantity}
+              onChange={(e) => setStockQuantity(e.target.value)}
+              className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+              placeholder="例: 30"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="med-alert-date" className="block text-sm font-medium text-ink-700 mb-1">
+              在庫警告日
+            </label>
+            <input
+              id="med-alert-date"
+              type="date"
+              value={stockAlertDate}
+              onChange={(e) => setStockAlertDate(e.target.value)}
+              className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+            />
+            <p className="text-xs text-ink-400 mt-1">この日までに在庫が不足する場合に通知します</p>
+          </div>
+
+          <div>
+            <label htmlFor="med-instructions" className="block text-sm font-medium text-ink-700 mb-1">
+              服用方法
+            </label>
+            <textarea
+              id="med-instructions"
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+              rows={2}
+              placeholder="例: 食後に水と一緒に服用"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium"
+        >
+          {isEditing ? "更新する" : "追加する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 border border-primary-200 text-ink-700 rounded-lg hover:bg-primary-50 transition-colors"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/medications/MedicationList.tsx
+++ b/frontend/app/components/medications/MedicationList.tsx
@@ -1,0 +1,401 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Pill, Check, Pencil, Clock, ChevronUp, ChevronDown, AlertCircle } from "lucide-react";
+import type { Medication } from "@/lib/types";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+
+export interface MedicationViewModel {
+  medication: Medication;
+  isLowStock: boolean;
+  displayInfo: { name: string; categoryLabel: string; dosageInfo: string };
+}
+
+export interface MedicationScheduleInfo {
+  scheduleId: string;
+  time: string;
+  label: string; // "毎日", "月・水・金", "21日毎" etc.
+}
+
+export interface MedicationScheduleMap {
+  [medicationId: string]: MedicationScheduleInfo[];
+}
+
+interface MedicationListProps {
+  medications: MedicationViewModel[];
+  isLoading: boolean;
+  onDelete: (medicationId: string) => void;
+  onMarkTaken?: (medicationId: string) => Promise<void>;
+  onMarkPastTaken?: (medicationId: string, takenAt: string) => Promise<void>;
+  onEdit?: (medication: Medication) => void;
+  onReorder?: (medicationIds: string[]) => Promise<void>;
+  scheduleMap?: MedicationScheduleMap;
+  scheduleEditUrl?: string;
+}
+
+export const MedicationList: React.FC<MedicationListProps> = ({
+  medications,
+  isLoading,
+  onDelete,
+  onMarkTaken,
+  onMarkPastTaken,
+  onEdit,
+  onReorder,
+  scheduleMap,
+  scheduleEditUrl,
+}) => {
+  // 並び替えの体感速度を上げるためにローカルで楽観的に更新する
+  const [localOrder, setLocalOrder] = useState<MedicationViewModel[]>(medications);
+  const reorderTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inFlightRef = useRef(false);
+  const queuedOrderRef = useRef<string[] | null>(null);
+
+  useEffect(() => {
+    setLocalOrder(medications);
+  }, [medications]);
+
+  useEffect(
+    () => () => {
+      if (reorderTimeoutRef.current) clearTimeout(reorderTimeoutRef.current);
+    },
+    [],
+  );
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (medications.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="薬がまだ登録されていません"
+        subMessage="上の「追加」から薬を追加してください"
+      />
+    );
+  }
+
+  const flushReorder = async () => {
+    if (!onReorder || inFlightRef.current) return;
+    const payload = queuedOrderRef.current;
+    if (!payload) return;
+    queuedOrderRef.current = null;
+    inFlightRef.current = true;
+    try {
+      await onReorder(payload);
+    } catch {
+      queuedOrderRef.current = null;
+      setLocalOrder(medications);
+    } finally {
+      inFlightRef.current = false;
+      if (queuedOrderRef.current) void flushReorder();
+    }
+  };
+
+  const handleMove = (index: number, direction: "up" | "down") => {
+    if (!onReorder) return;
+    const targetIndex = direction === "up" ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= localOrder.length) return;
+    const newList = [...localOrder];
+    [newList[index], newList[targetIndex]] = [newList[targetIndex], newList[index]];
+    setLocalOrder(newList);
+    if (reorderTimeoutRef.current) clearTimeout(reorderTimeoutRef.current);
+    reorderTimeoutRef.current = setTimeout(() => {
+      queuedOrderRef.current = newList.map((vm) => vm.medication.id);
+      void flushReorder();
+    }, 400);
+  };
+
+  return (
+    <div className="space-y-3">
+      {localOrder.map((vm, index) => (
+        <MedicationCard
+          key={vm.medication.id}
+          viewModel={vm}
+          onDelete={onDelete}
+          onMarkTaken={onMarkTaken}
+          onMarkPastTaken={onMarkPastTaken}
+          onEdit={onEdit}
+          onMoveUp={onReorder && index > 0 ? () => handleMove(index, "up") : undefined}
+          onMoveDown={onReorder && index < localOrder.length - 1 ? () => handleMove(index, "down") : undefined}
+          schedules={scheduleMap?.[vm.medication.id]}
+          scheduleEditUrl={scheduleEditUrl}
+        />
+      ))}
+    </div>
+  );
+};
+
+export interface MedicationCardProps {
+  viewModel: MedicationViewModel;
+  onDelete: (medicationId: string) => void;
+  onMarkTaken?: (medicationId: string) => Promise<void>;
+  onMarkPastTaken?: (medicationId: string, takenAt: string) => Promise<void>;
+  onEdit?: (medication: Medication) => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  schedules?: MedicationScheduleInfo[];
+  scheduleEditUrl?: string;
+}
+
+const MedicationCard: React.FC<MedicationCardProps> = React.memo(
+  ({
+    viewModel,
+    onDelete,
+    onMarkTaken,
+    onMarkPastTaken,
+    onEdit,
+    onMoveUp,
+    onMoveDown,
+    schedules,
+    scheduleEditUrl,
+  }) => {
+    const { medication, isLowStock, displayInfo } = viewModel;
+    const [isTaken, setIsTaken] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+    const [isPastRecordOpen, setIsPastRecordOpen] = useState(false);
+    const [pastDate, setPastDate] = useState("");
+    const [pastTime, setPastTime] = useState("12:00");
+    const [isPastSubmitting, setIsPastSubmitting] = useState(false);
+    const [pastRecordSuccess, setPastRecordSuccess] = useState(false);
+
+    const handleMarkTaken = async () => {
+      if (!onMarkTaken || isSubmitting) return;
+      setIsSubmitting(true);
+      try {
+        await onMarkTaken(medication.id);
+        setIsTaken(true);
+      } finally {
+        setIsSubmitting(false);
+      }
+    };
+
+    const handlePastRecordSubmit = async () => {
+      if (!onMarkPastTaken || !pastDate || isPastSubmitting) return;
+      setIsPastSubmitting(true);
+      try {
+        const takenAt = new Date(`${pastDate}T${pastTime}:00`).toISOString();
+        await onMarkPastTaken(medication.id, takenAt);
+        setPastRecordSuccess(true);
+        setTimeout(() => {
+          setIsPastRecordOpen(false);
+          setPastRecordSuccess(false);
+          setPastDate("");
+          setPastTime("12:00");
+        }, 1500);
+      } finally {
+        setIsPastSubmitting(false);
+      }
+    };
+
+    return (
+      <div className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+        <div className="flex items-center justify-between">
+          {(onMoveUp || onMoveDown) && (
+            <div className="flex flex-col mr-2 -my-1">
+              <button
+                onClick={onMoveUp}
+                disabled={!onMoveUp}
+                className={`p-0.5 rounded ${
+                  onMoveUp ? "text-ink-500 hover:text-ink-700 hover:bg-primary-50" : "text-primary-100"
+                }`}
+                aria-label="上に移動"
+              >
+                <ChevronUp size={16} />
+              </button>
+              <button
+                onClick={onMoveDown}
+                disabled={!onMoveDown}
+                className={`p-0.5 rounded ${
+                  onMoveDown ? "text-ink-500 hover:text-ink-700 hover:bg-primary-50" : "text-primary-100"
+                }`}
+                aria-label="下に移動"
+              >
+                <ChevronDown size={16} />
+              </button>
+            </div>
+          )}
+          <div className="flex-1">
+            <div className="flex items-center flex-wrap gap-x-2 gap-y-1">
+              <Pill size={20} className="text-primary-600" />
+              <p className="font-semibold text-ink-800">{displayInfo.name}</p>
+              {medication.status === "paused" && (
+                <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-bold border border-red-300">
+                  休薬
+                </span>
+              )}
+              {medication.status === "discontinued" && (
+                <span className="px-2 py-0.5 bg-red-600 text-white text-xs rounded-full font-bold">中止</span>
+              )}
+              {isLowStock && (
+                <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-medium">
+                  在庫少
+                </span>
+              )}
+            </div>
+            <div className="mt-1 text-sm text-ink-500 space-y-0.5">
+              <p>{displayInfo.categoryLabel}</p>
+              {displayInfo.dosageInfo && <p>{displayInfo.dosageInfo}</p>}
+              {medication.stockQuantity !== null && medication.stockQuantity !== undefined && (
+                <p>在庫: {medication.stockQuantity}日分</p>
+              )}
+              {medication.stockAlertDate && (
+                <p>警告日: {new Date(medication.stockAlertDate).toLocaleDateString("ja-JP")}</p>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            {onEdit && (
+              <button
+                onClick={() => onEdit(medication)}
+                className="text-ink-500 hover:text-ink-700 text-sm px-2 py-1 rounded-md hover:bg-primary-50 transition-colors"
+                aria-label="編集"
+              >
+                <Pencil size={14} />
+              </button>
+            )}
+            {onMarkPastTaken && (
+              <button
+                onClick={() => setIsPastRecordOpen(true)}
+                className="text-ink-500 hover:text-ink-700 text-sm px-2 py-1 rounded-md hover:bg-primary-50 transition-colors"
+                aria-label="過去の記録"
+              >
+                <Clock size={14} />
+              </button>
+            )}
+            {onMarkTaken &&
+              (isTaken ? (
+                <span className="flex items-center space-x-1 text-green-600 text-sm font-medium px-3 py-1">
+                  <Check size={16} />
+                  <span>記録済み</span>
+                </span>
+              ) : (
+                <button
+                  onClick={handleMarkTaken}
+                  disabled={isSubmitting}
+                  className="bg-green-500 text-white px-3 py-1 rounded-full text-sm font-medium hover:bg-green-600 disabled:opacity-50 transition-colors"
+                  aria-label="飲んだ"
+                >
+                  {isSubmitting ? "記録中..." : "飲んだ"}
+                </button>
+              ))}
+            <button
+              onClick={() => setIsDeleteDialogOpen(true)}
+              className="text-red-500 hover:text-red-700 text-sm px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
+              aria-label="削除"
+            >
+              削除
+            </button>
+          </div>
+        </div>
+        <div className="mt-2 pt-2 border-t border-primary-100">
+          {schedules && schedules.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {schedules.map((s) => {
+                const chipClass =
+                  "inline-flex items-center space-x-1 px-2 py-0.5 bg-primary-50 text-primary-700 rounded-full text-xs";
+                const content = (
+                  <>
+                    <Clock size={10} />
+                    <span>{s.time}</span>
+                    <span className="text-primary-500">{s.label}</span>
+                  </>
+                );
+                return scheduleEditUrl ? (
+                  <a
+                    key={s.scheduleId}
+                    href={scheduleEditUrl}
+                    className={`${chipClass} hover:bg-primary-100 transition-colors`}
+                  >
+                    {content}
+                  </a>
+                ) : (
+                  <span key={s.scheduleId} className={chipClass}>
+                    {content}
+                  </span>
+                );
+              })}
+            </div>
+          ) : (
+            <span className="inline-flex items-center space-x-1 px-2 py-1 bg-amber-50 text-amber-700 rounded-full text-xs">
+              <AlertCircle size={12} />
+              <span>スケジュール未設定</span>
+            </span>
+          )}
+        </div>
+        <ConfirmationDialog
+          title="薬の削除"
+          message={`「${displayInfo.name}」を削除しますか？この操作は取り消せません。`}
+          isOpen={isDeleteDialogOpen}
+          onConfirm={() => {
+            setIsDeleteDialogOpen(false);
+            onDelete(medication.id);
+          }}
+          onCancel={() => setIsDeleteDialogOpen(false)}
+          isDangerous
+        />
+        {isPastRecordOpen && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+            <div className="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+              <h2 className="mb-2 text-lg font-bold text-ink-800">過去の服薬記録</h2>
+              <p className="mb-4 text-sm text-ink-600">「{displayInfo.name}」の飲み忘れを記録します</p>
+              {pastRecordSuccess ? (
+                <div className="flex items-center justify-center py-4 text-green-600">
+                  <Check size={20} className="mr-2" />
+                  <span className="font-medium">記録しました</span>
+                </div>
+              ) : (
+                <>
+                  <div className="space-y-3 mb-6">
+                    <div>
+                      <label className="block text-sm font-medium text-ink-700 mb-1">日付</label>
+                      <input
+                        type="date"
+                        value={pastDate}
+                        onChange={(e) => setPastDate(e.target.value)}
+                        max={new Date().toISOString().split("T")[0]}
+                        className="w-full rounded-md border border-primary-200 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-ink-700 mb-1">時刻</label>
+                      <input
+                        type="time"
+                        value={pastTime}
+                        onChange={(e) => setPastTime(e.target.value)}
+                        className="w-full rounded-md border border-primary-200 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                      />
+                    </div>
+                  </div>
+                  <div className="flex justify-end gap-3">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setIsPastRecordOpen(false);
+                        setPastDate("");
+                        setPastTime("12:00");
+                      }}
+                      className="rounded-md border border-primary-200 px-4 py-2 text-sm text-ink-700 hover:bg-primary-50"
+                    >
+                      キャンセル
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handlePastRecordSubmit}
+                      disabled={!pastDate || isPastSubmitting}
+                      className="rounded-md bg-primary-600 px-4 py-2 text-sm text-white hover:bg-primary-700 disabled:opacity-50"
+                    >
+                      {isPastSubmitting ? "記録中..." : "記録する"}
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+MedicationCard.displayName = "MedicationCard";

--- a/frontend/app/components/medications/MemberMedications.tsx
+++ b/frontend/app/components/medications/MemberMedications.tsx
@@ -1,0 +1,383 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, Clock, X, Check } from "lucide-react";
+import { api } from "@/lib/api";
+import type { Medication, Member, Schedule } from "@/lib/types";
+import { MemberIcon, type MemberType, type PetType } from "@/components/shared/MemberIcon";
+import {
+  MedicationList,
+  type MedicationViewModel,
+  type MedicationScheduleMap,
+} from "@/components/medications/MedicationList";
+import {
+  MedicationForm,
+  type MedicationFormData,
+  type MedicationCategory,
+} from "@/components/medications/MedicationForm";
+import {
+  ScheduleForm,
+  type ScheduleFormData,
+  type DayOfWeek,
+} from "@/components/medications/ScheduleForm";
+
+const CATEGORY_LABELS: Record<MedicationCategory, string> = {
+  regular: "常用薬",
+  supplement: "サプリメント",
+  prn: "頓服薬",
+  inhaler: "吸入薬",
+  eye_drops: "目薬",
+  patch: "湿布",
+  topical: "塗り薬",
+  flea_tick: "ノミ・ダニ薬",
+  heartworm: "フィラリア薬",
+};
+
+function getCategoryLabel(category: string): string {
+  return CATEGORY_LABELS[category as MedicationCategory] ?? category;
+}
+
+const DAY_LABELS: Record<DayOfWeek, string> = {
+  mon: "月",
+  tue: "火",
+  wed: "水",
+  thu: "木",
+  fri: "金",
+  sat: "土",
+  sun: "日",
+};
+const DAY_ORDER: DayOfWeek[] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+
+function getScheduleLabel(daysOfWeek: readonly string[], intervalDays?: number | null): string {
+  if (intervalDays === -1) return "頓服";
+  if (intervalDays && intervalDays > 0) return `${intervalDays}日毎`;
+  if (daysOfWeek.length === 0 || daysOfWeek.length === 7) return "毎日";
+  return DAY_ORDER.filter((d) => daysOfWeek.includes(d))
+    .map((d) => DAY_LABELS[d])
+    .join("・");
+}
+
+/** 在庫が残り日数より少ないかどうかを判定する（旧 MedicationEntity.isLowStock 相当） */
+function computeIsLowStock(medication: Medication): boolean {
+  if (
+    medication.stockQuantity === null ||
+    medication.stockQuantity === undefined ||
+    !medication.stockAlertDate
+  ) {
+    return false;
+  }
+  const today = new Date();
+  const alertDate = new Date(medication.stockAlertDate);
+  const daysUntilAlert = Math.ceil(
+    (alertDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  if (daysUntilAlert <= 0) return false;
+  return medication.stockQuantity < daysUntilAlert;
+}
+
+function toViewModel(medication: Medication): MedicationViewModel {
+  const dosageInfo = [medication.dosageAmount, medication.frequency].filter(Boolean).join(" / ");
+  return {
+    medication,
+    isLowStock: computeIsLowStock(medication),
+    displayInfo: {
+      name: medication.name,
+      categoryLabel: getCategoryLabel(medication.category),
+      dosageInfo,
+    },
+  };
+}
+
+interface MemberMedicationsProps {
+  member: Member;
+  categoryFilter: MedicationCategory | null;
+}
+
+export function MemberMedications({ member, categoryFilter }: MemberMedicationsProps) {
+  const qc = useQueryClient();
+  const [editingMed, setEditingMed] = useState<Medication | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addedMedName, setAddedMedName] = useState<string | null>(null);
+  const [scheduleTargetName, setScheduleTargetName] = useState<string | null>(null);
+  const editFormRef = useRef<HTMLDivElement>(null);
+  const addFormRef = useRef<HTMLDivElement>(null);
+
+  const { data: medications = [], isLoading } = useQuery({
+    queryKey: ["medications", member.id],
+    queryFn: () => api.get<Medication[]>(`/members/${member.id}/medications`),
+  });
+
+  const { data: schedules = [] } = useQuery({
+    queryKey: ["schedules"],
+    queryFn: () => api.get<Schedule[]>("/schedules"),
+  });
+
+  const invalidateMeds = () => qc.invalidateQueries({ queryKey: ["medications", member.id] });
+  const invalidateSchedules = () => qc.invalidateQueries({ queryKey: ["schedules"] });
+
+  const createMedication = useMutation({
+    mutationFn: (data: MedicationFormData) =>
+      api.post<Medication>("/medications", {
+        memberId: member.id,
+        name: data.name,
+        category: data.category,
+        dosageAmount: data.dosage || undefined,
+        frequency: data.frequency || undefined,
+        stockQuantity: data.stockQuantity,
+        stockAlertDate: data.stockAlertDate,
+        instructions: data.instructions,
+      }),
+    onSuccess: (_created, data) => {
+      invalidateMeds();
+      setShowAddForm(false);
+      setAddedMedName(data.name);
+      setScheduleTargetName(data.name);
+    },
+  });
+
+  const updateMedication = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: MedicationFormData }) =>
+      api.patch<Medication>(`/medications/${id}`, {
+        name: data.name,
+        dosageAmount: data.dosage || null,
+        frequency: data.frequency || null,
+        stockQuantity: data.stockQuantity ?? null,
+        stockAlertDate: data.stockAlertDate ?? null,
+        instructions: data.instructions ?? null,
+        status: data.status,
+      }),
+    onSuccess: () => {
+      invalidateMeds();
+      setEditingMed(null);
+    },
+  });
+
+  const deleteMedication = useMutation({
+    mutationFn: (id: string) => api.delete(`/medications/${id}`),
+    onSuccess: invalidateMeds,
+  });
+
+  const reorderMedications = useMutation({
+    mutationFn: (orderedIds: string[]) => api.post("/medications/reorder", { orderedIds }),
+    onSuccess: invalidateMeds,
+  });
+
+  const createRecord = useMutation({
+    mutationFn: ({ medicationId, takenAt }: { medicationId: string; takenAt?: string }) =>
+      api.post("/records", {
+        memberId: member.id,
+        medicationId,
+        ...(takenAt ? { takenAt } : {}),
+      }),
+  });
+
+  const createSchedule = useMutation({
+    mutationFn: ({ medicationId, data }: { medicationId: string; data: ScheduleFormData }) =>
+      api.post<Schedule>("/schedules", {
+        medicationId,
+        memberId: member.id,
+        scheduledTime: data.scheduledTime,
+        daysOfWeek: data.daysOfWeek,
+        intervalDays: data.intervalDays,
+        startDate: data.startDate,
+        isEnabled: true,
+        reminderMinutesBefore: data.reminderMinutesBefore,
+      }),
+    onSuccess: invalidateSchedules,
+  });
+
+  const scheduleMap = useMemo<MedicationScheduleMap>(() => {
+    const map: MedicationScheduleMap = {};
+    const memberSchedules = schedules.filter((s) => s.memberId === member.id);
+    for (const s of memberSchedules) {
+      if (!map[s.medicationId]) map[s.medicationId] = [];
+      map[s.medicationId].push({
+        scheduleId: s.id,
+        time: s.scheduledTime,
+        label: getScheduleLabel(s.daysOfWeek, s.intervalDays),
+      });
+    }
+    return map;
+  }, [schedules, member.id]);
+
+  const viewModels = useMemo<MedicationViewModel[]>(
+    () => medications.map(toViewModel),
+    [medications],
+  );
+
+  const filteredMedications = useMemo(
+    () =>
+      categoryFilter
+        ? viewModels.filter((vm) => vm.medication.category === categoryFilter)
+        : viewModels,
+    [viewModels, categoryFilter],
+  );
+
+  const scheduleTargetMed = useMemo(
+    () =>
+      scheduleTargetName
+        ? medications.find((m) => m.name === scheduleTargetName) ?? null
+        : null,
+    [medications, scheduleTargetName],
+  );
+
+  useEffect(() => {
+    if (editingMed && editFormRef.current) {
+      editFormRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [editingMed]);
+
+  useEffect(() => {
+    if (showAddForm && addFormRef.current) {
+      addFormRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [showAddForm]);
+
+  const handleMarkTaken = async (medicationId: string) => {
+    await createRecord.mutateAsync({ medicationId });
+  };
+
+  const handleMarkPastTaken = async (medicationId: string, takenAt: string) => {
+    await createRecord.mutateAsync({ medicationId, takenAt });
+  };
+
+  const handleCreateSchedule = async (data: ScheduleFormData) => {
+    if (!scheduleTargetMed) return;
+    await createSchedule.mutateAsync({ medicationId: scheduleTargetMed.id, data });
+    setScheduleTargetName(null);
+    setAddedMedName(null);
+  };
+
+  const handleCreateMultipleSchedules = async (items: ScheduleFormData[]) => {
+    if (!scheduleTargetMed) return;
+    for (const data of items) {
+      await createSchedule.mutateAsync({ medicationId: scheduleTargetMed.id, data });
+    }
+    setScheduleTargetName(null);
+    setAddedMedName(null);
+  };
+
+  const displayInfo = {
+    memberType: member.memberType as MemberType,
+    petType: (member.petType ?? undefined) as PetType | undefined,
+    name: member.name,
+  };
+
+  return (
+    <section className="mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center space-x-2">
+          <MemberIcon
+            memberType={displayInfo.memberType}
+            petType={displayInfo.petType}
+            size={20}
+            className="text-ink-600"
+          />
+          <h2 className="font-semibold text-ink-800">{displayInfo.name}</h2>
+        </div>
+        <div className="flex items-center space-x-3">
+          <button
+            type="button"
+            onClick={() => {
+              setShowAddForm((v) => !v);
+              setAddedMedName(null);
+              setScheduleTargetName(null);
+            }}
+            className="flex items-center space-x-1 text-sm text-primary-600 hover:text-primary-700 transition-colors"
+            aria-label={showAddForm ? "閉じる" : "薬を追加"}
+          >
+            {showAddForm ? <X size={14} /> : <Plus size={14} />}
+            <span>{showAddForm ? "キャンセル" : "追加"}</span>
+          </button>
+        </div>
+      </div>
+
+      {showAddForm && (
+        <div
+          ref={addFormRef}
+          className="mb-4 bg-white rounded-lg shadow-md p-4 border border-primary-200"
+        >
+          <h3 className="text-sm font-semibold text-ink-700 mb-3">薬を追加</h3>
+          <MedicationForm
+            onSubmit={(data) => createMedication.mutate(data)}
+            onCancel={() => setShowAddForm(false)}
+          />
+        </div>
+      )}
+
+      {addedMedName && scheduleTargetMed && (
+        <div className="mb-4 bg-green-50 rounded-lg p-3 border border-green-200">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <Check size={16} className="text-green-600 shrink-0" />
+              <p className="text-sm text-green-800 font-medium truncate">
+                「{addedMedName}」を追加しました
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setAddedMedName(null);
+                setScheduleTargetName(null);
+              }}
+              className="text-green-500 hover:text-green-700 shrink-0"
+              aria-label="閉じる"
+            >
+              <X size={14} />
+            </button>
+          </div>
+          <p className="text-xs text-green-700 mt-1 ml-6">飲む時間を設定しますか？</p>
+          <div className="mt-3 ml-0">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-medium text-ink-600 flex items-center gap-1">
+                <Clock size={13} />
+                {addedMedName} のスケジュール
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  setAddedMedName(null);
+                  setScheduleTargetName(null);
+                }}
+                className="text-xs text-ink-400 hover:text-ink-600"
+              >
+                後で設定する
+              </button>
+            </div>
+            <ScheduleForm onSubmit={handleCreateSchedule} onSubmitMultiple={handleCreateMultipleSchedules} />
+          </div>
+        </div>
+      )}
+
+      {editingMed && (
+        <div
+          ref={editFormRef}
+          className="mb-3 bg-white rounded-lg shadow-md p-4 border border-primary-200"
+        >
+          <h3 className="text-sm font-semibold text-ink-700 mb-3">薬の編集</h3>
+          <MedicationForm
+            onSubmit={(data) => updateMedication.mutate({ id: editingMed.id, data })}
+            initialData={editingMed}
+            onCancel={() => setEditingMed(null)}
+          />
+        </div>
+      )}
+
+      <MedicationList
+        medications={filteredMedications}
+        isLoading={isLoading}
+        onDelete={(id) => deleteMedication.mutate(id)}
+        onMarkTaken={handleMarkTaken}
+        onMarkPastTaken={handleMarkPastTaken}
+        onEdit={(medication) => setEditingMed(medication)}
+        onReorder={
+          !categoryFilter
+            ? async (ids) => {
+                await reorderMedications.mutateAsync(ids);
+              }
+            : undefined
+        }
+        scheduleMap={scheduleMap}
+      />
+    </section>
+  );
+}

--- a/frontend/app/components/medications/ScheduleForm.tsx
+++ b/frontend/app/components/medications/ScheduleForm.tsx
@@ -1,0 +1,312 @@
+import React, { useState } from "react";
+
+export type DayOfWeek = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+
+export type ScheduleMode = "daily" | "weekdays" | "interval" | "prn" | "twice_daily" | "three_daily";
+
+export interface ScheduleFormData {
+  scheduledTime: string;
+  daysOfWeek: DayOfWeek[];
+  intervalDays?: number;
+  startDate?: string;
+  reminderMinutesBefore: number;
+}
+
+interface ScheduleFormProps {
+  onSubmit: (data: ScheduleFormData) => void;
+  onSubmitMultiple?: (data: ScheduleFormData[]) => void;
+}
+
+const TWICE_DAILY_LABELS = ["朝", "夜"];
+const THREE_DAILY_LABELS = ["朝", "昼", "夜"];
+
+const DAY_OPTIONS: { value: DayOfWeek; label: string }[] = [
+  { value: "mon", label: "月" },
+  { value: "tue", label: "火" },
+  { value: "wed", label: "水" },
+  { value: "thu", label: "木" },
+  { value: "fri", label: "金" },
+  { value: "sat", label: "土" },
+  { value: "sun", label: "日" },
+];
+
+const INTERVAL_OPTIONS = [
+  { value: 2, label: "2日毎" },
+  { value: 3, label: "3日毎" },
+  { value: 7, label: "1週間毎" },
+  { value: 14, label: "2週間毎" },
+  { value: 21, label: "3週間毎" },
+  { value: 28, label: "4週間毎" },
+  { value: 30, label: "1ヶ月毎" },
+  { value: 60, label: "2ヶ月毎" },
+  { value: 90, label: "3ヶ月毎" },
+];
+
+export const ScheduleForm: React.FC<ScheduleFormProps> = ({ onSubmit, onSubmitMultiple }) => {
+  const [scheduledTime, setScheduledTime] = useState("08:00");
+  const [mode, setMode] = useState<ScheduleMode>("daily");
+  const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
+  const [intervalDays, setIntervalDays] = useState("21");
+  const [startDate, setStartDate] = useState(() => {
+    const today = new Date();
+    return today.toISOString().split("T")[0];
+  });
+  const [reminderMinutes, setReminderMinutes] = useState("10");
+  const [twiceTimes, setTwiceTimes] = useState<[string, string]>(["08:00", "20:00"]);
+  const [threeTimes, setThreeTimes] = useState<[string, string, string]>([
+    "08:00",
+    "13:00",
+    "20:00",
+  ]);
+
+  const handleModeChange = (m: ScheduleMode) => {
+    setMode(m);
+    setTwiceTimes(["08:00", "20:00"]);
+    setThreeTimes(["08:00", "13:00", "20:00"]);
+  };
+
+  const toggleDay = (day: DayOfWeek) => {
+    setSelectedDays((prev) => (prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (mode === "weekdays" && selectedDays.length === 0) return;
+    if (mode === "interval" && !startDate) return;
+
+    const baseData = {
+      daysOfWeek: mode === "weekdays" ? selectedDays : ([] as DayOfWeek[]),
+      intervalDays:
+        mode === "prn" ? -1 : mode === "interval" ? parseInt(intervalDays, 10) : undefined,
+      startDate: mode === "interval" ? startDate : undefined,
+      reminderMinutesBefore: mode === "prn" ? 0 : parseInt(reminderMinutes, 10) || 0,
+    };
+
+    if (mode === "twice_daily" || mode === "three_daily") {
+      const times = mode === "twice_daily" ? twiceTimes : threeTimes;
+      const items = times.map((time) => ({ ...baseData, scheduledTime: time }));
+      if (onSubmitMultiple) {
+        onSubmitMultiple(items);
+      } else {
+        items.forEach((item) => onSubmit(item));
+      }
+    } else {
+      onSubmit({ ...baseData, scheduledTime: mode === "prn" ? "00:00" : scheduledTime });
+    }
+
+    setScheduledTime("08:00");
+    setSelectedDays([]);
+    setMode("daily");
+    setReminderMinutes("10");
+    setTwiceTimes(["08:00", "20:00"]);
+    setThreeTimes(["08:00", "13:00", "20:00"]);
+  };
+
+  const modeButtonClass = (m: ScheduleMode) =>
+    `flex items-center justify-center px-3 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
+      mode === m
+        ? "bg-primary-600 text-white border-primary-600"
+        : "bg-white text-ink-600 border-primary-200 hover:border-primary-400"
+    }`;
+
+  const timeLabelClass =
+    "inline-flex items-center justify-center w-8 h-8 rounded-full bg-primary-100 text-primary-700 text-xs font-bold shrink-0";
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <span className="block text-sm font-medium text-ink-700 mb-2">頻度</span>
+        <div className="flex flex-wrap gap-2 mb-2">
+          <button type="button" className={modeButtonClass("daily")} onClick={() => handleModeChange("daily")}>
+            毎日
+          </button>
+          <button
+            type="button"
+            className={modeButtonClass("weekdays")}
+            onClick={() => handleModeChange("weekdays")}
+          >
+            曜日指定
+          </button>
+          <button
+            type="button"
+            className={modeButtonClass("interval")}
+            onClick={() => handleModeChange("interval")}
+          >
+            間隔指定
+          </button>
+          <button
+            type="button"
+            className={modeButtonClass("twice_daily")}
+            onClick={() => handleModeChange("twice_daily")}
+          >
+            1日2回
+          </button>
+          <button
+            type="button"
+            className={modeButtonClass("three_daily")}
+            onClick={() => handleModeChange("three_daily")}
+          >
+            1日3回
+          </button>
+          <button type="button" className={modeButtonClass("prn")} onClick={() => handleModeChange("prn")}>
+            頓服
+          </button>
+        </div>
+
+        {mode === "prn" && (
+          <p className="text-xs text-ink-500 mt-1">
+            症状がある時だけ服用する薬です。ホーム画面には表示されません。
+          </p>
+        )}
+      </div>
+
+      {mode !== "prn" && mode !== "twice_daily" && mode !== "three_daily" && (
+        <div>
+          <label htmlFor="schedule-time" className="block text-sm font-medium text-ink-700 mb-1">
+            服薬時刻
+          </label>
+          <input
+            id="schedule-time"
+            type="time"
+            value={scheduledTime}
+            onChange={(e) => setScheduledTime(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+      )}
+
+      {mode !== "prn" && mode !== "twice_daily" && mode !== "three_daily" && (
+        <div>
+          {mode === "weekdays" && (
+            <div className="flex flex-wrap gap-2">
+              {DAY_OPTIONS.map(({ value, label }) => (
+                <label
+                  key={value}
+                  className={`flex items-center justify-center w-10 h-10 rounded-full cursor-pointer border-2 text-sm font-medium transition-colors ${
+                    selectedDays.includes(value)
+                      ? "bg-primary-600 text-white border-primary-600"
+                      : "bg-white text-ink-600 border-primary-200 hover:border-primary-400"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedDays.includes(value)}
+                    onChange={() => toggleDay(value)}
+                    className="sr-only"
+                    aria-label={label}
+                  />
+                  {label}
+                </label>
+              ))}
+              {selectedDays.length === 0 && (
+                <p className="w-full text-sm text-red-500 mt-1">曜日を選択してください</p>
+              )}
+            </div>
+          )}
+
+          {mode === "interval" && (
+            <div className="space-y-3 mt-2">
+              <div>
+                <label htmlFor="interval-days" className="block text-xs text-ink-500 mb-1">
+                  投与間隔
+                </label>
+                <select
+                  id="interval-days"
+                  value={intervalDays}
+                  onChange={(e) => setIntervalDays(e.target.value)}
+                  className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm"
+                >
+                  {INTERVAL_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="start-date" className="block text-xs text-ink-500 mb-1">
+                  開始日（最初の投与日）
+                </label>
+                <input
+                  id="start-date"
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm"
+                  required
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {(mode === "twice_daily" || mode === "three_daily") && (
+        <div>
+          <span className="block text-sm font-medium text-ink-700 mb-2">服薬時刻</span>
+          <div className="space-y-2">
+            {(mode === "twice_daily" ? TWICE_DAILY_LABELS : THREE_DAILY_LABELS).map((label, i) => (
+              <div key={label} className="flex items-center gap-3">
+                <span className={timeLabelClass}>{label}</span>
+                <input
+                  type="time"
+                  value={mode === "twice_daily" ? twiceTimes[i] : threeTimes[i]}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (mode === "twice_daily") {
+                      setTwiceTimes((prev) => {
+                        const next = [...prev] as [string, string];
+                        next[i] = val;
+                        return next;
+                      });
+                    } else {
+                      setThreeTimes((prev) => {
+                        const next = [...prev] as [string, string, string];
+                        next[i] = val;
+                        return next;
+                      });
+                    }
+                  }}
+                  className="flex-1 px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm"
+                />
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-ink-400 mt-2">
+            {mode === "twice_daily" ? "2回分" : "3回分"}
+            のスケジュールがまとめて登録されます。時刻は変更できます。
+          </p>
+        </div>
+      )}
+
+      {mode !== "prn" && (
+        <div>
+          <label htmlFor="reminder-minutes" className="block text-sm font-medium text-ink-700 mb-1">
+            リマインダー（分前）
+          </label>
+          <select
+            id="reminder-minutes"
+            value={reminderMinutes}
+            onChange={(e) => setReminderMinutes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
+          >
+            <option value="0">なし</option>
+            <option value="5">5分前</option>
+            <option value="10">10分前</option>
+            <option value="15">15分前</option>
+            <option value="30">30分前</option>
+            <option value="60">1時間前</option>
+          </select>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        className="w-full bg-primary-600 text-white py-2 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium"
+      >
+        スケジュールを追加
+      </button>
+    </form>
+  );
+};

--- a/frontend/app/components/members/MemberAvatarGroup.tsx
+++ b/frontend/app/components/members/MemberAvatarGroup.tsx
@@ -1,0 +1,36 @@
+interface AvatarMember {
+  id: string;
+  name: string;
+  memberType: "human" | "pet";
+}
+
+interface MemberAvatarGroupProps {
+  members: AvatarMember[];
+  max?: number;
+}
+
+export function MemberAvatarGroup({ members, max = 5 }: MemberAvatarGroupProps) {
+  const visible = members.slice(0, max);
+  const remaining = members.length - max;
+
+  return (
+    <div className="flex -space-x-2">
+      {visible.map((member) => (
+        <div
+          key={member.id}
+          className={`flex h-8 w-8 items-center justify-center rounded-full border-2 border-white text-xs font-bold text-white ${
+            member.memberType === "pet" ? "bg-amber-500" : "bg-primary-500"
+          }`}
+          title={member.name}
+        >
+          {member.name.charAt(0)}
+        </div>
+      ))}
+      {remaining > 0 && (
+        <div className="flex h-8 w-8 items-center justify-center rounded-full border-2 border-white bg-ink-400 text-xs font-bold text-white">
+          +{remaining}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/members/MemberForm.tsx
+++ b/frontend/app/components/members/MemberForm.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from "react";
+import type { Member } from "@/lib/types";
+
+export type MemberType = "human" | "pet";
+export type PetType = "dog" | "cat" | "rabbit" | "bird" | "other";
+
+export interface MemberFormData {
+  name: string;
+  memberType: MemberType;
+  petType?: PetType;
+  birthDate?: string;
+  notes?: string;
+}
+
+interface MemberFormProps {
+  onSubmit: (data: MemberFormData) => void;
+  initialData?: Member;
+  onCancel?: () => void;
+}
+
+export const MemberForm: React.FC<MemberFormProps> = ({ onSubmit, initialData, onCancel }) => {
+  const isEditing = !!initialData;
+  const [name, setName] = useState(initialData?.name || "");
+  const [memberType, setMemberType] = useState<MemberType>(
+    (initialData?.memberType as MemberType) || "human",
+  );
+  const [petType, setPetType] = useState<PetType>(
+    (initialData?.petType as PetType) || "dog",
+  );
+  const [birthDate, setBirthDate] = useState(
+    initialData?.birthDate ? new Date(initialData.birthDate).toISOString().split("T")[0] : "",
+  );
+  const [notes, setNotes] = useState(initialData?.notes || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) return;
+
+    const data: MemberFormData = {
+      name: name.trim(),
+      memberType,
+      ...(memberType === "pet" ? { petType } : {}),
+      ...(birthDate ? { birthDate } : {}),
+      ...(notes.trim() ? { notes: notes.trim() } : {}),
+    };
+
+    onSubmit(data);
+
+    if (!isEditing) {
+      setName("");
+      setMemberType("human");
+      setPetType("dog");
+      setBirthDate("");
+      setNotes("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="member-name" className="block text-sm font-medium text-ink-700 mb-1">
+          名前
+        </label>
+        <input
+          id="member-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="名前を入力"
+        />
+      </div>
+
+      {!isEditing && (
+        <div>
+          <label htmlFor="member-type" className="block text-sm font-medium text-ink-700 mb-1">
+            タイプ
+          </label>
+          <select
+            id="member-type"
+            value={memberType}
+            onChange={(e) => setMemberType(e.target.value as MemberType)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="human">家族</option>
+            <option value="pet">ペット</option>
+          </select>
+        </div>
+      )}
+
+      {memberType === "pet" && (
+        <div>
+          <label htmlFor="pet-type" className="block text-sm font-medium text-ink-700 mb-1">
+            ペットの種類
+          </label>
+          <select
+            id="pet-type"
+            value={petType}
+            onChange={(e) => setPetType(e.target.value as PetType)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="dog">犬</option>
+            <option value="cat">猫</option>
+            <option value="rabbit">うさぎ</option>
+            <option value="bird">鳥</option>
+            <option value="other">その他</option>
+          </select>
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="birth-date" className="block text-sm font-medium text-ink-700 mb-1">
+          生年月日
+        </label>
+        <input
+          id="birth-date"
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="member-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ
+        </label>
+        <textarea
+          id="member-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={3}
+          placeholder="メモを入力（任意）"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
+        >
+          {isEditing ? "更新する" : "追加する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 border border-primary-200 text-ink-700 rounded-lg hover:bg-primary-50 transition-colors"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/members/MemberList.tsx
+++ b/frontend/app/components/members/MemberList.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { Link } from "react-router";
+import { Pill, Pencil } from "lucide-react";
+import type { Member } from "@/lib/types";
+import { MemberIcon, type MemberType, type PetType } from "@/components/shared/MemberIcon";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { MemberSummaryCard, type MemberSummary } from "./MemberSummaryCard";
+
+interface MemberListProps {
+  members: Member[];
+  isLoading: boolean;
+  onDelete: (memberId: string) => void;
+  onEdit?: (member: Member) => void;
+  summaries?: MemberSummary[];
+}
+
+const memberTypeLabels: Record<string, string> = {
+  human: "家族",
+  pet: "ペット",
+};
+
+function getAge(birthDate: string | null): number | null {
+  if (!birthDate) return null;
+  const today = new Date();
+  const birth = new Date(birthDate);
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+export const MemberList: React.FC<MemberListProps> = ({
+  members,
+  isLoading,
+  onDelete,
+  onEdit,
+  summaries,
+}) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (members.length === 0) {
+    return (
+      <EmptyStatePrompt
+        message="メンバーがまだ登録されていません"
+        subMessage="上のフォームからメンバーを追加してください"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {members.map((member) => (
+        <MemberCard
+          key={member.id}
+          member={member}
+          onDelete={onDelete}
+          onEdit={onEdit}
+          summary={summaries?.find((s) => s.memberId === member.id)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export interface MemberCardProps {
+  member: Member;
+  onDelete: (memberId: string) => void;
+  onEdit?: (member: Member) => void;
+  summary?: MemberSummary;
+}
+
+const MemberCard: React.FC<MemberCardProps> = React.memo(({ member, onDelete, onEdit, summary }) => {
+  const age = getAge(member.birthDate);
+  const typeLabel = memberTypeLabels[member.memberType] ?? member.memberType;
+
+  return (
+    <div
+      className="bg-white rounded-lg shadow-md p-4 border border-primary-100"
+      data-testid="member-item"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <MemberIcon
+            memberType={member.memberType as MemberType}
+            petType={(member.petType ?? undefined) as PetType | undefined}
+            size={28}
+            className="text-ink-600"
+          />
+          <div>
+            <p className="font-semibold text-ink-800">{member.name}</p>
+            <div className="flex items-center space-x-2 text-sm text-ink-500">
+              <span>{typeLabel}</span>
+              {age !== null && <span>{age}歳</span>}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Link
+            to={`/members/${member.id}/medications`}
+            className="flex items-center space-x-1 text-primary-600 hover:text-primary-700 text-sm px-3 py-1 rounded-md hover:bg-primary-50 transition-colors"
+            aria-label="薬管理"
+          >
+            <Pill size={14} />
+            <span>薬管理</span>
+          </Link>
+          {onEdit && (
+            <button
+              onClick={() => onEdit(member)}
+              className="text-ink-500 hover:text-ink-700 text-sm px-2 py-1 rounded-md hover:bg-primary-50 transition-colors"
+              aria-label="編集"
+            >
+              <Pencil size={14} />
+            </button>
+          )}
+          <button
+            onClick={() => onDelete(member.id)}
+            className="text-red-500 hover:text-red-700 text-sm px-3 py-1 rounded-md hover:bg-red-50 transition-colors"
+            aria-label="削除"
+          >
+            削除
+          </button>
+        </div>
+      </div>
+      {summary && <MemberSummaryCard summary={summary} />}
+      {member.notes && <p className="mt-2 text-sm text-ink-500">{member.notes}</p>}
+    </div>
+  );
+});
+
+MemberCard.displayName = "MemberCard";

--- a/frontend/app/components/members/MemberQuickActions.tsx
+++ b/frontend/app/components/members/MemberQuickActions.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Link } from "react-router";
+import { Pill, Clock } from "lucide-react";
+import type { Member } from "@/lib/types";
+import { MemberIcon, type MemberType, type PetType } from "@/components/shared/MemberIcon";
+
+interface MemberQuickActionsProps {
+  member: Member;
+  medicationCount: number;
+  scheduleCount: number;
+}
+
+export const MemberQuickActions: React.FC<MemberQuickActionsProps> = ({
+  member,
+  medicationCount,
+  scheduleCount,
+}) => {
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-center space-x-2 mb-2">
+        <MemberIcon
+          memberType={member.memberType as MemberType}
+          petType={(member.petType ?? undefined) as PetType | undefined}
+          size={18}
+          className="text-ink-600"
+        />
+        <span className="text-sm font-medium text-ink-800">{member.name}</span>
+      </div>
+      <div className="flex space-x-2">
+        <Link
+          to={`/members/${member.id}/medications`}
+          className="flex-1 flex items-center justify-center space-x-1 px-2 py-1.5 bg-primary-50 text-primary-700 rounded text-xs hover:bg-primary-100 transition-colors"
+        >
+          <Pill size={12} />
+          <span>薬管理</span>
+          <span className="text-primary-500">{medicationCount}件</span>
+        </Link>
+        <div className="flex-1 flex items-center justify-center space-x-1 px-2 py-1.5 bg-primary-50 text-ink-600 rounded text-xs">
+          <Clock size={12} />
+          <span>スケジュール</span>
+          <span className="text-ink-400">{scheduleCount}件</span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/app/components/members/MemberSummaryCard.tsx
+++ b/frontend/app/components/members/MemberSummaryCard.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Pill, Calendar } from "lucide-react";
+
+export interface MemberSummary {
+  memberId: string;
+  memberName: string;
+  memberType: string;
+  medicationCount: number;
+  nextAppointmentDate: string | null;
+}
+
+interface MemberSummaryCardProps {
+  summary: MemberSummary;
+}
+
+function diffDays(from: Date, to: Date): number {
+  const toStartOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  return Math.round(
+    (toStartOfDay(to).getTime() - toStartOfDay(from).getTime()) / (1000 * 60 * 60 * 24),
+  );
+}
+
+function getAppointmentLabel(nextAppointmentDate: string | null): string {
+  if (!nextAppointmentDate) return "";
+  const days = diffDays(new Date(), new Date(nextAppointmentDate));
+  if (days === 0) return "今日";
+  if (days === 1) return "明日";
+  return `${days}日後`;
+}
+
+export const MemberSummaryCard: React.FC<MemberSummaryCardProps> = React.memo(({ summary }) => {
+  const appointmentLabel = getAppointmentLabel(summary.nextAppointmentDate);
+
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div className="flex items-center space-x-2 text-sm text-ink-600">
+        <Pill size={14} />
+        <span>{summary.medicationCount}種類</span>
+      </div>
+      {appointmentLabel && (
+        <div className="flex items-center space-x-1 text-sm text-orange-600">
+          <Calendar size={14} />
+          <span>次回通院: {appointmentLabel}</span>
+        </div>
+      )}
+    </div>
+  );
+});
+
+MemberSummaryCard.displayName = "MemberSummaryCard";

--- a/frontend/app/components/notification-settings/NotificationSettingsForm.tsx
+++ b/frontend/app/components/notification-settings/NotificationSettingsForm.tsx
@@ -1,0 +1,301 @@
+import { useState, useEffect } from "react";
+import { Bell, BellOff, Mail, Clock, Calendar } from "lucide-react";
+import type { NotificationSetting } from "@/lib/types";
+
+export type UpdateNotificationSettingInput = Partial<{
+  medicationReminderEnabled: boolean;
+  missedMedicationEnabled: boolean;
+  appointmentReminderEnabled: boolean;
+  lowStockAlertEnabled: boolean;
+  defaultReminderMinutesBefore: number;
+  defaultAppointmentReminderDaysBefore: number;
+  emailNotificationEnabled: boolean;
+}>;
+
+type NotificationTypeKey =
+  | "medication_reminder"
+  | "missed_medication"
+  | "appointment_reminder"
+  | "low_stock";
+
+const NOTIFICATION_TYPES: ReadonlyArray<{
+  key: NotificationTypeKey;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: "medication_reminder",
+    label: "服薬リマインダー",
+    description: "服薬時間になったら通知します",
+  },
+  {
+    key: "missed_medication",
+    label: "飲み忘れ通知",
+    description: "服薬時間を過ぎても記録がない場合に通知します",
+  },
+  {
+    key: "appointment_reminder",
+    label: "通院リマインダー",
+    description: "通院予約の前日に通知します",
+  },
+  {
+    key: "low_stock",
+    label: "在庫アラート",
+    description: "お薬の在庫が少なくなったら通知します",
+  },
+];
+
+const DEFAULT_NOTIFICATION_SETTING = {
+  medicationReminderEnabled: true,
+  missedMedicationEnabled: true,
+  appointmentReminderEnabled: true,
+  lowStockAlertEnabled: true,
+  defaultReminderMinutesBefore: 5,
+  defaultAppointmentReminderDaysBefore: 1,
+  emailNotificationEnabled: true,
+} as const;
+
+interface NotificationSettingsFormProps {
+  setting: NotificationSetting | null;
+  onSave: (input: UpdateNotificationSettingInput) => Promise<void>;
+  isLoading: boolean;
+}
+
+const REMINDER_MINUTES_OPTIONS = [
+  { value: 0, label: "なし" },
+  { value: 5, label: "5分前" },
+  { value: 10, label: "10分前" },
+  { value: 15, label: "15分前" },
+  { value: 30, label: "30分前" },
+  { value: 60, label: "1時間前" },
+];
+
+const APPOINTMENT_DAYS_OPTIONS = [
+  { value: 0, label: "当日" },
+  { value: 1, label: "1日前" },
+  { value: 2, label: "2日前" },
+  { value: 3, label: "3日前" },
+  { value: 7, label: "1週間前" },
+];
+
+const NOTIFICATION_FIELD_MAP: Record<NotificationTypeKey, keyof UpdateNotificationSettingInput> = {
+  medication_reminder: "medicationReminderEnabled",
+  missed_medication: "missedMedicationEnabled",
+  appointment_reminder: "appointmentReminderEnabled",
+  low_stock: "lowStockAlertEnabled",
+};
+
+export function NotificationSettingsForm({ setting, onSave, isLoading }: NotificationSettingsFormProps) {
+  const [isSaving, setIsSaving] = useState(false);
+  const [emailEnabled, setEmailEnabled] = useState(true);
+  const [enabledTypes, setEnabledTypes] = useState<Record<NotificationTypeKey, boolean>>({
+    medication_reminder: true,
+    missed_medication: true,
+    appointment_reminder: true,
+    low_stock: true,
+  });
+  const [reminderMinutes, setReminderMinutes] = useState(5);
+  const [appointmentDays, setAppointmentDays] = useState(1);
+
+  useEffect(() => {
+    const s = setting ?? DEFAULT_NOTIFICATION_SETTING;
+    setEmailEnabled(s.emailNotificationEnabled);
+    setEnabledTypes({
+      medication_reminder: s.medicationReminderEnabled,
+      missed_medication: s.missedMedicationEnabled,
+      appointment_reminder: s.appointmentReminderEnabled,
+      low_stock: s.lowStockAlertEnabled,
+    });
+    setReminderMinutes(s.defaultReminderMinutesBefore);
+    setAppointmentDays(s.defaultAppointmentReminderDaysBefore);
+  }, [setting]);
+
+  const handleToggleType = async (typeKey: NotificationTypeKey) => {
+    const prevValue = enabledTypes[typeKey];
+    const newValue = !prevValue;
+    setEnabledTypes((prev) => ({ ...prev, [typeKey]: newValue }));
+    const field = NOTIFICATION_FIELD_MAP[typeKey];
+    setIsSaving(true);
+    try {
+      await onSave({ [field]: newValue });
+    } catch {
+      setEnabledTypes((prev) => ({ ...prev, [typeKey]: prevValue }));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleToggleEmail = async () => {
+    const prevValue = emailEnabled;
+    const newValue = !prevValue;
+    setEmailEnabled(newValue);
+    setIsSaving(true);
+    try {
+      await onSave({ emailNotificationEnabled: newValue });
+    } catch {
+      setEmailEnabled(prevValue);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReminderMinutesChange = async (value: number) => {
+    const prevValue = reminderMinutes;
+    setReminderMinutes(value);
+    setIsSaving(true);
+    try {
+      await onSave({ defaultReminderMinutesBefore: value });
+    } catch {
+      setReminderMinutes(prevValue);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleAppointmentDaysChange = async (value: number) => {
+    const prevValue = appointmentDays;
+    setAppointmentDays(value);
+    setIsSaving(true);
+    try {
+      await onSave({ defaultAppointmentReminderDaysBefore: value });
+    } catch {
+      setAppointmentDays(prevValue);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center py-8">
+        <div className="animate-spin rounded-full h-6 w-6 border-2 border-primary-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <Mail size={18} className="text-primary-600" />
+            <h2 className="text-lg font-semibold text-ink-800">メール通知</h2>
+          </div>
+          <button
+            onClick={handleToggleEmail}
+            disabled={isSaving}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+              emailEnabled ? "bg-primary-600" : "bg-ink-300"
+            }`}
+            role="switch"
+            aria-checked={emailEnabled}
+            aria-label="メール通知の切り替え"
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                emailEnabled ? "translate-x-6" : "translate-x-1"
+              }`}
+            />
+          </button>
+        </div>
+        <p className="text-xs text-ink-500 mt-1">
+          メール通知を無効にすると、すべての通知が停止します
+        </p>
+      </section>
+
+      <section className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+        <div className="flex items-center space-x-2 mb-4">
+          {emailEnabled ? (
+            <Bell size={18} className="text-primary-600" />
+          ) : (
+            <BellOff size={18} className="text-ink-400" />
+          )}
+          <h2 className="text-lg font-semibold text-ink-800">通知の種類</h2>
+        </div>
+        <div className="space-y-3">
+          {NOTIFICATION_TYPES.map((type) => (
+            <div
+              key={type.key}
+              className={`flex items-center justify-between p-3 rounded-lg border ${
+                emailEnabled ? "border-primary-100 bg-white" : "border-primary-50 bg-primary-50/40"
+              }`}
+            >
+              <div className="flex-1 min-w-0">
+                <p className={`text-sm font-medium ${emailEnabled ? "text-ink-800" : "text-ink-400"}`}>
+                  {type.label}
+                </p>
+                <p className={`text-xs ${emailEnabled ? "text-ink-500" : "text-ink-400"}`}>
+                  {type.description}
+                </p>
+              </div>
+              <button
+                onClick={() => handleToggleType(type.key)}
+                disabled={!emailEnabled || isSaving}
+                className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ml-3 ${
+                  enabledTypes[type.key] && emailEnabled ? "bg-primary-600" : "bg-ink-300"
+                } ${!emailEnabled ? "opacity-50 cursor-not-allowed" : ""}`}
+                role="switch"
+                aria-checked={enabledTypes[type.key]}
+                aria-label={`${type.label}の切り替え`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                    enabledTypes[type.key] && emailEnabled ? "translate-x-6" : "translate-x-1"
+                  }`}
+                />
+              </button>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+        <div className="flex items-center space-x-2 mb-4">
+          <Clock size={18} className="text-primary-600" />
+          <h2 className="text-lg font-semibold text-ink-800">デフォルトリマインダー</h2>
+        </div>
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="reminder-minutes" className="block text-sm font-medium text-ink-700 mb-1">
+              服薬リマインダー（何分前）
+            </label>
+            <select
+              id="reminder-minutes"
+              value={reminderMinutes}
+              onChange={(e) => handleReminderMinutesChange(Number(e.target.value))}
+              disabled={!emailEnabled || isSaving}
+              className="w-full px-3 py-2 text-sm border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-primary-50 disabled:text-ink-400"
+            >
+              {REMINDER_MINUTES_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="appointment-days" className="block text-sm font-medium text-ink-700 mb-1">
+              <span className="flex items-center space-x-1">
+                <Calendar size={14} />
+                <span>通院リマインダー（何日前）</span>
+              </span>
+            </label>
+            <select
+              id="appointment-days"
+              value={appointmentDays}
+              onChange={(e) => handleAppointmentDaysChange(Number(e.target.value))}
+              disabled={!emailEnabled || isSaving}
+              className="w-full px-3 py-2 text-sm border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-primary-50 disabled:text-ink-400"
+            >
+              {APPOINTMENT_DAYS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/components/prescriptions/PrescriptionForm.tsx
+++ b/frontend/app/components/prescriptions/PrescriptionForm.tsx
@@ -1,0 +1,196 @@
+import React, { useState } from "react";
+import type { Member } from "@/lib/types";
+
+export interface PrescriptionFormData {
+  memberId: string;
+  prescriptionName: string;
+  prescribedBy?: string;
+  prescribedAt: string;
+  expiresAt?: string;
+  pharmacyName?: string;
+  notes?: string;
+}
+
+interface PrescriptionFormProps {
+  members: Member[];
+  onSubmit: (data: PrescriptionFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    prescriptionName: string;
+    prescribedBy?: string;
+    prescribedAt: string;
+    expiresAt?: string;
+    pharmacyName?: string;
+    notes?: string;
+  };
+}
+
+const toDateInput = (value: string | null | undefined): string => {
+  if (!value) return "";
+  return new Date(value).toISOString().split("T")[0];
+};
+
+const todayInput = (): string => new Date().toISOString().split("T")[0];
+
+export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
+  const [prescriptionName, setPrescriptionName] = useState(initialData?.prescriptionName || "");
+  const [prescribedBy, setPrescribedBy] = useState(initialData?.prescribedBy || "");
+  const [prescribedAt, setPrescribedAt] = useState(
+    initialData?.prescribedAt ? toDateInput(initialData.prescribedAt) : todayInput(),
+  );
+  const [expiresAt, setExpiresAt] = useState(toDateInput(initialData?.expiresAt));
+  const [pharmacyName, setPharmacyName] = useState(initialData?.pharmacyName || "");
+  const [notes, setNotes] = useState(initialData?.notes || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !prescriptionName.trim() || !prescribedAt) return;
+
+    onSubmit({
+      memberId,
+      prescriptionName: prescriptionName.trim(),
+      prescribedBy: prescribedBy.trim() || undefined,
+      prescribedAt: new Date(prescribedAt).toISOString(),
+      expiresAt: expiresAt ? new Date(expiresAt).toISOString() : undefined,
+      pharmacyName: pharmacyName.trim() || undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setPrescriptionName("");
+      setPrescribedBy("");
+      setExpiresAt("");
+      setPharmacyName("");
+      setNotes("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="rx-member" className="block text-sm font-medium text-ink-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="rx-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="rx-name" className="block text-sm font-medium text-ink-700 mb-1">
+          処方箋名
+        </label>
+        <input
+          id="rx-name"
+          type="text"
+          value={prescriptionName}
+          onChange={(e) => setPrescriptionName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="例: 高血圧治療薬、抗生物質"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="rx-doctor" className="block text-sm font-medium text-ink-700 mb-1">
+          処方医（任意）
+        </label>
+        <input
+          id="rx-doctor"
+          type="text"
+          value={prescribedBy}
+          onChange={(e) => setPrescribedBy(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="例: 山田太郎 医師"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="rx-date" className="block text-sm font-medium text-ink-700 mb-1">
+            処方日
+          </label>
+          <input
+            id="rx-date"
+            type="date"
+            value={prescribedAt}
+            onChange={(e) => setPrescribedAt(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="rx-expires" className="block text-sm font-medium text-ink-700 mb-1">
+            有効期限（任意）
+          </label>
+          <input
+            id="rx-expires"
+            type="date"
+            value={expiresAt}
+            onChange={(e) => setExpiresAt(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="rx-pharmacy" className="block text-sm font-medium text-ink-700 mb-1">
+          薬局名（任意）
+        </label>
+        <input
+          id="rx-pharmacy"
+          type="text"
+          value={pharmacyName}
+          onChange={(e) => setPharmacyName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="例: 調剤薬局ABC"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="rx-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="rx-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="リフィル回数、注意事項など"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
+        >
+          {initialData ? "更新する" : "登録する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-primary-50 text-ink-700 py-2 px-4 rounded-lg hover:bg-primary-100 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/prescriptions/PrescriptionList.tsx
+++ b/frontend/app/components/prescriptions/PrescriptionList.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X } from "lucide-react";
+import type { Prescription } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+export type PrescriptionWithMember = Prescription & { memberName?: string };
+
+export interface UpdatePrescriptionInput {
+  prescriptionName?: string;
+  prescribedBy?: string | null;
+  pharmacyName?: string | null;
+  notes?: string | null;
+}
+
+interface PrescriptionListProps {
+  prescriptions: PrescriptionWithMember[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdatePrescriptionInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const PrescriptionList: React.FC<PrescriptionListProps> = ({
+  prescriptions,
+  isLoading,
+  onUpdate,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (prescriptions.length === 0) {
+    return <EmptyStatePrompt message="処方箋が登録されていません" subMessage="上の＋ボタンから処方箋を追加できます" />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {prescriptions.map((p) => (
+        <PrescriptionCard key={p.id} prescription={p} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface PrescriptionCardProps {
+  prescription: PrescriptionWithMember;
+  onUpdate: (id: string, input: UpdatePrescriptionInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescription, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editName, setEditName] = useState(prescription.prescriptionName);
+  const [editDoctor, setEditDoctor] = useState(prescription.prescribedBy || "");
+  const [editPharmacy, setEditPharmacy] = useState(prescription.pharmacyName || "");
+  const [editNotes, setEditNotes] = useState(prescription.notes || "");
+
+  const now = new Date();
+  const expiresDate = prescription.expiresAt ? new Date(prescription.expiresAt) : null;
+  const isExpired = expiresDate && expiresDate < now;
+  const isExpiringSoon =
+    !isExpired && expiresDate && expiresDate.getTime() - now.getTime() < 7 * 24 * 60 * 60 * 1000;
+
+  const handleSave = async () => {
+    if (!editName.trim()) return;
+    await onUpdate(prescription.id, {
+      prescriptionName: editName.trim(),
+      prescribedBy: editDoctor.trim() || null,
+      pharmacyName: editPharmacy.trim() || null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(prescription.prescriptionName);
+    setEditDoctor(prescription.prescribedBy || "");
+    setEditPharmacy(prescription.pharmacyName || "");
+    setEditNotes(prescription.notes || "");
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200 space-y-3">
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">処方箋名</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">処方医</label>
+          <input
+            type="text"
+            value={editDoctor}
+            onChange={(e) => setEditDoctor(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">薬局名</label>
+          <input
+            type="text"
+            value={editPharmacy}
+            onChange={(e) => setEditPharmacy(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim()}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary text-white py-1.5 rounded-lg text-sm hover:bg-primary-dark transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-50 text-ink-700 py-1.5 rounded-lg text-sm hover:bg-primary-100 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2 flex-wrap gap-y-1">
+            <p className="font-medium text-ink-800 text-sm">{prescription.prescriptionName}</p>
+            {isExpired && <span className="text-xs bg-red-100 text-red-700 px-1.5 py-0.5 rounded">期限切れ</span>}
+            {isExpiringSoon && (
+              <span className="text-xs bg-yellow-100 text-yellow-700 px-1.5 py-0.5 rounded">期限間近</span>
+            )}
+            {prescription.memberName && (
+              <span className="text-xs bg-primary-50 text-ink-600 px-1.5 py-0.5 rounded">{prescription.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-ink-500 mt-1 space-y-0.5">
+            <p>処方日: {new Date(prescription.prescribedAt).toLocaleDateString("ja-JP")}</p>
+            {prescription.prescribedBy && <p>処方医: {prescription.prescribedBy}</p>}
+            {prescription.expiresAt && (
+              <p>有効期限: {new Date(prescription.expiresAt).toLocaleDateString("ja-JP")}</p>
+            )}
+            {prescription.pharmacyName && <p>薬局: {prescription.pharmacyName}</p>}
+            {prescription.notes && <p className="text-ink-400">{prescription.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <ConfirmationDialog
+        title="処方箋の削除"
+        message={`「${prescription.prescriptionName}」を削除しますか？この操作は取り消せません。`}
+        isOpen={isDeleteDialogOpen}
+        onConfirm={() => {
+          setIsDeleteDialogOpen(false);
+          onDelete(prescription.id);
+        }}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        isDangerous
+      />
+    </div>
+  );
+});
+
+PrescriptionCard.displayName = "PrescriptionCard";

--- a/frontend/app/components/schedules/ScheduleConflictBadge.tsx
+++ b/frontend/app/components/schedules/ScheduleConflictBadge.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { AlertCircle } from "lucide-react";
+
+interface ScheduleConflictBadgeProps {
+  conflictCount: number;
+  message?: string;
+}
+
+export const ScheduleConflictBadge: React.FC<ScheduleConflictBadgeProps> = ({
+  conflictCount,
+  message,
+}) => {
+  if (conflictCount === 0) return null;
+
+  return (
+    <div className="flex items-center space-x-1 px-2 py-1 bg-orange-50 text-orange-700 rounded text-xs">
+      <AlertCircle size={12} />
+      <span>{message || `${conflictCount}件の重複`}</span>
+    </div>
+  );
+};

--- a/frontend/app/components/schedules/ScheduleTimelineView.tsx
+++ b/frontend/app/components/schedules/ScheduleTimelineView.tsx
@@ -1,0 +1,55 @@
+import React, { useMemo } from "react";
+import { Check, Clock } from "lucide-react";
+
+export interface TimelineItem {
+  id: string;
+  time: string;
+  medicationName: string;
+  memberName: string;
+  isCompleted: boolean;
+}
+
+interface ScheduleTimelineViewProps {
+  items: TimelineItem[];
+}
+
+export const ScheduleTimelineView: React.FC<ScheduleTimelineViewProps> = ({ items }) => {
+  const sortedItems = useMemo(
+    () => [...items].sort((a, b) => a.time.localeCompare(b.time)),
+    [items],
+  );
+
+  if (sortedItems.length === 0) {
+    return (
+      <div className="text-center py-6 text-ink-400 text-sm">今日のスケジュールはありません</div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {sortedItems.map((item) => (
+        <div key={item.id} className="flex items-center space-x-3 py-2">
+          <span className="text-xs font-mono text-ink-500 w-12 text-right">{item.time}</span>
+          <div className="relative">
+            {item.isCompleted ? (
+              <span
+                aria-label="完了済み"
+                className="flex items-center justify-center w-5 h-5 bg-green-500 rounded-full"
+              >
+                <Check size={12} className="text-white" />
+              </span>
+            ) : (
+              <span className="flex items-center justify-center w-5 h-5 border-2 border-primary-200 rounded-full">
+                <Clock size={10} className="text-ink-400" />
+              </span>
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-ink-800 truncate">{item.medicationName}</p>
+            <p className="text-xs text-ink-400 truncate">{item.memberName}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/frontend/app/components/schedules/WeekdaySelector.tsx
+++ b/frontend/app/components/schedules/WeekdaySelector.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+const WEEKDAYS = ["月", "火", "水", "木", "金", "土", "日"] as const;
+
+interface WeekdaySelectorProps {
+  selectedDays: string[];
+  onChange: (days: string[]) => void;
+  disabled?: boolean;
+}
+
+export function WeekdaySelector({
+  selectedDays,
+  onChange,
+  disabled = false,
+}: WeekdaySelectorProps) {
+  const handleToggle = (day: string) => {
+    if (selectedDays.includes(day)) {
+      onChange(selectedDays.filter((d) => d !== day));
+    } else {
+      onChange([...selectedDays, day]);
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      {WEEKDAYS.map((day) => (
+        <label
+          key={day}
+          className={`flex cursor-pointer items-center justify-center rounded-md border px-3 py-1.5 text-sm transition-colors ${
+            selectedDays.includes(day)
+              ? "border-primary-500 bg-primary-50 text-primary-700"
+              : "border-primary-200 bg-white text-ink-600 hover:bg-primary-50"
+          } ${disabled ? "cursor-not-allowed opacity-50" : ""}`}
+        >
+          <input
+            type="checkbox"
+            checked={selectedDays.includes(day)}
+            onChange={() => handleToggle(day)}
+            disabled={disabled}
+            className="sr-only"
+          />
+          {day}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/components/shared/BottomNavigation.tsx
+++ b/frontend/app/components/shared/BottomNavigation.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Link } from "react-router";
+import { Home, Pill, Calendar, Activity, Settings, type LucideIcon } from "lucide-react";
+
+interface NavItem {
+  path: string;
+  icon: LucideIcon;
+  label: string;
+}
+
+const navItems: NavItem[] = [
+  { path: "/", icon: Home, label: "ホーム" },
+  { path: "/medications", icon: Pill, label: "お薬" },
+  { path: "/health-logs", icon: Activity, label: "体調" },
+  { path: "/appointments", icon: Calendar, label: "通院" },
+  { path: "/settings", icon: Settings, label: "設定" },
+];
+
+interface BottomNavigationProps {
+  activePath: string;
+}
+
+export const BottomNavigation: React.FC<BottomNavigationProps> = ({ activePath }) => {
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 bg-white border-t border-primary-100 shadow-lg"
+      aria-label="メインナビゲーション"
+    >
+      <div className="max-w-md mx-auto flex justify-around py-2">
+        {navItems.map(({ path, icon, label }) => {
+          const isActive = activePath === path;
+          return (
+            <Link
+              key={path}
+              to={path}
+              {...(isActive && { "aria-current": "page" as const })}
+              className={`flex flex-col items-center text-xs transition-colors ${
+                isActive ? "text-primary-700 font-semibold" : "text-ink-400 hover:text-primary-600"
+              }`}
+            >
+              {React.createElement(icon, { size: 20, className: "mb-0.5" })}
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};

--- a/frontend/app/components/shared/CategoryFilter.tsx
+++ b/frontend/app/components/shared/CategoryFilter.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+
+export type MedicationCategory =
+  | "regular"
+  | "supplement"
+  | "prn"
+  | "inhaler"
+  | "eye_drops"
+  | "patch"
+  | "topical"
+  | "flea_tick"
+  | "heartworm";
+
+const CATEGORY_LABELS: Record<MedicationCategory, string> = {
+  regular: "常用薬",
+  supplement: "サプリメント",
+  prn: "頓服薬",
+  inhaler: "吸入薬",
+  eye_drops: "目薬",
+  patch: "湿布",
+  topical: "塗り薬",
+  flea_tick: "ノミ・ダニ薬",
+  heartworm: "フィラリア薬",
+};
+
+export function getAllMedicationCategories(): Array<{ id: MedicationCategory; label: string }> {
+  return (Object.entries(CATEGORY_LABELS) as Array<[MedicationCategory, string]>).map(
+    ([id, label]) => ({ id, label }),
+  );
+}
+
+interface CategoryFilterProps {
+  selectedCategory: MedicationCategory | null;
+  onSelect: (category: MedicationCategory | null) => void;
+  availableCategories?: MedicationCategory[];
+}
+
+export const CategoryFilter: React.FC<CategoryFilterProps> = ({
+  selectedCategory,
+  onSelect,
+  availableCategories,
+}) => {
+  const allCategories = getAllMedicationCategories();
+  const categories = availableCategories
+    ? allCategories.filter((c) => availableCategories.includes(c.id))
+    : allCategories;
+
+  if (categories.length <= 1) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-3" role="tablist" aria-label="カテゴリフィルター">
+      <button
+        role="tab"
+        aria-selected={selectedCategory === null}
+        onClick={() => onSelect(null)}
+        className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+          selectedCategory === null
+            ? "bg-primary-700 text-white border border-primary-700"
+            : "bg-white text-ink-700 border border-primary-200 hover:bg-primary-50"
+        }`}
+      >
+        すべて
+      </button>
+      {categories.map((cat) => (
+        <button
+          key={cat.id}
+          role="tab"
+          aria-selected={selectedCategory === cat.id}
+          onClick={() => onSelect(cat.id)}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+            selectedCategory === cat.id
+              ? "bg-primary-700 text-white border border-primary-700"
+              : "bg-white text-ink-700 border border-primary-200 hover:bg-primary-50"
+          }`}
+        >
+          {cat.label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/frontend/app/components/shared/CharacterIcon.tsx
+++ b/frontend/app/components/shared/CharacterIcon.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Dog, Cat, Rabbit, Bird } from "lucide-react";
+import type { CharacterType } from "@/lib/character";
+
+interface CharacterIconProps {
+  type: CharacterType;
+  size?: number;
+  className?: string;
+}
+
+const iconMap = {
+  dog: Dog,
+  cat: Cat,
+  rabbit: Rabbit,
+  bird: Bird,
+} as const;
+
+export const CharacterIcon: React.FC<CharacterIconProps> = ({ type, size = 32, className }) => {
+  const Icon = iconMap[type];
+  return <Icon size={size} className={className} aria-hidden="true" />;
+};

--- a/frontend/app/components/shared/ConfirmationDialog.tsx
+++ b/frontend/app/components/shared/ConfirmationDialog.tsx
@@ -1,0 +1,46 @@
+interface ConfirmationDialogProps {
+  title: string;
+  message: string;
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDangerous?: boolean;
+}
+
+export function ConfirmationDialog({
+  title,
+  message,
+  isOpen,
+  onConfirm,
+  onCancel,
+  isDangerous = false,
+}: ConfirmationDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="mx-4 w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <h2 className="mb-2 text-lg font-bold text-ink-800">{title}</h2>
+        <p className="mb-6 text-ink-600">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-xl border border-primary-200 px-4 py-2 text-ink-700 hover:bg-primary-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={`rounded-xl px-4 py-2 text-white ${
+              isDangerous ? "bg-red-600 hover:bg-red-700" : "bg-primary hover:bg-primary-dark"
+            }`}
+          >
+            確認
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/shared/DateRangeSelector.tsx
+++ b/frontend/app/components/shared/DateRangeSelector.tsx
@@ -1,0 +1,43 @@
+interface DateRangeSelectorProps {
+  startDate: string;
+  endDate: string;
+  onStartChange: (date: string) => void;
+  onEndChange: (date: string) => void;
+}
+
+export function DateRangeSelector({
+  startDate,
+  endDate,
+  onStartChange,
+  onEndChange,
+}: DateRangeSelectorProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <div>
+        <label htmlFor="start-date" className="mb-1 block text-sm font-medium text-ink-700">
+          開始日
+        </label>
+        <input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(e) => onStartChange(e.target.value)}
+          className="rounded-xl border border-primary-200 px-3 py-2 text-sm"
+        />
+      </div>
+      <span className="mt-6 text-ink-400">〜</span>
+      <div>
+        <label htmlFor="end-date" className="mb-1 block text-sm font-medium text-ink-700">
+          終了日
+        </label>
+        <input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(e) => onEndChange(e.target.value)}
+          className="rounded-xl border border-primary-200 px-3 py-2 text-sm"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/shared/EmptyStatePrompt.tsx
+++ b/frontend/app/components/shared/EmptyStatePrompt.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Inbox } from "lucide-react";
+
+interface EmptyStatePromptProps {
+  message: string;
+  subMessage?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export const EmptyStatePrompt: React.FC<EmptyStatePromptProps> = ({
+  message,
+  subMessage,
+  actionLabel,
+  onAction,
+}) => {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <Inbox size={40} className="text-primary-200 mb-3" />
+      <p className="text-ink-500 text-sm font-medium">{message}</p>
+      {subMessage && <p className="text-ink-400 text-xs mt-1">{subMessage}</p>}
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          className="mt-4 px-4 py-2 bg-primary text-white text-sm rounded-xl hover:bg-primary-dark transition-colors"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/frontend/app/components/shared/ErrorBoundary.tsx
+++ b/frontend/app/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("エラーバウンダリーが例外をキャッチしました:", error, errorInfo);
+  }
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-primary-50">
+          <div className="text-center p-8">
+            <h1 className="text-xl font-bold text-red-600 mb-4">エラーが発生しました</h1>
+            <p className="text-ink-600 mb-6">{this.state.error?.message}</p>
+            <button
+              onClick={this.handleReload}
+              className="bg-primary text-white px-6 py-2 rounded-xl hover:bg-primary-dark transition-colors"
+            >
+              再読み込み
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/app/components/shared/HealthScoreIndicator.tsx
+++ b/frontend/app/components/shared/HealthScoreIndicator.tsx
@@ -1,0 +1,21 @@
+interface HealthScoreIndicatorProps {
+  score: number;
+  label?: string;
+}
+
+function getScoreStyle(score: number): string {
+  if (score >= 70) return "text-green-600 bg-green-50 border-green-200";
+  if (score >= 40) return "text-yellow-600 bg-yellow-50 border-yellow-200";
+  return "text-red-600 bg-red-50 border-red-200";
+}
+
+export function HealthScoreIndicator({ score, label }: HealthScoreIndicatorProps) {
+  const style = getScoreStyle(score);
+
+  return (
+    <div className={`inline-flex flex-col items-center rounded-2xl border px-4 py-2 ${style}`}>
+      <span className="text-2xl font-bold">{score}</span>
+      {label && <span className="text-xs font-medium">{label}</span>}
+    </div>
+  );
+}

--- a/frontend/app/components/shared/LoadingSpinner.tsx
+++ b/frontend/app/components/shared/LoadingSpinner.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Loader2 } from "lucide-react";
+
+interface LoadingSpinnerProps {
+  message?: string;
+}
+
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ message = "読み込み中..." }) => {
+  return (
+    <div className="flex justify-center items-center py-8">
+      <Loader2 size={20} className="animate-spin text-primary mr-2" />
+      <p className="text-ink-500 text-sm">{message}</p>
+    </div>
+  );
+};

--- a/frontend/app/components/shared/MedicationSortSelector.tsx
+++ b/frontend/app/components/shared/MedicationSortSelector.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+export type MedicationSortKey = "name" | "category" | "stock";
+
+interface MedicationSortSelectorProps {
+  value: MedicationSortKey;
+  onChange: (key: MedicationSortKey) => void;
+}
+
+const sortOptions: { key: MedicationSortKey; label: string }[] = [
+  { key: "name", label: "名前順" },
+  { key: "category", label: "カテゴリ順" },
+  { key: "stock", label: "在庫順" },
+];
+
+export const MedicationSortSelector: React.FC<MedicationSortSelectorProps> = ({
+  value,
+  onChange,
+}) => {
+  return (
+    <div className="flex space-x-1 mb-3">
+      {sortOptions.map((opt) => (
+        <button
+          key={opt.key}
+          onClick={() => onChange(opt.key)}
+          className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+            value === opt.key
+              ? "bg-primary-100 text-primary-700"
+              : "bg-primary-50 text-ink-500 hover:bg-primary-100"
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/frontend/app/components/shared/MemberFilter.tsx
+++ b/frontend/app/components/shared/MemberFilter.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+export interface MemberOption {
+  id: string;
+  name: string;
+}
+
+interface MemberFilterProps {
+  members: MemberOption[];
+  selectedMemberId: string | null;
+  onSelect: (memberId: string | null) => void;
+}
+
+export const MemberFilter: React.FC<MemberFilterProps> = ({
+  members,
+  selectedMemberId,
+  onSelect,
+}) => {
+  if (members.length === 0) return null;
+
+  return (
+    <div
+      className="flex space-x-2 overflow-x-auto pb-2"
+      role="tablist"
+      aria-label="メンバーフィルター"
+    >
+      <button
+        onClick={() => onSelect(null)}
+        className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
+          selectedMemberId === null
+            ? "bg-primary-700 text-white border border-primary-700"
+            : "bg-white text-ink-700 border border-primary-200 hover:bg-primary-50"
+        }`}
+        role="tab"
+        aria-selected={selectedMemberId === null}
+      >
+        全員
+      </button>
+      {members.map((member) => (
+        <button
+          key={member.id}
+          onClick={() => onSelect(member.id)}
+          className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
+            selectedMemberId === member.id
+              ? "bg-primary-700 text-white border border-primary-700"
+              : "bg-white text-ink-700 border border-primary-200 hover:bg-primary-50"
+          }`}
+          role="tab"
+          aria-selected={selectedMemberId === member.id}
+        >
+          {member.name}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/frontend/app/components/shared/MemberIcon.tsx
+++ b/frontend/app/components/shared/MemberIcon.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { User, Dog, Cat, Rabbit, Bird, PawPrint, type LucideIcon } from "lucide-react";
+
+export type MemberType = "human" | "pet";
+export type PetType = "dog" | "cat" | "rabbit" | "bird" | "other";
+
+interface MemberIconProps {
+  memberType: MemberType;
+  petType?: PetType;
+  size?: number;
+  className?: string;
+}
+
+const petIconMap: Record<PetType, LucideIcon> = {
+  dog: Dog,
+  cat: Cat,
+  rabbit: Rabbit,
+  bird: Bird,
+  other: PawPrint,
+};
+
+export const MemberIcon: React.FC<MemberIconProps> = ({
+  memberType,
+  petType,
+  size = 24,
+  className,
+}) => {
+  if (memberType === "pet") {
+    const Icon = petIconMap[petType || "other"];
+    return <Icon size={size} className={className} aria-hidden="true" />;
+  }
+  return <User size={size} className={className} aria-hidden="true" />;
+};

--- a/frontend/app/components/shared/NotificationToast.tsx
+++ b/frontend/app/components/shared/NotificationToast.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { CheckCircle, XCircle, Info, X } from "lucide-react";
+
+type ToastType = "success" | "error" | "info";
+
+interface NotificationToastProps {
+  message: string;
+  type: ToastType;
+  onClose?: () => void;
+}
+
+const typeStyles: Record<ToastType, string> = {
+  success: "border-green-300 bg-green-50 text-green-800",
+  error: "border-red-300 bg-red-50 text-red-800",
+  info: "border-blue-300 bg-blue-50 text-blue-800",
+};
+
+const typeIcons: Record<ToastType, React.ReactNode> = {
+  success: <CheckCircle className="h-5 w-5 text-green-600" />,
+  error: <XCircle className="h-5 w-5 text-red-600" />,
+  info: <Info className="h-5 w-5 text-blue-600" />,
+};
+
+export function NotificationToast({ message, type, onClose }: NotificationToastProps) {
+  return (
+    <div className={`flex items-center gap-3 rounded-2xl border px-4 py-3 ${typeStyles[type]}`}>
+      {typeIcons[type]}
+      <span className="flex-1 text-sm font-medium">{message}</span>
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="閉じる"
+          className="rounded-full p-1 hover:bg-black/10"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/shared/SectionTitle.tsx
+++ b/frontend/app/components/shared/SectionTitle.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+interface SectionTitleProps {
+  children: React.ReactNode;
+  accentColor?: "pink" | "mint" | "ink";
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  rightAction?: React.ReactNode;
+}
+
+const ACCENT_CLASS: Record<NonNullable<SectionTitleProps["accentColor"]>, string> = {
+  pink: "bg-primary-500",
+  mint: "bg-accent-300",
+  ink: "bg-ink-700",
+};
+
+const SIZE_CLASS: Record<NonNullable<SectionTitleProps["size"]>, string> = {
+  sm: "text-sm",
+  md: "text-base",
+  lg: "text-lg",
+};
+
+export const SectionTitle: React.FC<SectionTitleProps> = ({
+  children,
+  accentColor = "pink",
+  size = "md",
+  className = "",
+  rightAction,
+}) => {
+  return (
+    <div className={`flex items-center justify-between mb-3 ${className}`}>
+      <h2 className={`flex items-center font-bold text-ink-800 ${SIZE_CLASS[size]}`}>
+        <span className={`inline-block w-1 h-4 rounded-sm mr-2 ${ACCENT_CLASS[accentColor]}`} />
+        {children}
+      </h2>
+      {rightAction}
+    </div>
+  );
+};

--- a/frontend/app/components/shared/SectionWithForm.tsx
+++ b/frontend/app/components/shared/SectionWithForm.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { type LucideIcon, Plus, X } from "lucide-react";
+import { Link } from "react-router";
+
+/**
+ * セクション共通コンポーネント
+ * 通院管理ページの各セクション(ワクチン、検査、アレルギー等)の
+ * ヘッダー・フォーム表示切替・メンバー未登録警告を共通化
+ */
+interface SectionWithFormProps {
+  /** セクションタイトル */
+  title: string;
+  /** タイトル横のアイコン */
+  icon: LucideIcon;
+  /** フォーム表示中かどうか */
+  showForm: boolean;
+  /** フォーム表示切替コールバック */
+  onToggleForm: () => void;
+  /** メンバーが利用可能か(認証・読み込み完了 and メンバー1件以上) */
+  membersReady: boolean;
+  /** メンバーが0件か */
+  hasNoMembers: boolean;
+  /** フォームコンテンツ(showForm && membersReady時に表示) */
+  formContent: React.ReactNode;
+  /** リストコンテンツ(常に表示) */
+  children: React.ReactNode;
+  /** フォーム追加ボタンのaria-label */
+  addLabel: string;
+  /** フォームのタイトル */
+  formTitle: string;
+}
+
+export const SectionWithForm: React.FC<SectionWithFormProps> = ({
+  title,
+  icon: Icon,
+  showForm,
+  onToggleForm,
+  membersReady,
+  hasNoMembers,
+  formContent,
+  children,
+  addLabel,
+  formTitle,
+}) => {
+  return (
+    <div className="mt-8">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center space-x-2">
+          <Icon size={18} className="text-primary-600" />
+          <h2 className="text-base font-bold text-ink-800">{title}</h2>
+        </div>
+        <button
+          onClick={onToggleForm}
+          className="bg-primary text-white p-1.5 rounded-full hover:bg-primary-dark transition-colors"
+          aria-label={showForm ? "閉じる" : addLabel}
+        >
+          {showForm ? <X size={16} /> : <Plus size={16} />}
+        </button>
+      </div>
+
+      {showForm && membersReady && !hasNoMembers && (
+        <div className="mb-4 bg-white rounded-2xl shadow-md p-4 border border-primary-100">
+          <h3 className="text-sm font-semibold text-ink-700 mb-3">{formTitle}</h3>
+          {formContent}
+        </div>
+      )}
+
+      {showForm && hasNoMembers && (
+        <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-2xl p-4 text-sm text-yellow-700">
+          先に
+          <Link
+            to="/members"
+            className="underline font-medium text-yellow-800 hover:text-yellow-900"
+          >
+            メンバーページ
+          </Link>
+          でメンバーを登録してください。
+        </div>
+      )}
+
+      {children}
+    </div>
+  );
+};

--- a/frontend/app/components/shared/StatisticsBadge.tsx
+++ b/frontend/app/components/shared/StatisticsBadge.tsx
@@ -1,0 +1,29 @@
+type Level = "excellent" | "good" | "warning" | "critical";
+
+interface StatisticsBadgeProps {
+  label: string;
+  value: number | string;
+  unit?: string;
+  level?: Level;
+}
+
+const levelStyles: Record<Level, string> = {
+  excellent: "bg-blue-50 text-blue-700",
+  good: "bg-green-50 text-green-700",
+  warning: "bg-yellow-50 text-yellow-700",
+  critical: "bg-red-50 text-red-700",
+};
+
+export function StatisticsBadge({ label, value, unit, level = "good" }: StatisticsBadgeProps) {
+  return (
+    <div
+      className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 ${levelStyles[level]}`}
+    >
+      <span className="text-sm font-medium">{label}</span>
+      <span className="text-lg font-bold">
+        {value}
+        {unit && <span className="ml-0.5 text-sm">{unit}</span>}
+      </span>
+    </div>
+  );
+}

--- a/frontend/app/components/shared/TabSwitch.tsx
+++ b/frontend/app/components/shared/TabSwitch.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+export interface TabOption {
+  id: string;
+  label: string;
+  count?: number;
+}
+
+interface TabSwitchProps {
+  tabs: TabOption[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+}
+
+export const TabSwitch: React.FC<TabSwitchProps> = ({ tabs, activeTab, onTabChange }) => {
+  return (
+    <div className="flex bg-primary-50 rounded-2xl p-1 mb-4" role="tablist">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          onClick={() => onTabChange(tab.id)}
+          className={`flex-1 py-2 px-3 rounded-xl text-sm font-medium transition-colors ${
+            activeTab === tab.id
+              ? "bg-white text-primary-600 shadow-sm"
+              : "text-ink-500 hover:text-ink-700"
+          }`}
+        >
+          {tab.label}
+          {tab.count !== undefined && (
+            <span
+              className={`ml-1 text-xs ${
+                activeTab === tab.id ? "text-primary-400" : "text-ink-400"
+              }`}
+            >
+              ({tab.count})
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/frontend/app/components/shared/TimePickerInput.tsx
+++ b/frontend/app/components/shared/TimePickerInput.tsx
@@ -1,0 +1,32 @@
+interface TimePickerInputProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  disabled?: boolean;
+}
+
+export function TimePickerInput({
+  label,
+  value,
+  onChange,
+  error,
+  disabled = false,
+}: TimePickerInputProps) {
+  return (
+    <div>
+      <label htmlFor={`time-${label}`} className="mb-1 block text-sm font-medium text-ink-700">
+        {label}
+      </label>
+      <input
+        id={`time-${label}`}
+        type="time"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="rounded-xl border border-primary-200 px-3 py-2 text-sm disabled:bg-primary-50 disabled:text-ink-400"
+      />
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/app/components/temperatures/TemperatureChart.tsx
+++ b/frontend/app/components/temperatures/TemperatureChart.tsx
@@ -1,0 +1,184 @@
+import React, { useMemo } from "react";
+import type { TemperatureRecordView } from "@/hooks/health-logs";
+
+interface TemperatureChartProps {
+  records: TemperatureRecordView[];
+  /** 表示する直近日数 (デフォルト7日) */
+  days?: number;
+}
+
+const VIEWBOX_WIDTH = 320;
+const VIEWBOX_HEIGHT = 180;
+const PADDING_LEFT = 32;
+const PADDING_RIGHT = 12;
+const PADDING_TOP = 16;
+const PADDING_BOTTOM = 28;
+const PLOT_WIDTH = VIEWBOX_WIDTH - PADDING_LEFT - PADDING_RIGHT;
+const PLOT_HEIGHT = VIEWBOX_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+
+const Y_MIN = 35.0;
+const Y_MAX = 40.0;
+const Y_TICKS = [35, 36, 37, 38, 39, 40];
+const FEVER_LINE = 37.5;
+
+export const TemperatureChart: React.FC<TemperatureChartProps> = ({
+  records,
+  days = 7,
+}) => {
+  const { points, xLabels, hasData } = useMemo(() => {
+    const now = new Date();
+    const endTs = now.getTime();
+    const startTs = endTs - days * 24 * 60 * 60 * 1000;
+
+    const inRange = records.filter((r) => {
+      const t = r.measuredAt.getTime();
+      return t >= startTs && t <= endTs;
+    });
+
+    const sorted = [...inRange].sort(
+      (a, b) => a.measuredAt.getTime() - b.measuredAt.getTime(),
+    );
+
+    const xFromTs = (ts: number) =>
+      PADDING_LEFT + ((ts - startTs) / (endTs - startTs)) * PLOT_WIDTH;
+    const yFromTemp = (temp: number) => {
+      const clamped = Math.max(Y_MIN, Math.min(Y_MAX, temp));
+      return PADDING_TOP + (1 - (clamped - Y_MIN) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
+    };
+
+    const pts = sorted.map((r) => ({
+      x: xFromTs(r.measuredAt.getTime()),
+      y: yFromTemp(r.temperature),
+      record: r,
+    }));
+
+    const labels: { x: number; label: string }[] = [];
+    const labelCount = Math.min(days, 4);
+    for (let i = 0; i < labelCount; i++) {
+      const ts = startTs + ((endTs - startTs) * i) / (labelCount - 1 || 1);
+      const d = new Date(ts);
+      labels.push({
+        x: xFromTs(ts),
+        label: `${d.getMonth() + 1}/${d.getDate()}`,
+      });
+    }
+
+    return { points: pts, xLabels: labels, hasData: sorted.length > 0 };
+  }, [records, days]);
+
+  const pathD = useMemo(() => {
+    if (points.length === 0) return "";
+    return points
+      .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`)
+      .join(" ");
+  }, [points]);
+
+  const feverY =
+    PADDING_TOP + (1 - (FEVER_LINE - Y_MIN) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm p-3 border border-primary-100">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold text-ink-700">
+          体温推移（直近{days}日）
+        </h3>
+        <span className="text-xs text-ink-400">単位: °C</span>
+      </div>
+      {!hasData ? (
+        <div className="py-8 text-center text-sm text-ink-400">
+          この期間の体温記録はありません
+        </div>
+      ) : (
+        <svg
+          viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+          className="w-full h-auto"
+          role="img"
+          aria-label="体温推移グラフ"
+        >
+          {Y_TICKS.map((t) => {
+            const y =
+              PADDING_TOP + (1 - (t - Y_MIN) / (Y_MAX - Y_MIN)) * PLOT_HEIGHT;
+            return (
+              <g key={t}>
+                <line
+                  x1={PADDING_LEFT}
+                  x2={VIEWBOX_WIDTH - PADDING_RIGHT}
+                  y1={y}
+                  y2={y}
+                  stroke="#e5e7eb"
+                  strokeWidth={1}
+                />
+                <text
+                  x={PADDING_LEFT - 4}
+                  y={y + 3}
+                  textAnchor="end"
+                  fontSize={9}
+                  fill="#9ca3af"
+                >
+                  {t}
+                </text>
+              </g>
+            );
+          })}
+
+          <line
+            x1={PADDING_LEFT}
+            x2={VIEWBOX_WIDTH - PADDING_RIGHT}
+            y1={feverY}
+            y2={feverY}
+            stroke="#fca5a5"
+            strokeWidth={1}
+            strokeDasharray="3 2"
+          />
+          <text
+            x={VIEWBOX_WIDTH - PADDING_RIGHT}
+            y={feverY - 2}
+            textAnchor="end"
+            fontSize={8}
+            fill="#dc2626"
+          >
+            発熱境界 37.5
+          </text>
+
+          {xLabels.map((l, i) => (
+            <text
+              key={i}
+              x={l.x}
+              y={VIEWBOX_HEIGHT - PADDING_BOTTOM + 14}
+              textAnchor="middle"
+              fontSize={9}
+              fill="#9ca3af"
+            >
+              {l.label}
+            </text>
+          ))}
+
+          {pathD && (
+            <path
+              d={pathD}
+              fill="none"
+              stroke="#16a34a"
+              strokeWidth={1.5}
+              strokeLinejoin="round"
+            />
+          )}
+
+          {points.map((p) => (
+            <circle
+              key={p.record.id}
+              cx={p.x}
+              cy={p.y}
+              r={3}
+              fill={p.record.temperature >= FEVER_LINE ? "#dc2626" : "#16a34a"}
+            >
+              <title>
+                {p.record.measuredAt.toLocaleString("ja-JP")} -{" "}
+                {p.record.temperature}°C
+              </title>
+            </circle>
+          ))}
+        </svg>
+      )}
+    </div>
+  );
+};

--- a/frontend/app/components/temperatures/TemperatureForm.tsx
+++ b/frontend/app/components/temperatures/TemperatureForm.tsx
@@ -1,0 +1,179 @@
+import React, { useState } from "react";
+import { X } from "lucide-react";
+
+export interface TemperatureFormData {
+  memberId: string;
+  temperature: number;
+  measuredAt: string;
+  notes?: string;
+}
+
+interface TemperatureFormProps {
+  members: { id: string; name: string }[];
+  onSubmit: (data: TemperatureFormData) => Promise<void>;
+  onCancel: () => void;
+}
+
+function getNowLocalIsoForInput(): string {
+  const now = new Date();
+  const tzOffsetMs = now.getTimezoneOffset() * 60_000;
+  return new Date(now.getTime() - tzOffsetMs).toISOString().slice(0, 16);
+}
+
+export const TemperatureForm: React.FC<TemperatureFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+}) => {
+  const [memberId, setMemberId] = useState(members[0]?.id ?? "");
+  const [temperature, setTemperature] = useState("36.5");
+  const [measuredAt, setMeasuredAt] = useState(getNowLocalIsoForInput());
+  const [notes, setNotes] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!memberId) {
+      setError("メンバーを選択してください");
+      return;
+    }
+
+    const tempNum = parseFloat(temperature);
+    if (!Number.isFinite(tempNum) || tempNum < 30 || tempNum > 45) {
+      setError("体温は30.0〜45.0の範囲で入力してください");
+      return;
+    }
+    if (!measuredAt) {
+      setError("計測時刻を選択してください");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit({
+        memberId,
+        temperature: tempNum,
+        measuredAt: new Date(measuredAt).toISOString(),
+        notes: notes.trim() || undefined,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "保存に失敗しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white rounded-2xl shadow-sm p-4 border border-primary-100"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-ink-800">体温を記録</h3>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-ink-400 hover:text-ink-600"
+          aria-label="閉じる"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <label
+            htmlFor="temp-member"
+            className="block text-sm font-medium text-ink-700 mb-1"
+          >
+            メンバー
+          </label>
+          <select
+            id="temp-member"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm outline-none focus:border-primary"
+          >
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label
+              htmlFor="temp-value"
+              className="block text-sm font-medium text-ink-700 mb-1"
+            >
+              体温 (°C)
+            </label>
+            <input
+              id="temp-value"
+              type="number"
+              step="0.1"
+              min="30"
+              max="45"
+              value={temperature}
+              onChange={(e) => setTemperature(e.target.value)}
+              className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm outline-none focus:border-primary"
+              inputMode="decimal"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="temp-time"
+              className="block text-sm font-medium text-ink-700 mb-1"
+            >
+              計測時刻
+            </label>
+            <input
+              id="temp-time"
+              type="datetime-local"
+              value={measuredAt}
+              onChange={(e) => setMeasuredAt(e.target.value)}
+              className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm outline-none focus:border-primary"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor="temp-notes"
+            className="block text-sm font-medium text-ink-700 mb-1"
+          >
+            メモ（任意）
+          </label>
+          <textarea
+            id="temp-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="例: 解熱剤服用後 / 朝起床時"
+            className="w-full px-3 py-2 border border-primary-200 rounded-xl text-sm resize-none outline-none focus:border-primary"
+            rows={2}
+            maxLength={500}
+          />
+        </div>
+
+        {error && (
+          <div className="rounded-xl bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting || !memberId}
+          className="w-full py-2 bg-primary text-white rounded-xl font-medium hover:bg-primary-dark disabled:opacity-50 transition-colors"
+        >
+          {isSubmitting ? "記録中..." : "記録する"}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/temperatures/TemperatureRecordList.tsx
+++ b/frontend/app/components/temperatures/TemperatureRecordList.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { Trash2, Thermometer } from "lucide-react";
+import {
+  classifyTemperature,
+  getTemperatureCategoryColor,
+  getTemperatureCategoryLabel,
+  type TemperatureRecordView,
+} from "@/hooks/health-logs";
+
+interface TemperatureRecordListProps {
+  records: TemperatureRecordView[];
+  isLoading: boolean;
+  onDelete: (id: string) => void;
+}
+
+function formatDateTime(d: Date): string {
+  const m = d.getMonth() + 1;
+  const day = d.getDate();
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${m}/${day} ${hh}:${mm}`;
+}
+
+export const TemperatureRecordList: React.FC<TemperatureRecordListProps> = ({
+  records,
+  isLoading,
+  onDelete,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="py-4 text-center text-sm text-ink-400">読み込み中...</div>
+    );
+  }
+
+  if (records.length === 0) {
+    return (
+      <div className="py-4 text-center text-sm text-ink-400">
+        体温の記録はまだありません
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {records.map((r) => {
+        const category = classifyTemperature(r.temperature);
+        const colorClass = getTemperatureCategoryColor(category);
+        const categoryLabel = getTemperatureCategoryLabel(category);
+        return (
+          <li
+            key={r.id}
+            className="flex items-center justify-between rounded-2xl border border-primary-100 bg-white p-3"
+          >
+            <div className="flex items-center space-x-3">
+              <Thermometer size={18} className={colorClass} />
+              <div>
+                <div className="flex items-baseline space-x-2">
+                  <span className={`text-base font-semibold ${colorClass}`}>
+                    {r.temperature.toFixed(1)}°C
+                  </span>
+                  <span className="text-xs text-ink-500">{categoryLabel}</span>
+                </div>
+                <div className="text-xs text-ink-500">
+                  {r.memberName ? `${r.memberName}・` : ""}
+                  {formatDateTime(r.measuredAt)}
+                </div>
+                {r.notes && (
+                  <div className="mt-1 text-xs text-ink-600">{r.notes}</div>
+                )}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => onDelete(r.id)}
+              className="p-1 text-ink-400 hover:text-red-600"
+              aria-label="削除"
+            >
+              <Trash2 size={16} />
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/frontend/app/components/ui.tsx
+++ b/frontend/app/components/ui.tsx
@@ -11,7 +11,7 @@ export function Button({
       className={clsx(
         "inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-medium transition disabled:opacity-50",
         variant === "primary" && "bg-primary text-white hover:bg-primary-dark",
-        variant === "ghost" && "bg-slate-100 text-slate-700 hover:bg-slate-200",
+        variant === "ghost" && "bg-primary-50 text-ink-700 hover:bg-primary-100",
         variant === "danger" && "bg-red-50 text-red-600 hover:bg-red-100",
         className,
       )}
@@ -24,7 +24,7 @@ export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElem
   return (
     <input
       className={clsx(
-        "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-primary",
+        "w-full rounded-xl border border-primary-200 bg-white px-3 py-2 text-sm text-ink-700 outline-none focus:border-primary",
         className,
       )}
       {...props}
@@ -34,7 +34,7 @@ export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElem
 
 export function Card({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <div className={clsx("rounded-2xl border border-slate-100 bg-white p-4 shadow-sm", className)}>
+    <div className={clsx("rounded-2xl border border-primary-100 bg-white p-4 shadow-sm", className)}>
       {children}
     </div>
   );

--- a/frontend/app/components/vaccinations/VaccinationForm.tsx
+++ b/frontend/app/components/vaccinations/VaccinationForm.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from "react";
+import type { Member } from "@/lib/types";
+
+export interface VaccinationFormData {
+  memberId: string;
+  vaccineName: string;
+  vaccinatedAt: string;
+  nextScheduledDate?: string;
+  notes?: string;
+}
+
+interface VaccinationFormProps {
+  members: Member[];
+  onSubmit: (data: VaccinationFormData) => void;
+  onCancel?: () => void;
+  initialData?: {
+    memberId: string;
+    vaccineName: string;
+    vaccinatedAt: string;
+    nextScheduledDate?: string | null;
+    notes?: string | null;
+  };
+}
+
+const toDateInput = (value: string | null | undefined): string => {
+  if (!value) return "";
+  return new Date(value).toISOString().split("T")[0];
+};
+
+const todayInput = (): string => new Date().toISOString().split("T")[0];
+
+export const VaccinationForm: React.FC<VaccinationFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
+  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
+  const [vaccineName, setVaccineName] = useState(initialData?.vaccineName || "");
+  const [vaccinatedAt, setVaccinatedAt] = useState(
+    initialData?.vaccinatedAt ? toDateInput(initialData.vaccinatedAt) : todayInput(),
+  );
+  const [nextScheduledDate, setNextScheduledDate] = useState(toDateInput(initialData?.nextScheduledDate));
+  const [notes, setNotes] = useState(initialData?.notes || "");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberId || !vaccineName.trim() || !vaccinatedAt) return;
+
+    onSubmit({
+      memberId,
+      vaccineName: vaccineName.trim(),
+      vaccinatedAt: new Date(vaccinatedAt).toISOString(),
+      nextScheduledDate: nextScheduledDate ? new Date(nextScheduledDate).toISOString() : undefined,
+      notes: notes.trim() || undefined,
+    });
+
+    if (!initialData) {
+      setVaccineName("");
+      setVaccinatedAt(todayInput());
+      setNextScheduledDate("");
+      setNotes("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label htmlFor="vacc-member" className="block text-sm font-medium text-ink-700 mb-1">
+          メンバー
+        </label>
+        <select
+          id="vacc-member"
+          value={memberId}
+          onChange={(e) => setMemberId(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        >
+          <option value="">選択してください</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="vacc-name" className="block text-sm font-medium text-ink-700 mb-1">
+          ワクチンの種類
+        </label>
+        <input
+          id="vacc-name"
+          type="text"
+          value={vaccineName}
+          onChange={(e) => setVaccineName(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+          placeholder="例: インフルエンザ、混合ワクチン"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vacc-date" className="block text-sm font-medium text-ink-700 mb-1">
+          ワクチン接種日
+        </label>
+        <input
+          id="vacc-date"
+          type="date"
+          value={vaccinatedAt}
+          onChange={(e) => setVaccinatedAt(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          required
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vacc-next" className="block text-sm font-medium text-ink-700 mb-1">
+          次回ワクチン予定日（任意）
+        </label>
+        <input
+          id="vacc-next"
+          type="date"
+          value={nextScheduledDate}
+          onChange={(e) => setNextScheduledDate(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="vacc-notes" className="block text-sm font-medium text-ink-700 mb-1">
+          メモ（任意）
+        </label>
+        <textarea
+          id="vacc-notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          rows={2}
+          placeholder="メモを入力"
+        />
+      </div>
+
+      <div className="flex space-x-2">
+        <button
+          type="submit"
+          className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
+        >
+          {initialData ? "更新する" : "登録する"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-primary-50 text-ink-700 py-2 px-4 rounded-lg hover:bg-primary-100 transition-colors font-medium"
+          >
+            キャンセル
+          </button>
+        )}
+      </div>
+    </form>
+  );
+};

--- a/frontend/app/components/vaccinations/VaccinationList.tsx
+++ b/frontend/app/components/vaccinations/VaccinationList.tsx
@@ -1,0 +1,210 @@
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X, Calendar } from "lucide-react";
+import type { Vaccination } from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
+
+export type VaccinationWithMember = Vaccination & { memberName?: string };
+
+export interface UpdateVaccinationInput {
+  vaccineName?: string;
+  vaccinatedAt?: string;
+  nextScheduledDate?: string | null;
+  notes?: string | null;
+}
+
+const formatDateJP = (value: string): string =>
+  new Date(value).toLocaleDateString("ja-JP", { year: "numeric", month: "long", day: "numeric" });
+
+const toDateInput = (value: string | null | undefined): string => {
+  if (!value) return "";
+  return new Date(value).toISOString().split("T")[0];
+};
+
+interface VaccinationListProps {
+  vaccinations: VaccinationWithMember[];
+  isLoading: boolean;
+  onUpdate: (id: string, input: UpdateVaccinationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+export const VaccinationList: React.FC<VaccinationListProps> = ({ vaccinations, isLoading, onUpdate, onDelete }) => {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (vaccinations.length === 0) {
+    return <EmptyStatePrompt message="ワクチン記録がありません" subMessage="上の＋ボタンから記録を追加できます" />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {vaccinations.map((vaccination) => (
+        <VaccinationCard key={vaccination.id} vaccination={vaccination} onUpdate={onUpdate} onDelete={onDelete} />
+      ))}
+    </div>
+  );
+};
+
+interface VaccinationCardProps {
+  vaccination: VaccinationWithMember;
+  onUpdate: (id: string, input: UpdateVaccinationInput) => Promise<void>;
+  onDelete: (id: string) => void;
+}
+
+const VaccinationCard: React.FC<VaccinationCardProps> = React.memo(({ vaccination, onUpdate, onDelete }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [editName, setEditName] = useState(vaccination.vaccineName);
+  const [editDate, setEditDate] = useState(toDateInput(vaccination.vaccinatedAt));
+  const [editNextDate, setEditNextDate] = useState(toDateInput(vaccination.nextScheduledDate));
+  const [editNotes, setEditNotes] = useState(vaccination.notes || "");
+
+  const handleSave = async () => {
+    if (!editName.trim() || !editDate) return;
+    await onUpdate(vaccination.id, {
+      vaccineName: editName.trim(),
+      vaccinatedAt: new Date(editDate).toISOString(),
+      nextScheduledDate: editNextDate ? new Date(editNextDate).toISOString() : null,
+      notes: editNotes.trim() || null,
+    });
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditName(vaccination.vaccineName);
+    setEditDate(toDateInput(vaccination.vaccinatedAt));
+    setEditNextDate(toDateInput(vaccination.nextScheduledDate));
+    setEditNotes(vaccination.notes || "");
+    setIsEditing(false);
+  };
+
+  const nextDate = vaccination.nextScheduledDate ? new Date(vaccination.nextScheduledDate) : null;
+  const isNextDateUpcoming = nextDate && nextDate > new Date();
+  const isNextDatePast = nextDate && nextDate <= new Date();
+
+  if (isEditing) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-200 space-y-3">
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">ワクチンの種類</label>
+          <input
+            type="text"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">接種日</label>
+          <input
+            type="date"
+            value={editDate}
+            onChange={(e) => setEditDate(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">次回予定日</label>
+          <input
+            type="date"
+            value={editNextDate}
+            onChange={(e) => setEditNextDate(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-ink-500 mb-1">メモ</label>
+          <textarea
+            value={editNotes}
+            onChange={(e) => setEditNotes(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
+            rows={2}
+          />
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={!editName.trim() || !editDate}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary text-white py-1.5 rounded-lg text-sm hover:bg-primary-dark transition-colors disabled:opacity-50"
+          >
+            <Check size={14} />
+            <span>保存</span>
+          </button>
+          <button
+            onClick={handleCancel}
+            className="flex-1 flex items-center justify-center space-x-1 bg-primary-50 text-ink-700 py-1.5 rounded-lg text-sm hover:bg-primary-100 transition-colors"
+          >
+            <X size={14} />
+            <span>キャンセル</span>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3 border border-primary-100">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2">
+            <p className="font-medium text-ink-800 text-sm">{vaccination.vaccineName}</p>
+            {vaccination.memberName && (
+              <span className="text-xs bg-primary-50 text-ink-600 px-1.5 py-0.5 rounded">{vaccination.memberName}</span>
+            )}
+          </div>
+          <div className="text-xs text-ink-500 mt-1 space-y-0.5">
+            <p className="flex items-center space-x-1">
+              <Calendar size={10} />
+              <span>接種日: {formatDateJP(vaccination.vaccinatedAt)}</span>
+            </p>
+            {vaccination.nextScheduledDate && (
+              <p
+                className={`flex items-center space-x-1 ${
+                  isNextDatePast ? "text-red-500 font-medium" : isNextDateUpcoming ? "text-primary-500" : ""
+                }`}
+              >
+                <Calendar size={10} />
+                <span>次回予定: {formatDateJP(vaccination.nextScheduledDate)}</span>
+                {isNextDatePast && <span>(期限切れ)</span>}
+              </p>
+            )}
+            {vaccination.notes && <p className="text-ink-400">{vaccination.notes}</p>}
+          </div>
+        </div>
+        <div className="flex items-center space-x-1 flex-shrink-0">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-ink-400 hover:text-primary-500 p-1 transition-colors"
+            aria-label="編集"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={() => setIsDeleteDialogOpen(true)}
+            className="text-ink-400 hover:text-red-500 p-1 transition-colors"
+            aria-label="削除"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <ConfirmationDialog
+        title="ワクチン記録の削除"
+        message={`「${vaccination.vaccineName}」を削除しますか？この操作は取り消せません。`}
+        isOpen={isDeleteDialogOpen}
+        onConfirm={() => {
+          setIsDeleteDialogOpen(false);
+          onDelete(vaccination.id);
+        }}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        isDangerous
+      />
+    </div>
+  );
+});
+
+VaccinationCard.displayName = "VaccinationCard";

--- a/frontend/app/hooks/dashboard.ts
+++ b/frontend/app/hooks/dashboard.ts
@@ -1,0 +1,465 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type {
+  Appointment,
+  Hospital,
+  Medication,
+  MedicationRecord,
+  Member,
+  Schedule,
+  TodaySchedule,
+} from "@/lib/types";
+
+// ---- ドメインロジック (旧 domain/entities から忠実移植) ----
+
+export type DayOfWeek = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
+export type ScheduleStatus = "pending" | "completed" | "overdue";
+export type OverdueLevel = "none" | "warning" | "danger";
+
+const VALID_DAYS: readonly DayOfWeek[] = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+const DAY_MAP: Record<number, DayOfWeek> = {
+  0: "sun", 1: "mon", 2: "tue", 3: "wed", 4: "thu", 5: "fri", 6: "sat",
+};
+
+const PROXIMITY_SOON_MINUTES = 30;
+const PROXIMITY_NEAR_MINUTES = 60;
+
+function normalizeDays(days: string[] | null | undefined): DayOfWeek[] {
+  if (!days) return [];
+  return days.filter((d): d is DayOfWeek => VALID_DAYS.includes(d as DayOfWeek));
+}
+
+function getScheduledDateTime(scheduledTime: string, baseTime: Date): Date {
+  const [hours, minutes] = scheduledTime.split(":").map(Number);
+  const dt = new Date(baseTime);
+  dt.setHours(hours, minutes, 0, 0);
+  return dt;
+}
+
+export function getScheduleStatus(scheduledTime: string, currentTime: Date, isCompleted: boolean): ScheduleStatus {
+  if (isCompleted) return "completed";
+  const scheduledDateTime = getScheduledDateTime(scheduledTime, currentTime);
+  if (currentTime > scheduledDateTime) return "overdue";
+  return "pending";
+}
+
+export function getOverdueLevel(scheduledTime: string, currentTime: Date, isCompleted: boolean): OverdueLevel {
+  if (isCompleted) return "none";
+  const scheduledDateTime = getScheduledDateTime(scheduledTime, currentTime);
+  const diffMs = currentTime.getTime() - scheduledDateTime.getTime();
+  if (diffMs <= 0) return "none";
+  const diffMinutes = diffMs / (1000 * 60);
+  if (diffMinutes >= PROXIMITY_NEAR_MINUTES) return "danger";
+  if (diffMinutes >= PROXIMITY_SOON_MINUTES) return "warning";
+  return "none";
+}
+
+export function getOverdueMinutes(scheduledTime: string, currentTime: Date): number {
+  const scheduledDateTime = getScheduledDateTime(scheduledTime, currentTime);
+  const diffMs = currentTime.getTime() - scheduledDateTime.getTime();
+  if (diffMs <= 0) return 0;
+  return Math.floor(diffMs / (1000 * 60));
+}
+
+export function getOverdueLevelStyle(level: OverdueLevel): { bg: string; text: string; border: string } {
+  switch (level) {
+    case "danger":
+      return { bg: "bg-red-50", text: "text-red-600", border: "border-red-300" };
+    case "warning":
+      return { bg: "bg-orange-50", text: "text-orange-600", border: "border-orange-300" };
+    default:
+      return { bg: "", text: "", border: "" };
+  }
+}
+
+interface ScheduleLike {
+  daysOfWeek: string[] | null;
+  intervalDays: number | null;
+  startDate: string | null;
+  isEnabled: boolean;
+}
+
+function isActiveOnDay(s: ScheduleLike, scheduledTime: string, date: Date): boolean {
+  if (!s.isEnabled) return false;
+  if (s.intervalDays === -1) return false;
+  if (s.intervalDays && s.intervalDays > 0 && s.startDate) {
+    const start = new Date(s.startDate);
+    start.setHours(0, 0, 0, 0);
+    const target = new Date(date);
+    target.setHours(0, 0, 0, 0);
+    const diffDays = Math.round((target.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+    if (diffDays < 0) return false;
+    return diffDays % s.intervalDays === 0;
+  }
+  const days = normalizeDays(s.daysOfWeek);
+  if (days.length === 0) return true;
+  return days.includes(DAY_MAP[date.getDay()]);
+}
+
+// アドヒアランス
+function getActiveDaysCount(days: DayOfWeek[]): number {
+  return days.length === 0 ? 7 : days.length;
+}
+function calculateWeeklyExpected(schedules: { daysOfWeek: DayOfWeek[] }[]): number {
+  return schedules.reduce((sum, s) => sum + Math.min(getActiveDaysCount(s.daysOfWeek), 7), 0);
+}
+function calculateMonthlyExpected(schedules: { daysOfWeek: DayOfWeek[] }[]): number {
+  return schedules.reduce((sum, s) => sum + Math.round(getActiveDaysCount(s.daysOfWeek) * (30 / 7)), 0);
+}
+function calculateRate(actual: number, expected: number): number {
+  if (expected <= 0) return 0;
+  return Math.min(100, Math.round((actual / expected) * 100));
+}
+
+export function getRateLevel(rate: number): "excellent" | "good" | "warning" | "poor" {
+  if (rate >= 90) return "excellent";
+  if (rate >= 70) return "good";
+  if (rate >= 50) return "warning";
+  return "poor";
+}
+export function getRateLabel(rate: number): string {
+  const labels: Record<ReturnType<typeof getRateLevel>, string> = {
+    excellent: "優秀",
+    good: "良好",
+    warning: "注意",
+    poor: "要改善",
+  };
+  return labels[getRateLevel(rate)];
+}
+
+// 在庫
+export function getRemainingDaysLabel(remainingDays: number | null): string {
+  if (remainingDays === null) return "残量不明";
+  if (remainingDays === 0) return "在庫切れ";
+  return `約${remainingDays}日分`;
+}
+
+// ---- ViewModel 型 ----
+
+export interface TodayScheduleViewModel {
+  scheduleId: string;
+  medicationId: string;
+  medicationName: string;
+  userId: string;
+  memberId: string;
+  memberName: string;
+  memberType: "human" | "pet";
+  scheduledTime: string;
+  medicationDisplayOrder: number;
+  status: ScheduleStatus;
+  isEnabled: boolean;
+  reminderMinutesBefore: number;
+}
+
+export interface MissedDose {
+  date: string;
+  scheduleId: string;
+  medicationId: string;
+  medicationName: string;
+  memberName: string;
+  memberId: string;
+  scheduledTime: string;
+}
+
+export interface StockAlert {
+  medicationId: string;
+  medicationName: string;
+  memberId: string;
+  memberName: string;
+  stockQuantity: number | null;
+  stockAlertDate: string;
+  daysUntilAlert: number;
+  isOverdue: boolean;
+  remainingDays: number | null;
+}
+
+export interface MemberAdherenceStats {
+  memberId: string;
+  memberName: string;
+  weeklyRate: number;
+  monthlyRate: number;
+  weeklyCount: number;
+  monthlyCount: number;
+}
+
+export interface AdherenceStats {
+  overall: { weeklyRate: number; monthlyRate: number; weeklyCount: number; monthlyCount: number };
+  members: MemberAdherenceStats[];
+}
+
+export interface EnrichedAppointment extends Appointment {
+  memberName: string | null;
+  hospitalName: string | null;
+}
+
+function toDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * ホーム画面で必要な全データを取得し、クライアント側で集計する。
+ * Go バックエンドは集計エンドポイントを持たないため、一覧 API から算出する。
+ */
+export function useDashboardData(userId: string | null) {
+  const enabled = !!userId;
+
+  const todayQuery = useQuery({
+    queryKey: ["schedules", "today"],
+    queryFn: () => api.get<TodaySchedule[]>("/schedules/today"),
+    enabled,
+  });
+  const schedulesQuery = useQuery({
+    queryKey: ["schedules"],
+    queryFn: () => api.get<Schedule[]>("/schedules"),
+    enabled,
+  });
+  const recordsQuery = useQuery({
+    queryKey: ["records"],
+    queryFn: () => api.get<MedicationRecord[]>("/records"),
+    enabled,
+  });
+  const medicationsQuery = useQuery({
+    queryKey: ["medications"],
+    queryFn: () => api.get<Medication[]>("/medications"),
+    enabled,
+  });
+  const membersQuery = useQuery({
+    queryKey: ["members"],
+    queryFn: () => api.get<Member[]>("/members"),
+    enabled,
+  });
+  const appointmentsQuery = useQuery({
+    queryKey: ["appointments"],
+    queryFn: () => api.get<Appointment[]>("/appointments"),
+    enabled,
+  });
+  const hospitalsQuery = useQuery({
+    queryKey: ["hospitals"],
+    queryFn: () => api.get<Hospital[]>("/hospitals"),
+    enabled,
+  });
+
+  const members = useMemo(() => membersQuery.data ?? [], [membersQuery.data]);
+  const medications = useMemo(() => medicationsQuery.data ?? [], [medicationsQuery.data]);
+  const records = useMemo(() => recordsQuery.data ?? [], [recordsQuery.data]);
+  const allSchedules = useMemo(() => schedulesQuery.data ?? [], [schedulesQuery.data]);
+  const appointments = useMemo(() => appointmentsQuery.data ?? [], [appointmentsQuery.data]);
+  const hospitals = useMemo(() => hospitalsQuery.data ?? [], [hospitalsQuery.data]);
+
+  const memberNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const m of members) map.set(m.id, m.name);
+    return map;
+  }, [members]);
+
+  const todaySchedules = useMemo<TodayScheduleViewModel[]>(() => {
+    const now = new Date();
+    const items = (todayQuery.data ?? []).map((item): TodayScheduleViewModel => ({
+      scheduleId: item.id,
+      medicationId: item.medicationId,
+      medicationName: item.medicationName,
+      userId: item.userId,
+      memberId: item.memberId,
+      memberName: item.memberName,
+      memberType: item.memberType === "pet" ? "pet" : "human",
+      scheduledTime: item.scheduledTime,
+      medicationDisplayOrder: item.medicationDisplayOrder ?? 0,
+      status: getScheduleStatus(item.scheduledTime, now, item.isCompleted),
+      isEnabled: item.isEnabled,
+      reminderMinutesBefore: item.reminderMinutesBefore ?? 10,
+    }));
+    items.sort((a, b) => {
+      const timeCompare = a.scheduledTime.localeCompare(b.scheduledTime);
+      if (timeCompare !== 0) return timeCompare;
+      const memberCompare = a.memberName.localeCompare(b.memberName);
+      if (memberCompare !== 0) return memberCompare;
+      return a.medicationDisplayOrder - b.medicationDisplayOrder;
+    });
+    return items;
+  }, [todayQuery.data]);
+
+  const missedDoses = useMemo<MissedDose[]>(() => {
+    if (allSchedules.length === 0) return [];
+    const medMap = new Map(medications.map((m) => [m.id, m]));
+
+    const recordedKeys = new Set<string>();
+    for (const r of records) {
+      if (!r.scheduleId) continue;
+      recordedKeys.add(`${toDateKey(new Date(r.takenAt))}-${r.scheduleId}`);
+    }
+
+    const now = new Date();
+    const result: MissedDose[] = [];
+    for (let offset = 1; offset <= 7; offset++) {
+      const target = new Date(now);
+      target.setDate(target.getDate() - offset);
+      const dateKey = toDateKey(target);
+
+      for (const s of allSchedules) {
+        if (!s.isEnabled) continue;
+        if (!isActiveOnDay(s, s.scheduledTime, target)) continue;
+        if (recordedKeys.has(`${dateKey}-${s.id}`)) continue;
+
+        const med = medMap.get(s.medicationId);
+        result.push({
+          date: dateKey,
+          scheduleId: s.id,
+          medicationId: s.medicationId,
+          medicationName: med?.name ?? "お薬",
+          memberName: memberNameMap.get(s.memberId) ?? "",
+          memberId: s.memberId,
+          scheduledTime: s.scheduledTime,
+        });
+      }
+    }
+    result.sort((a, b) => {
+      const dateCompare = b.date.localeCompare(a.date);
+      if (dateCompare !== 0) return dateCompare;
+      return a.scheduledTime.localeCompare(b.scheduledTime);
+    });
+    return result;
+  }, [allSchedules, medications, records, memberNameMap]);
+
+  const stockAlerts = useMemo<StockAlert[]>(() => {
+    const todayKey = toDateKey(new Date());
+    const alerts: StockAlert[] = [];
+    for (const med of medications) {
+      if (!med.isActive) continue;
+      if (!med.stockAlertDate) continue;
+      const alertKey = med.stockAlertDate.slice(0, 10);
+      const daysUntilAlert = Math.round(
+        (new Date(`${alertKey}T00:00:00`).getTime() - new Date(`${todayKey}T00:00:00`).getTime()) /
+          (1000 * 60 * 60 * 24),
+      );
+      if (daysUntilAlert > 7) continue;
+      alerts.push({
+        medicationId: med.id,
+        medicationName: med.name,
+        memberId: med.memberId,
+        memberName: memberNameMap.get(med.memberId) ?? "",
+        stockQuantity: med.stockQuantity,
+        stockAlertDate: alertKey,
+        daysUntilAlert: Math.max(0, daysUntilAlert),
+        isOverdue: daysUntilAlert < 0,
+        remainingDays: med.stockQuantity,
+      });
+    }
+    alerts.sort((a, b) => {
+      if (a.isOverdue !== b.isOverdue) return a.isOverdue ? -1 : 1;
+      return a.daysUntilAlert - b.daysUntilAlert;
+    });
+    return alerts;
+  }, [medications, memberNameMap]);
+
+  const adherenceStats = useMemo<AdherenceStats>(() => {
+    if (allSchedules.length === 0) {
+      return { overall: { weeklyRate: 0, monthlyRate: 0, weeklyCount: 0, monthlyCount: 0 }, members: [] };
+    }
+    const now = new Date();
+
+    const countRecordsInWindow = (memberId: string | null, days: number): number => {
+      const start = new Date(now);
+      start.setDate(start.getDate() - days);
+      return records.filter((r) => {
+        if (memberId && r.memberId !== memberId) return false;
+        const t = new Date(r.takenAt).getTime();
+        return t >= start.getTime() && t <= now.getTime();
+      }).length;
+    };
+
+    const schedulesFor = (memberId: string | null) =>
+      allSchedules
+        .filter((s) => s.isEnabled && (!memberId || s.memberId === memberId))
+        .map((s) => ({ daysOfWeek: normalizeDays(s.daysOfWeek) }));
+
+    const overallWeeklyExpected = calculateWeeklyExpected(schedulesFor(null));
+    const overallMonthlyExpected = calculateMonthlyExpected(schedulesFor(null));
+
+    const memberStats = members
+      .map((m): MemberAdherenceStats | null => {
+        const weeklyExpected = calculateWeeklyExpected(schedulesFor(m.id));
+        if (weeklyExpected === 0) return null;
+        const monthlyExpected = calculateMonthlyExpected(schedulesFor(m.id));
+        const weeklyCount = countRecordsInWindow(m.id, 7);
+        const monthlyCount = countRecordsInWindow(m.id, 30);
+        return {
+          memberId: m.id,
+          memberName: m.name,
+          weeklyRate: calculateRate(weeklyCount, weeklyExpected),
+          monthlyRate: calculateRate(monthlyCount, monthlyExpected),
+          weeklyCount,
+          monthlyCount,
+        };
+      })
+      .filter((s): s is MemberAdherenceStats => s !== null);
+
+    const overallWeeklyCount = countRecordsInWindow(null, 7);
+    const overallMonthlyCount = countRecordsInWindow(null, 30);
+
+    return {
+      overall: {
+        weeklyRate: calculateRate(overallWeeklyCount, overallWeeklyExpected),
+        monthlyRate: calculateRate(overallMonthlyCount, overallMonthlyExpected),
+        weeklyCount: overallWeeklyCount,
+        monthlyCount: overallMonthlyCount,
+      },
+      members: memberStats,
+    };
+  }, [allSchedules, records, members]);
+
+  const enrichedAppointments = useMemo<EnrichedAppointment[]>(() => {
+    const hospitalMap = new Map(hospitals.map((h) => [h.id, h.name]));
+    return appointments.map((a) => ({
+      ...a,
+      memberName: memberNameMap.get(a.memberId) ?? null,
+      hospitalName: a.hospitalId ? hospitalMap.get(a.hospitalId) ?? null : null,
+    }));
+  }, [appointments, hospitals, memberNameMap]);
+
+  return {
+    todaySchedules,
+    todayLoading: todayQuery.isLoading,
+    missedDoses,
+    missedLoading: schedulesQuery.isLoading || recordsQuery.isLoading || medicationsQuery.isLoading,
+    stockAlerts,
+    stockLoading: medicationsQuery.isLoading,
+    adherenceStats,
+    adherenceLoading: schedulesQuery.isLoading || recordsQuery.isLoading,
+    appointments: enrichedAppointments,
+    appointmentsLoading: appointmentsQuery.isLoading,
+    members,
+  };
+}
+
+export interface MarkRecordInput {
+  memberId: string;
+  medicationId: string;
+  scheduleId: string;
+  takenAt?: string;
+  notes?: string;
+}
+
+/**
+ * 服薬記録を作成し、関連クエリを無効化する。
+ */
+export function useMarkRecord() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: MarkRecordInput) =>
+      api.post<MedicationRecord>("/records", {
+        memberId: input.memberId,
+        medicationId: input.medicationId,
+        scheduleId: input.scheduleId,
+        ...(input.takenAt ? { takenAt: input.takenAt } : {}),
+        ...(input.notes ? { notes: input.notes } : {}),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["schedules", "today"] });
+      qc.invalidateQueries({ queryKey: ["records"] });
+    },
+  });
+}

--- a/frontend/app/hooks/health-logs.ts
+++ b/frontend/app/hooks/health-logs.ts
@@ -1,0 +1,460 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type {
+  BodyMeasurement,
+  HealthLog,
+  Member,
+  TemperatureRecord,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// 体調記録ドメインロジック（旧 HealthLogEntity / TemperatureRecordEntity から移植）
+// ---------------------------------------------------------------------------
+
+export const CONDITION_LEVELS = [1, 2, 3, 4, 5] as const;
+export type ConditionLevel = (typeof CONDITION_LEVELS)[number];
+
+export const SYMPTOM_OPTIONS = [
+  "headache",
+  "fever",
+  "fatigue",
+  "nausea",
+  "stomachache",
+  "dizziness",
+  "cough",
+  "runny_nose",
+  "joint_pain",
+  "insomnia",
+  "menstrual_pain",
+  "vomiting",
+  "diarrhea",
+  "bloody_urine",
+  "bleeding",
+  "eye_discharge",
+  "loss_of_appetite",
+  "lethargy",
+] as const;
+export type SymptomType = (typeof SYMPTOM_OPTIONS)[number];
+
+export const SYMPTOM_LABELS: Record<SymptomType, string> = {
+  headache: "頭痛",
+  fever: "発熱",
+  fatigue: "倦怠感",
+  nausea: "吐き気",
+  stomachache: "腹痛",
+  dizziness: "めまい",
+  cough: "咳",
+  runny_nose: "鼻水",
+  joint_pain: "関節痛",
+  insomnia: "不眠",
+  menstrual_pain: "生理痛",
+  vomiting: "嘔吐",
+  diarrhea: "下痢",
+  bloody_urine: "血尿",
+  bleeding: "出血",
+  eye_discharge: "目ヤニ",
+  loss_of_appetite: "食欲不振",
+  lethargy: "元気がない",
+};
+
+const CONDITION_LABELS: Record<ConditionLevel, string> = {
+  1: "とても悪い",
+  2: "悪い",
+  3: "普通",
+  4: "良い",
+  5: "とても良い",
+};
+
+const CONDITION_COLORS: Record<ConditionLevel, string> = {
+  1: "text-red-600",
+  2: "text-orange-500",
+  3: "text-yellow-500",
+  4: "text-green-500",
+  5: "text-green-600",
+};
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+export function getConditionLabel(level: ConditionLevel): string {
+  return CONDITION_LABELS[level];
+}
+
+export function getConditionColor(level: ConditionLevel): string {
+  return CONDITION_COLORS[level];
+}
+
+export function getSymptomLabel(symptom: SymptomType): string {
+  return SYMPTOM_LABELS[symptom];
+}
+
+function toDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function getDayOfWeekLabel(date: Date): string {
+  return DAY_LABELS[date.getDay()];
+}
+
+// クライアント側で扱う体調記録（日付を Date 化し、メンバー名を付与）
+export interface HealthLogView {
+  id: string;
+  memberId: string;
+  memberName: string;
+  conditionLevel: ConditionLevel;
+  symptoms: SymptomType[];
+  notes?: string;
+  recordedAt: Date;
+}
+
+export interface DailyHealthLogGroup {
+  date: string;
+  logs: HealthLogView[];
+}
+
+export interface DailyAverage {
+  date: string;
+  dayLabel: string;
+  average: number | null;
+}
+
+export interface SymptomFrequency {
+  symptom: SymptomType;
+  count: number;
+}
+
+/** 日付ごとにグループ化（新しい順） */
+export function groupByDate(logs: HealthLogView[]): DailyHealthLogGroup[] {
+  const groups = new Map<string, HealthLogView[]>();
+  for (const log of logs) {
+    const dateStr = toDateKey(log.recordedAt);
+    if (!groups.has(dateStr)) groups.set(dateStr, []);
+    groups.get(dateStr)!.push(log);
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([date, dateLogs]) => ({
+      date,
+      logs: dateLogs.sort(
+        (a, b) => b.recordedAt.getTime() - a.recordedAt.getTime(),
+      ),
+    }));
+}
+
+/** 日付を日本語形式でフォーマット */
+export function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  return `${date.getMonth() + 1}月${date.getDate()}日(${getDayOfWeekLabel(date)})`;
+}
+
+/** 日ごとの平均体調レベルを算出（古い→新しい順） */
+export function getDailyAverages(
+  logs: HealthLogView[],
+  days: number,
+  today: Date,
+): DailyAverage[] {
+  const result: DailyAverage[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const dateKey = toDateKey(d);
+    const dayLabel = getDayOfWeekLabel(d);
+    const dayLogs = logs.filter((log) => toDateKey(log.recordedAt) === dateKey);
+    if (dayLogs.length === 0) {
+      result.push({ date: dateKey, dayLabel, average: null });
+    } else {
+      const sum = dayLogs.reduce((acc, log) => acc + log.conditionLevel, 0);
+      result.push({
+        date: dateKey,
+        dayLabel,
+        average: Math.round(sum / dayLogs.length),
+      });
+    }
+  }
+  return result;
+}
+
+/** 最も多い症状を取得 */
+export function getMostFrequentSymptoms(
+  logs: HealthLogView[],
+  limit = 3,
+): SymptomFrequency[] {
+  const counts = new Map<SymptomType, number>();
+  for (const log of logs) {
+    for (const symptom of log.symptoms) {
+      counts.set(symptom, (counts.get(symptom) ?? 0) + 1);
+    }
+  }
+  return Array.from(counts.entries())
+    .map(([symptom, count]) => ({ symptom, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// 体温記録ロジック
+// ---------------------------------------------------------------------------
+
+export type TemperatureCategory =
+  | "hypothermia"
+  | "normal"
+  | "low_fever"
+  | "fever"
+  | "high_fever";
+
+const TEMP_CATEGORY_LABELS: Record<TemperatureCategory, string> = {
+  hypothermia: "低体温",
+  normal: "平熱",
+  low_fever: "微熱",
+  fever: "発熱",
+  high_fever: "高熱",
+};
+
+const TEMP_CATEGORY_COLORS: Record<TemperatureCategory, string> = {
+  hypothermia: "text-blue-600",
+  normal: "text-green-600",
+  low_fever: "text-yellow-600",
+  fever: "text-orange-600",
+  high_fever: "text-red-600",
+};
+
+export function classifyTemperature(temperature: number): TemperatureCategory {
+  if (temperature < 35.0) return "hypothermia";
+  if (temperature < 37.5) return "normal";
+  if (temperature < 38.0) return "low_fever";
+  if (temperature < 39.0) return "fever";
+  return "high_fever";
+}
+
+export function getTemperatureCategoryLabel(
+  category: TemperatureCategory,
+): string {
+  return TEMP_CATEGORY_LABELS[category];
+}
+
+export function getTemperatureCategoryColor(
+  category: TemperatureCategory,
+): string {
+  return TEMP_CATEGORY_COLORS[category];
+}
+
+export interface TemperatureRecordView {
+  id: string;
+  memberId: string;
+  memberName?: string;
+  temperature: number;
+  measuredAt: Date;
+  notes?: string;
+}
+
+export interface BodyMeasurementView {
+  id: string;
+  memberId: string;
+  memberName?: string;
+  weight?: number;
+  height?: number;
+  recordedAt: string;
+  notes?: string;
+}
+
+// ---------------------------------------------------------------------------
+// データ取得フック（React Query）
+// ---------------------------------------------------------------------------
+
+function memberNameOf(members: Member[] | undefined, memberId: string): string {
+  return members?.find((m) => m.id === memberId)?.name ?? "";
+}
+
+export function useMembersQuery() {
+  return useQuery({
+    queryKey: ["members"],
+    queryFn: () => api.get<Member[]>("/members"),
+  });
+}
+
+export interface CreateHealthLogInput {
+  memberId: string;
+  conditionLevel: number;
+  symptoms?: string[];
+  notes?: string;
+}
+
+export function useHealthLogs(members: Member[] | undefined) {
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ["health-logs"],
+    queryFn: () => api.get<HealthLog[]>("/health-logs"),
+  });
+
+  const logs: HealthLogView[] = (query.data ?? []).map((h) => ({
+    id: h.id,
+    memberId: h.memberId,
+    memberName: memberNameOf(members, h.memberId),
+    conditionLevel: (h.conditionLevel as ConditionLevel) ?? 3,
+    symptoms: (h.symptoms ?? []) as SymptomType[],
+    notes: h.notes ?? undefined,
+    recordedAt: new Date(h.recordedAt),
+  }));
+
+  const groups = groupByDate(logs);
+
+  const createMutation = useMutation({
+    mutationFn: (input: CreateHealthLogInput) =>
+      api.post<HealthLog>("/health-logs", {
+        memberId: input.memberId,
+        conditionLevel: input.conditionLevel,
+        symptoms: input.symptoms,
+        notes: input.notes,
+        recordedAt: new Date().toISOString(),
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["health-logs"] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/health-logs/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["health-logs"] }),
+  });
+
+  return {
+    logs,
+    groups,
+    isLoading: query.isLoading,
+    createLog: (input: CreateHealthLogInput) =>
+      createMutation.mutateAsync(input),
+    deleteLog: (id: string) => deleteMutation.mutateAsync(id),
+  };
+}
+
+export interface CreateTemperatureInput {
+  memberId: string;
+  temperature: number;
+  measuredAt: string;
+  notes?: string;
+}
+
+export function useTemperatureRecords(members: Member[] | undefined) {
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ["temperature-records"],
+    queryFn: () => api.get<TemperatureRecord[]>("/temperature-records"),
+  });
+
+  const records: TemperatureRecordView[] = (query.data ?? [])
+    .map((r) => ({
+      id: r.id,
+      memberId: r.memberId,
+      memberName: memberNameOf(members, r.memberId) || undefined,
+      temperature: r.temperature,
+      measuredAt: new Date(r.measuredAt),
+      notes: r.notes ?? undefined,
+    }))
+    .sort((a, b) => b.measuredAt.getTime() - a.measuredAt.getTime());
+
+  const createMutation = useMutation({
+    mutationFn: (input: CreateTemperatureInput) =>
+      api.post<TemperatureRecord>("/temperature-records", {
+        memberId: input.memberId,
+        temperature: input.temperature,
+        measuredAt: input.measuredAt,
+        notes: input.notes,
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["temperature-records"] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/temperature-records/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["temperature-records"] }),
+  });
+
+  return {
+    records,
+    isLoading: query.isLoading,
+    createRecord: (input: CreateTemperatureInput) =>
+      createMutation.mutateAsync(input),
+    deleteRecord: (id: string) => deleteMutation.mutateAsync(id),
+  };
+}
+
+export interface CreateBodyMeasurementInput {
+  memberId: string;
+  weight?: number;
+  height?: number;
+  recordedAt: string;
+  notes?: string;
+}
+
+export interface UpdateBodyMeasurementInput {
+  weight?: number | null;
+  height?: number | null;
+  notes?: string | null;
+}
+
+export function useBodyMeasurements(members: Member[] | undefined) {
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey: ["body-measurements"],
+    queryFn: () => api.get<BodyMeasurement[]>("/body-measurements"),
+  });
+
+  const measurements: BodyMeasurementView[] = (query.data ?? [])
+    .map((m) => ({
+      id: m.id,
+      memberId: m.memberId,
+      memberName: memberNameOf(members, m.memberId) || undefined,
+      weight: m.weight ?? undefined,
+      height: m.height ?? undefined,
+      recordedAt: m.recordedAt,
+      notes: m.notes ?? undefined,
+    }))
+    .sort(
+      (a, b) =>
+        new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime(),
+    );
+
+  const createMutation = useMutation({
+    mutationFn: (input: CreateBodyMeasurementInput) =>
+      api.post<BodyMeasurement>("/body-measurements", {
+        memberId: input.memberId,
+        weight: input.weight,
+        height: input.height,
+        recordedAt: new Date(input.recordedAt).toISOString(),
+        notes: input.notes,
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["body-measurements"] }),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      id,
+      input,
+    }: {
+      id: string;
+      input: UpdateBodyMeasurementInput;
+    }) => api.patch<BodyMeasurement>(`/body-measurements/${id}`, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["body-measurements"] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/body-measurements/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["body-measurements"] }),
+  });
+
+  return {
+    measurements,
+    isLoading: query.isLoading,
+    createMeasurement: (input: CreateBodyMeasurementInput) =>
+      createMutation.mutateAsync(input),
+    updateMeasurement: async (
+      id: string,
+      input: UpdateBodyMeasurementInput,
+    ): Promise<void> => {
+      await updateMutation.mutateAsync({ id, input });
+    },
+    deleteMeasurement: (id: string) => deleteMutation.mutateAsync(id),
+  };
+}

--- a/frontend/app/hooks/history.ts
+++ b/frontend/app/hooks/history.ts
@@ -1,0 +1,148 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { MedicationRecord, Member, Medication, HealthLog } from "@/lib/types";
+
+/** 表示用に氏名・薬名を付与した服薬記録 */
+export interface EnrichedRecord {
+  id: string;
+  memberId: string;
+  memberName: string;
+  medicationId: string;
+  medicationName: string;
+  takenAt: Date;
+  notes?: string;
+  dosageAmount?: string;
+}
+
+export interface DailyRecordGroup {
+  date: string;
+  records: EnrichedRecord[];
+}
+
+export interface CreateRecordInput {
+  memberId: string;
+  medicationId: string;
+  takenAt: string;
+  notes?: string;
+}
+
+/** Date を YYYY-MM-DD のローカル日付キーに変換 */
+export function toDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+/** 日付を「M月D日(曜)」形式でフォーマット */
+export function formatRecordDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  return `${date.getMonth() + 1}月${date.getDate()}日(${WEEKDAY_LABELS[date.getDay()]})`;
+}
+
+/** 時刻を HH:mm 形式でフォーマット */
+export function formatRecordTime(date: Date): string {
+  const h = date.getHours().toString().padStart(2, "0");
+  const m = date.getMinutes().toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+/** 記録を日付ごとにグループ化（新しい順） */
+export function groupByDate(records: EnrichedRecord[]): DailyRecordGroup[] {
+  const groups = new Map<string, EnrichedRecord[]>();
+  for (const record of records) {
+    const dateStr = toDateKey(record.takenAt);
+    if (!groups.has(dateStr)) groups.set(dateStr, []);
+    groups.get(dateStr)!.push(record);
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([date, recs]) => ({ date, records: recs }));
+}
+
+/** メンバーIDでグループをフィルタ（空グループは除外） */
+export function filterGroupsByMember(groups: DailyRecordGroup[], memberId: string | null): DailyRecordGroup[] {
+  if (memberId === null) return groups;
+  return groups
+    .map((g) => ({ ...g, records: g.records.filter((r) => r.memberId === memberId) }))
+    .filter((g) => g.records.length > 0);
+}
+
+interface UseMedicationHistoryResult {
+  groups: DailyRecordGroup[];
+  records: EnrichedRecord[];
+  healthLogs: HealthLog[];
+  members: Member[];
+  isLoading: boolean;
+  deleteRecord: (recordId: string) => Promise<void>;
+  createRecord: (input: CreateRecordInput) => Promise<void>;
+}
+
+export function useMedicationHistory(): UseMedicationHistoryResult {
+  const qc = useQueryClient();
+
+  const { data: rawRecords, isLoading: recordsLoading } = useQuery({
+    queryKey: ["records"],
+    queryFn: () => api.get<MedicationRecord[]>("/records"),
+  });
+
+  const { data: members } = useQuery({
+    queryKey: ["members"],
+    queryFn: () => api.get<Member[]>("/members"),
+  });
+
+  const { data: medications } = useQuery({
+    queryKey: ["medications"],
+    queryFn: () => api.get<Medication[]>("/medications"),
+  });
+
+  const { data: healthLogs } = useQuery({
+    queryKey: ["health-logs"],
+    queryFn: () => api.get<HealthLog[]>("/health-logs"),
+  });
+
+  const enriched = useMemo<EnrichedRecord[]>(() => {
+    if (!rawRecords) return [];
+    const memberMap = new Map((members ?? []).map((m) => [m.id, m.name]));
+    const medMap = new Map((medications ?? []).map((m) => [m.id, m.name]));
+    return rawRecords.map((r) => ({
+      id: r.id,
+      memberId: r.memberId,
+      memberName: memberMap.get(r.memberId) ?? "",
+      medicationId: r.medicationId,
+      medicationName: medMap.get(r.medicationId) ?? "",
+      takenAt: new Date(r.takenAt),
+      notes: r.notes ?? undefined,
+      dosageAmount: r.dosageAmount ?? undefined,
+    }));
+  }, [rawRecords, members, medications]);
+
+  const groups = useMemo(() => groupByDate(enriched), [enriched]);
+
+  const deleteMutation = useMutation({
+    mutationFn: (recordId: string) => api.delete(`/records/${recordId}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["records"] }),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (input: CreateRecordInput) => api.post("/records", input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["records"] }),
+  });
+
+  return {
+    groups,
+    records: enriched,
+    healthLogs: healthLogs ?? [],
+    members: members ?? [],
+    isLoading: recordsLoading,
+    deleteRecord: async (recordId: string) => {
+      await deleteMutation.mutateAsync(recordId);
+    },
+    createRecord: async (input: CreateRecordInput) => {
+      await createMutation.mutateAsync(input);
+    },
+  };
+}

--- a/frontend/app/lib/character.ts
+++ b/frontend/app/lib/character.ts
@@ -1,0 +1,255 @@
+export type CharacterType = 'dog' | 'cat' | 'rabbit' | 'bird';
+
+export type CharacterMood =
+  | 'happy'
+  | 'excited'
+  | 'normal'
+  | 'reminding'
+  | 'worried'
+  | 'sad'
+  | 'cheering';
+
+export interface CharacterConfig {
+  type: CharacterType;
+  name: string;
+  suffix: string;
+  sounds: {
+    normal: string;
+    medicationReminder: string;
+    missedMedication: string;
+    medicationComplete: string;
+    exerciseCheer: string;
+  };
+  messages: {
+    medicationReminder: string;
+    missedMedication: string;
+    medicationComplete: string;
+    exerciseCheer: string;
+    lowStock: string;
+    appointmentReminder: string;
+    vaccineReminder: string;
+    checkupReminder: string;
+  };
+}
+
+const VALID_TYPES: CharacterType[] = ['dog', 'cat', 'rabbit', 'bird'];
+
+const LOYALTY_HIGH_THRESHOLD = 80;
+const LOYALTY_MODERATE_THRESHOLD = 40;
+
+/**
+ * 文字列がCharacterTypeか検証する
+ */
+export function isValidCharacterType(type: string): type is CharacterType {
+  return VALID_TYPES.includes(type as CharacterType);
+}
+
+/**
+ * タイプからConfigを取得する(無効時はdogをデフォルトで返す)
+ */
+export function getCharacterConfig(type: string): CharacterConfig {
+  if (isValidCharacterType(type)) {
+    return CHARACTER_CONFIGS[type];
+  }
+  return CHARACTER_CONFIGS.dog;
+}
+
+/**
+ * 全キャラクタータイプのリストを返す
+ */
+export function getAllCharacterTypes(): CharacterType[] {
+  return [...VALID_TYPES];
+}
+
+/**
+ * 服薬遵守率に応じたムードを判定する
+ */
+export function getMoodByAdherence(rate: number): CharacterMood {
+  if (rate >= 90) return 'happy';
+  if (rate >= 70) return 'normal';
+  if (rate >= 50) return 'reminding';
+  if (rate >= 30) return 'worried';
+  return 'sad';
+}
+
+/**
+ * ムードの日本語ラベルを返す
+ */
+export function getMoodLabel(mood: CharacterMood): string {
+  const labels: Record<CharacterMood, string> = {
+    happy: '喜び',
+    excited: '興奮',
+    normal: '通常',
+    reminding: 'お知らせ',
+    worried: '心配',
+    sad: '悲しみ',
+    cheering: '応援',
+  };
+  return labels[mood];
+}
+
+/**
+ * ムードに応じたメッセージを返す
+ */
+export function getMoodMessage(mood: CharacterMood): string {
+  const messages: Record<CharacterMood, string> = {
+    happy: 'とても良い調子です',
+    excited: '素晴らしい成果です',
+    normal: 'いつも通りです',
+    reminding: 'お薬を忘れずに',
+    worried: '少し心配しています',
+    sad: '一緒に頑張りましょう',
+    cheering: '応援しています',
+  };
+  return messages[mood];
+}
+
+/**
+ * 時間帯に応じた挨拶テキストを返す
+ */
+export function getTimeBasedGreeting(hour: number): string {
+  if (hour >= 5 && hour < 12) return 'おはようございます';
+  if (hour >= 12 && hour < 18) return 'こんにちは';
+  return 'こんばんは';
+}
+
+/**
+ * 挨拶に含めるコンテキスト情報を構築する
+ */
+export function getGreetingContext(info: {
+  pendingMedications: number;
+  upcomingAppointments: number;
+  memberName: string;
+}): string {
+  const parts: string[] = [];
+  if (info.pendingMedications > 0) {
+    parts.push(`${info.memberName}さんの服薬が${info.pendingMedications}件あります`);
+  }
+  if (info.upcomingAppointments > 0) {
+    parts.push(`通院予定が${info.upcomingAppointments}件あります`);
+  }
+  if (parts.length === 0) {
+    return `${info.memberName}さんの今日の予定はありません`;
+  }
+  return parts.join('。');
+}
+
+/**
+ * 挨拶テキストとコンテキストを組み合わせたメッセージを生成する
+ */
+export function buildGreetingMessage(
+  hour: number,
+  info: { pendingMedications: number; upcomingAppointments: number; memberName: string },
+): string {
+  const greeting = getTimeBasedGreeting(hour);
+  const context = getGreetingContext(info);
+  return `${greeting}、${info.memberName}さん。${context}`;
+}
+
+/**
+ * キャラクター使用日数から忠誠度スコアを算出する（0-100）
+ */
+export function getCharacterLoyaltyScore(usageDays: number, totalDays: number): number {
+  if (totalDays <= 0 || usageDays <= 0) return 0;
+  return Math.min(100, Math.round((usageDays / totalDays) * 100));
+}
+
+/**
+ * 忠誠度スコアに応じたラベルを返す
+ */
+export function getCharacterLoyaltyScoreLabel(score: number): string {
+  if (score >= LOYALTY_HIGH_THRESHOLD) return '忠実';
+  if (score >= LOYALTY_MODERATE_THRESHOLD) return '普通';
+  return '浮気性';
+}
+
+export const CHARACTER_CONFIGS: Record<CharacterType, CharacterConfig> = {
+  dog: {
+    type: 'dog',
+    name: 'いぬ',
+    suffix: 'ワン',
+    sounds: {
+      normal: '/sounds/dog/bark.mp3',
+      medicationReminder: '/sounds/dog/reminder.mp3',
+      missedMedication: '/sounds/dog/missed.mp3',
+      medicationComplete: '/sounds/dog/complete.mp3',
+      exerciseCheer: '/sounds/dog/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'ワンッ！お薬の時間だよ',
+      missedMedication: 'クゥーン...お薬まだ飲んでないよ？',
+      medicationComplete: 'ワン！よくできたね！',
+      exerciseCheer: 'ワンワン！よく頑張ったね！',
+      lowStock: 'ワンッ！お薬が少なくなってきたよ',
+      appointmentReminder: 'ワン！今日は病院の日だよ',
+      vaccineReminder: 'ワン！もうすぐ注射の日だよ',
+      checkupReminder: 'ワン！健康診断の日だよ',
+    },
+  },
+  cat: {
+    type: 'cat',
+    name: 'ねこ',
+    suffix: 'ニャ',
+    sounds: {
+      normal: '/sounds/cat/meow.mp3',
+      medicationReminder: '/sounds/cat/reminder.mp3',
+      missedMedication: '/sounds/cat/missed.mp3',
+      medicationComplete: '/sounds/cat/complete.mp3',
+      exerciseCheer: '/sounds/cat/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'ニャー、お薬の時間だよ',
+      missedMedication: 'ニャッ！お薬まだ飲んでないよ？',
+      medicationComplete: 'ゴロゴロ...えらいね',
+      exerciseCheer: 'ニャー！よく頑張ったね',
+      lowStock: 'ニャー、お薬が少なくなってきたよ',
+      appointmentReminder: 'ニャー、今日は病院の日だよ',
+      vaccineReminder: 'ニャー、もうすぐ注射の日だよ',
+      checkupReminder: 'ニャー、健康診断の日だよ',
+    },
+  },
+  rabbit: {
+    type: 'rabbit',
+    name: 'うさぎ',
+    suffix: 'ピョン',
+    sounds: {
+      normal: '/sounds/rabbit/squeak.mp3',
+      medicationReminder: '/sounds/rabbit/reminder.mp3',
+      missedMedication: '/sounds/rabbit/missed.mp3',
+      medicationComplete: '/sounds/rabbit/complete.mp3',
+      exerciseCheer: '/sounds/rabbit/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'プウプウ、お薬の時間だよ',
+      missedMedication: 'ダンダンッ！お薬まだ飲んでないよ？',
+      medicationComplete: 'プウプウ...えらいね',
+      exerciseCheer: 'プウプウ！よく頑張ったね',
+      lowStock: 'プウプウ、お薬が少なくなってきたよ',
+      appointmentReminder: 'プウプウ、今日は病院の日だよ',
+      vaccineReminder: 'プウプウ、もうすぐ注射の日だよ',
+      checkupReminder: 'プウプウ、健康診断の日だよ',
+    },
+  },
+  bird: {
+    type: 'bird',
+    name: 'インコ',
+    suffix: 'ピィ',
+    sounds: {
+      normal: '/sounds/bird/chirp.mp3',
+      medicationReminder: '/sounds/bird/reminder.mp3',
+      missedMedication: '/sounds/bird/missed.mp3',
+      medicationComplete: '/sounds/bird/complete.mp3',
+      exerciseCheer: '/sounds/bird/cheer.mp3',
+    },
+    messages: {
+      medicationReminder: 'ピピッ！お薬の時間だよ',
+      missedMedication: 'ギャギャッ！お薬まだ飲んでないよ？',
+      medicationComplete: 'ピィー！えらいね',
+      exerciseCheer: 'ピピピッ！よく頑張ったね',
+      lowStock: 'ピピッ！お薬が少なくなってきたよ',
+      appointmentReminder: 'ピピッ！今日は病院の日だよ',
+      vaccineReminder: 'ピピッ！もうすぐ注射の日だよ',
+      checkupReminder: 'ピピッ！健康診断の日だよ',
+    },
+  },
+};

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -81,3 +81,147 @@ export interface MedicationRecord {
   notes: string | null;
   dosageAmount: string | null;
 }
+
+export interface Hospital {
+  id: string;
+  userId: string;
+  name: string;
+  hospitalType: string | null;
+  address: string | null;
+  phoneNumber: string | null;
+  department: string | null;
+  doctorName: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface Appointment {
+  id: string;
+  userId: string;
+  memberId: string;
+  hospitalId: string | null;
+  appointmentType: string | null;
+  appointmentDate: string;
+  description: string | null;
+  testResults: string | null;
+  cost: number | null;
+  reminderEnabled: boolean;
+  reminderDaysBefore: number;
+  createdAt: string;
+}
+
+export interface HealthLog {
+  id: string;
+  userId: string;
+  memberId: string;
+  conditionLevel: number;
+  symptoms: string[];
+  notes: string | null;
+  recordedAt: string;
+}
+
+export interface Vaccination {
+  id: string;
+  userId: string;
+  memberId: string;
+  vaccineName: string;
+  vaccinatedAt: string;
+  nextScheduledDate: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface Examination {
+  id: string;
+  userId: string;
+  memberId: string;
+  examinationType: string;
+  examinedAt: string;
+  nextScheduledDate: string | null;
+  notes: string | null;
+  imageData: string | null;
+  createdAt: string;
+}
+
+export interface Insurance {
+  id: string;
+  userId: string;
+  memberId: string;
+  insuranceType: string;
+  providerName: string | null;
+  policyNumber: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface Allergy {
+  id: string;
+  userId: string;
+  memberId: string;
+  allergenName: string;
+  allergyType: string;
+  severity: string;
+  symptoms: string | null;
+  diagnosedAt: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface BodyMeasurement {
+  id: string;
+  userId: string;
+  memberId: string;
+  weight: number | null;
+  height: number | null;
+  recordedAt: string;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface TemperatureRecord {
+  id: string;
+  userId: string;
+  memberId: string;
+  temperature: number;
+  measuredAt: string;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface EmergencyContact {
+  id: string;
+  userId: string;
+  memberId: string;
+  contactName: string;
+  phoneNumber: string;
+  relationship: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface Prescription {
+  id: string;
+  userId: string;
+  memberId: string;
+  prescriptionName: string;
+  prescribedBy: string | null;
+  prescribedAt: string;
+  expiresAt: string | null;
+  pharmacyName: string | null;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface NotificationSetting {
+  id: string;
+  userId: string;
+  medicationReminderEnabled: boolean;
+  missedMedicationEnabled: boolean;
+  appointmentReminderEnabled: boolean;
+  lowStockAlertEnabled: boolean;
+  defaultReminderMinutesBefore: number;
+  defaultAppointmentReminderDaysBefore: number;
+  emailNotificationEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -16,7 +16,14 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#e8d4dc" />
         <title>HealthFamily</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap"
+        />
         <Meta />
         <Links />
       </head>
@@ -47,7 +54,7 @@ export default function App() {
 
 export function HydrateFallback() {
   return (
-    <div className="flex min-h-screen items-center justify-center text-slate-500">
+    <div className="flex min-h-screen items-center justify-center text-ink-500">
       読み込み中...
     </div>
   );

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -1,14 +1,29 @@
 import { type RouteConfig, index, layout, route } from "@react-router/dev/routes";
 
 export default [
+  // 公開ルート
   route("login", "routes/login.tsx"),
   route("signup", "routes/signup.tsx"),
   route("verify", "routes/verify.tsx"),
+  route("forgot-password", "routes/forgot-password.tsx"),
+  route("reset-password", "routes/reset-password.tsx"),
 
   // 認証済みレイアウト配下
   layout("routes/_authed.tsx", [
     index("routes/home.tsx"),
     route("members", "routes/members.tsx"),
+    route("members/:memberId", "routes/members.$memberId.tsx"),
+    route(
+      "members/:memberId/medications",
+      "routes/members.$memberId.medications.tsx",
+    ),
     route("medications", "routes/medications.tsx"),
+    route("appointments", "routes/appointments.tsx"),
+    route("hospitals", "routes/hospitals.tsx"),
+    route("health-logs", "routes/health-logs.tsx"),
+    route("history", "routes/history.tsx"),
+    route("settings", "routes/settings.tsx"),
+    route("settings/notifications", "routes/settings.notifications.tsx"),
+    route("guide", "routes/guide.tsx"),
   ]),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/_authed.tsx
+++ b/frontend/app/routes/_authed.tsx
@@ -1,12 +1,29 @@
 import { NavLink, Outlet } from "react-router";
 import { clsx } from "clsx";
-import { CalendarCheck, Home, Pill, Users } from "lucide-react";
+import {
+  Activity,
+  Calendar,
+  CalendarCheck,
+  Home,
+  Pill,
+  Settings,
+  type LucideIcon,
+} from "lucide-react";
 import { useAuth, useRequireAuth } from "@/lib/auth";
 
-const navItems = [
+interface NavItem {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  end: boolean;
+}
+
+const navItems: NavItem[] = [
   { to: "/", label: "ホーム", icon: Home, end: true },
-  { to: "/members", label: "メンバー", icon: Users, end: false },
-  { to: "/medications", label: "おくすり", icon: Pill, end: false },
+  { to: "/medications", label: "お薬", icon: Pill, end: false },
+  { to: "/health-logs", label: "体調", icon: Activity, end: false },
+  { to: "/appointments", label: "通院", icon: Calendar, end: false },
+  { to: "/settings", label: "設定", icon: Settings, end: false },
 ];
 
 export default function AuthedLayout() {
@@ -15,7 +32,7 @@ export default function AuthedLayout() {
 
   if (loading || !user) {
     return (
-      <div className="flex min-h-screen items-center justify-center text-slate-500">
+      <div className="flex min-h-screen items-center justify-center text-ink-500">
         読み込み中...
       </div>
     );
@@ -23,12 +40,12 @@ export default function AuthedLayout() {
 
   return (
     <div className="mx-auto flex min-h-screen max-w-2xl flex-col">
-      <header className="flex items-center justify-between border-b border-slate-100 bg-white px-4 py-3">
+      <header className="flex items-center justify-between border-b border-primary-100 bg-white px-4 py-3">
         <div className="flex items-center gap-2 font-semibold text-primary">
           <CalendarCheck className="h-5 w-5" />
           HealthFamily
         </div>
-        <button onClick={logout} className="text-sm text-slate-500 hover:text-slate-700">
+        <button onClick={logout} className="text-sm text-ink-500 hover:text-ink-700">
           ログアウト
         </button>
       </header>
@@ -37,7 +54,7 @@ export default function AuthedLayout() {
         <Outlet />
       </main>
 
-      <nav className="fixed inset-x-0 bottom-0 mx-auto flex max-w-2xl justify-around border-t border-slate-100 bg-white py-2">
+      <nav className="fixed inset-x-0 bottom-0 mx-auto flex max-w-2xl justify-around border-t border-primary-100 bg-white py-2">
         {navItems.map(({ to, label, icon: Icon, end }) => (
           <NavLink
             key={to}
@@ -46,7 +63,7 @@ export default function AuthedLayout() {
             className={({ isActive }) =>
               clsx(
                 "flex flex-col items-center gap-1 px-4 py-1 text-xs",
-                isActive ? "text-primary" : "text-slate-400",
+                isActive ? "text-primary" : "text-ink-400",
               )
             }
           >

--- a/frontend/app/routes/appointments.tsx
+++ b/frontend/app/routes/appointments.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { MapPin, Plus, X } from "lucide-react";
+import { api } from "@/lib/api";
+import type { Appointment, Hospital, Member } from "@/lib/types";
+import { TabSwitch } from "@/components/shared/TabSwitch";
+import { MiniCalendar } from "@/components/appointments/MiniCalendar";
+import { AppointmentForm, type AppointmentFormData } from "@/components/appointments/AppointmentForm";
+import {
+  AppointmentList,
+  type AppointmentFilter,
+  getAppointmentCounts,
+} from "@/components/appointments/AppointmentList";
+
+export default function Appointments() {
+  const qc = useQueryClient();
+  const [showForm, setShowForm] = useState(false);
+  const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
+  const [activeTab, setActiveTab] = useState<AppointmentFilter>("upcoming");
+  const [updateError, setUpdateError] = useState<string | null>(null);
+  const editFormRef = useRef<HTMLDivElement>(null);
+
+  const { data: members = [], isLoading: membersLoading } = useQuery({
+    queryKey: ["members"],
+    queryFn: () => api.get<Member[]>("/members"),
+  });
+
+  const { data: appointments = [], isLoading } = useQuery({
+    queryKey: ["appointments"],
+    queryFn: () => api.get<Appointment[]>("/appointments"),
+  });
+
+  const { data: hospitals = [] } = useQuery({
+    queryKey: ["hospitals"],
+    queryFn: () => api.get<Hospital[]>("/hospitals"),
+  });
+
+  const hasNoMembers = !membersLoading && members.length === 0;
+
+  const memberNameOf = (memberId: string): string =>
+    members.find((m) => m.id === memberId)?.name ?? "";
+  const hospitalNameOf = (hospitalId: string | null): string =>
+    hospitalId ? (hospitals.find((h) => h.id === hospitalId)?.name ?? "") : "";
+
+  const appointmentDates = useMemo(
+    () => appointments.map((a) => new Date(a.appointmentDate)),
+    [appointments],
+  );
+  const counts = useMemo(() => getAppointmentCounts(appointments), [appointments]);
+  const tabs = useMemo(
+    () => [
+      { id: "upcoming", label: "今後の予定", count: counts.upcoming },
+      { id: "past", label: "過去の予定", count: counts.past },
+    ],
+    [counts],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (data: AppointmentFormData) =>
+      api.post<Appointment>("/appointments", {
+        memberId: data.memberId,
+        hospitalId: data.hospitalId,
+        appointmentDate: new Date(data.appointmentDate).toISOString(),
+        type: data.type,
+        notes: data.notes,
+      }),
+    onSuccess: () => {
+      setShowForm(false);
+      qc.invalidateQueries({ queryKey: ["appointments"] });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: AppointmentFormData }) =>
+      api.patch<Appointment>(`/appointments/${id}`, {
+        appointmentDate: new Date(data.appointmentDate).toISOString(),
+        hospitalId: data.hospitalId,
+        type: data.type,
+        notes: data.notes,
+      }),
+    onSuccess: () => {
+      setEditingAppointment(null);
+      qc.invalidateQueries({ queryKey: ["appointments"] });
+    },
+    onError: () => setUpdateError("更新に失敗しました。もう一度お試しください。"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/appointments/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["appointments"] }),
+  });
+
+  const handleCreate = (data: AppointmentFormData) => {
+    createMutation.mutate(data);
+  };
+
+  const handleEdit = (appointment: Appointment) => {
+    setEditingAppointment(appointment);
+    setShowForm(false);
+    setUpdateError(null);
+  };
+
+  useEffect(() => {
+    if (editingAppointment && editFormRef.current) {
+      editFormRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [editingAppointment]);
+
+  const handleUpdate = (data: AppointmentFormData) => {
+    if (!editingAppointment) return;
+    setUpdateError(null);
+    updateMutation.mutate({ id: editingAppointment.id, data });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingAppointment(null);
+  };
+
+  const handleDelete = (appointmentId: string) => {
+    if (!window.confirm("この予約を削除しますか？")) return;
+    deleteMutation.mutate(appointmentId);
+  };
+
+  const handleToggleForm = () => {
+    if (showForm) {
+      setShowForm(false);
+    } else {
+      setEditingAppointment(null);
+      setShowForm(true);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold text-ink-800 tracking-wide">通院管理</h1>
+        <button
+          onClick={handleToggleForm}
+          className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
+          aria-label={showForm ? "閉じる" : "予約を追加"}
+        >
+          {showForm ? <X size={20} /> : <Plus size={20} />}
+        </button>
+      </div>
+
+      {showForm && !membersLoading && members.length > 0 && (
+        <div className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+          <h2 className="text-sm font-semibold text-ink-700 mb-3">通院予約の追加</h2>
+          <AppointmentForm members={members} hospitals={hospitals} onSubmit={handleCreate} />
+        </div>
+      )}
+
+      {showForm && hasNoMembers && (
+        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-700">
+          先に
+          <Link to="/members" className="underline font-medium text-amber-800 hover:text-amber-900">
+            メンバーページ
+          </Link>
+          でメンバーを登録してください。
+        </div>
+      )}
+
+      {editingAppointment && !membersLoading && members.length > 0 && (
+        <div ref={editFormRef} className="bg-white rounded-lg shadow-md p-4 border border-primary-200">
+          <h2 className="text-sm font-semibold text-ink-700 mb-3">通院予約の編集</h2>
+          {updateError && (
+            <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2 mb-3">{updateError}</p>
+          )}
+          <AppointmentForm
+            key={editingAppointment.id}
+            members={members}
+            hospitals={hospitals}
+            onSubmit={handleUpdate}
+            initialData={editingAppointment}
+            onCancel={handleCancelEdit}
+          />
+        </div>
+      )}
+
+      <MiniCalendar appointmentDates={appointmentDates} />
+
+      <TabSwitch
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={(id) => setActiveTab(id as AppointmentFilter)}
+      />
+
+      <AppointmentList
+        appointments={appointments}
+        isLoading={isLoading}
+        filter={activeTab}
+        memberNameOf={memberNameOf}
+        hospitalNameOf={hospitalNameOf}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />
+
+      <div className="mt-6">
+        <Link
+          to="/hospitals"
+          className="flex items-center justify-between bg-white rounded-lg p-4 border border-primary-100 hover:border-primary-300 transition-colors"
+        >
+          <div className="flex items-center space-x-3">
+            <MapPin size={18} className="text-primary-600" />
+            <span className="text-sm font-medium text-ink-700">かかりつけ医(病院)</span>
+          </div>
+          <span className="text-xs text-ink-400">{hospitals.length}件</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/forgot-password.tsx
+++ b/frontend/app/routes/forgot-password.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { api, ApiError } from "@/lib/api";
+
+export default function ForgotPassword() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage("");
+    setIsSubmitting(true);
+
+    try {
+      await api.post("/auth/forgot-password", { email }, false);
+      navigate(`/reset-password?email=${encodeURIComponent(email)}`);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setErrorMessage(err.message || "送信に失敗しました");
+      } else {
+        setErrorMessage(
+          "通信エラーが発生しました。インターネット接続を確認して再試行してください。",
+        );
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-primary-50/30 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <img
+            src="/icon.svg"
+            alt="HealthFamily"
+            width={80}
+            height={80}
+            className="mx-auto mb-2 rounded-2xl"
+          />
+          <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
+          <p className="mt-2 text-ink-500">パスワードの再設定</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="bg-white shadow-md rounded-lg p-6 space-y-4">
+          <p className="text-sm text-ink-600">
+            登録済みのメールアドレスを入力してください。リセットコードをお送りします。
+          </p>
+
+          {errorMessage && (
+            <div className="bg-red-50 text-red-700 p-3 rounded-md text-sm" role="alert">
+              {errorMessage}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-ink-700 mb-1">
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-primary-200 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+              placeholder="example@example.com"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full bg-primary-600 text-white py-2 rounded-md font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? "送信中..." : "リセットコードを送信"}
+          </button>
+
+          <p className="text-center text-sm text-ink-500">
+            <Link to="/login" className="text-primary-600 hover:underline">
+              ログイン画面に戻る
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/guide.tsx
+++ b/frontend/app/routes/guide.tsx
@@ -1,0 +1,281 @@
+import { useState, type ReactNode } from "react";
+import { Link } from "react-router";
+import {
+  ArrowLeft,
+  Home,
+  Pill,
+  Activity,
+  Calendar,
+  Settings,
+  Users,
+  Check,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+
+interface GuideSection {
+  id: string;
+  icon: ReactNode;
+  title: string;
+  steps: {
+    title: string;
+    description: string;
+  }[];
+}
+
+const guideSections: GuideSection[] = [
+  {
+    id: "getting-started",
+    icon: <Home size={20} className="text-primary-600" />,
+    title: "はじめに（初期設定）",
+    steps: [
+      {
+        title: "1. メンバーを登録する",
+        description:
+          "お薬タブ、またはホーム画面の案内から「メンバーを登録」をタップします。ご家族の名前やペットの名前を登録してください。人間・ペットどちらも登録できます。",
+      },
+      {
+        title: "2. お薬を登録する",
+        description:
+          "お薬タブの「＋」ボタンからお薬を追加します。お薬の名前、メンバー、カテゴリ（内服薬・外用薬など）を入力してください。",
+      },
+      {
+        title: "3. スケジュールを設定する",
+        description:
+          "お薬の詳細画面から「スケジュール追加」をタップ。服薬する時間と曜日（または間隔）を設定すると、ホーム画面に毎日の予定が表示されます。",
+      },
+    ],
+  },
+  {
+    id: "daily-use",
+    icon: <Check size={20} className="text-green-600" />,
+    title: "毎日の使い方",
+    steps: [
+      {
+        title: "ホーム画面で予定を確認",
+        description:
+          "ホーム画面に今日の服薬予定が時間順で表示されます。メンバーごとにフィルタリングもできます。",
+      },
+      {
+        title: "お薬を飲んだらチェック",
+        description:
+          "各予定の右側にある緑色のチェックボタンをタップすると、服薬記録がつきます。日付を変更してメモを追加することもできます（例：「昨日の飲み忘れ分」）。",
+      },
+      {
+        title: "飲み忘れアラートを確認",
+        description:
+          "ホーム画面の上部に、過去7日間の飲み忘れが赤いアラートで表示されます。飲み忘れに気づいたら「履歴から記録を追加」から記録できます。",
+      },
+    ],
+  },
+  {
+    id: "history",
+    icon: <Calendar size={20} className="text-blue-600" />,
+    title: "履歴の確認・記録の追加",
+    steps: [
+      {
+        title: "カレンダーで履歴を確認",
+        description:
+          "通院タブの隣にある服薬履歴ページでは、カレンダー形式で記録を確認できます。日付をタップすると、その日の詳細が表示されます。色の濃さで記録の多さがわかります。",
+      },
+      {
+        title: "過去の記録を追加する",
+        description:
+          "カレンダーで日付を選択し、「＋ 記録を追加」をタップ。メンバーとお薬を選んで登録できます。複数のお薬を一度に選択して同時登録も可能です。",
+      },
+      {
+        title: "メモの編集・削除",
+        description:
+          "各記録の鉛筆アイコンをタップするとメモを編集できます。ゴミ箱アイコンで記録自体の削除もできます。",
+      },
+    ],
+  },
+  {
+    id: "medications",
+    icon: <Pill size={20} className="text-primary-600" />,
+    title: "お薬の管理",
+    steps: [
+      {
+        title: "お薬の一覧",
+        description:
+          "お薬タブでは登録したお薬が一覧表示されます。タップすると詳細・スケジュール・在庫情報を確認できます。",
+      },
+      {
+        title: "在庫の管理",
+        description:
+          "お薬の詳細画面で在庫数を設定できます。残りが少なくなると、ホーム画面に在庫アラートが表示されます。",
+      },
+      {
+        title: "スケジュールの設定",
+        description:
+          "毎日・特定の曜日・○日おきなど、柔軟にスケジュールを設定できます。リマインダーの通知時間も個別に設定可能です。",
+      },
+    ],
+  },
+  {
+    id: "members",
+    icon: <Users size={20} className="text-purple-600" />,
+    title: "メンバーの管理",
+    steps: [
+      {
+        title: "メンバーの追加",
+        description:
+          "お薬タブの上部、またはメンバー管理ページから家族やペットを追加できます。名前とタイプ（人間・ペット）を設定します。",
+      },
+      {
+        title: "メンバーの詳細",
+        description:
+          "メンバーをタップすると、そのメンバー専用の情報（お薬・通院・アレルギー・予防接種・体重記録など）をまとめて確認できます。",
+      },
+    ],
+  },
+  {
+    id: "health-logs",
+    icon: <Activity size={20} className="text-orange-600" />,
+    title: "体調の記録",
+    steps: [
+      {
+        title: "体調を記録する",
+        description:
+          "体調タブから日々の体調を記録できます。体温、症状、気分などを入力して、体調の変化を把握しましょう。",
+      },
+      {
+        title: "記録を振り返る",
+        description:
+          "過去の体調記録を一覧で確認できます。通院時に医師に体調の変化を伝えるのに役立ちます。",
+      },
+    ],
+  },
+  {
+    id: "appointments",
+    icon: <Calendar size={20} className="text-teal-600" />,
+    title: "通院の管理",
+    steps: [
+      {
+        title: "通院予定を追加",
+        description:
+          "通院タブから予約情報を登録できます。病院名、日時、診療科目などを記録しましょう。",
+      },
+      {
+        title: "ホーム画面でリマインド",
+        description:
+          "近日中の通院予定がホーム画面に表示されるので、うっかり忘れを防げます。",
+      },
+    ],
+  },
+  {
+    id: "settings",
+    icon: <Settings size={20} className="text-ink-600" />,
+    title: "設定",
+    steps: [
+      {
+        title: "通知設定",
+        description:
+          "設定画面から通知のON/OFF、リマインダーのタイミングなどを調整できます。",
+      },
+      {
+        title: "緊急連絡先",
+        description:
+          "かかりつけ医や家族の連絡先を登録しておくと、いざという時にすぐ確認できます。",
+      },
+      {
+        title: "キャラクター選択",
+        description:
+          "ホーム画面に表示されるキャラクターを変更できます。お好みのキャラクターを選んでください。",
+      },
+    ],
+  },
+];
+
+export default function GuidePage() {
+  const [openSections, setOpenSections] = useState<Set<string>>(
+    new Set(["getting-started", "daily-use"]),
+  );
+
+  const toggleSection = (id: string) => {
+    setOpenSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center space-x-3">
+        <Link
+          to="/settings"
+          className="p-1 text-ink-500 hover:text-ink-700 transition-colors"
+          aria-label="設定に戻る"
+        >
+          <ArrowLeft size={20} />
+        </Link>
+        <h1 className="text-xl font-bold text-ink-800">使い方ガイド</h1>
+      </div>
+
+      <div className="bg-primary-50 border border-primary-200 rounded-lg p-4">
+        <h2 className="text-sm font-bold text-primary-800 mb-1">HealthFamily へようこそ</h2>
+        <p className="text-xs text-primary-700 leading-relaxed">
+          家族やペットのお薬・通院・体調をまとめて管理できるアプリです。
+          まずはメンバーとお薬を登録して、毎日の服薬チェックを始めましょう。
+        </p>
+      </div>
+
+      {guideSections.map((section) => {
+        const isOpen = openSections.has(section.id);
+        return (
+          <div
+            key={section.id}
+            className="bg-white rounded-lg shadow-sm border border-primary-100 overflow-hidden"
+          >
+            <button
+              onClick={() => toggleSection(section.id)}
+              id={`guide-button-${section.id}`}
+              aria-expanded={isOpen}
+              aria-controls={`guide-panel-${section.id}`}
+              className="w-full flex items-center justify-between px-4 py-3 hover:bg-primary-50 transition-colors"
+            >
+              <div className="flex items-center space-x-3">
+                {section.icon}
+                <span className="text-sm font-semibold text-ink-800">{section.title}</span>
+              </div>
+              {isOpen ? (
+                <ChevronUp size={16} className="text-ink-400" />
+              ) : (
+                <ChevronDown size={16} className="text-ink-400" />
+              )}
+            </button>
+            {isOpen && (
+              <div
+                id={`guide-panel-${section.id}`}
+                role="region"
+                aria-labelledby={`guide-button-${section.id}`}
+                className="px-4 pb-4 space-y-3"
+              >
+                {section.steps.map((step, idx) => (
+                  <div key={idx} className="flex space-x-3">
+                    <div className="flex-shrink-0 mt-0.5">
+                      <div className="w-5 h-5 rounded-full bg-primary-100 text-primary-600 flex items-center justify-center text-xs font-bold">
+                        {idx + 1}
+                      </div>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-ink-800">{step.title}</p>
+                      <p className="text-xs text-ink-500 leading-relaxed mt-0.5">
+                        {step.description}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/routes/health-logs.tsx
+++ b/frontend/app/routes/health-logs.tsx
@@ -1,0 +1,227 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router";
+import { Plus, X, Activity, Ruler, Thermometer } from "lucide-react";
+import { HealthLogList } from "@/components/health-logs/HealthLogList";
+import { HealthLogForm } from "@/components/health-logs/HealthLogForm";
+import { HealthWeeklyTrend } from "@/components/health-logs/HealthWeeklyTrend";
+import { SymptomFrequencySummary } from "@/components/health-logs/SymptomFrequencySummary";
+import {
+  BodyMeasurementForm,
+  type BodyMeasurementFormData,
+} from "@/components/body-measurements/BodyMeasurementForm";
+import { BodyMeasurementList } from "@/components/body-measurements/BodyMeasurementList";
+import {
+  TemperatureForm,
+  type TemperatureFormData,
+} from "@/components/temperatures/TemperatureForm";
+import { TemperatureChart } from "@/components/temperatures/TemperatureChart";
+import { TemperatureRecordList } from "@/components/temperatures/TemperatureRecordList";
+import {
+  getDailyAverages,
+  getMostFrequentSymptoms,
+  useBodyMeasurements,
+  useHealthLogs,
+  useMembersQuery,
+  useTemperatureRecords,
+} from "@/hooks/health-logs";
+
+export default function HealthLogs() {
+  const { data: members, isLoading: membersLoading } = useMembersQuery();
+  const { logs, groups, isLoading, createLog, deleteLog } =
+    useHealthLogs(members);
+  const {
+    measurements,
+    isLoading: measurementsLoading,
+    createMeasurement,
+    updateMeasurement,
+    deleteMeasurement,
+  } = useBodyMeasurements(members);
+  const {
+    records: temperatureRecords,
+    isLoading: temperatureLoading,
+    createRecord: createTemperature,
+    deleteRecord: deleteTemperature,
+  } = useTemperatureRecords(members);
+
+  const [showForm, setShowForm] = useState(false);
+  const [showMeasurementForm, setShowMeasurementForm] = useState(false);
+  const [showTemperatureForm, setShowTemperatureForm] = useState(false);
+
+  const weeklyAverages = useMemo(
+    () => getDailyAverages(logs, 7, new Date()),
+    [logs],
+  );
+
+  const frequentSymptoms = useMemo(
+    () => getMostFrequentSymptoms(logs, 5),
+    [logs],
+  );
+
+  const memberList = members ?? [];
+
+  const handleSubmit = async (input: {
+    memberId: string;
+    conditionLevel: number;
+    symptoms?: string[];
+    notes?: string;
+  }) => {
+    await createLog(input);
+    setShowForm(false);
+  };
+
+  const handleCreateMeasurement = async (data: BodyMeasurementFormData) => {
+    await createMeasurement(data);
+    setShowMeasurementForm(false);
+  };
+
+  const handleDeleteMeasurement = async (id: string) => {
+    if (!window.confirm("この記録を削除しますか？")) return;
+    await deleteMeasurement(id);
+  };
+
+  const handleCreateTemperature = async (data: TemperatureFormData) => {
+    await createTemperature(data);
+    setShowTemperatureForm(false);
+  };
+
+  const handleDeleteTemperature = async (id: string) => {
+    if (!window.confirm("この体温記録を削除しますか？")) return;
+    await deleteTemperature(id);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <Activity size={22} className="text-primary-600" />
+          <h1 className="text-xl font-bold text-ink-800 tracking-wide">
+            体調記録
+          </h1>
+        </div>
+        {!showForm && (
+          <button
+            onClick={() => setShowForm(true)}
+            className="flex items-center space-x-1 px-3 py-1.5 bg-primary text-white text-sm rounded-xl hover:bg-primary-dark transition-colors"
+          >
+            <Plus size={16} />
+            <span>記録する</span>
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <div className="mb-4">
+          <HealthLogForm
+            members={memberList.map((m) => ({ id: m.id, name: m.name }))}
+            onSubmit={handleSubmit}
+            onCancel={() => setShowForm(false)}
+          />
+        </div>
+      )}
+
+      <HealthWeeklyTrend averages={weeklyAverages} />
+
+      <SymptomFrequencySummary symptoms={frequentSymptoms} />
+
+      <HealthLogList groups={groups} isLoading={isLoading} onDelete={deleteLog} />
+
+      <div className="mt-8">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center space-x-2">
+            <Ruler size={18} className="text-primary-600" />
+            <h2 className="text-base font-bold text-ink-800">体重・身長記録</h2>
+          </div>
+          <button
+            onClick={() => setShowMeasurementForm(!showMeasurementForm)}
+            className="bg-primary text-white p-1.5 rounded-full hover:bg-primary-dark transition-colors"
+            aria-label={showMeasurementForm ? "閉じる" : "記録を追加"}
+          >
+            {showMeasurementForm ? <X size={16} /> : <Plus size={16} />}
+          </button>
+        </div>
+
+        {showMeasurementForm && !membersLoading && memberList.length > 0 && (
+          <div className="mb-4 bg-white rounded-2xl shadow-sm p-4 border border-primary-100">
+            <h3 className="text-sm font-semibold text-ink-700 mb-3">
+              体重・身長の記録
+            </h3>
+            <BodyMeasurementForm
+              members={memberList}
+              onSubmit={handleCreateMeasurement}
+              onCancel={() => setShowMeasurementForm(false)}
+            />
+          </div>
+        )}
+
+        {showMeasurementForm && !membersLoading && memberList.length === 0 && (
+          <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-2xl p-4 text-sm text-yellow-700">
+            先に
+            <Link
+              to="/members"
+              className="underline font-medium text-yellow-800 hover:text-yellow-900"
+            >
+              メンバーページ
+            </Link>
+            でメンバーを登録してください。
+          </div>
+        )}
+
+        <BodyMeasurementList
+          measurements={measurements}
+          isLoading={measurementsLoading}
+          onUpdate={updateMeasurement}
+          onDelete={handleDeleteMeasurement}
+        />
+      </div>
+
+      <div className="mt-8">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center space-x-2">
+            <Thermometer size={18} className="text-primary-600" />
+            <h2 className="text-base font-bold text-ink-800">体温記録</h2>
+          </div>
+          <button
+            onClick={() => setShowTemperatureForm(!showTemperatureForm)}
+            className="bg-primary text-white p-1.5 rounded-full hover:bg-primary-dark transition-colors"
+            aria-label={showTemperatureForm ? "閉じる" : "体温を追加"}
+          >
+            {showTemperatureForm ? <X size={16} /> : <Plus size={16} />}
+          </button>
+        </div>
+
+        {showTemperatureForm && !membersLoading && memberList.length > 0 && (
+          <div className="mb-4">
+            <TemperatureForm
+              members={memberList.map((m) => ({ id: m.id, name: m.name }))}
+              onSubmit={handleCreateTemperature}
+              onCancel={() => setShowTemperatureForm(false)}
+            />
+          </div>
+        )}
+
+        {showTemperatureForm && !membersLoading && memberList.length === 0 && (
+          <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-2xl p-4 text-sm text-yellow-700">
+            先に
+            <Link
+              to="/members"
+              className="underline font-medium text-yellow-800 hover:text-yellow-900"
+            >
+              メンバーページ
+            </Link>
+            でメンバーを登録してください。
+          </div>
+        )}
+
+        <div className="mb-3">
+          <TemperatureChart records={temperatureRecords} />
+        </div>
+
+        <TemperatureRecordList
+          records={temperatureRecords}
+          isLoading={temperatureLoading}
+          onDelete={handleDeleteTemperature}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/history.tsx
+++ b/frontend/app/routes/history.tsx
@@ -1,0 +1,135 @@
+import { useState, useMemo, useCallback } from "react";
+import { Calendar, List, Plus } from "lucide-react";
+import { MedicationHistoryList } from "@/components/history/MedicationHistoryList";
+import { MedicationCalendar } from "@/components/history/MedicationCalendar";
+import { AddPastRecordForm } from "@/components/history/AddPastRecordForm";
+import { MemberFilter } from "@/components/shared/MemberFilter";
+import { api } from "@/lib/api";
+import type { Medication } from "@/lib/types";
+import {
+  useMedicationHistory,
+  filterGroupsByMember,
+  formatRecordDate,
+  toDateKey,
+  type DailyRecordGroup,
+} from "@/hooks/history";
+
+type ViewMode = "list" | "calendar";
+
+export default function History() {
+  const { groups, records, healthLogs, members, isLoading, deleteRecord, createRecord } = useMedicationHistory();
+  const [viewMode, setViewMode] = useState<ViewMode>("calendar");
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const memberOptions = useMemo(() => members.map((m) => ({ id: m.id, name: m.name })), [members]);
+
+  const fetchMedicationsByMember = useCallback(async (memberId: string) => {
+    const meds = await api.get<Medication[]>(`/members/${memberId}/medications`);
+    return meds.map((m) => ({ id: m.id, name: m.name, memberId: m.memberId }));
+  }, []);
+
+  // メンバーフィルタ適用済みグループ
+  const memberFilteredGroups = useMemo(
+    () => filterGroupsByMember(groups, selectedMemberId),
+    [groups, selectedMemberId],
+  );
+
+  // カレンダー用のメンバーフィルタ適用済みフラット配列
+  const allRecords = useMemo(
+    () => (selectedMemberId === null ? records : records.filter((r) => r.memberId === selectedMemberId)),
+    [records, selectedMemberId],
+  );
+
+  // 選択日のレコードをフィルタリング
+  const filteredGroups = useMemo<DailyRecordGroup[]>(() => {
+    if (!selectedDate) return memberFilteredGroups;
+    return memberFilteredGroups
+      .map((g) => ({
+        ...g,
+        records: g.records.filter((r) => toDateKey(r.takenAt) === selectedDate),
+      }))
+      .filter((g) => g.records.length > 0);
+  }, [memberFilteredGroups, selectedDate]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold text-ink-800 tracking-wide">服薬履歴</h1>
+        <div className="flex items-center space-x-1 bg-primary-50 rounded-lg p-0.5">
+          <button
+            onClick={() => setViewMode("calendar")}
+            className={`p-1.5 rounded-md transition-colors ${
+              viewMode === "calendar" ? "bg-white shadow-sm text-primary-600" : "text-ink-500"
+            }`}
+            aria-label="カレンダー表示"
+          >
+            <Calendar size={18} />
+          </button>
+          <button
+            onClick={() => {
+              setViewMode("list");
+              setSelectedDate(null);
+            }}
+            className={`p-1.5 rounded-md transition-colors ${
+              viewMode === "list" ? "bg-white shadow-sm text-primary-600" : "text-ink-500"
+            }`}
+            aria-label="リスト表示"
+          >
+            <List size={18} />
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <MemberFilter members={memberOptions} selectedMemberId={selectedMemberId} onSelect={setSelectedMemberId} />
+      </div>
+
+      {viewMode === "calendar" ? (
+        <div className="space-y-4">
+          <MedicationCalendar
+            records={allRecords}
+            healthLogs={healthLogs}
+            onSelectDate={(dateKey) => {
+              setSelectedDate(dateKey === selectedDate ? null : dateKey);
+              setShowAddForm(false);
+            }}
+            selectedDate={selectedDate}
+          />
+          {selectedDate && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-semibold text-ink-600">{formatRecordDate(selectedDate)} の記録</h3>
+                {!showAddForm && (
+                  <button
+                    onClick={() => setShowAddForm(true)}
+                    className="flex items-center space-x-1 text-xs text-primary-600 hover:text-primary-700 font-medium"
+                  >
+                    <Plus size={14} />
+                    <span>記録を追加</span>
+                  </button>
+                )}
+              </div>
+              {showAddForm && (
+                <div className="mb-3">
+                  <AddPastRecordForm
+                    selectedDate={selectedDate}
+                    members={memberOptions}
+                    fetchMedicationsByMember={fetchMedicationsByMember}
+                    onSubmit={createRecord}
+                    onClose={() => setShowAddForm(false)}
+                  />
+                </div>
+              )}
+              <MedicationHistoryList groups={filteredGroups} isLoading={isLoading} onDelete={deleteRecord} />
+            </div>
+          )}
+          {!selectedDate && <p className="text-center text-sm text-ink-400 py-2">日付をタップして詳細を表示</p>}
+        </div>
+      ) : (
+        <MedicationHistoryList groups={memberFilteredGroups} isLoading={isLoading} onDelete={deleteRecord} />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,71 +1,157 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check } from "lucide-react";
-import { clsx } from "clsx";
-import { api } from "@/lib/api";
+import { useCallback, useMemo, useState } from "react";
 import { useAuth } from "@/lib/auth";
-import type { TodaySchedule } from "@/lib/types";
-import { Card } from "@/components/ui";
+import { useDashboardData, useMarkRecord, type MissedDose } from "@/hooks/dashboard";
+import { GreetingCard } from "@/components/dashboard/GreetingCard";
+import { WeeklySummaryCard } from "@/components/dashboard/WeeklySummaryCard";
+import { MissedDosesAlert } from "@/components/dashboard/MissedDosesAlert";
+import { TodayScheduleList } from "@/components/dashboard/TodayScheduleList";
+import { StockAlertList } from "@/components/dashboard/StockAlertList";
+import { AdherenceStatsCard } from "@/components/dashboard/AdherenceStatsCard";
+import { UpcomingAppointments } from "@/components/dashboard/UpcomingAppointments";
+import { MemberFilter } from "@/components/shared/MemberFilter";
+import { SectionTitle } from "@/components/shared/SectionTitle";
+
+function buildTakenAtISO(date: string, scheduledTime: string): string {
+  return new Date(`${date}T${scheduledTime}:00+09:00`).toISOString();
+}
 
 export default function Home() {
   const { user } = useAuth();
-  const qc = useQueryClient();
+  const userId = user?.id ?? null;
 
-  const { data: schedules, isLoading } = useQuery({
-    queryKey: ["schedules", "today"],
-    queryFn: () => api.get<TodaySchedule[]>("/schedules/today"),
-  });
+  const {
+    todaySchedules,
+    todayLoading,
+    missedDoses,
+    missedLoading,
+    stockAlerts,
+    stockLoading,
+    adherenceStats,
+    adherenceLoading,
+    appointments,
+    appointmentsLoading,
+    members,
+  } = useDashboardData(userId);
 
-  const takeMutation = useMutation({
-    mutationFn: (s: TodaySchedule) =>
-      api.post("/records", { medicationId: s.medicationId, scheduleId: s.id }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["schedules", "today"] }),
-  });
+  const markRecord = useMarkRecord();
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+
+  const handleMarkCompleted = useCallback(
+    async (scheduleId: string, options?: { takenAt?: string; notes?: string }) => {
+      const target = todaySchedules.find((s) => s.scheduleId === scheduleId);
+      if (!target) return;
+      await markRecord.mutateAsync({
+        memberId: target.memberId,
+        medicationId: target.medicationId,
+        scheduleId: target.scheduleId,
+        takenAt: options?.takenAt,
+        notes: options?.notes,
+      });
+    },
+    [todaySchedules, markRecord],
+  );
+
+  const handleMarkMultipleCompleted = useCallback(
+    async (scheduleIds: string[]) => {
+      let failed = 0;
+      for (const scheduleId of scheduleIds) {
+        try {
+          await handleMarkCompleted(scheduleId);
+        } catch {
+          failed++;
+        }
+      }
+      if (failed > 0) {
+        throw new Error(`${failed}件の記録に失敗しました`);
+      }
+    },
+    [handleMarkCompleted],
+  );
+
+  const handleMarkMissedAsTaken = useCallback(
+    async (dose: MissedDose) => {
+      const takenAt = buildTakenAtISO(dose.date, dose.scheduledTime);
+      await markRecord.mutateAsync({
+        memberId: dose.memberId,
+        medicationId: dose.medicationId,
+        scheduleId: dose.scheduleId,
+        takenAt,
+      });
+    },
+    [markRecord],
+  );
+
+  const handleMarkMultipleMissedAsTaken = useCallback(
+    async (doses: MissedDose[]) => {
+      let failed = 0;
+      for (const dose of doses) {
+        try {
+          await handleMarkMissedAsTaken(dose);
+        } catch {
+          failed++;
+        }
+      }
+      if (failed > 0) {
+        throw new Error(`${failed}件の記録に失敗しました`);
+      }
+    },
+    [handleMarkMissedAsTaken],
+  );
+
+  const filteredSchedules = useMemo(
+    () =>
+      selectedMemberId
+        ? todaySchedules.filter((s) => s.memberId === selectedMemberId)
+        : todaySchedules,
+    [todaySchedules, selectedMemberId],
+  );
+
+  const memberOptions = useMemo(
+    () => members.map((m) => ({ id: m.id, name: m.name })),
+    [members],
+  );
 
   return (
-    <div className="space-y-5">
-      <div>
-        <p className="text-sm text-slate-500">こんにちは</p>
-        <h1 className="text-2xl font-bold text-slate-800">
-          {user?.displayName ?? "ご家族"} さん
-        </h1>
-      </div>
+    <div className="space-y-0">
+      <GreetingCard
+        displayName={user?.displayName ?? ""}
+        weeklyRate={adherenceStats?.overall.weeklyRate}
+      />
 
-      <section>
-        <h2 className="mb-3 text-sm font-semibold text-slate-600">今日のおくすり</h2>
-        {isLoading ? (
-          <p className="text-sm text-slate-400">読み込み中...</p>
-        ) : !schedules || schedules.length === 0 ? (
-          <Card>
-            <p className="text-sm text-slate-400">今日の服薬予定はありません</p>
-          </Card>
-        ) : (
-          <div className="space-y-2">
-            {schedules.map((s) => (
-              <Card key={s.id} className="flex items-center justify-between">
-                <div>
-                  <p className="font-medium text-slate-800">{s.medicationName}</p>
-                  <p className="text-xs text-slate-500">
-                    {s.memberName}・{s.scheduledTime}
-                  </p>
-                </div>
-                <button
-                  disabled={s.isCompleted || takeMutation.isPending}
-                  onClick={() => takeMutation.mutate(s)}
-                  className={clsx(
-                    "flex h-10 w-10 items-center justify-center rounded-full transition",
-                    s.isCompleted
-                      ? "bg-green-100 text-green-600"
-                      : "bg-slate-100 text-slate-400 hover:bg-primary hover:text-white",
-                  )}
-                  aria-label="服薬完了"
-                >
-                  <Check className="h-5 w-5" />
-                </button>
-              </Card>
-            ))}
-          </div>
-        )}
-      </section>
+      <WeeklySummaryCard schedules={todaySchedules} isLoading={todayLoading} />
+
+      <MissedDosesAlert
+        missedDoses={missedDoses}
+        isLoading={missedLoading}
+        onMarkAsTaken={handleMarkMissedAsTaken}
+        onMarkMultipleAsTaken={handleMarkMultipleMissedAsTaken}
+      />
+
+      <SectionTitle accentColor="pink" size="lg">
+        今日の予定
+      </SectionTitle>
+      <div className="mb-4">
+        <MemberFilter
+          members={memberOptions}
+          selectedMemberId={selectedMemberId}
+          onSelect={setSelectedMemberId}
+        />
+      </div>
+      <TodayScheduleList
+        schedules={filteredSchedules}
+        isLoading={todayLoading}
+        onMarkCompleted={handleMarkCompleted}
+        onMarkMultipleCompleted={handleMarkMultipleCompleted}
+        hasMembers={members.length > 0}
+      />
+
+      <div className="mt-6">
+        <StockAlertList alerts={stockAlerts} isLoading={stockLoading} />
+
+        <AdherenceStatsCard stats={adherenceStats} isLoading={adherenceLoading} />
+
+        <UpcomingAppointments appointments={appointments} isLoading={appointmentsLoading} />
+      </div>
     </div>
   );
 }

--- a/frontend/app/routes/hospitals.tsx
+++ b/frontend/app/routes/hospitals.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+import { ArrowLeft, Plus, X } from "lucide-react";
+import { api } from "@/lib/api";
+import type { Hospital } from "@/lib/types";
+import { HospitalList, type UpdateHospitalInput } from "@/components/hospitals/HospitalList";
+import { HospitalForm, type HospitalFormData } from "@/components/hospitals/HospitalForm";
+
+export default function Hospitals() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const [showForm, setShowForm] = useState(false);
+
+  const { data: hospitals = [], isLoading } = useQuery({
+    queryKey: ["hospitals"],
+    queryFn: () => api.get<Hospital[]>("/hospitals"),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: HospitalFormData) =>
+      api.post<Hospital>("/hospitals", {
+        name: data.name,
+        address: data.address,
+        phone: data.phone,
+        department: data.department,
+        doctorName: data.doctorName,
+        notes: data.notes,
+      }),
+    onSuccess: () => {
+      setShowForm(false);
+      qc.invalidateQueries({ queryKey: ["hospitals"] });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateHospitalInput }) =>
+      api.patch<Hospital>(`/hospitals/${id}`, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["hospitals"] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/hospitals/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["hospitals"] }),
+  });
+
+  const handleCreate = (data: HospitalFormData) => {
+    createMutation.mutate(data);
+  };
+
+  const handleUpdate = async (hospitalId: string, input: UpdateHospitalInput) => {
+    await updateMutation.mutateAsync({ id: hospitalId, input });
+  };
+
+  const handleDelete = (hospitalId: string) => {
+    deleteMutation.mutate(hospitalId);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <button
+            onClick={() => navigate("/appointments")}
+            className="text-ink-600 hover:text-ink-800 transition-colors"
+            aria-label="通院管理に戻る"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <h1 className="text-xl font-bold text-ink-800 tracking-wide">かかりつけ医(病院)</h1>
+        </div>
+        <button
+          onClick={() => setShowForm(!showForm)}
+          className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
+          aria-label={showForm ? "閉じる" : "病院を追加"}
+        >
+          {showForm ? <X size={20} /> : <Plus size={20} />}
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+          <h2 className="text-sm font-semibold text-ink-700 mb-3">病院の追加</h2>
+          <HospitalForm onSubmit={handleCreate} />
+        </div>
+      )}
+
+      <HospitalList
+        hospitals={hospitals}
+        isLoading={isLoading}
+        onUpdate={handleUpdate}
+        onDelete={handleDelete}
+      />
+    </div>
+  );
+}

--- a/frontend/app/routes/login.tsx
+++ b/frontend/app/routes/login.tsx
@@ -54,7 +54,7 @@ export default function Login() {
             {submitting ? "ログイン中..." : "ログイン"}
           </Button>
         </form>
-        <div className="mt-4 flex justify-between text-sm text-slate-500">
+        <div className="mt-4 flex justify-between text-sm text-ink-500">
           <Link to="/signup" className="hover:text-primary">
             新規登録
           </Link>

--- a/frontend/app/routes/medications.tsx
+++ b/frontend/app/routes/medications.tsx
@@ -1,113 +1,46 @@
-import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Pill, Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router";
 import { api } from "@/lib/api";
-import type { Medication, Member } from "@/lib/types";
-import { Button, Card, ErrorText, Input } from "@/components/ui";
+import type { Member } from "@/lib/types";
+import { CategoryFilter, type MedicationCategory } from "@/components/shared/CategoryFilter";
+import { MemberMedications } from "@/components/medications/MemberMedications";
 
 export default function Medications() {
-  const qc = useQueryClient();
-  const [memberId, setMemberId] = useState("");
-  const [name, setName] = useState("");
-  const [dosageAmount, setDosageAmount] = useState("");
-  const [error, setError] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<MedicationCategory | null>(null);
 
-  const { data: members } = useQuery({
+  const { data: members = [], isLoading } = useQuery({
     queryKey: ["members"],
     queryFn: () => api.get<Member[]>("/members"),
   });
 
-  const { data: medications, isLoading } = useQuery({
-    queryKey: ["medications"],
-    queryFn: () => api.get<Medication[]>("/medications"),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: () =>
-      api.post<Medication>("/medications", {
-        memberId,
-        name,
-        dosageAmount: dosageAmount || undefined,
-      }),
-    onSuccess: () => {
-      setName("");
-      setDosageAmount("");
-      setError(null);
-      qc.invalidateQueries({ queryKey: ["medications"] });
-    },
-    onError: (e: Error) => setError(e.message),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/medications/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["medications"] }),
-  });
-
-  const memberName = (id: string) => members?.find((m) => m.id === id)?.name ?? "";
+  const hasMembers = useMemo(() => members.length > 0, [members]);
 
   return (
-    <div className="space-y-5">
-      <h1 className="text-xl font-bold text-slate-800">おくすり</h1>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold text-ink-800 tracking-wide">お薬</h1>
+      </div>
 
-      <Card>
-        <div className="space-y-3">
-          <select
-            value={memberId}
-            onChange={(e) => setMemberId(e.target.value)}
-            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-primary"
-          >
-            <option value="">メンバーを選択</option>
-            {members?.map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.name}
-              </option>
-            ))}
-          </select>
-          <Input placeholder="薬の名前" value={name} onChange={(e) => setName(e.target.value)} />
-          <Input
-            placeholder="用量（例: 1錠）"
-            value={dosageAmount}
-            onChange={(e) => setDosageAmount(e.target.value)}
-          />
-          <ErrorText>{error}</ErrorText>
-          <Button
-            onClick={() => memberId && name.trim() && createMutation.mutate()}
-            disabled={createMutation.isPending}
-            className="w-full"
-          >
-            <Plus className="mr-2 h-4 w-4" /> 追加する
-          </Button>
-        </div>
-      </Card>
+      {!isLoading && hasMembers && (
+        <CategoryFilter selectedCategory={selectedCategory} onSelect={setSelectedCategory} />
+      )}
 
       {isLoading ? (
-        <p className="text-sm text-slate-400">読み込み中...</p>
-      ) : (
-        <div className="space-y-2">
-          {medications?.map((m) => (
-            <Card key={m.id} className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
-                  <Pill className="h-5 w-5" />
-                </span>
-                <div>
-                  <p className="font-medium text-slate-800">{m.name}</p>
-                  <p className="text-xs text-slate-500">
-                    {memberName(m.memberId)}
-                    {m.dosageAmount ? `・${m.dosageAmount}` : ""}
-                  </p>
-                </div>
-              </div>
-              <button
-                onClick={() => deleteMutation.mutate(m.id)}
-                className="text-slate-300 hover:text-red-500"
-                aria-label="削除"
-              >
-                <Trash2 className="h-5 w-5" />
-              </button>
-            </Card>
-          ))}
+        <div className="flex justify-center items-center py-8">
+          <p className="text-ink-500">読み込み中...</p>
         </div>
+      ) : members.length === 0 ? (
+        <div className="flex flex-col justify-center items-center py-12">
+          <p className="text-ink-500 text-lg mb-4">メンバーがまだ登録されていません</p>
+          <Link to="/members" className="text-primary-600 hover:text-primary-700 font-medium transition-colors">
+            メンバーを追加する
+          </Link>
+        </div>
+      ) : (
+        members.map((member) => (
+          <MemberMedications key={member.id} member={member} categoryFilter={selectedCategory} />
+        ))
       )}
     </div>
   );

--- a/frontend/app/routes/members.$memberId.medications.tsx
+++ b/frontend/app/routes/members.$memberId.medications.tsx
@@ -1,0 +1,354 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate, useParams } from "react-router";
+import { ArrowLeft, Plus, X, Clock, Pill, Trash2 } from "lucide-react";
+import { api } from "@/lib/api";
+import type { Medication, Schedule } from "@/lib/types";
+import { Button, Card, ErrorText, Input } from "@/components/ui";
+import { BottomNavigation } from "@/components/shared/BottomNavigation";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
+
+interface CreateMedicationBody {
+  memberId: string;
+  name: string;
+  category: string;
+  dosageAmount?: string;
+  frequency?: string;
+  instructions?: string;
+}
+
+interface CreateScheduleBody {
+  medicationId: string;
+  memberId: string;
+  scheduledTime: string;
+  daysOfWeek: string[];
+  reminderMinutesBefore: number;
+}
+
+const DAY_LABELS: Record<string, string> = {
+  mon: "月",
+  tue: "火",
+  wed: "水",
+  thu: "木",
+  fri: "金",
+  sat: "土",
+  sun: "日",
+};
+
+export default function MemberMedications() {
+  const { memberId = "" } = useParams();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const [showMedForm, setShowMedForm] = useState(false);
+  const [medName, setMedName] = useState("");
+  const [medDosage, setMedDosage] = useState("");
+  const [medFrequency, setMedFrequency] = useState("");
+  const [medInstructions, setMedInstructions] = useState("");
+  const [medError, setMedError] = useState<string | null>(null);
+
+  const [scheduleTarget, setScheduleTarget] = useState<Medication | null>(null);
+  const [scheduledTime, setScheduledTime] = useState("08:00");
+  const [reminderMinutes, setReminderMinutes] = useState("10");
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
+
+  const { data: medications = [], isLoading } = useQuery({
+    queryKey: ["members", memberId, "medications"],
+    queryFn: () => api.get<Medication[]>(`/members/${memberId}/medications`),
+    enabled: !!memberId,
+  });
+
+  const { data: allSchedules = [], isLoading: schedulesLoading } = useQuery({
+    queryKey: ["schedules"],
+    queryFn: () => api.get<Schedule[]>("/schedules"),
+  });
+
+  const memberSchedules = useMemo(
+    () => allSchedules.filter((s) => s.memberId === memberId),
+    [allSchedules, memberId],
+  );
+
+  const medicationName = (id: string) =>
+    medications.find((m) => m.id === id)?.name ?? "";
+
+  const createMedMutation = useMutation({
+    mutationFn: (body: CreateMedicationBody) => api.post<Medication>("/medications", body),
+    onSuccess: () => {
+      setMedName("");
+      setMedDosage("");
+      setMedFrequency("");
+      setMedInstructions("");
+      setMedError(null);
+      setShowMedForm(false);
+      qc.invalidateQueries({ queryKey: ["members", memberId, "medications"] });
+      qc.invalidateQueries({ queryKey: ["medications"] });
+    },
+    onError: (e: Error) => setMedError(e.message),
+  });
+
+  const deleteMedMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/medications/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["members", memberId, "medications"] });
+      qc.invalidateQueries({ queryKey: ["medications"] });
+    },
+  });
+
+  const createScheduleMutation = useMutation({
+    mutationFn: (body: CreateScheduleBody) => api.post<Schedule>("/schedules", body),
+    onSuccess: () => {
+      setScheduleTarget(null);
+      setScheduledTime("08:00");
+      setReminderMinutes("10");
+      setScheduleError(null);
+      qc.invalidateQueries({ queryKey: ["schedules"] });
+    },
+    onError: (e: Error) => setScheduleError(e.message),
+  });
+
+  const deleteScheduleMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/schedules/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["schedules"] }),
+  });
+
+  const handleCreateMedication = () => {
+    if (!medName.trim()) return;
+    createMedMutation.mutate({
+      memberId,
+      name: medName.trim(),
+      category: "regular",
+      dosageAmount: medDosage.trim() || undefined,
+      frequency: medFrequency.trim() || undefined,
+      instructions: medInstructions.trim() || undefined,
+    });
+  };
+
+  const handleCreateSchedule = () => {
+    if (!scheduleTarget) return;
+    createScheduleMutation.mutate({
+      medicationId: scheduleTarget.id,
+      memberId,
+      scheduledTime,
+      daysOfWeek: ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+      reminderMinutesBefore: parseInt(reminderMinutes, 10) || 0,
+    });
+  };
+
+  return (
+    <div className="min-h-screen pb-20">
+      <header className="bg-gradient-header shadow-soft">
+        <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={() => navigate("/members")}
+              className="text-ink-600 hover:text-ink-800 transition-colors"
+              aria-label="メンバー一覧に戻る"
+            >
+              <ArrowLeft size={20} />
+            </button>
+            <h1 className="text-xl font-bold text-ink-800 tracking-wide">薬管理</h1>
+          </div>
+          <button
+            onClick={() => setShowMedForm(!showMedForm)}
+            className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
+            aria-label={showMedForm ? "閉じる" : "薬を追加"}
+          >
+            {showMedForm ? <X size={20} /> : <Plus size={20} />}
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 py-4">
+        {showMedForm && (
+          <div className="mb-6">
+            <Card>
+              <div className="space-y-3">
+                <Input
+                  placeholder="薬の名前"
+                  value={medName}
+                  onChange={(e) => setMedName(e.target.value)}
+                />
+                <Input
+                  placeholder="用量（例: 1錠）"
+                  value={medDosage}
+                  onChange={(e) => setMedDosage(e.target.value)}
+                />
+                <Input
+                  placeholder="服用回数（例: 1日3回）"
+                  value={medFrequency}
+                  onChange={(e) => setMedFrequency(e.target.value)}
+                />
+                <Input
+                  placeholder="服用方法・メモ（任意）"
+                  value={medInstructions}
+                  onChange={(e) => setMedInstructions(e.target.value)}
+                />
+                <ErrorText>{medError}</ErrorText>
+                <Button
+                  onClick={handleCreateMedication}
+                  disabled={createMedMutation.isPending}
+                  className="w-full"
+                >
+                  <Plus className="mr-2 h-4 w-4" /> 追加する
+                </Button>
+              </div>
+            </Card>
+          </div>
+        )}
+
+        {scheduleTarget && (
+          <div className="mb-6 bg-white rounded-lg shadow-md p-4 border border-primary-200">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center space-x-2">
+                <Clock size={18} className="text-primary-600" />
+                <h2 className="font-semibold text-ink-800">
+                  {scheduleTarget.name} のスケジュール
+                </h2>
+              </div>
+              <button
+                onClick={() => setScheduleTarget(null)}
+                className="text-ink-400 hover:text-ink-600 transition-colors"
+                aria-label="閉じる"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div className="space-y-3">
+              <div>
+                <label
+                  htmlFor="scheduled-time"
+                  className="block text-sm font-medium text-ink-700 mb-1"
+                >
+                  時刻
+                </label>
+                <Input
+                  id="scheduled-time"
+                  type="time"
+                  value={scheduledTime}
+                  onChange={(e) => setScheduledTime(e.target.value)}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="reminder-minutes"
+                  className="block text-sm font-medium text-ink-700 mb-1"
+                >
+                  通知（何分前）
+                </label>
+                <Input
+                  id="reminder-minutes"
+                  type="number"
+                  min={0}
+                  value={reminderMinutes}
+                  onChange={(e) => setReminderMinutes(e.target.value)}
+                />
+              </div>
+              <ErrorText>{scheduleError}</ErrorText>
+              <Button
+                onClick={handleCreateSchedule}
+                disabled={createScheduleMutation.isPending}
+                className="w-full"
+              >
+                スケジュールを追加
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : medications.length === 0 ? (
+          <EmptyStatePrompt
+            message="お薬がまだ登録されていません"
+            subMessage="右上のボタンからお薬を追加してください"
+          />
+        ) : (
+          <div className="space-y-2">
+            {medications.map((med) => (
+              <Card key={med.id} className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+                    <Pill className="h-5 w-5" />
+                  </span>
+                  <div>
+                    <p className="font-medium text-ink-800">{med.name}</p>
+                    <p className="text-xs text-ink-500">
+                      {[med.dosageAmount, med.frequency].filter(Boolean).join("・")}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={() => deleteMedMutation.mutate(med.id)}
+                  className="text-ink-400 hover:text-red-500"
+                  aria-label="削除"
+                >
+                  <Trash2 className="h-5 w-5" />
+                </button>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {medications.length > 0 && !scheduleTarget && (
+          <div className="mt-6">
+            <h2 className="text-sm font-medium text-ink-600 mb-3">スケジュール追加</h2>
+            <div className="space-y-2">
+              {medications.map((med) => (
+                <button
+                  key={med.id}
+                  onClick={() => setScheduleTarget(med)}
+                  className="w-full flex items-center justify-between bg-white rounded-lg p-3 border border-primary-100 hover:border-primary-300 transition-colors text-left"
+                >
+                  <span className="text-sm text-ink-700">{med.name}</span>
+                  <Clock size={16} className="text-ink-400" />
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {memberSchedules.length > 0 && (
+          <div id="schedules" className="mt-6">
+            <h2 className="text-sm font-medium text-ink-600 mb-3">スケジュール管理</h2>
+            {schedulesLoading ? (
+              <LoadingSpinner />
+            ) : (
+              <div className="space-y-2">
+                {memberSchedules.map((schedule) => (
+                  <Card key={schedule.id} className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+                        <Clock className="h-5 w-5" />
+                      </span>
+                      <div>
+                        <p className="font-medium text-ink-800">
+                          {medicationName(schedule.medicationId)}
+                        </p>
+                        <p className="text-xs text-ink-500">
+                          {schedule.scheduledTime}
+                          {schedule.daysOfWeek.length > 0 &&
+                            schedule.daysOfWeek.length < 7 &&
+                            `・${schedule.daysOfWeek.map((d) => DAY_LABELS[d] ?? d).join("")}`}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => deleteScheduleMutation.mutate(schedule.id)}
+                      className="text-ink-400 hover:text-red-500"
+                      aria-label="削除"
+                    >
+                      <Trash2 className="h-5 w-5" />
+                    </button>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+
+      <BottomNavigation activePath="/members" />
+    </div>
+  );
+}

--- a/frontend/app/routes/members.$memberId.tsx
+++ b/frontend/app/routes/members.$memberId.tsx
@@ -1,0 +1,9 @@
+import { Navigate, useParams } from "react-router";
+
+/**
+ * メンバー詳細はお薬管理画面を兼ねるため、お薬管理へリダイレクトする。
+ */
+export default function MemberDetail() {
+  const { memberId } = useParams();
+  return <Navigate to={`/members/${memberId}/medications`} replace />;
+}

--- a/frontend/app/routes/members.tsx
+++ b/frontend/app/routes/members.tsx
@@ -1,28 +1,88 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Trash2, UserPlus } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
-import type { Member } from "@/lib/types";
-import { Button, Card, ErrorText, Input } from "@/components/ui";
+import type { Appointment, Medication, Member } from "@/lib/types";
+import { MemberList } from "@/components/members/MemberList";
+import { MemberForm, type MemberFormData } from "@/components/members/MemberForm";
+import type { MemberSummary } from "@/components/members/MemberSummaryCard";
+import { BottomNavigation } from "@/components/shared/BottomNavigation";
+
+interface CreateMemberBody {
+  name: string;
+  memberType: string;
+  petType?: string;
+  birthDate?: string;
+  notes?: string;
+}
+
+interface UpdateMemberBody {
+  name?: string;
+  petType?: string;
+  birthDate?: string;
+  notes?: string;
+}
 
 export default function Members() {
   const qc = useQueryClient();
-  const [name, setName] = useState("");
-  const [memberType, setMemberType] = useState<"human" | "pet">("human");
-  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [editingMember, setEditingMember] = useState<Member | null>(null);
 
-  const { data: members, isLoading } = useQuery({
+  const { data: members = [], isLoading } = useQuery({
     queryKey: ["members"],
     queryFn: () => api.get<Member[]>("/members"),
   });
 
+  const { data: medications = [] } = useQuery({
+    queryKey: ["medications"],
+    queryFn: () => api.get<Medication[]>("/medications"),
+  });
+
+  const { data: appointments = [] } = useQuery({
+    queryKey: ["appointments"],
+    queryFn: () => api.get<Appointment[]>("/appointments"),
+  });
+
+  // /members/summary が無いためクライアント側で集計する
+  const summaries = useMemo<MemberSummary[]>(() => {
+    const now = new Date();
+    return members.map((member) => {
+      const medicationCount = medications.filter(
+        (med) => med.memberId === member.id && med.isActive,
+      ).length;
+      const upcoming = appointments
+        .filter(
+          (a) => a.memberId === member.id && new Date(a.appointmentDate).getTime() >= now.getTime(),
+        )
+        .sort(
+          (a, b) =>
+            new Date(a.appointmentDate).getTime() - new Date(b.appointmentDate).getTime(),
+        );
+      return {
+        memberId: member.id,
+        memberName: member.name,
+        memberType: member.memberType,
+        medicationCount,
+        nextAppointmentDate: upcoming[0]?.appointmentDate ?? null,
+      };
+    });
+  }, [members, medications, appointments]);
+
   const createMutation = useMutation({
-    mutationFn: () => api.post<Member>("/members", { name, memberType }),
+    mutationFn: (body: CreateMemberBody) => api.post<Member>("/members", body),
     onSuccess: () => {
-      setName("");
+      setShowForm(false);
       qc.invalidateQueries({ queryKey: ["members"] });
     },
-    onError: (e: Error) => setError(e.message),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateMemberBody }) =>
+      api.patch<Member>(`/members/${id}`, body),
+    onSuccess: () => {
+      setEditingMember(null);
+      qc.invalidateQueries({ queryKey: ["members"] });
+    },
   });
 
   const deleteMutation = useMutation({
@@ -30,61 +90,94 @@ export default function Members() {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["members"] }),
   });
 
+  const handleCreate = (data: MemberFormData) => {
+    createMutation.mutate({
+      name: data.name,
+      memberType: data.memberType,
+      petType: data.petType,
+      birthDate: data.birthDate,
+      notes: data.notes,
+    });
+  };
+
+  const handleEdit = (member: Member) => {
+    setEditingMember(member);
+    setShowForm(false);
+  };
+
+  const handleUpdate = (data: MemberFormData) => {
+    if (!editingMember) return;
+    updateMutation.mutate({
+      id: editingMember.id,
+      body: {
+        name: data.name,
+        petType: data.petType,
+        birthDate: data.birthDate,
+        notes: data.notes,
+      },
+    });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingMember(null);
+  };
+
   return (
-    <div className="space-y-5">
-      <h1 className="text-xl font-bold text-slate-800">メンバー</h1>
-
-      <Card>
-        <div className="space-y-3">
-          <div className="flex gap-2">
-            <button
-              onClick={() => setMemberType("human")}
-              className={`flex-1 rounded-xl py-2 text-sm ${memberType === "human" ? "bg-primary text-white" : "bg-slate-100 text-slate-600"}`}
-            >
-              家族
-            </button>
-            <button
-              onClick={() => setMemberType("pet")}
-              className={`flex-1 rounded-xl py-2 text-sm ${memberType === "pet" ? "bg-primary text-white" : "bg-slate-100 text-slate-600"}`}
-            >
-              ペット
-            </button>
-          </div>
-          <Input placeholder="名前" value={name} onChange={(e) => setName(e.target.value)} />
-          <ErrorText>{error}</ErrorText>
-          <Button
-            onClick={() => name.trim() && createMutation.mutate()}
-            disabled={createMutation.isPending}
-            className="w-full"
+    <div className="min-h-screen pb-20">
+      <header className="bg-gradient-header shadow-soft">
+        <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
+          <h1 className="text-xl font-bold text-ink-800 tracking-wide">メンバー</h1>
+          <button
+            onClick={() => {
+              setShowForm(!showForm);
+              setEditingMember(null);
+            }}
+            className="bg-primary-600 text-white p-2 rounded-full hover:bg-primary-700 transition-colors"
+            aria-label={showForm ? "閉じる" : "メンバーを追加"}
           >
-            <UserPlus className="mr-2 h-4 w-4" /> 追加する
-          </Button>
+            {showForm ? <X size={20} /> : <Plus size={20} />}
+          </button>
         </div>
-      </Card>
+      </header>
 
-      {isLoading ? (
-        <p className="text-sm text-slate-400">読み込み中...</p>
-      ) : (
-        <div className="space-y-2">
-          {members?.map((m) => (
-            <Card key={m.id} className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-slate-800">{m.name}</p>
-                <p className="text-xs text-slate-500">
-                  {m.memberType === "pet" ? "ペット" : "家族"}
-                </p>
-              </div>
-              <button
-                onClick={() => deleteMutation.mutate(m.id)}
-                className="text-slate-300 hover:text-red-500"
-                aria-label="削除"
-              >
-                <Trash2 className="h-5 w-5" />
-              </button>
-            </Card>
-          ))}
-        </div>
-      )}
+      <main className="max-w-md mx-auto px-4 py-4">
+        {showForm && (
+          <div className="mb-6">
+            <MemberForm onSubmit={handleCreate} />
+          </div>
+        )}
+
+        {editingMember && (
+          <div className="mb-6 bg-white rounded-lg shadow-md p-4 border border-primary-200">
+            <h2 className="text-sm font-semibold text-ink-700 mb-3">メンバー編集</h2>
+            <MemberForm
+              onSubmit={handleUpdate}
+              initialData={editingMember}
+              onCancel={handleCancelEdit}
+            />
+          </div>
+        )}
+
+        <MemberList
+          members={members}
+          isLoading={isLoading}
+          onDelete={(memberId) => {
+            const member = members.find((m) => m.id === memberId);
+            const name = member?.name || "このメンバー";
+            if (
+              window.confirm(
+                `${name}を削除しますか？\n関連するお薬やスケジュールも全て削除されます。`,
+              )
+            ) {
+              deleteMutation.mutate(memberId);
+            }
+          }}
+          onEdit={handleEdit}
+          summaries={summaries}
+        />
+      </main>
+
+      <BottomNavigation activePath="/members" />
     </div>
   );
 }

--- a/frontend/app/routes/reset-password.tsx
+++ b/frontend/app/routes/reset-password.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router";
+import { Eye, EyeOff } from "lucide-react";
+import { api, ApiError } from "@/lib/api";
+
+export default function ResetPassword() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const emailParam = searchParams.get("email") ?? "";
+
+  const [email] = useState(emailParam);
+  const [code, setCode] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  useEffect(() => {
+    if (!emailParam) {
+      navigate("/forgot-password", { replace: true });
+    }
+  }, [emailParam, navigate]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErrorMessage("");
+    setSuccessMessage("");
+
+    if (newPassword !== confirmPassword) {
+      setErrorMessage("パスワードが一致しません");
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setErrorMessage("パスワードは8文字以上で入力してください");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await api.post("/auth/reset-password", { email, code, newPassword }, false);
+      setSuccessMessage("パスワードを再設定しました。ログイン画面に移動します。");
+      setTimeout(() => navigate("/login"), 2000);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setErrorMessage(err.message || "再設定に失敗しました");
+      } else {
+        setErrorMessage("再設定に失敗しました");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-primary-50/30 px-4">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center">
+          <img
+            src="/icon.svg"
+            alt="HealthFamily"
+            width={80}
+            height={80}
+            className="mx-auto mb-2 rounded-2xl"
+          />
+          <h1 className="text-3xl font-bold text-primary-600">HealthFamily</h1>
+          <p className="mt-2 text-ink-500">新しいパスワードの設定</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="bg-white shadow-md rounded-lg p-6 space-y-4">
+          <p className="text-sm text-ink-600">
+            <strong>{email}</strong> に送信された6桁のリセットコードと新しいパスワードを入力してください。
+          </p>
+
+          {errorMessage && (
+            <div className="bg-red-50 text-red-700 p-3 rounded-md text-sm" role="alert">
+              {errorMessage}
+            </div>
+          )}
+
+          {successMessage && (
+            <div className="bg-green-50 text-green-700 p-3 rounded-md text-sm" role="alert">
+              {successMessage}
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="code" className="block text-sm font-medium text-ink-700 mb-1">
+              リセットコード
+            </label>
+            <input
+              id="code"
+              type="text"
+              required
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              className="w-full px-3 py-3 border border-primary-200 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 text-center text-2xl tracking-widest"
+              placeholder="000000"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="newPassword" className="block text-sm font-medium text-ink-700 mb-1">
+              新しいパスワード
+            </label>
+            <div className="relative">
+              <input
+                id="newPassword"
+                type={showNewPassword ? "text" : "password"}
+                required
+                minLength={8}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className="w-full px-3 py-2 pr-10 border border-primary-200 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+                placeholder="8文字以上"
+              />
+              <button
+                type="button"
+                onClick={() => setShowNewPassword(!showNewPassword)}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-ink-400 hover:text-ink-600"
+                aria-label={showNewPassword ? "パスワードを隠す" : "パスワードを表示"}
+              >
+                {showNewPassword ? <Eye className="w-5 h-5" /> : <EyeOff className="w-5 h-5" />}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-ink-700 mb-1">
+              パスワード確認
+            </label>
+            <div className="relative">
+              <input
+                id="confirmPassword"
+                type={showConfirmPassword ? "text" : "password"}
+                required
+                minLength={8}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="w-full px-3 py-2 pr-10 border border-primary-200 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+                placeholder="もう一度入力"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute inset-y-0 right-0 flex items-center pr-3 text-ink-400 hover:text-ink-600"
+                aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示"}
+              >
+                {showConfirmPassword ? <Eye className="w-5 h-5" /> : <EyeOff className="w-5 h-5" />}
+              </button>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || code.length !== 6}
+            className="w-full bg-primary-600 text-white py-2 rounded-md font-medium hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          >
+            {isSubmitting ? "再設定中..." : "パスワードを再設定"}
+          </button>
+
+          <p className="text-center text-sm text-ink-500">
+            <Link to="/login" className="text-primary-600 hover:underline">
+              ログイン画面に戻る
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/settings.notifications.tsx
+++ b/frontend/app/routes/settings.notifications.tsx
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router";
+import { ArrowLeft } from "lucide-react";
+import { api } from "@/lib/api";
+import type { NotificationSetting } from "@/lib/types";
+import {
+  NotificationSettingsForm,
+  type UpdateNotificationSettingInput,
+} from "@/components/notification-settings/NotificationSettingsForm";
+
+export default function NotificationSettingsPage() {
+  const qc = useQueryClient();
+
+  const { data: setting = null, isLoading, error } = useQuery({
+    queryKey: ["notification-settings"],
+    queryFn: () => api.get<NotificationSetting>("/notification-settings"),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (input: UpdateNotificationSettingInput) =>
+      api.put<NotificationSetting>("/notification-settings", input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["notification-settings"] }),
+  });
+
+  const handleSave = async (input: UpdateNotificationSettingInput) => {
+    await updateMutation.mutateAsync(input);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-3">
+        <Link
+          to="/settings"
+          className="p-1 text-ink-500 hover:text-ink-700 transition-colors"
+          aria-label="設定に戻る"
+        >
+          <ArrowLeft size={20} />
+        </Link>
+        <h1 className="text-xl font-bold text-ink-800">通知設定</h1>
+      </div>
+
+      {error && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          設定の読み込みに失敗しました
+        </div>
+      )}
+
+      <NotificationSettingsForm setting={setting} onSave={handleSave} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -1,0 +1,250 @@
+import { useState, useEffect } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router";
+import { LogOut, Pencil, Check, X, Plus, Phone, Bell, ChevronRight, HelpCircle } from "lucide-react";
+import { api } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import type { User, Member, EmergencyContact } from "@/lib/types";
+import { CharacterSelector } from "@/components/character/CharacterSelector";
+import {
+  EmergencyContactForm,
+  type EmergencyContactFormData,
+} from "@/components/emergency-contacts/EmergencyContactForm";
+import {
+  EmergencyContactList,
+  type EmergencyContactWithMember,
+  type UpdateEmergencyContactInput,
+} from "@/components/emergency-contacts/EmergencyContactList";
+import { SectionTitle } from "@/components/shared/SectionTitle";
+
+export default function Settings() {
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const { data: profile } = useQuery({
+    queryKey: ["users", "me"],
+    queryFn: () => api.get<User>("/users/me"),
+  });
+
+  const { data: members = [], isLoading: membersLoading } = useQuery({
+    queryKey: ["members"],
+    queryFn: () => api.get<Member[]>("/members"),
+  });
+
+  const { data: contacts = [], isLoading: contactsLoading } = useQuery({
+    queryKey: ["emergency-contacts"],
+    queryFn: () => api.get<EmergencyContact[]>("/emergency-contacts"),
+  });
+
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [displayName, setDisplayName] = useState("");
+  const [showContactForm, setShowContactForm] = useState(false);
+
+  useEffect(() => {
+    if (profile) {
+      setDisplayName(profile.displayName || "");
+    }
+  }, [profile]);
+
+  const updateProfileMutation = useMutation({
+    mutationFn: (input: { displayName: string }) => api.patch<User>("/users/me", input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["users", "me"] }),
+  });
+
+  const createContactMutation = useMutation({
+    mutationFn: (data: EmergencyContactFormData) =>
+      api.post<EmergencyContact>("/emergency-contacts", data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["emergency-contacts"] }),
+  });
+
+  const updateContactMutation = useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateEmergencyContactInput }) =>
+      api.patch<EmergencyContact>(`/emergency-contacts/${id}`, input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["emergency-contacts"] }),
+  });
+
+  const deleteContactMutation = useMutation({
+    mutationFn: (id: string) => api.delete(`/emergency-contacts/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["emergency-contacts"] }),
+  });
+
+  const contactsWithMember: EmergencyContactWithMember[] = contacts.map((c) => ({
+    ...c,
+    memberName: members.find((m) => m.id === c.memberId)?.name,
+  }));
+
+  const handleSaveName = async () => {
+    if (!displayName.trim()) return;
+    await updateProfileMutation.mutateAsync({ displayName: displayName.trim() });
+    setIsEditingName(false);
+  };
+
+  const handleCancelEdit = () => {
+    setDisplayName(profile?.displayName || "");
+    setIsEditingName(false);
+  };
+
+  const handleCreateContact = async (data: EmergencyContactFormData) => {
+    await createContactMutation.mutateAsync(data);
+    setShowContactForm(false);
+  };
+
+  const handleUpdateContact = async (id: string, input: UpdateEmergencyContactInput) => {
+    await updateContactMutation.mutateAsync({ id, input });
+  };
+
+  const handleDeleteContact = (id: string) => {
+    if (!window.confirm("この緊急連絡先を削除しますか？")) return;
+    deleteContactMutation.mutate(id);
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate("/login", { replace: true });
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-bold text-ink-800">設定</h1>
+
+      <section className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+        <SectionTitle accentColor="pink" size="lg">
+          アカウント
+        </SectionTitle>
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs text-ink-400">メールアドレス</p>
+            <p className="text-sm text-ink-700">{user?.email}</p>
+          </div>
+          <div>
+            <p className="text-xs text-ink-400">表示名</p>
+            {isEditingName ? (
+              <div className="flex items-center space-x-2 mt-1">
+                <input
+                  type="text"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  className="flex-1 px-3 py-1.5 text-sm border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                  placeholder="表示名を入力"
+                  autoFocus
+                />
+                <button
+                  onClick={handleSaveName}
+                  disabled={updateProfileMutation.isPending || !displayName.trim()}
+                  className="p-1.5 text-green-600 hover:bg-green-50 rounded-md transition-colors disabled:opacity-50"
+                  aria-label="保存"
+                >
+                  <Check size={16} />
+                </button>
+                <button
+                  onClick={handleCancelEdit}
+                  className="p-1.5 text-ink-400 hover:bg-primary-50 rounded-md transition-colors"
+                  aria-label="キャンセル"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center space-x-2">
+                <p className="text-sm text-ink-700">{profile?.displayName || "未設定"}</p>
+                <button
+                  onClick={() => setIsEditingName(true)}
+                  className="p-1 text-ink-400 hover:text-ink-600 transition-colors"
+                  aria-label="表示名を編集"
+                >
+                  <Pencil size={14} />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <Link
+        to="/settings/notifications"
+        className="flex items-center justify-between bg-white rounded-lg shadow-md p-4 border border-primary-100 hover:bg-primary-50 transition-colors"
+      >
+        <div className="flex items-center space-x-3">
+          <Bell size={20} className="text-primary-600" />
+          <div>
+            <p className="text-sm font-semibold text-ink-800">通知設定</p>
+            <p className="text-xs text-ink-500">リマインダーやアラートの設定</p>
+          </div>
+        </div>
+        <ChevronRight size={18} className="text-ink-400" />
+      </Link>
+
+      <Link
+        to="/guide"
+        className="flex items-center justify-between bg-white rounded-lg shadow-md p-4 border border-primary-100 hover:bg-primary-50 transition-colors"
+      >
+        <div className="flex items-center space-x-3">
+          <HelpCircle size={20} className="text-primary-600" />
+          <div>
+            <p className="text-sm font-semibold text-ink-800">使い方ガイド</p>
+            <p className="text-xs text-ink-500">アプリの基本的な使い方を確認</p>
+          </div>
+        </div>
+        <ChevronRight size={18} className="text-ink-400" />
+      </Link>
+
+      <section className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+        <h2 className="text-lg font-semibold text-ink-800 mb-4">キャラクター選択</h2>
+        <CharacterSelector />
+      </section>
+
+      <section className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center space-x-2">
+            <Phone size={18} className="text-primary-600" />
+            <h2 className="text-lg font-semibold text-ink-800">緊急連絡先</h2>
+          </div>
+          <button
+            onClick={() => setShowContactForm(!showContactForm)}
+            className="bg-primary-600 text-white p-1.5 rounded-full hover:bg-primary-700 transition-colors"
+            aria-label={showContactForm ? "閉じる" : "緊急連絡先を追加"}
+          >
+            {showContactForm ? <X size={16} /> : <Plus size={16} />}
+          </button>
+        </div>
+
+        {showContactForm && !membersLoading && members.length > 0 && (
+          <div className="mb-4 bg-primary-50/50 rounded-lg p-4 border border-primary-100">
+            <h3 className="text-sm font-semibold text-ink-700 mb-3">緊急連絡先の追加</h3>
+            <EmergencyContactForm
+              members={members}
+              onSubmit={handleCreateContact}
+              onCancel={() => setShowContactForm(false)}
+            />
+          </div>
+        )}
+
+        {showContactForm && !membersLoading && members.length === 0 && (
+          <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-sm text-yellow-700">
+            先に
+            <Link to="/members" className="underline font-medium text-yellow-800 hover:text-yellow-900">
+              メンバーページ
+            </Link>
+            でメンバーを登録してください。
+          </div>
+        )}
+
+        <EmergencyContactList
+          contacts={contactsWithMember}
+          isLoading={contactsLoading}
+          onUpdate={handleUpdateContact}
+          onDelete={handleDeleteContact}
+        />
+      </section>
+
+      <button
+        onClick={handleLogout}
+        className="w-full flex items-center justify-center space-x-2 bg-white text-red-600 border border-red-200 rounded-lg py-3 px-4 hover:bg-red-50 transition-colors font-medium"
+      >
+        <LogOut size={18} />
+        <span>ログアウト</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/routes/signup.tsx
+++ b/frontend/app/routes/signup.tsx
@@ -55,7 +55,7 @@ export default function Signup() {
             {submitting ? "登録中..." : "登録して認証コードを送る"}
           </Button>
         </form>
-        <div className="mt-4 text-center text-sm text-slate-500">
+        <div className="mt-4 text-center text-sm text-ink-500">
           <Link to="/login" className="hover:text-primary">
             ログインへ戻る
           </Link>

--- a/frontend/app/routes/verify.tsx
+++ b/frontend/app/routes/verify.tsx
@@ -46,7 +46,7 @@ export default function Verify() {
     <div className="flex min-h-screen items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <h1 className="mb-2 text-center text-xl font-semibold text-primary">メール認証</h1>
-        <p className="mb-6 text-center text-sm text-slate-500">
+        <p className="mb-6 text-center text-sm text-ink-500">
           メールに届いた6桁のコードを入力してください
         </p>
         <form onSubmit={onSubmit} className="space-y-4">
@@ -69,7 +69,7 @@ export default function Verify() {
             {submitting ? "認証中..." : "認証する"}
           </Button>
         </form>
-        <button onClick={resend} className="mt-4 w-full text-center text-sm text-slate-500 hover:text-primary">
+        <button onClick={resend} className="mt-4 w-full text-center text-sm text-ink-500 hover:text-primary">
           コードを再送する
         </button>
       </Card>

--- a/frontend/app/stores/characterStore.ts
+++ b/frontend/app/stores/characterStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { CHARACTER_CONFIGS } from '@/lib/character';
+import type { CharacterType, CharacterConfig } from '@/lib/character';
+
+type MessageKey = keyof CharacterConfig['messages'];
+
+interface CharacterState {
+  selectedCharacter: CharacterType;
+  setCharacter: (character: CharacterType) => void;
+  getConfig: () => CharacterConfig;
+  getMessage: (key: MessageKey) => string;
+}
+
+export const useCharacterStore = create<CharacterState>()(
+  persist(
+    (set, get) => ({
+      selectedCharacter: 'cat',
+
+      setCharacter: (character: CharacterType) => {
+        set({ selectedCharacter: character });
+      },
+
+      getConfig: () => {
+        return CHARACTER_CONFIGS[get().selectedCharacter];
+      },
+
+      getMessage: (key: MessageKey) => {
+        return CHARACTER_CONFIGS[get().selectedCharacter].messages[key];
+      },
+    }),
+    {
+      name: 'character-storage',
+      partialize: (state) => ({ selectedCharacter: state.selectedCharacter }),
+    },
+  ),
+);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.1.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@react-router/dev": "^7.1.0",
@@ -1575,7 +1576,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1862,7 +1863,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -3397,6 +3398,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@react-router/dev": "^7.1.0",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,14 +1,52 @@
 import type { Config } from "tailwindcss";
 
+// 旧 Next.js 版の「Maison Blanche」パレット（エレガント・優美）を踏襲
+// ブランド/テーマカラー = ダスティピンク #e8d4dc、アクセント = セージミント
 export default {
   content: ["./app/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
+        // primary: ダスティピンク系（タブのテーマカラー #e8d4dc を中心に展開）
         primary: {
-          DEFAULT: "#7c9cbf",
-          dark: "#5d7da0",
+          DEFAULT: "#c094a4",
+          dark: "#a07485",
+          50: "#fbf6f7",
+          100: "#f7eef1",
+          200: "#f2e6e6",
+          300: "#e8d4dc",
+          400: "#d8b8c5",
+          500: "#c094a4",
+          600: "#a07485",
+          700: "#7d5b6a",
+          800: "#5a4250",
+          900: "#3d2c37",
         },
+        // accent: セージミント系
+        accent: {
+          DEFAULT: "#94b3b3",
+          50: "#f5f9f9",
+          100: "#eaf2f2",
+          200: "#d4e2e2",
+          300: "#b9cfcf",
+          400: "#94b3b3",
+          500: "#6f9494",
+          600: "#557777",
+          700: "#445e5e",
+          800: "#374a4a",
+          900: "#283434",
+        },
+        // ink: 落ち着いた本文/見出し色
+        ink: {
+          400: "#a0939a",
+          500: "#7a6b73",
+          600: "#5e4f57",
+          700: "#473b41",
+          800: "#33282d",
+        },
+      },
+      fontFamily: {
+        sans: ['"Noto Sans JP"', "system-ui", "sans-serif"],
       },
     },
   },


### PR DESCRIPTION
## Summary
- 旧 Next.js の全画面(15ページ相当: home/members(+詳細/薬)/medications/appointments/hospitals/health-logs/history/settings(+notifications)/guide/forgot-password/reset-password)を React Router v7(SPA) へ移植
- components/shared(19) + dashboard + 各機能コンポーネント(計83相当)を react-query/useAuth/Go API/react-router に適合して移植
- Maison Blanche 配色(ダスティピンク #e8d4dc + セージミント + ink)、Noto Sans JP、theme-color を適用し旧デザインを踏襲
- 依存整合: zustand 追加(characterStore 移植)。lucide-react/react-query/date-fns/zod/clsx は既存一致
- `npm run typecheck` / `npm run build` 通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 健康管理機能の大幅拡張：アレルギー記録、ワクチン接種履歴、検査結果、体温・体重記録に対応
  * 通院予約管理機能をカレンダー表示で実装
  * 緊急連絡先・保険情報・処方箋の登録・管理機能を追加
  * ダッシュボードに服薬達成率・見逃し投与アラート・在庫警告を表示
  * 健康トレンドの週間グラフ表示と症状頻度集計機能
  * メンバー別の詳細管理画面と通知設定画面を追加
  * ガイド画面を新規実装

* **スタイル**
  * デザインカラースキームを更新（より読みやすい配色へ変更）
  * Noto Sans JPフォントを導入

<!-- end of auto-generated comment: release notes by coderabbit.ai -->