### PR TITLE
perf: コールドスタート防止＋DB常時ウォーム接続で取得高速化

### DIFF
--- a/.github/workflows/keep-warm.yml
+++ b/.github/workflows/keep-warm.yml
@@ -1,0 +1,23 @@
+name: Keep Render API warm
+
+# Render の無料インスタンスは無アクセス15分でスリープし、次回アクセスで
+# 50秒級のコールドスタートが発生する。定期的に /health を叩いてウォーム維持する。
+on:
+  schedule:
+    - cron: "*/10 * * * *" # 10分毎（GitHub cron は遅延し得るが概ねスリープを防げる）
+  workflow_dispatch: {}
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping health endpoint
+        run: |
+          for i in 1 2 3; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" -m 90 https://healthfamily-api.onrender.com/health || echo 000)
+            echo "attempt $i -> HTTP $code"
+            [ "$code" = "200" ] && exit 0
+            sleep 10
+          done
+          # ウォームアップ目的のため、失敗してもワークフローは落とさない
+          exit 0

--- a/backend/internal/infrastructure/database/db.go
+++ b/backend/internal/infrastructure/database/db.go
@@ -18,8 +18,13 @@ func New(ctx context.Context, databaseURL string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	// クロスリージョン(API:Singapore ↔ DB:Sydney)のため、接続確立コスト(TLS往復)を
+	// リクエスト毎に払わないよう常時ウォーム接続を維持する。
 	cfg.MaxConns = 10
-	cfg.MaxConnIdleTime = 5 * time.Minute
+	cfg.MinConns = 2                        // 最低2本を常時オープン
+	cfg.MaxConnIdleTime = 30 * time.Minute  // アイドルでもすぐ閉じない
+	cfg.MaxConnLifetime = 1 * time.Hour     // 長寿命接続を再利用
+	cfg.HealthCheckPeriod = 1 * time.Minute // アイドル接続を定期検査してウォーム維持
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {


### PR DESCRIPTION
## Summary
- **keep-warm ワークフロー**: 10分毎に `/health` を ping し、Render 無料インスタンスのスリープ(無アクセス15分)→コールドスタート(50秒級)を防止
- **pgxpool 調整**: `MinConns=2` / `MaxConnLifetime=1h` / `HealthCheckPeriod=1m` を設定。クロスリージョン(API:Singapore ↔ DB:Sydney, ~90ms)の接続確立(TLS往復)をリクエスト毎に払わず、常時ウォームな接続を再利用
- 計測上、データ件数は小さくクエリ実行は高速。遅さの主因はコールドスタート/接続確立/低CPU(free)であり、本PRはその上位2要因に対処

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 定期的なヘルスチェック機能を導入し、サービスの継続稼働を支援しました
* データベース接続プール設定を最適化し、複数リージョン環境での接続の安定性とパフォーマンスを向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->