### PR TITLE
feat: 医療費控除の2制度シミュレーション + 明細書CSVエクスポート

### DIFF
--- a/backend/internal/domain/entity/expense.go
+++ b/backend/internal/domain/entity/expense.go
@@ -28,4 +28,8 @@ type ExpenseSummary struct {
 	DeductibleTotal int            `json:"deductibleTotal"`
 	ByCategory      map[string]int `json:"byCategory"`
 	ByMonth         []MonthlyTotal `json:"byMonth"`
+	// 2制度シミュレーション（簡易。所得の5%ルールは所得不明のため10万円固定で概算）
+	RegularDeduction        int    `json:"regularDeduction"`        // 通常医療費控除の控除対象額(10万円超過分)
+	SelfMedicationDeduction int    `json:"selfMedicationDeduction"` // セルフメディケーション税制の控除対象額
+	RecommendedScheme       string `json:"recommendedScheme"`       // "regular" | "selfmed" | "none"
 }

--- a/backend/internal/usecase/expense_usecase.go
+++ b/backend/internal/usecase/expense_usecase.go
@@ -74,7 +74,28 @@ func (uc *ExpenseUsecase) Summary(ctx context.Context, userID string, year int) 
 	if year <= 0 {
 		return nil, domain.NewValidation("集計対象の年を指定してください")
 	}
-	return uc.expenses.Summary(ctx, userID, year)
+	s, err := uc.expenses.Summary(ctx, userID, year)
+	if err != nil {
+		return nil, err
+	}
+	// 2制度シミュレーション（簡易）
+	const (
+		regularThreshold = 100000 // 通常医療費控除の足切り(所得200万未満は所得5%だが所得不明のため固定)
+		selfMedFloor     = 12000  // セルフメディケーション税制の足切り
+		selfMedCap       = 88000  // セルフメディケーション税制の上限
+	)
+	s.RegularDeduction = max(0, s.DeductibleTotal-regularThreshold)
+	pharmacy := s.ByCategory["pharmacy"] // 薬局(OTC)購入分をセルフメディケーション対象の概算に使う
+	s.SelfMedicationDeduction = min(selfMedCap, max(0, pharmacy-selfMedFloor))
+	switch {
+	case s.RegularDeduction == 0 && s.SelfMedicationDeduction == 0:
+		s.RecommendedScheme = "none"
+	case s.RegularDeduction >= s.SelfMedicationDeduction:
+		s.RecommendedScheme = "regular"
+	default:
+		s.RecommendedScheme = "selfmed"
+	}
+	return s, nil
 }
 
 // Create は入力を検証し、不完全/不正なら保存せず ValidationError を返す。

--- a/frontend/app/components/expenses/ExpenseSummaryCard.tsx
+++ b/frontend/app/components/expenses/ExpenseSummaryCard.tsx
@@ -39,7 +39,15 @@ export const ExpenseSummaryCard: React.FC<ExpenseSummaryCardProps> = ({ summary,
     );
   }
 
-  const { year, total, deductibleTotal, byCategory } = summary;
+  const {
+    year,
+    total,
+    deductibleTotal,
+    byCategory,
+    regularDeduction,
+    selfMedicationDeduction,
+    recommendedScheme,
+  } = summary;
   const reachedThreshold = deductibleTotal >= DEDUCTION_THRESHOLD;
   const progressRatio = Math.min(deductibleTotal / DEDUCTION_THRESHOLD, 1);
   const progressPercent = Math.round(progressRatio * 100);
@@ -99,6 +107,49 @@ export const ExpenseSummaryCard: React.FC<ExpenseSummaryCardProps> = ({ summary,
             あと{currencyFormatter.format(DEDUCTION_THRESHOLD - deductibleTotal)}で控除対象
           </p>
         )}
+      </div>
+
+      <div className="space-y-2 border-t border-ink-400/10 pt-3">
+        <p className="text-xs font-semibold text-ink-600">医療費控除シミュレーション（概算）</p>
+        <div className="grid grid-cols-2 gap-2">
+          <div
+            className={`rounded-xl border p-2.5 ${
+              recommendedScheme === "regular"
+                ? "border-primary bg-primary-50"
+                : "border-ink-400/10"
+            }`}
+          >
+            <p className="text-xs text-ink-500">通常医療費控除</p>
+            <p className="mt-0.5 text-sm font-bold text-ink-800">
+              {currencyFormatter.format(regularDeduction)}
+            </p>
+            {recommendedScheme === "regular" && (
+              <span className="mt-1 inline-block rounded-full bg-primary px-2 py-0.5 text-[10px] font-medium text-white">
+                おすすめ
+              </span>
+            )}
+          </div>
+          <div
+            className={`rounded-xl border p-2.5 ${
+              recommendedScheme === "selfmed"
+                ? "border-primary bg-primary-50"
+                : "border-ink-400/10"
+            }`}
+          >
+            <p className="text-xs text-ink-500">セルフメディケーション税制</p>
+            <p className="mt-0.5 text-sm font-bold text-ink-800">
+              {currencyFormatter.format(selfMedicationDeduction)}
+            </p>
+            {recommendedScheme === "selfmed" && (
+              <span className="mt-1 inline-block rounded-full bg-primary px-2 py-0.5 text-[10px] font-medium text-white">
+                おすすめ
+              </span>
+            )}
+          </div>
+        </div>
+        <p className="text-[11px] leading-relaxed text-ink-400">
+          ※2制度は選択適用（併用不可）。所得による足切り(5%)は未考慮の概算です。セルフメディケーションは薬局(OTC)購入分から試算しています。
+        </p>
       </div>
 
       {categoryEntries.length > 0 && (

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -40,6 +40,10 @@ export interface ExpenseSummary {
   deductibleTotal: number;
   byCategory: Record<string, number>;
   byMonth: MonthlyTotal[];
+  // 2制度シミュレーション（簡易）
+  regularDeduction: number;
+  selfMedicationDeduction: number;
+  recommendedScheme: "regular" | "selfmed" | "none";
 }
 
 export interface User {

--- a/frontend/app/routes/expenses.tsx
+++ b/frontend/app/routes/expenses.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, X } from "lucide-react";
+import { Download, Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
 import type { Expense, ExpenseSummary, Member } from "@/lib/types";
 import { SectionTitle } from "@/components/shared/SectionTitle";
@@ -80,6 +80,47 @@ export default function Expenses() {
     deleteMutation.mutate(id);
   };
 
+  // 国税庁「医療費控除の明細書」風の区分にカテゴリをマッピング
+  const TAX_DIVISION: Record<string, string> = {
+    hospital: "診療・治療",
+    checkup: "診療・治療",
+    medication: "医薬品購入",
+    pharmacy: "医薬品購入",
+    transport: "その他の医療費",
+    insurance: "その他の医療費",
+    pet: "その他の医療費",
+    other: "その他の医療費",
+  };
+
+  const memberNameMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const mem of members) m.set(mem.id, mem.name);
+    return m;
+  }, [members]);
+
+  const handleExportCsv = () => {
+    if (expenses.length === 0) return;
+    const esc = (v: string) => `"${v.replace(/"/g, '""')}"`;
+    const header = ["医療を受けた人", "支払先", "医療費の区分", "支払った金額", "支払日", "控除対象"];
+    const rows = expenses.map((e) => [
+      e.memberId ? (memberNameMap.get(e.memberId) ?? "") : "世帯",
+      e.description ?? "",
+      TAX_DIVISION[e.category] ?? "その他の医療費",
+      String(e.amount),
+      e.expenseDate.slice(0, 10),
+      e.isDeductible ? "対象" : "対象外",
+    ]);
+    const csv = [header, ...rows].map((r) => r.map(esc).join(",")).join("\r\n");
+    // Excel での文字化け防止に UTF-8 BOM を付与
+    const blob = new Blob(["﻿" + csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `医療費控除明細書_${year}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="space-y-5">
       <SectionTitle accentColor="primary" size="lg">
@@ -102,6 +143,15 @@ export default function Expenses() {
             </option>
           ))}
         </select>
+        <button
+          onClick={handleExportCsv}
+          disabled={expenses.length === 0}
+          className="ml-auto flex items-center gap-1.5 rounded-xl bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 transition hover:bg-primary-100 disabled:opacity-50"
+          title="医療費控除の明細書(CSV)をダウンロード"
+        >
+          <Download size={16} />
+          明細書CSV
+        </button>
       </div>
 
       <ExpenseSummaryCard summary={summary} isLoading={summaryLoading} />


### PR DESCRIPTION
## Summary
- **2制度シミュレーション**: `/expenses/summary` に概算を追加。`regularDeduction`(通常医療費控除=控除対象の10万円超過分)・`selfMedicationDeduction`(セルフメディケーション=薬局OTC分から1.2万円超〜上限8.8万円)・`recommendedScheme`。SummaryCardで通常 vs セルフメディケーションを並べ、おすすめを強調(選択適用・所得5%未考慮の注記つき)。
- **明細書CSVエクスポート**: `/expenses` に「明細書CSV」ボタン。国税庁「医療費控除の明細書」風カラム(医療を受けた人/支払先/区分/金額/支払日/控除対象)でその年の支出をCSV出力(UTF-8 BOMでExcel文字化け防止)。
- backend `build`/`vet`・frontend `typecheck`/`build` 通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **医療費控除シミュレーション**: 通常医療費控除とセルフメディケーション税制の控除対象額を自動計算し、最適なスキームを提案します。
* **CSV明細書ダウンロード**: 選択期間の支出明細をCSV形式でダウンロードできます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->