### PR TITLE
chore: .gitignore をモノレポ/Playwright用に整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,18 @@ coverage/
 CLAUDE.md
 .vercel
 .env.production
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/
+blob-report/
+.last-run.json
+
+# Go backend
+backend/app
+
+# frontend build/deps
+frontend/node_modules/
+frontend/build/
+frontend/.react-router/


### PR DESCRIPTION
## Summary
- Playwright 成果物(test-results/ 等)とモノレポのビルド/依存(backend/app, frontend/node_modules・build・.react-router)を .gitignore に追加