### PR TITLE
feat(frontend): 起動時ヘルスチェックゲート＋メンテナンス画面

### DIFF
--- a/frontend/app/components/BackendGate.tsx
+++ b/frontend/app/components/BackendGate.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Loader2, ServerCrash } from "lucide-react";
+import { pingHealth } from "@/lib/api";
+
+type Status = "checking" | "ready" | "down";
+
+// コールドスタート(~50秒)をカバーするためのリトライ上限
+const MAX_TOTAL_MS = 80_000;
+const RETRY_DELAY_MS = 3_000;
+const SLOW_HINT_MS = 4_000;
+
+/**
+ * アプリ起動時にバックエンドの /health を確認するゲート。
+ * - 応答するまで「起動中」画面を表示しつつリトライ(コールドスタート中も待機)
+ * - 一定時間応答が無ければ「メンテナンス」画面＋再試行ボタン
+ * - 応答が得られたら子(アプリ本体)を描画
+ * ユーザーアクセス自体がバックエンドのウォームアップを兼ねる。
+ */
+export function BackendGate({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<Status>("checking");
+  const [slow, setSlow] = useState(false);
+  const runIdRef = useRef(0);
+
+  const run = useCallback(async () => {
+    const myRun = ++runIdRef.current;
+    setStatus("checking");
+    setSlow(false);
+    const start = Date.now();
+    const slowTimer = setTimeout(() => setSlow(true), SLOW_HINT_MS);
+    try {
+      while (runIdRef.current === myRun) {
+        const ok = await pingHealth();
+        if (runIdRef.current !== myRun) return;
+        if (ok) {
+          setStatus("ready");
+          return;
+        }
+        if (Date.now() - start > MAX_TOTAL_MS) {
+          setStatus("down");
+          return;
+        }
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+      }
+    } finally {
+      clearTimeout(slowTimer);
+    }
+  }, []);
+
+  useEffect(() => {
+    run();
+    return () => {
+      // アンマウント時に進行中ループを無効化
+      runIdRef.current++;
+    };
+  }, [run]);
+
+  if (status === "ready") return <>{children}</>;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-6">
+      <div className="w-full max-w-sm rounded-2xl border border-primary-100 bg-white p-8 text-center shadow-sm">
+        {status === "checking" ? (
+          <>
+            <Loader2 className="mx-auto mb-4 h-8 w-8 animate-spin text-primary" />
+            <h1 className="mb-2 text-lg font-semibold text-ink-800">起動中です</h1>
+            <p className="text-sm text-ink-500">
+              {slow
+                ? "サーバーを起動しています。初回は1分ほどかかる場合があります…"
+                : "サーバーに接続しています…"}
+            </p>
+          </>
+        ) : (
+          <>
+            <ServerCrash className="mx-auto mb-4 h-8 w-8 text-primary" />
+            <h1 className="mb-2 text-lg font-semibold text-ink-800">ただいまメンテナンス中です</h1>
+            <p className="mb-6 text-sm text-ink-500">
+              サーバーに接続できませんでした。しばらくしてから再度お試しください。
+            </p>
+            <button
+              onClick={run}
+              className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-2 text-sm font-medium text-white transition hover:bg-primary-dark"
+            >
+              再試行する
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -6,6 +6,26 @@ const API_BASE =
 
 const TOKEN_KEY = "hf_token";
 
+/**
+ * バックエンドのヘルスチェック。指定タイムアウト内に 200 が返れば true。
+ * コールドスタート中/到達不能時は false（呼び出し側でリトライ/メンテ表示する）。
+ */
+export async function pingHealth(timeoutMs = 8000): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${API_BASE}/health`, {
+      signal: controller.signal,
+      cache: "no-store",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export function getToken(): string | null {
   if (typeof window === "undefined") return null;
   return window.localStorage.getItem(TOKEN_KEY);

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "./lib/auth";
+import { BackendGate } from "./components/BackendGate";
 import "./app.css";
 
 export function Layout({ children }: { children: React.ReactNode }) {
@@ -45,9 +46,11 @@ export default function App() {
   );
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <Outlet />
-      </AuthProvider>
+      <BackendGate>
+        <AuthProvider>
+          <Outlet />
+        </AuthProvider>
+      </BackendGate>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- アプリ起動時に `/health` を確認するゲートを追加。応答するまで「起動中」画面を表示しつつリトライ（Render無料インスタンスのコールドスタート ~50秒中も壊れたUI/失敗フェッチを見せない）
- 一定時間(~80秒)応答が無ければ「メンテナンス中」画面＋再試行ボタン
- ユーザーアクセス自体がウォームアップを兼ね、keep-warm ワークフローと併用してコールドスタート体感を解消