### PR TITLE
feat: 飲み忘れ一覧を日付別アコーディオンに改善

### DIFF
--- a/frontend/app/components/dashboard/MissedDosesAlert.tsx
+++ b/frontend/app/components/dashboard/MissedDosesAlert.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { AlertTriangle, Check, Loader2 } from "lucide-react";
+import { AlertTriangle, Check, ChevronDown, Loader2 } from "lucide-react";
 import type { MissedDose } from "@/hooks/dashboard";
 
 interface MissedDosesAlertProps {
@@ -40,6 +40,8 @@ export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({
 }) => {
   const [recordingId, setRecordingId] = useState<string | null>(null);
   const [bulkTarget, setBulkTarget] = useState<string | null>(null);
+  // null = 初期状態（最新日のみ開く）。ユーザーが操作したら Set で明示管理する。
+  const [openDates, setOpenDates] = useState<Set<string> | null>(null);
 
   const dateGroups = useMemo(() => {
     if (missedDoses.length === 0) return [];
@@ -57,7 +59,28 @@ export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({
     return groups;
   }, [missedDoses]);
 
+  // 初期表示は「最新の日付だけ開く」。大量の飲み忘れで画面が埋まらないようにする。
+  const defaultOpen = useMemo(
+    () => new Set(dateGroups[0] ? [dateGroups[0].date] : []),
+    [dateGroups],
+  );
+  const open = openDates ?? defaultOpen;
+  const allOpen = dateGroups.length > 0 && dateGroups.every((g) => open.has(g.date));
+
   if (isLoading || missedDoses.length === 0) return null;
+
+  const toggleDate = (date: string) => {
+    setOpenDates((prev) => {
+      const next = new Set(prev ?? defaultOpen);
+      if (next.has(date)) next.delete(date);
+      else next.add(date);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setOpenDates(allOpen ? new Set() : new Set(dateGroups.map((g) => g.date)));
+  };
 
   const handleMarkOne = async (dose: MissedDose) => {
     if (!onMarkAsTaken) return;
@@ -90,22 +113,30 @@ export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({
     }
   };
 
+  const busy = bulkTarget !== null || recordingId !== null;
+
   return (
     <div className="mb-4">
-      <div className="bg-red-50 border border-red-200 rounded-2xl overflow-hidden">
-        <div className="flex items-center justify-between gap-2 px-4 py-2.5 bg-red-100">
+      <div className="bg-white border border-red-200 rounded-2xl shadow-sm overflow-hidden">
+        {/* ヘッダー: 件数サマリ + 全て記録 */}
+        <div className="flex items-center justify-between gap-2 px-4 py-3 bg-red-50 border-b border-red-100">
           <div className="flex items-center gap-2 min-w-0">
-            <AlertTriangle size={18} className="text-red-600 flex-shrink-0" />
-            <h3 className="text-sm font-bold text-red-800 truncate">
-              飲み忘れがあります（{missedDoses.length}件）
-            </h3>
+            <span className="flex-shrink-0 w-8 h-8 rounded-full bg-red-100 flex items-center justify-center">
+              <AlertTriangle size={16} className="text-red-600" />
+            </span>
+            <div className="min-w-0">
+              <h3 className="text-sm font-bold text-red-800 leading-tight">飲み忘れがあります</h3>
+              <p className="text-xs text-red-600/80 leading-tight">
+                {missedDoses.length}件 ・ {dateGroups.length}日分
+              </p>
+            </div>
           </div>
           {onMarkMultipleAsTaken && (
             <button
               type="button"
               onClick={handleMarkAll}
-              disabled={bulkTarget !== null || recordingId !== null}
-              className="flex items-center gap-1 text-xs text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 px-2 py-1 rounded font-medium flex-shrink-0"
+              disabled={busy}
+              className="flex items-center gap-1 text-xs text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 px-2.5 py-1.5 rounded-lg font-medium flex-shrink-0 transition-colors"
             >
               {bulkTarget === "all" ? (
                 <Loader2 size={12} className="animate-spin" />
@@ -116,60 +147,112 @@ export const MissedDosesAlert: React.FC<MissedDosesAlertProps> = ({
             </button>
           )}
         </div>
-        <div className="px-4 py-3 space-y-3">
-          {dateGroups.map((group) => (
-            <div key={group.date}>
-              <div className="flex items-center justify-between mb-1">
-                <p className="text-xs font-semibold text-red-700">{group.dateLabel}</p>
-                {onMarkMultipleAsTaken && group.items.length > 1 && (
-                  <button
-                    type="button"
-                    onClick={() => handleMarkAllForDate(group)}
-                    disabled={bulkTarget !== null || recordingId !== null}
-                    className="text-xs text-red-600 hover:text-red-800 disabled:opacity-50 font-medium flex items-center gap-1"
-                  >
-                    {bulkTarget === group.date ? (
-                      <Loader2 size={11} className="animate-spin" />
-                    ) : null}
-                    <span>この日全て記録</span>
-                  </button>
+
+        {/* 全展開トグル（2日分以上のときだけ） */}
+        {dateGroups.length > 1 && (
+          <div className="flex justify-end px-4 pt-2">
+            <button
+              type="button"
+              onClick={toggleAll}
+              className="text-xs text-red-600 hover:text-red-800 font-medium"
+            >
+              {allOpen ? "すべて折りたたむ" : "すべて開く"}
+            </button>
+          </div>
+        )}
+
+        {/* 日付ごとのアコーディオン */}
+        <div className="divide-y divide-red-100/70">
+          {dateGroups.map((group) => {
+            const isOpen = open.has(group.date);
+            return (
+              <div key={group.date}>
+                <button
+                  type="button"
+                  onClick={() => toggleDate(group.date)}
+                  aria-expanded={isOpen}
+                  className="w-full flex items-center justify-between gap-2 px-4 py-2.5 hover:bg-red-50/50 transition-colors"
+                >
+                  <span className="flex items-center gap-2 min-w-0">
+                    <ChevronDown
+                      size={16}
+                      className={`text-red-400 flex-shrink-0 transition-transform ${isOpen ? "" : "-rotate-90"}`}
+                    />
+                    <span className="text-sm font-semibold text-red-700 truncate">
+                      {group.dateLabel}
+                    </span>
+                    <span className="flex-shrink-0 text-[11px] font-semibold text-red-700 bg-red-100 rounded-full px-1.5 py-0.5">
+                      {group.items.length}件
+                    </span>
+                  </span>
+                  {onMarkMultipleAsTaken && group.items.length > 1 && (
+                    <span
+                      role="button"
+                      tabIndex={0}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleMarkAllForDate(group);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          handleMarkAllForDate(group);
+                        }
+                      }}
+                      className="flex items-center gap-1 text-xs text-red-600 hover:text-red-800 font-medium flex-shrink-0"
+                    >
+                      {bulkTarget === group.date ? (
+                        <Loader2 size={11} className="animate-spin" />
+                      ) : null}
+                      <span>この日全て記録</span>
+                    </span>
+                  )}
+                </button>
+
+                {isOpen && (
+                  <ul className="px-4 pb-3 pt-0.5 space-y-1">
+                    {group.items.map((dose) => {
+                      const key = `${dose.date}-${dose.scheduleId}`;
+                      const isRecording = recordingId === key;
+                      return (
+                        <li
+                          key={key}
+                          className="flex items-center justify-between gap-2 text-sm bg-red-50/40 rounded-lg px-2.5 py-1.5"
+                        >
+                          <span className="text-ink-800 min-w-0 truncate">
+                            <span className="text-ink-500">{dose.memberName}</span>{" "}
+                            <span className="font-medium">{dose.medicationName}</span>
+                          </span>
+                          <div className="flex items-center gap-2 flex-shrink-0">
+                            <span className="text-xs text-ink-500 tabular-nums">
+                              {dose.scheduledTime}
+                            </span>
+                            {onMarkAsTaken && (
+                              <button
+                                type="button"
+                                onClick={() => handleMarkOne(dose)}
+                                disabled={isRecording || bulkTarget !== null}
+                                aria-label="記録する"
+                                className="flex items-center gap-1 text-xs text-red-700 hover:text-white hover:bg-red-600 disabled:opacity-50 border border-red-300 hover:border-red-600 px-2 py-0.5 rounded-md transition-colors"
+                              >
+                                {isRecording ? (
+                                  <Loader2 size={11} className="animate-spin" />
+                                ) : (
+                                  <Check size={11} />
+                                )}
+                                <span>記録</span>
+                              </button>
+                            )}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
                 )}
               </div>
-              <div className="space-y-1">
-                {group.items.map((dose) => {
-                  const key = `${dose.date}-${dose.scheduleId}`;
-                  const isRecording = recordingId === key;
-                  return (
-                    <div key={key} className="flex items-center justify-between gap-2 text-sm">
-                      <span className="text-ink-800 min-w-0 truncate">
-                        <span className="text-ink-500">{dose.memberName}</span>{" "}
-                        <span className="font-medium">{dose.medicationName}</span>
-                      </span>
-                      <div className="flex items-center gap-2 flex-shrink-0">
-                        <span className="text-xs text-ink-500">{dose.scheduledTime}</span>
-                        {onMarkAsTaken && (
-                          <button
-                            type="button"
-                            onClick={() => handleMarkOne(dose)}
-                            disabled={isRecording || bulkTarget !== null}
-                            aria-label="記録する"
-                            className="flex items-center gap-1 text-xs text-red-700 hover:text-white hover:bg-red-600 disabled:opacity-50 border border-red-300 hover:border-red-600 px-2 py-0.5 rounded transition-colors"
-                          >
-                            {isRecording ? (
-                              <Loader2 size={11} className="animate-spin" />
-                            ) : (
-                              <Check size={11} />
-                            )}
-                            <span>記録</span>
-                          </button>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- 飲み忘れ一覧（`MissedDosesAlert`）を全件フラット表示から日付別の折りたたみ式アコーディオンに変更
- 大量（例: 122件）の飲み忘れでダッシュボードが埋め尽くされる問題を解消
- 初期表示は最新日のみ展開、それ以外は折りたたみ
- ヘッダーに「◯件・◯日分」サマリ、各日付に件数バッジを表示
- 「すべて開く / すべて折りたたむ」トグルを追加（2日分以上のとき）
- 既存操作（「全て記録」「この日全て記録」「記録」）とローディング表示は維持
- カード内をネスト `<button>` にしないよう、行内アクションは `role="button"` で実装