### PR TITLE
feat: 医療費の月次予算(パーソナライズ)＋予算消化トラッキング

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -50,6 +50,7 @@ func main() {
 	schedRepo := persistence.NewScheduleRepository(db)
 	recordRepo := persistence.NewMedicationRecordRepository(db)
 	expenseRepo := persistence.NewExpenseRepository(db)
+	budgetRepo := persistence.NewBudgetRepository(db)
 
 	handlers := &router.Handlers{
 		Auth:       handler.NewAuthHandler(usecase.NewAuthUsecase(userRepo, tm, mail)),
@@ -58,6 +59,7 @@ func main() {
 		Schedule:   handler.NewScheduleHandler(usecase.NewScheduleUsecase(schedRepo, medRepo)),
 		Record:     handler.NewRecordHandler(usecase.NewRecordUsecase(recordRepo, medRepo, memberRepo)),
 		Expense:    handler.NewExpenseHandler(usecase.NewExpenseUsecase(expenseRepo, memberRepo)),
+		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(budgetRepo)),
 	}
 
 	engine := router.Setup(handlers, tm, db, cfg.AllowedOrigins)

--- a/backend/internal/domain/entity/budget.go
+++ b/backend/internal/domain/entity/budget.go
@@ -1,0 +1,12 @@
+package entity
+
+import "time"
+
+// Budget は医療費の月次予算（ユーザー単位のパーソナライズ設定）
+type Budget struct {
+	ID            string    `json:"id"`
+	UserID        string    `json:"userId"`
+	MonthlyAmount int       `json:"monthlyAmount"` // 円/月。0は未設定扱い
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}

--- a/backend/internal/domain/repository/budget.go
+++ b/backend/internal/domain/repository/budget.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"context"
+
+	"healthfamily/internal/domain/entity"
+)
+
+// BudgetRepository は月次予算（ユーザー単位）永続化の抽象
+type BudgetRepository interface {
+	Get(ctx context.Context, userID string) (*entity.Budget, error) // 未設定なら nil
+	Upsert(ctx context.Context, userID string, monthlyAmount int) (*entity.Budget, error)
+}

--- a/backend/internal/infrastructure/persistence/budget_repository.go
+++ b/backend/internal/infrastructure/persistence/budget_repository.go
@@ -1,0 +1,51 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/infrastructure/database"
+	"healthfamily/internal/pkg/auth"
+)
+
+// BudgetRepository は "Budget" テーブルの生SQL実装（ユーザー単位の単一行）
+type BudgetRepository struct {
+	db *database.DB
+}
+
+func NewBudgetRepository(db *database.DB) *BudgetRepository {
+	return &BudgetRepository{db: db}
+}
+
+const budgetColumns = `"id", "userId", "monthlyAmount", "createdAt", "updatedAt"`
+
+func scanBudget(row pgx.Row) (*entity.Budget, error) {
+	var b entity.Budget
+	err := row.Scan(&b.ID, &b.UserID, &b.MonthlyAmount, &b.CreatedAt, &b.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+func (r *BudgetRepository) Get(ctx context.Context, userID string) (*entity.Budget, error) {
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+budgetColumns+` FROM "Budget" WHERE "userId"=$1`, userID)
+	return scanBudget(row)
+}
+
+func (r *BudgetRepository) Upsert(ctx context.Context, userID string, monthlyAmount int) (*entity.Budget, error) {
+	id := auth.NewID()
+	row := r.db.Pool.QueryRow(ctx,
+		`INSERT INTO "Budget" ("id", "userId", "monthlyAmount", "createdAt", "updatedAt")
+		 VALUES ($1, $2, $3, now(), now())
+		 ON CONFLICT ("userId") DO UPDATE
+		   SET "monthlyAmount" = EXCLUDED."monthlyAmount", "updatedAt" = now()
+		 RETURNING `+budgetColumns,
+		id, userID, monthlyAmount)
+	return scanBudget(row)
+}

--- a/backend/internal/interface/handler/budget_handler.go
+++ b/backend/internal/interface/handler/budget_handler.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"healthfamily/internal/interface/middleware"
+	"healthfamily/internal/pkg/response"
+	"healthfamily/internal/usecase"
+)
+
+// BudgetHandler は月次予算エンドポイント
+type BudgetHandler struct {
+	uc *usecase.BudgetUsecase
+}
+
+func NewBudgetHandler(uc *usecase.BudgetUsecase) *BudgetHandler {
+	return &BudgetHandler{uc: uc}
+}
+
+func (h *BudgetHandler) Get(c *gin.Context) {
+	userID := middleware.UserID(c)
+	b, err := h.uc.Get(c.Request.Context(), userID)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, b)
+}
+
+type setBudgetRequest struct {
+	MonthlyAmount int `json:"monthlyAmount"`
+}
+
+func (h *BudgetHandler) Set(c *gin.Context) {
+	userID := middleware.UserID(c)
+	var req setBudgetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, 400, "入力内容が正しくありません")
+		return
+	}
+	b, err := h.uc.Set(c.Request.Context(), userID, req.MonthlyAmount)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, b)
+}

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -20,6 +20,7 @@ type Handlers struct {
 	Schedule   *handler.ScheduleHandler
 	Record     *handler.RecordHandler
 	Expense    *handler.ExpenseHandler
+	Budget     *handler.BudgetHandler
 }
 
 // Setup はGinエンジンを構築する
@@ -95,6 +96,10 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 		authed.POST("/expenses", h.Expense.Create)
 		authed.PATCH("/expenses/:expenseId", h.Expense.Update)
 		authed.DELETE("/expenses/:expenseId", h.Expense.Delete)
+
+		// 月次予算（パーソナライズ）
+		authed.GET("/budget", h.Budget.Get)
+		authed.PUT("/budget", h.Budget.Set)
 
 		// 残りリソース（病院・予約・健康ログ・予防接種・検査・保険・アレルギー・
 		// 身体測定・体温・緊急連絡先・処方箋・通知設定・ユーザープロフィール）

--- a/backend/internal/interface/router/router_smoke_test.go
+++ b/backend/internal/interface/router/router_smoke_test.go
@@ -22,6 +22,7 @@ func TestSetupRegistersWithoutPanic(t *testing.T) {
 		Schedule:   handler.NewScheduleHandler(usecase.NewScheduleUsecase(nil, nil)),
 		Record:     handler.NewRecordHandler(usecase.NewRecordUsecase(nil, nil, nil)),
 		Expense:    handler.NewExpenseHandler(usecase.NewExpenseUsecase(nil, nil)),
+		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(nil)),
 	}
 	engine := Setup(h, tm, db, []string{"http://localhost:5173"})
 	if engine == nil {

--- a/backend/internal/usecase/budget_usecase.go
+++ b/backend/internal/usecase/budget_usecase.go
@@ -1,0 +1,38 @@
+package usecase
+
+import (
+	"context"
+
+	"healthfamily/internal/domain"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
+)
+
+// BudgetUsecase は月次予算（パーソナライズ）のビジネスロジック
+type BudgetUsecase struct {
+	budgets repository.BudgetRepository
+}
+
+func NewBudgetUsecase(budgets repository.BudgetRepository) *BudgetUsecase {
+	return &BudgetUsecase{budgets: budgets}
+}
+
+// Get は予算を返す。未設定なら monthlyAmount=0 のデフォルトを返す。
+func (uc *BudgetUsecase) Get(ctx context.Context, userID string) (*entity.Budget, error) {
+	b, err := uc.budgets.Get(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		return &entity.Budget{UserID: userID, MonthlyAmount: 0}, nil
+	}
+	return b, nil
+}
+
+// Set は予算を保存する。不正な金額(負数)は保存させない。
+func (uc *BudgetUsecase) Set(ctx context.Context, userID string, monthlyAmount int) (*entity.Budget, error) {
+	if monthlyAmount < 0 {
+		return nil, domain.NewValidation("予算は0円以上で入力してください")
+	}
+	return uc.budgets.Upsert(ctx, userID, monthlyAmount)
+}

--- a/backend/migrations/0003_budget.sql
+++ b/backend/migrations/0003_budget.sql
@@ -1,0 +1,8 @@
+-- 医療費の月次予算（ユーザー単位のパーソナライズ設定）。既存DBに安全な no-op。
+CREATE TABLE IF NOT EXISTS "Budget" (
+    "id"            TEXT PRIMARY KEY,
+    "userId"        TEXT NOT NULL UNIQUE REFERENCES "User"("id") ON DELETE CASCADE,
+    "monthlyAmount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt"     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updatedAt"     TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/frontend/app/components/expenses/BudgetCard.tsx
+++ b/frontend/app/components/expenses/BudgetCard.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from "react";
+import { PiggyBank, Pencil, Check, X } from "lucide-react";
+import type { Budget, ExpenseSummary } from "@/lib/types";
+import { Card } from "@/components/ui";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+
+const currency = new Intl.NumberFormat("ja-JP", {
+  style: "currency",
+  currency: "JPY",
+  maximumFractionDigits: 0,
+});
+
+const MONTH_LABELS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
+
+interface BudgetCardProps {
+  budget: Budget | undefined;
+  summary: ExpenseSummary | undefined;
+  isLoading: boolean;
+  onSave: (monthlyAmount: number) => void;
+}
+
+export const BudgetCard: React.FC<BudgetCardProps> = ({
+  budget,
+  summary,
+  isLoading,
+  onSave,
+}) => {
+  const monthly = budget?.monthlyAmount ?? 0;
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(String(monthly));
+
+  if (isLoading) {
+    return (
+      <Card>
+        <LoadingSpinner />
+      </Card>
+    );
+  }
+
+  const startEdit = () => {
+    setValue(String(monthly));
+    setEditing(true);
+  };
+
+  const save = () => {
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < 0) return;
+    onSave(Math.floor(n));
+    setEditing(false);
+  };
+
+  // 選択年の月別支出（summary.byMonth）。予算超過月を赤で示す。
+  const byMonth = new Map<number, number>();
+  for (const m of summary?.byMonth ?? []) byMonth.set(m.month, m.total);
+  const maxSpend = Math.max(monthly, ...Array.from(byMonth.values()), 1);
+  const annualBudget = monthly * 12;
+  const annualSpent = summary?.total ?? 0;
+  const annualRatio = annualBudget > 0 ? Math.min(annualSpent / annualBudget, 1) : 0;
+
+  return (
+    <Card className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="flex items-center gap-1.5 text-base font-bold text-ink-800">
+          <PiggyBank size={18} className="text-primary" />
+          月次予算
+        </h3>
+        {!editing && (
+          <button
+            onClick={startEdit}
+            className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-ink-500 transition hover:bg-ink-400/10 hover:text-ink-700"
+          >
+            <Pencil size={13} />
+            {monthly > 0 ? "変更" : "設定"}
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-ink-500">¥</span>
+          <input
+            type="number"
+            min={0}
+            step={1000}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="w-36 rounded-xl border border-ink-400/30 bg-white px-3 py-2 text-sm text-ink-800 outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+            autoFocus
+          />
+          <span className="text-sm text-ink-500">/ 月</span>
+          <button
+            onClick={save}
+            className="ml-auto flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white hover:bg-primary-dark"
+            aria-label="保存"
+          >
+            <Check size={16} />
+          </button>
+          <button
+            onClick={() => setEditing(false)}
+            className="flex h-8 w-8 items-center justify-center rounded-full bg-ink-400/10 text-ink-600 hover:bg-ink-400/20"
+            aria-label="キャンセル"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      ) : monthly === 0 ? (
+        <p className="text-sm text-ink-500">
+          月次予算を設定すると、月別の医療費が予算内かどうかを可視化できます。
+        </p>
+      ) : (
+        <>
+          <div className="flex items-baseline justify-between">
+            <span className="text-2xl font-bold text-ink-800">{currency.format(monthly)}</span>
+            <span className="text-xs text-ink-500">/ 月</span>
+          </div>
+
+          {/* 年間予算の消化 */}
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-xs text-ink-500">
+              <span>{summary?.year}年の消化（年間予算 {currency.format(annualBudget)}）</span>
+              <span>{Math.round(annualRatio * 100)}%</span>
+            </div>
+            <div className="h-2.5 w-full overflow-hidden rounded-full bg-ink-400/10">
+              <div
+                className={`h-full rounded-full ${annualSpent > annualBudget ? "bg-red-400" : "bg-primary"}`}
+                style={{ width: `${Math.round(annualRatio * 100)}%` }}
+              />
+            </div>
+          </div>
+
+          {/* 月別バー（予算超過は赤） */}
+          <div>
+            <p className="mb-1.5 text-xs font-semibold text-ink-600">月別の支出（赤=予算超過）</p>
+            <div className="flex items-end gap-1" style={{ height: 72 }}>
+              {MONTH_LABELS.map((label, i) => {
+                const spend = byMonth.get(i + 1) ?? 0;
+                const h = Math.round((spend / maxSpend) * 60);
+                const over = spend > monthly;
+                return (
+                  <div key={label} className="flex flex-1 flex-col items-center gap-1">
+                    <div
+                      className={`w-full rounded-t ${over ? "bg-red-400" : "bg-primary/70"}`}
+                      style={{ height: `${Math.max(h, spend > 0 ? 3 : 0)}px` }}
+                      title={`${label}月: ${currency.format(spend)}`}
+                    />
+                    <span className="text-[9px] text-ink-400">{label}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+    </Card>
+  );
+};

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -34,6 +34,15 @@ export interface MonthlyTotal {
   total: number;
 }
 
+// 医療費の月次予算（ユーザー単位のパーソナライズ）
+export interface Budget {
+  id: string;
+  userId: string;
+  monthlyAmount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ExpenseSummary {
   year: number;
   total: number;

--- a/frontend/app/routes/expenses.tsx
+++ b/frontend/app/routes/expenses.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Download, Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
-import type { Expense, ExpenseSummary, Member } from "@/lib/types";
+import type { Budget, Expense, ExpenseSummary, Member } from "@/lib/types";
 import { SectionTitle } from "@/components/shared/SectionTitle";
 import { MemberFilter } from "@/components/shared/MemberFilter";
 import { ExpenseForm, type ExpenseFormData } from "@/components/expenses/ExpenseForm";
@@ -11,6 +11,7 @@ import {
   type UpdateExpenseInput,
 } from "@/components/expenses/ExpenseList";
 import { ExpenseSummaryCard } from "@/components/expenses/ExpenseSummaryCard";
+import { BudgetCard } from "@/components/expenses/BudgetCard";
 
 const YEAR_OPTIONS_COUNT = 5;
 
@@ -44,6 +45,17 @@ export default function Expenses() {
   const { data: summary, isLoading: summaryLoading } = useQuery({
     queryKey: ["expenses", "summary", year],
     queryFn: () => api.get<ExpenseSummary>(`/expenses/summary?year=${year}`),
+  });
+
+  const { data: budget, isLoading: budgetLoading } = useQuery({
+    queryKey: ["budget"],
+    queryFn: () => api.get<Budget>("/budget"),
+  });
+
+  const saveBudgetMutation = useMutation({
+    mutationFn: (monthlyAmount: number) =>
+      api.put<Budget>("/budget", { monthlyAmount }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["budget"] }),
   });
 
   const invalidateAll = () => {
@@ -155,6 +167,13 @@ export default function Expenses() {
       </div>
 
       <ExpenseSummaryCard summary={summary} isLoading={summaryLoading} />
+
+      <BudgetCard
+        budget={budget}
+        summary={summary}
+        isLoading={budgetLoading}
+        onSave={(amount) => saveBudgetMutation.mutate(amount)}
+      />
 
       <MemberFilter
         members={members}


### PR DESCRIPTION
## Summary
費用×パーソナライズ機能。ユーザーが自分で月次予算を設定し、医療費の消化を可視化する。
- **バックエンド**: `Budget` リソース + migration `0003`(`"Budget"`テーブル, ユーザー単位 upsert)。`GET /budget`(未設定はデフォルト0)・`PUT /budget`(負数は保存させないバリデーション)。
- **フロント**: `BudgetCard` で月次予算の設定/変更、年間予算の消化バー、**月別支出バー(予算超過は赤)**。`/expenses` に配線。
- backend `build`/`vet`/`test`・frontend `typecheck`/`build` 通過。