### PR TITLE
perf: 集計エンドポイント追加・過剰フェッチ削減(API/フロント設計最適化)

### DIFF
--- a/backend/internal/domain/entity/entities.go
+++ b/backend/internal/domain/entity/entities.go
@@ -81,6 +81,13 @@ type MedicationRecord struct {
 	DosageAmount *string   `json:"dosageAmount"`
 }
 
+// MemberSummary はメンバーと薬数の集計（一覧画面向けの読み取りモデル、N+1回避）
+type MemberSummary struct {
+	Member
+	MedicationCount       int `json:"medicationCount"`
+	ActiveMedicationCount int `json:"activeMedicationCount"`
+}
+
 // TodaySchedule は今日の服薬予定（薬・メンバー情報を結合した読み取りモデル）
 type TodaySchedule struct {
 	Schedule

--- a/backend/internal/domain/repository/repository.go
+++ b/backend/internal/domain/repository/repository.go
@@ -36,6 +36,7 @@ type UpdateMemberInput struct {
 // MemberRepository はメンバー永続化の抽象
 type MemberRepository interface {
 	List(ctx context.Context, userID string) ([]entity.Member, error)
+	ListSummary(ctx context.Context, userID string) ([]entity.MemberSummary, error)
 	FindByID(ctx context.Context, id string) (*entity.Member, error)
 	Create(ctx context.Context, in CreateMemberInput) (*entity.Member, error)
 	Update(ctx context.Context, id string, in UpdateMemberInput) (*entity.Member, error)
@@ -73,6 +74,7 @@ type MedicationRepository interface {
 	ListByMember(ctx context.Context, memberID string) ([]entity.Medication, error)
 	ListByUser(ctx context.Context, userID string) ([]entity.Medication, error)
 	FindByID(ctx context.Context, id string) (*entity.Medication, error)
+	ListAlerts(ctx context.Context, userID string) ([]entity.Medication, error)
 	Create(ctx context.Context, in CreateMedicationInput) (*entity.Medication, error)
 	Update(ctx context.Context, id string, in UpdateMedicationInput) (*entity.Medication, error)
 	UpdateStock(ctx context.Context, id string, quantity int) (*entity.Medication, error)
@@ -124,9 +126,18 @@ type CreateRecordInput struct {
 	TakenAt      *time.Time
 }
 
+// RecordFilter は服薬記録の絞り込み条件（任意。ゼロ値は無指定）
+type RecordFilter struct {
+	MemberID string     // 空なら全メンバー
+	From     *time.Time // takenAt >= From
+	To       *time.Time // takenAt <  To
+	Limit    int        // 0なら無制限
+}
+
 // MedicationRecordRepository は服薬記録永続化の抽象
 type MedicationRecordRepository interface {
 	ListByUser(ctx context.Context, userID string) ([]entity.MedicationRecord, error)
+	ListByUserFiltered(ctx context.Context, userID string, f RecordFilter) ([]entity.MedicationRecord, error)
 	ListByMember(ctx context.Context, memberID string) ([]entity.MedicationRecord, error)
 	FindByID(ctx context.Context, id string) (*entity.MedicationRecord, error)
 	Create(ctx context.Context, in CreateRecordInput) (*entity.MedicationRecord, error)

--- a/backend/internal/infrastructure/persistence/aggregate_queries.go
+++ b/backend/internal/infrastructure/persistence/aggregate_queries.go
@@ -1,0 +1,110 @@
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
+)
+
+// ListByUserFiltered は任意の絞り込み(メンバー/期間/件数上限)で服薬記録を返す。
+// 全パラメータ未指定なら ListByUser と同等。ダッシュボード/履歴の期間ウィンドウ取得に使う。
+func (r *MedicationRecordRepository) ListByUserFiltered(ctx context.Context, userID string, f repository.RecordFilter) ([]entity.MedicationRecord, error) {
+	query := `SELECT ` + recordColumns + ` FROM "MedicationRecord" WHERE "userId"=$1`
+	args := []any{userID}
+	n := 1
+	if f.MemberID != "" {
+		n++
+		query += ` AND "memberId"=$` + strconv.Itoa(n)
+		args = append(args, f.MemberID)
+	}
+	if f.From != nil {
+		n++
+		query += ` AND "takenAt" >= $` + strconv.Itoa(n)
+		args = append(args, *f.From)
+	}
+	if f.To != nil {
+		n++
+		query += ` AND "takenAt" < $` + strconv.Itoa(n)
+		args = append(args, *f.To)
+	}
+	query += ` ORDER BY "takenAt" DESC`
+	if f.Limit > 0 {
+		query += ` LIMIT ` + strconv.Itoa(f.Limit)
+	}
+
+	rows, err := r.db.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	list := make([]entity.MedicationRecord, 0)
+	for rows.Next() {
+		var rec entity.MedicationRecord
+		if err := rows.Scan(&rec.ID, &rec.MemberID, &rec.MedicationID, &rec.UserID, &rec.ScheduleID,
+			&rec.TakenAt, &rec.Notes, &rec.DosageAmount); err != nil {
+			return nil, err
+		}
+		list = append(list, rec)
+	}
+	return list, rows.Err()
+}
+
+// ListSummary はメンバーごとの薬数を単一SQL(LEFT JOIN + GROUP BY)で集計して返す(N+1回避)。
+func (r *MemberRepository) ListSummary(ctx context.Context, userID string) ([]entity.MemberSummary, error) {
+	rows, err := r.db.Pool.Query(ctx,
+		`SELECT m."id", m."userId", m."memberType", m."name", m."petType", m."photoUrl",
+			m."birthDate", m."notes", m."createdAt", m."updatedAt",
+			COUNT(med."id") AS medication_count,
+			COUNT(med."id") FILTER (WHERE med."isActive") AS active_count
+		 FROM "Member" m
+		 LEFT JOIN "Medication" med ON med."memberId" = m."id"
+		 WHERE m."userId" = $1
+		 GROUP BY m."id"
+		 ORDER BY m."createdAt" ASC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	list := make([]entity.MemberSummary, 0)
+	for rows.Next() {
+		var s entity.MemberSummary
+		if err := rows.Scan(&s.ID, &s.UserID, &s.MemberType, &s.Name, &s.PetType, &s.PhotoURL,
+			&s.BirthDate, &s.Notes, &s.CreatedAt, &s.UpdatedAt,
+			&s.MedicationCount, &s.ActiveMedicationCount); err != nil {
+			return nil, err
+		}
+		list = append(list, s)
+	}
+	return list, rows.Err()
+}
+
+// ListAlerts は在庫僅少(残数<=5 もしくは在庫アラート日が7日以内)の有効な薬を返す。
+func (r *MedicationRepository) ListAlerts(ctx context.Context, userID string) ([]entity.Medication, error) {
+	const lowStockThreshold = 5
+	query := `SELECT ` + medColumns + ` FROM "Medication"
+		 WHERE "userId"=$1 AND "isActive" = TRUE
+		   AND (
+		     ("stockQuantity" IS NOT NULL AND "stockQuantity" <= $2)
+		     OR ("stockAlertDate" IS NOT NULL AND "stockAlertDate" <= now() + interval '7 days')
+		   )
+		 ORDER BY "stockQuantity" ASC NULLS LAST, "createdAt" ASC`
+	rows, err := r.db.Pool.Query(ctx, query, userID, lowStockThreshold)
+	if err != nil {
+		return nil, fmt.Errorf("list alerts: %w", err)
+	}
+	defer rows.Close()
+	list := make([]entity.Medication, 0)
+	for rows.Next() {
+		var m entity.Medication
+		if err := rows.Scan(&m.ID, &m.MemberID, &m.UserID, &m.Name, &m.Category, &m.DosageAmount,
+			&m.Frequency, &m.StockQuantity, &m.StockAlertDate, &m.IntervalHours, &m.Instructions,
+			&m.DisplayOrder, &m.IsActive, &m.Status, &m.CreatedAt, &m.UpdatedAt); err != nil {
+			return nil, err
+		}
+		list = append(list, m)
+	}
+	return list, rows.Err()
+}

--- a/backend/internal/interface/handler/medication_handler.go
+++ b/backend/internal/interface/handler/medication_handler.go
@@ -27,6 +27,16 @@ func (h *MedicationHandler) ListByUser(c *gin.Context) {
 	response.Success(c, list)
 }
 
+func (h *MedicationHandler) Alerts(c *gin.Context) {
+	userID := middleware.UserID(c)
+	list, err := h.uc.ListAlerts(c.Request.Context(), userID)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, list)
+}
+
 func (h *MedicationHandler) ListByMember(c *gin.Context) {
 	userID := middleware.UserID(c)
 	list, err := h.uc.ListByMember(c.Request.Context(), userID, c.Param("memberId"))

--- a/backend/internal/interface/handler/member_handler.go
+++ b/backend/internal/interface/handler/member_handler.go
@@ -27,6 +27,16 @@ func (h *MemberHandler) List(c *gin.Context) {
 	response.Success(c, members)
 }
 
+func (h *MemberHandler) Summary(c *gin.Context) {
+	userID := middleware.UserID(c)
+	list, err := h.uc.ListSummary(c.Request.Context(), userID)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, list)
+}
+
 func (h *MemberHandler) Get(c *gin.Context) {
 	userID := middleware.UserID(c)
 	m, err := h.uc.Get(c.Request.Context(), userID, c.Param("memberId"))

--- a/backend/internal/interface/handler/record_handler.go
+++ b/backend/internal/interface/handler/record_handler.go
@@ -1,6 +1,9 @@
 package handler
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"healthfamily/internal/domain/repository"
 	"healthfamily/internal/interface/middleware"
@@ -19,7 +22,28 @@ func NewRecordHandler(uc *usecase.RecordUsecase) *RecordHandler {
 
 func (h *RecordHandler) ListByUser(c *gin.Context) {
 	userID := middleware.UserID(c)
-	list, err := h.uc.ListByUser(c.Request.Context(), userID)
+
+	// 任意フィルタ: memberId / from / to / days / limit（未指定なら全件＝後方互換）
+	f := repository.RecordFilter{MemberID: c.Query("memberId")}
+	if from := c.Query("from"); from != "" {
+		f.From = parseDate(&from)
+	}
+	if to := c.Query("to"); to != "" {
+		f.To = parseDate(&to)
+	}
+	if days := c.Query("days"); days != "" {
+		if d, err := strconv.Atoi(days); err == nil && d > 0 {
+			t := time.Now().AddDate(0, 0, -d)
+			f.From = &t
+		}
+	}
+	if limit := c.Query("limit"); limit != "" {
+		if l, err := strconv.Atoi(limit); err == nil && l > 0 {
+			f.Limit = l
+		}
+	}
+
+	list, err := h.uc.ListFiltered(c.Request.Context(), userID, f)
 	if err != nil {
 		response.HandleDomainError(c, err)
 		return

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -61,6 +61,7 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 	authed.Use(middleware.RateLimit("api", 120, time.Minute, middleware.PerUser))
 	{
 		authed.GET("/members", h.Member.List)
+		authed.GET("/members/summary", h.Member.Summary)
 		authed.POST("/members", h.Member.Create)
 		authed.GET("/members/:memberId", h.Member.Get)
 		authed.PATCH("/members/:memberId", h.Member.Update)
@@ -69,6 +70,7 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 		authed.GET("/members/:memberId/records", h.Record.ListByMember)
 
 		authed.GET("/medications", h.Medication.ListByUser)
+		authed.GET("/medications/alerts", h.Medication.Alerts)
 		authed.POST("/medications", h.Medication.Create)
 		authed.POST("/medications/reorder", h.Medication.Reorder)
 		authed.GET("/medications/:medicationId", h.Medication.Get)

--- a/backend/internal/usecase/medication_usecase.go
+++ b/backend/internal/usecase/medication_usecase.go
@@ -57,6 +57,11 @@ func (uc *MedicationUsecase) ListByUser(ctx context.Context, userID string) ([]e
 	return uc.medications.ListByUser(ctx, userID)
 }
 
+// ListAlerts は在庫僅少の薬を返す
+func (uc *MedicationUsecase) ListAlerts(ctx context.Context, userID string) ([]entity.Medication, error) {
+	return uc.medications.ListAlerts(ctx, userID)
+}
+
 func (uc *MedicationUsecase) Get(ctx context.Context, userID, medID string) (*entity.Medication, error) {
 	return uc.ensureMedOwner(ctx, userID, medID)
 }

--- a/backend/internal/usecase/member_usecase.go
+++ b/backend/internal/usecase/member_usecase.go
@@ -36,6 +36,11 @@ func (uc *MemberUsecase) List(ctx context.Context, userID string) ([]entity.Memb
 	return uc.members.List(ctx, userID)
 }
 
+// ListSummary はメンバー＋薬数の集計を返す（N+1回避）
+func (uc *MemberUsecase) ListSummary(ctx context.Context, userID string) ([]entity.MemberSummary, error) {
+	return uc.members.ListSummary(ctx, userID)
+}
+
 func (uc *MemberUsecase) Get(ctx context.Context, userID, memberID string) (*entity.Member, error) {
 	return uc.ensureOwner(ctx, userID, memberID)
 }

--- a/backend/internal/usecase/record_usecase.go
+++ b/backend/internal/usecase/record_usecase.go
@@ -23,6 +23,23 @@ func (uc *RecordUsecase) ListByUser(ctx context.Context, userID string) ([]entit
 	return uc.records.ListByUser(ctx, userID)
 }
 
+// ListFiltered はメンバー/期間/件数で絞り込んで記録を返す。memberId指定時は所有権を確認する。
+func (uc *RecordUsecase) ListFiltered(ctx context.Context, userID string, f repository.RecordFilter) ([]entity.MedicationRecord, error) {
+	if f.MemberID != "" {
+		m, err := uc.members.FindByID(ctx, f.MemberID)
+		if err != nil {
+			return nil, err
+		}
+		if m == nil {
+			return nil, domain.NewNotFound("メンバー")
+		}
+		if m.UserID != userID {
+			return nil, domain.NewForbidden("このメンバーにアクセスする権限がありません")
+		}
+	}
+	return uc.records.ListByUserFiltered(ctx, userID, f)
+}
+
 func (uc *RecordUsecase) ListByMember(ctx context.Context, userID, memberID string) ([]entity.MedicationRecord, error) {
 	m, err := uc.members.FindByID(ctx, memberID)
 	if err != nil {

--- a/frontend/app/hooks/dashboard.ts
+++ b/frontend/app/hooks/dashboard.ts
@@ -217,9 +217,11 @@ export function useDashboardData(userId: string | null) {
     queryFn: () => api.get<Schedule[]>("/schedules"),
     enabled,
   });
+  // ダッシュボードの集計は週次/月次のみ。全件ではなく直近40日に絞って取得する。
+  // (invalidateQueries({queryKey:["records"]}) はプレフィックス一致でこのキーも無効化する)
   const recordsQuery = useQuery({
-    queryKey: ["records"],
-    queryFn: () => api.get<MedicationRecord[]>("/records"),
+    queryKey: ["records", "window", 40],
+    queryFn: () => api.get<MedicationRecord[]>("/records?days=40"),
     enabled,
   });
   const medicationsQuery = useQuery({

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -30,6 +30,12 @@ export interface Member {
   updatedAt: string;
 }
 
+// /members/summary のレスポンス（Member + 薬数。N+1回避のサーバ集計）
+export interface MemberWithCounts extends Member {
+  medicationCount: number;
+  activeMedicationCount: number;
+}
+
 export interface Medication {
   id: string;
   memberId: string;

--- a/frontend/app/routes/members.tsx
+++ b/frontend/app/routes/members.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
-import type { Appointment, Medication, Member } from "@/lib/types";
+import type { Appointment, Member, MemberWithCounts } from "@/lib/types";
 import { MemberList } from "@/components/members/MemberList";
 import { MemberForm, type MemberFormData } from "@/components/members/MemberForm";
 import type { MemberSummary } from "@/components/members/MemberSummaryCard";
@@ -28,14 +28,10 @@ export default function Members() {
   const [showForm, setShowForm] = useState(false);
   const [editingMember, setEditingMember] = useState<Member | null>(null);
 
+  // サーバ集計の /members/summary を使用（全medications取得＋クライアント集計のN+1を解消）
   const { data: members = [], isLoading } = useQuery({
     queryKey: ["members"],
-    queryFn: () => api.get<Member[]>("/members"),
-  });
-
-  const { data: medications = [] } = useQuery({
-    queryKey: ["medications"],
-    queryFn: () => api.get<Medication[]>("/medications"),
+    queryFn: () => api.get<MemberWithCounts[]>("/members/summary"),
   });
 
   const { data: appointments = [] } = useQuery({
@@ -43,13 +39,11 @@ export default function Members() {
     queryFn: () => api.get<Appointment[]>("/appointments"),
   });
 
-  // /members/summary が無いためクライアント側で集計する
+  // サーバ集計(activeMedicationCount)＋直近予約をビューモデルに合成する
   const summaries = useMemo<MemberSummary[]>(() => {
     const now = new Date();
     return members.map((member) => {
-      const medicationCount = medications.filter(
-        (med) => med.memberId === member.id && med.isActive,
-      ).length;
+      const medicationCount = member.activeMedicationCount;
       const upcoming = appointments
         .filter(
           (a) => a.memberId === member.id && new Date(a.appointmentDate).getTime() >= now.getTime(),
@@ -66,7 +60,7 @@ export default function Members() {
         nextAppointmentDate: upcoming[0]?.appointmentDate ?? null,
       };
     });
-  }, [members, medications, appointments]);
+  }, [members, appointments]);
 
   const createMutation = useMutation({
     mutationFn: (body: CreateMemberBody) => api.post<Member>("/members", body),


### PR DESCRIPTION
## Summary
### バックエンドAPI設計の最適化（追加・後方互換）
- `GET /records` に `memberId/from/to/days/limit` フィルタを追加（期間ウィンドウ取得。未指定時は従来通り全件）
- `GET /members/summary` を追加：メンバー＋薬数を単一SQL(LEFT JOIN + GROUP BY + FILTER)で集計し **N+1 を解消**
- `GET /medications/alerts` を追加：在庫僅少(残数≤5 もしくはアラート日7日以内)を SQL でフィルタ

### フロントエンド設計の最適化
- メンバー画面: 全 `/medications` 取得＋クライアント集計を廃止し `/members/summary` 利用に切替
- ダッシュボード: `records` を全件取得→**直近40日ウィンドウ**に変更（週次/月次集計に十分・無制限フェッチを解消）
- `MemberWithCounts` 型追加

backend は build/vet/test・ルート登録スモークテスト通過、frontend は typecheck/build 通過。集計SQLは Supabase 実機で検証済み。