### PR TITLE
feat: カテゴリ別予算/超過アラート/ダッシュボード個人化/医師共有PDF/飲み合わせチェック

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -51,6 +51,7 @@ func main() {
 	recordRepo := persistence.NewMedicationRecordRepository(db)
 	expenseRepo := persistence.NewExpenseRepository(db)
 	budgetRepo := persistence.NewBudgetRepository(db)
+	dashboardPrefRepo := persistence.NewDashboardPreferenceRepository(db)
 
 	handlers := &router.Handlers{
 		Auth:       handler.NewAuthHandler(usecase.NewAuthUsecase(userRepo, tm, mail)),
@@ -59,7 +60,8 @@ func main() {
 		Schedule:   handler.NewScheduleHandler(usecase.NewScheduleUsecase(schedRepo, medRepo)),
 		Record:     handler.NewRecordHandler(usecase.NewRecordUsecase(recordRepo, medRepo, memberRepo)),
 		Expense:    handler.NewExpenseHandler(usecase.NewExpenseUsecase(expenseRepo, memberRepo)),
-		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(budgetRepo)),
+		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(budgetRepo, expenseRepo, userRepo, mail)),
+		Dashboard:  handler.NewDashboardPreferenceHandler(usecase.NewDashboardPreferenceUsecase(dashboardPrefRepo)),
 	}
 
 	engine := router.Setup(handlers, tm, db, cfg.AllowedOrigins)

--- a/backend/internal/domain/entity/budget.go
+++ b/backend/internal/domain/entity/budget.go
@@ -2,11 +2,37 @@ package entity
 
 import "time"
 
+// CategoryBudget はカテゴリ別の月次予算
+type CategoryBudget struct {
+	Category      string `json:"category"`
+	MonthlyAmount int    `json:"monthlyAmount"`
+}
+
 // Budget は医療費の月次予算（ユーザー単位のパーソナライズ設定）
 type Budget struct {
-	ID            string    `json:"id"`
-	UserID        string    `json:"userId"`
-	MonthlyAmount int       `json:"monthlyAmount"` // 円/月。0は未設定扱い
-	CreatedAt     time.Time `json:"createdAt"`
-	UpdatedAt     time.Time `json:"updatedAt"`
+	ID               string           `json:"id"`
+	UserID           string           `json:"userId"`
+	MonthlyAmount    int              `json:"monthlyAmount"` // 円/月。0は未設定扱い
+	AlertEnabled     bool             `json:"alertEnabled"`  // 予算超過アラートを有効にするか
+	LastAlertedMonth *string          `json:"lastAlertedMonth"`
+	Categories       []CategoryBudget `json:"categories"`
+	CreatedAt        time.Time        `json:"createdAt"`
+	UpdatedAt        time.Time        `json:"updatedAt"`
+}
+
+// BudgetAlertStatus は当月の予算超過判定結果
+type BudgetAlertStatus struct {
+	OverBudget     bool     `json:"overBudget"`
+	MonthTotal     int      `json:"monthTotal"`
+	MonthlyAmount  int      `json:"monthlyAmount"`
+	OverCategories []string `json:"overCategories"`
+	EmailSent      bool     `json:"emailSent"`
+}
+
+// DashboardPreference はダッシュボードのパーソナライズ設定（ユーザー単位）
+type DashboardPreference struct {
+	UserID          string   `json:"userId"`
+	HiddenCards     []string `json:"hiddenCards"`
+	CardOrder       []string `json:"cardOrder"`
+	DefaultMemberID *string  `json:"defaultMemberId"`
 }

--- a/backend/internal/domain/repository/budget.go
+++ b/backend/internal/domain/repository/budget.go
@@ -6,8 +6,22 @@ import (
 	"healthfamily/internal/domain/entity"
 )
 
-// BudgetRepository は月次予算（ユーザー単位）永続化の抽象
+// SetBudgetInput は予算保存入力（カテゴリ別はこの内容で置き換え）
+type SetBudgetInput struct {
+	MonthlyAmount int
+	AlertEnabled  bool
+	Categories    []entity.CategoryBudget
+}
+
+// BudgetRepository は月次予算（ユーザー単位、カテゴリ別含む）永続化の抽象
 type BudgetRepository interface {
-	Get(ctx context.Context, userID string) (*entity.Budget, error) // 未設定なら nil
-	Upsert(ctx context.Context, userID string, monthlyAmount int) (*entity.Budget, error)
+	Get(ctx context.Context, userID string) (*entity.Budget, error) // categories を含む。未設定なら nil
+	Set(ctx context.Context, userID string, in SetBudgetInput) (*entity.Budget, error)
+	MarkAlerted(ctx context.Context, userID, month string) error
+}
+
+// DashboardPreferenceRepository はダッシュボード設定（ユーザー単位）永続化の抽象
+type DashboardPreferenceRepository interface {
+	Get(ctx context.Context, userID string) (*entity.DashboardPreference, error) // 未設定なら nil
+	Upsert(ctx context.Context, userID string, hiddenCards, cardOrder []string, defaultMemberID *string) (*entity.DashboardPreference, error)
 }

--- a/backend/internal/infrastructure/persistence/budget_repository.go
+++ b/backend/internal/infrastructure/persistence/budget_repository.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
 	"healthfamily/internal/infrastructure/database"
 	"healthfamily/internal/pkg/auth"
 )
 
-// BudgetRepository は "Budget" テーブルの生SQL実装（ユーザー単位の単一行）
+// BudgetRepository は "Budget" / "CategoryBudget" テーブルの生SQL実装
 type BudgetRepository struct {
 	db *database.DB
 }
@@ -19,11 +20,11 @@ func NewBudgetRepository(db *database.DB) *BudgetRepository {
 	return &BudgetRepository{db: db}
 }
 
-const budgetColumns = `"id", "userId", "monthlyAmount", "createdAt", "updatedAt"`
+const budgetColumns = `"id", "userId", "monthlyAmount", "alertEnabled", "lastAlertedMonth", "createdAt", "updatedAt"`
 
 func scanBudget(row pgx.Row) (*entity.Budget, error) {
 	var b entity.Budget
-	err := row.Scan(&b.ID, &b.UserID, &b.MonthlyAmount, &b.CreatedAt, &b.UpdatedAt)
+	err := row.Scan(&b.ID, &b.UserID, &b.MonthlyAmount, &b.AlertEnabled, &b.LastAlertedMonth, &b.CreatedAt, &b.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -33,19 +34,84 @@ func scanBudget(row pgx.Row) (*entity.Budget, error) {
 	return &b, nil
 }
 
-func (r *BudgetRepository) Get(ctx context.Context, userID string) (*entity.Budget, error) {
-	row := r.db.Pool.QueryRow(ctx, `SELECT `+budgetColumns+` FROM "Budget" WHERE "userId"=$1`, userID)
-	return scanBudget(row)
+func (r *BudgetRepository) loadCategories(ctx context.Context, userID string) ([]entity.CategoryBudget, error) {
+	rows, err := r.db.Pool.Query(ctx,
+		`SELECT "category", "monthlyAmount" FROM "CategoryBudget" WHERE "userId"=$1 ORDER BY "category"`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	list := make([]entity.CategoryBudget, 0)
+	for rows.Next() {
+		var c entity.CategoryBudget
+		if err := rows.Scan(&c.Category, &c.MonthlyAmount); err != nil {
+			return nil, err
+		}
+		list = append(list, c)
+	}
+	return list, rows.Err()
 }
 
-func (r *BudgetRepository) Upsert(ctx context.Context, userID string, monthlyAmount int) (*entity.Budget, error) {
+func (r *BudgetRepository) Get(ctx context.Context, userID string) (*entity.Budget, error) {
+	row := r.db.Pool.QueryRow(ctx, `SELECT `+budgetColumns+` FROM "Budget" WHERE "userId"=$1`, userID)
+	b, err := scanBudget(row)
+	if err != nil || b == nil {
+		return b, err
+	}
+	cats, err := r.loadCategories(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	b.Categories = cats
+	return b, nil
+}
+
+func (r *BudgetRepository) Set(ctx context.Context, userID string, in repository.SetBudgetInput) (*entity.Budget, error) {
+	tx, err := r.db.Pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
 	id := auth.NewID()
-	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO "Budget" ("id", "userId", "monthlyAmount", "createdAt", "updatedAt")
-		 VALUES ($1, $2, $3, now(), now())
+	row := tx.QueryRow(ctx,
+		`INSERT INTO "Budget" ("id", "userId", "monthlyAmount", "alertEnabled", "createdAt", "updatedAt")
+		 VALUES ($1, $2, $3, $4, now(), now())
 		 ON CONFLICT ("userId") DO UPDATE
-		   SET "monthlyAmount" = EXCLUDED."monthlyAmount", "updatedAt" = now()
+		   SET "monthlyAmount" = EXCLUDED."monthlyAmount",
+		       "alertEnabled" = EXCLUDED."alertEnabled",
+		       "updatedAt" = now()
 		 RETURNING `+budgetColumns,
-		id, userID, monthlyAmount)
-	return scanBudget(row)
+		id, userID, in.MonthlyAmount, in.AlertEnabled)
+	b, err := scanBudget(row)
+	if err != nil {
+		return nil, err
+	}
+
+	// カテゴリ別予算は指定内容で置き換え
+	if _, err := tx.Exec(ctx, `DELETE FROM "CategoryBudget" WHERE "userId"=$1`, userID); err != nil {
+		return nil, err
+	}
+	for _, c := range in.Categories {
+		if c.MonthlyAmount <= 0 {
+			continue
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO "CategoryBudget" ("id", "userId", "category", "monthlyAmount", "createdAt", "updatedAt")
+			 VALUES ($1,$2,$3,$4, now(), now())`,
+			auth.NewID(), userID, c.Category, c.MonthlyAmount); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	b.Categories, err = r.loadCategories(ctx, userID)
+	return b, err
+}
+
+func (r *BudgetRepository) MarkAlerted(ctx context.Context, userID, month string) error {
+	_, err := r.db.Pool.Exec(ctx,
+		`UPDATE "Budget" SET "lastAlertedMonth"=$2, "updatedAt"=now() WHERE "userId"=$1`, userID, month)
+	return err
 }

--- a/backend/internal/infrastructure/persistence/dashboard_preference_repository.go
+++ b/backend/internal/infrastructure/persistence/dashboard_preference_repository.go
@@ -1,0 +1,59 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/infrastructure/database"
+	"healthfamily/internal/pkg/auth"
+)
+
+// DashboardPreferenceRepository は "DashboardPreference" テーブルの生SQL実装（ユーザー単位の単一行）
+type DashboardPreferenceRepository struct {
+	db *database.DB
+}
+
+func NewDashboardPreferenceRepository(db *database.DB) *DashboardPreferenceRepository {
+	return &DashboardPreferenceRepository{db: db}
+}
+
+func (r *DashboardPreferenceRepository) Get(ctx context.Context, userID string) (*entity.DashboardPreference, error) {
+	var p entity.DashboardPreference
+	err := r.db.Pool.QueryRow(ctx,
+		`SELECT "userId", "hiddenCards", "cardOrder", "defaultMemberId" FROM "DashboardPreference" WHERE "userId"=$1`,
+		userID).Scan(&p.UserID, &p.HiddenCards, &p.CardOrder, &p.DefaultMemberID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *DashboardPreferenceRepository) Upsert(ctx context.Context, userID string, hiddenCards, cardOrder []string, defaultMemberID *string) (*entity.DashboardPreference, error) {
+	if hiddenCards == nil {
+		hiddenCards = []string{}
+	}
+	if cardOrder == nil {
+		cardOrder = []string{}
+	}
+	var p entity.DashboardPreference
+	err := r.db.Pool.QueryRow(ctx,
+		`INSERT INTO "DashboardPreference" ("id", "userId", "hiddenCards", "cardOrder", "defaultMemberId", "createdAt", "updatedAt")
+		 VALUES ($1,$2,$3,$4,$5, now(), now())
+		 ON CONFLICT ("userId") DO UPDATE
+		   SET "hiddenCards"=EXCLUDED."hiddenCards",
+		       "cardOrder"=EXCLUDED."cardOrder",
+		       "defaultMemberId"=EXCLUDED."defaultMemberId",
+		       "updatedAt"=now()
+		 RETURNING "userId", "hiddenCards", "cardOrder", "defaultMemberId"`,
+		auth.NewID(), userID, hiddenCards, cardOrder, defaultMemberID).
+		Scan(&p.UserID, &p.HiddenCards, &p.CardOrder, &p.DefaultMemberID)
+	if err != nil {
+		return nil, err
+	}
+	return &p, nil
+}

--- a/backend/internal/interface/handler/budget_handler.go
+++ b/backend/internal/interface/handler/budget_handler.go
@@ -2,12 +2,14 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
 	"healthfamily/internal/interface/middleware"
 	"healthfamily/internal/pkg/response"
 	"healthfamily/internal/usecase"
 )
 
-// BudgetHandler は月次予算エンドポイント
+// BudgetHandler は月次予算・カテゴリ別予算・予算超過アラートのエンドポイント
 type BudgetHandler struct {
 	uc *usecase.BudgetUsecase
 }
@@ -26,8 +28,15 @@ func (h *BudgetHandler) Get(c *gin.Context) {
 	response.Success(c, b)
 }
 
+type categoryBudgetReq struct {
+	Category      string `json:"category"`
+	MonthlyAmount int    `json:"monthlyAmount"`
+}
+
 type setBudgetRequest struct {
-	MonthlyAmount int `json:"monthlyAmount"`
+	MonthlyAmount int                 `json:"monthlyAmount"`
+	AlertEnabled  *bool               `json:"alertEnabled"`
+	Categories    []categoryBudgetReq `json:"categories"`
 }
 
 func (h *BudgetHandler) Set(c *gin.Context) {
@@ -37,10 +46,33 @@ func (h *BudgetHandler) Set(c *gin.Context) {
 		response.Error(c, 400, "入力内容が正しくありません")
 		return
 	}
-	b, err := h.uc.Set(c.Request.Context(), userID, req.MonthlyAmount)
+	alertEnabled := true
+	if req.AlertEnabled != nil {
+		alertEnabled = *req.AlertEnabled
+	}
+	cats := make([]entity.CategoryBudget, 0, len(req.Categories))
+	for _, c := range req.Categories {
+		cats = append(cats, entity.CategoryBudget{Category: c.Category, MonthlyAmount: c.MonthlyAmount})
+	}
+	b, err := h.uc.Set(c.Request.Context(), userID, repository.SetBudgetInput{
+		MonthlyAmount: req.MonthlyAmount,
+		AlertEnabled:  alertEnabled,
+		Categories:    cats,
+	})
 	if err != nil {
 		response.HandleDomainError(c, err)
 		return
 	}
 	response.Success(c, b)
+}
+
+// Alert は当月の予算超過を判定し、必要ならメール通知する。
+func (h *BudgetHandler) Alert(c *gin.Context) {
+	userID := middleware.UserID(c)
+	status, err := h.uc.CheckAlert(c.Request.Context(), userID)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, status)
 }

--- a/backend/internal/interface/handler/dashboard_preference_handler.go
+++ b/backend/internal/interface/handler/dashboard_preference_handler.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"healthfamily/internal/interface/middleware"
+	"healthfamily/internal/pkg/response"
+	"healthfamily/internal/usecase"
+)
+
+// DashboardPreferenceHandler はダッシュボードのパーソナライズ設定エンドポイント
+type DashboardPreferenceHandler struct {
+	uc *usecase.DashboardPreferenceUsecase
+}
+
+func NewDashboardPreferenceHandler(uc *usecase.DashboardPreferenceUsecase) *DashboardPreferenceHandler {
+	return &DashboardPreferenceHandler{uc: uc}
+}
+
+func (h *DashboardPreferenceHandler) Get(c *gin.Context) {
+	userID := middleware.UserID(c)
+	p, err := h.uc.Get(c.Request.Context(), userID)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, p)
+}
+
+type setDashboardPrefRequest struct {
+	HiddenCards     []string `json:"hiddenCards"`
+	CardOrder       []string `json:"cardOrder"`
+	DefaultMemberID *string  `json:"defaultMemberId"`
+}
+
+func (h *DashboardPreferenceHandler) Set(c *gin.Context) {
+	userID := middleware.UserID(c)
+	var req setDashboardPrefRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, 400, "入力内容が正しくありません")
+		return
+	}
+	p, err := h.uc.Set(c.Request.Context(), userID, req.HiddenCards, req.CardOrder, req.DefaultMemberID)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, p)
+}

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -21,6 +21,7 @@ type Handlers struct {
 	Record     *handler.RecordHandler
 	Expense    *handler.ExpenseHandler
 	Budget     *handler.BudgetHandler
+	Dashboard  *handler.DashboardPreferenceHandler
 }
 
 // Setup はGinエンジンを構築する
@@ -97,9 +98,14 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 		authed.PATCH("/expenses/:expenseId", h.Expense.Update)
 		authed.DELETE("/expenses/:expenseId", h.Expense.Delete)
 
-		// 月次予算（パーソナライズ）
+		// 月次予算（カテゴリ別・アラート含むパーソナライズ）
 		authed.GET("/budget", h.Budget.Get)
 		authed.PUT("/budget", h.Budget.Set)
+		authed.POST("/budget/alert", h.Budget.Alert)
+
+		// ダッシュボードのパーソナライズ設定
+		authed.GET("/dashboard-preferences", h.Dashboard.Get)
+		authed.PUT("/dashboard-preferences", h.Dashboard.Set)
 
 		// 残りリソース（病院・予約・健康ログ・予防接種・検査・保険・アレルギー・
 		// 身体測定・体温・緊急連絡先・処方箋・通知設定・ユーザープロフィール）

--- a/backend/internal/interface/router/router_smoke_test.go
+++ b/backend/internal/interface/router/router_smoke_test.go
@@ -22,7 +22,8 @@ func TestSetupRegistersWithoutPanic(t *testing.T) {
 		Schedule:   handler.NewScheduleHandler(usecase.NewScheduleUsecase(nil, nil)),
 		Record:     handler.NewRecordHandler(usecase.NewRecordUsecase(nil, nil, nil)),
 		Expense:    handler.NewExpenseHandler(usecase.NewExpenseUsecase(nil, nil)),
-		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(nil)),
+		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(nil, nil, nil, mailer.NewResendMailer("", ""))),
+		Dashboard:  handler.NewDashboardPreferenceHandler(usecase.NewDashboardPreferenceUsecase(nil)),
 	}
 	engine := Setup(h, tm, db, []string{"http://localhost:5173"})
 	if engine == nil {

--- a/backend/internal/pkg/mailer/mailer.go
+++ b/backend/internal/pkg/mailer/mailer.go
@@ -13,6 +13,7 @@ import (
 type Mailer interface {
 	SendVerificationCode(ctx context.Context, to, code string) error
 	SendResetCode(ctx context.Context, to, code string) error
+	SendBudgetAlert(ctx context.Context, to, monthLabel string, monthTotal, monthlyBudget int) error
 }
 
 // ResendMailer は Resend API を使ったメール送信実装
@@ -60,4 +61,11 @@ func (m *ResendMailer) SendVerificationCode(ctx context.Context, to, code string
 func (m *ResendMailer) SendResetCode(ctx context.Context, to, code string) error {
 	html := fmt.Sprintf(`<p>HealthFamily パスワード再設定コード: <strong>%s</strong></p><p>10分以内に入力してください。</p>`, code)
 	return m.send(ctx, to, "HealthFamily パスワード再設定", html)
+}
+
+func (m *ResendMailer) SendBudgetAlert(ctx context.Context, to, monthLabel string, monthTotal, monthlyBudget int) error {
+	html := fmt.Sprintf(
+		`<p>%s の医療費が月次予算を超えました。</p><p>今月の医療費: <strong>%d円</strong> / 予算: %d円</p><p>HealthFamily で内訳をご確認ください。</p>`,
+		monthLabel, monthTotal, monthlyBudget)
+	return m.send(ctx, to, "HealthFamily 予算超過のお知らせ", html)
 }

--- a/backend/internal/usecase/budget_usecase.go
+++ b/backend/internal/usecase/budget_usecase.go
@@ -2,37 +2,103 @@ package usecase
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"healthfamily/internal/domain"
 	"healthfamily/internal/domain/entity"
 	"healthfamily/internal/domain/repository"
+	"healthfamily/internal/pkg/mailer"
 )
 
-// BudgetUsecase は月次予算（パーソナライズ）のビジネスロジック
+var jst = time.FixedZone("Asia/Tokyo", 9*60*60)
+
+// BudgetUsecase は月次予算（パーソナライズ）と予算超過アラートのビジネスロジック
 type BudgetUsecase struct {
-	budgets repository.BudgetRepository
+	budgets  repository.BudgetRepository
+	expenses repository.ExpenseRepository
+	users    repository.UserRepository
+	mail     mailer.Mailer
+	now      func() time.Time
 }
 
-func NewBudgetUsecase(budgets repository.BudgetRepository) *BudgetUsecase {
-	return &BudgetUsecase{budgets: budgets}
+func NewBudgetUsecase(budgets repository.BudgetRepository, expenses repository.ExpenseRepository, users repository.UserRepository, mail mailer.Mailer) *BudgetUsecase {
+	return &BudgetUsecase{budgets: budgets, expenses: expenses, users: users, mail: mail, now: time.Now}
 }
 
-// Get は予算を返す。未設定なら monthlyAmount=0 のデフォルトを返す。
+// Get は予算を返す。未設定なら既定値(0円・アラート有効)を返す。
 func (uc *BudgetUsecase) Get(ctx context.Context, userID string) (*entity.Budget, error) {
 	b, err := uc.budgets.Get(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
 	if b == nil {
-		return &entity.Budget{UserID: userID, MonthlyAmount: 0}, nil
+		return &entity.Budget{UserID: userID, MonthlyAmount: 0, AlertEnabled: true, Categories: []entity.CategoryBudget{}}, nil
 	}
 	return b, nil
 }
 
-// Set は予算を保存する。不正な金額(負数)は保存させない。
-func (uc *BudgetUsecase) Set(ctx context.Context, userID string, monthlyAmount int) (*entity.Budget, error) {
-	if monthlyAmount < 0 {
+// Set は予算（総額・カテゴリ別・アラート設定）を保存する。負の金額は保存させない。
+func (uc *BudgetUsecase) Set(ctx context.Context, userID string, in repository.SetBudgetInput) (*entity.Budget, error) {
+	if in.MonthlyAmount < 0 {
 		return nil, domain.NewValidation("予算は0円以上で入力してください")
 	}
-	return uc.budgets.Upsert(ctx, userID, monthlyAmount)
+	for _, c := range in.Categories {
+		if c.MonthlyAmount < 0 {
+			return nil, domain.NewValidation("カテゴリ予算は0円以上で入力してください")
+		}
+	}
+	return uc.budgets.Set(ctx, userID, in)
+}
+
+// CheckAlert は当月の支出が予算（総額/カテゴリ別）を超えているか判定し、
+// 有効かつ当月未通知なら一度だけメールを送る。
+func (uc *BudgetUsecase) CheckAlert(ctx context.Context, userID string) (*entity.BudgetAlertStatus, error) {
+	b, err := uc.Get(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	now := uc.now().In(jst)
+	year, month := now.Year(), int(now.Month())
+
+	exps, err := uc.expenses.List(ctx, userID, repository.ExpenseFilter{Year: year})
+	if err != nil {
+		return nil, err
+	}
+	monthTotal := 0
+	perCat := map[string]int{}
+	for _, e := range exps {
+		if int(e.ExpenseDate.In(jst).Month()) != month {
+			continue
+		}
+		monthTotal += e.Amount
+		perCat[e.Category] += e.Amount
+	}
+
+	overCats := make([]string, 0)
+	for _, c := range b.Categories {
+		if c.MonthlyAmount > 0 && perCat[c.Category] > c.MonthlyAmount {
+			overCats = append(overCats, c.Category)
+		}
+	}
+	overTotal := b.MonthlyAmount > 0 && monthTotal > b.MonthlyAmount
+	status := &entity.BudgetAlertStatus{
+		OverBudget:     overTotal || len(overCats) > 0,
+		MonthTotal:     monthTotal,
+		MonthlyAmount:  b.MonthlyAmount,
+		OverCategories: overCats,
+	}
+
+	monthKey := fmt.Sprintf("%04d-%02d", year, month)
+	alreadyAlerted := b.LastAlertedMonth != nil && *b.LastAlertedMonth == monthKey
+	if status.OverBudget && b.AlertEnabled && !alreadyAlerted {
+		if u, e := uc.users.FindByID(ctx, userID); e == nil && u != nil {
+			// メール送信は best-effort（失敗してもアラート表示は行う）
+			_ = uc.mail.SendBudgetAlert(ctx, u.Email, monthKey, monthTotal, b.MonthlyAmount)
+		}
+		if e := uc.budgets.MarkAlerted(ctx, userID, monthKey); e == nil {
+			status.EmailSent = true
+		}
+	}
+	return status, nil
 }

--- a/backend/internal/usecase/dashboard_preference_usecase.go
+++ b/backend/internal/usecase/dashboard_preference_usecase.go
@@ -1,0 +1,37 @@
+package usecase
+
+import (
+	"context"
+
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
+)
+
+// DashboardPreferenceUsecase はダッシュボードのパーソナライズ設定
+type DashboardPreferenceUsecase struct {
+	prefs repository.DashboardPreferenceRepository
+}
+
+func NewDashboardPreferenceUsecase(prefs repository.DashboardPreferenceRepository) *DashboardPreferenceUsecase {
+	return &DashboardPreferenceUsecase{prefs: prefs}
+}
+
+// Get は設定を返す。未設定なら既定値（全カード表示・既定メンバーなし）。
+func (uc *DashboardPreferenceUsecase) Get(ctx context.Context, userID string) (*entity.DashboardPreference, error) {
+	p, err := uc.prefs.Get(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return &entity.DashboardPreference{UserID: userID, HiddenCards: []string{}, CardOrder: []string{}}, nil
+	}
+	return p, nil
+}
+
+// Set は設定を保存する。
+func (uc *DashboardPreferenceUsecase) Set(ctx context.Context, userID string, hiddenCards, cardOrder []string, defaultMemberID *string) (*entity.DashboardPreference, error) {
+	if defaultMemberID != nil && *defaultMemberID == "" {
+		defaultMemberID = nil
+	}
+	return uc.prefs.Upsert(ctx, userID, hiddenCards, cardOrder, defaultMemberID)
+}

--- a/backend/migrations/0004_budget_personalization.sql
+++ b/backend/migrations/0004_budget_personalization.sql
@@ -1,0 +1,28 @@
+-- 予算のパーソナライズ拡張（カテゴリ別予算・アラート設定）とダッシュボード設定。既存DBに安全な no-op。
+
+-- 既存 Budget にアラート設定と最終アラート月を追加
+ALTER TABLE "Budget" ADD COLUMN IF NOT EXISTS "alertEnabled" BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE "Budget" ADD COLUMN IF NOT EXISTS "lastAlertedMonth" TEXT; -- "YYYY-MM"
+
+-- カテゴリ別の月次予算
+CREATE TABLE IF NOT EXISTS "CategoryBudget" (
+    "id"            TEXT PRIMARY KEY,
+    "userId"        TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "category"      TEXT NOT NULL,
+    "monthlyAmount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt"     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updatedAt"     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE ("userId", "category")
+);
+CREATE INDEX IF NOT EXISTS "CategoryBudget_userId_idx" ON "CategoryBudget"("userId");
+
+-- ダッシュボードのパーソナライズ設定（ユーザー単位）
+CREATE TABLE IF NOT EXISTS "DashboardPreference" (
+    "id"              TEXT PRIMARY KEY,
+    "userId"          TEXT NOT NULL UNIQUE REFERENCES "User"("id") ON DELETE CASCADE,
+    "hiddenCards"     TEXT[] NOT NULL DEFAULT '{}',
+    "cardOrder"       TEXT[] NOT NULL DEFAULT '{}',
+    "defaultMemberId" TEXT,
+    "createdAt"       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    "updatedAt"       TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/frontend/app/components/dashboard/DashboardSettings.tsx
+++ b/frontend/app/components/dashboard/DashboardSettings.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ArrowDown, ArrowUp, Check, Eye, EyeOff, X } from "lucide-react";
+import { api } from "@/lib/api";
+import type { DashboardPreference, Member } from "@/lib/types";
+import { Button, Card, ErrorText } from "@/components/ui";
+
+// ダッシュボードで制御可能なカード(greeting は常時表示のため対象外)
+export const DASHBOARD_CARD_KEYS = [
+  "weeklySummary",
+  "missedDoses",
+  "todaySchedule",
+  "stockAlerts",
+  "adherence",
+  "upcomingAppointments",
+] as const;
+
+export type DashboardCardKey = (typeof DASHBOARD_CARD_KEYS)[number];
+
+// 並び替え対象となる下部カード
+export const ORDERABLE_CARD_KEYS: readonly DashboardCardKey[] = [
+  "stockAlerts",
+  "adherence",
+  "upcomingAppointments",
+];
+
+const CARD_LABELS: Record<DashboardCardKey, string> = {
+  weeklySummary: "今週のサマリー",
+  missedDoses: "飲み忘れアラート",
+  todaySchedule: "今日の予定",
+  stockAlerts: "在庫アラート",
+  adherence: "服薬達成率",
+  upcomingAppointments: "次回の通院予定",
+};
+
+interface DashboardSettingsProps {
+  preference: DashboardPreference;
+  members: Member[];
+  onClose: () => void;
+}
+
+export function DashboardSettings({ preference, members, onClose }: DashboardSettingsProps) {
+  const qc = useQueryClient();
+
+  const [hiddenCards, setHiddenCards] = useState<string[]>(preference.hiddenCards);
+  const [defaultMemberId, setDefaultMemberId] = useState<string | null>(
+    preference.defaultMemberId,
+  );
+  // 並び替え対象キーのみを安定順序で保持する
+  const [order, setOrder] = useState<DashboardCardKey[]>(() =>
+    buildOrder(preference.cardOrder),
+  );
+
+  // preference が外部更新された場合に追従する
+  useEffect(() => {
+    setHiddenCards(preference.hiddenCards);
+    setDefaultMemberId(preference.defaultMemberId);
+    setOrder(buildOrder(preference.cardOrder));
+  }, [preference]);
+
+  const hiddenSet = useMemo(() => new Set(hiddenCards), [hiddenCards]);
+
+  const mutation = useMutation({
+    mutationFn: (input: {
+      hiddenCards: string[];
+      cardOrder: string[];
+      defaultMemberId: string | null;
+    }) => api.put<DashboardPreference>("/dashboard-preferences", input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dashboard-preferences"] });
+      onClose();
+    },
+  });
+
+  const toggleCard = (key: DashboardCardKey) => {
+    setHiddenCards((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    );
+  };
+
+  const moveCard = (index: number, direction: -1 | 1) => {
+    setOrder((prev) => {
+      const next = [...prev];
+      const target = index + direction;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    mutation.mutate({
+      hiddenCards,
+      cardOrder: order,
+      defaultMemberId,
+    });
+  };
+
+  return (
+    <Card className="space-y-5">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-bold text-ink-800">ダッシュボードの表示設定</h2>
+        <button
+          onClick={onClose}
+          className="rounded-full p-1.5 text-ink-400 transition hover:bg-primary-50 hover:text-ink-700"
+          aria-label="閉じる"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* 表示/非表示トグル */}
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-ink-700">表示するカード</h3>
+        <ul className="space-y-1.5">
+          {DASHBOARD_CARD_KEYS.map((key) => {
+            const visible = !hiddenSet.has(key);
+            return (
+              <li key={key}>
+                <button
+                  type="button"
+                  onClick={() => toggleCard(key)}
+                  className="flex w-full items-center justify-between rounded-xl border border-ink-400/10 bg-white px-3.5 py-2.5 text-sm text-ink-800 transition hover:bg-primary-50"
+                  aria-pressed={visible}
+                >
+                  <span className={visible ? "" : "text-ink-400 line-through"}>
+                    {CARD_LABELS[key]}
+                  </span>
+                  {visible ? (
+                    <span className="flex items-center gap-1 text-primary-700">
+                      <Eye size={16} />
+                      <span className="text-xs font-medium">表示</span>
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 text-ink-400">
+                      <EyeOff size={16} />
+                      <span className="text-xs font-medium">非表示</span>
+                    </span>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      {/* 既定メンバー */}
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-ink-700">既定の表示メンバー</h3>
+        <select
+          value={defaultMemberId ?? ""}
+          onChange={(e) => setDefaultMemberId(e.target.value === "" ? null : e.target.value)}
+          className="w-full rounded-xl border border-ink-400/30 bg-white px-3.5 py-2.5 text-sm text-ink-800 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+          aria-label="既定の表示メンバー"
+        >
+          <option value="">指定しない(全員)</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      {/* 並び替え */}
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-ink-700">下部カードの並び順</h3>
+        <ul className="space-y-1.5">
+          {order.map((key, index) => (
+            <li
+              key={key}
+              className="flex items-center justify-between rounded-xl border border-ink-400/10 bg-white px-3.5 py-2.5 text-sm text-ink-800"
+            >
+              <span>{CARD_LABELS[key]}</span>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => moveCard(index, -1)}
+                  disabled={index === 0}
+                  className="rounded-lg p-1.5 text-ink-600 transition hover:bg-primary-50 disabled:opacity-30"
+                  aria-label={`${CARD_LABELS[key]}を上へ`}
+                >
+                  <ArrowUp size={16} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => moveCard(index, 1)}
+                  disabled={index === order.length - 1}
+                  className="rounded-lg p-1.5 text-ink-600 transition hover:bg-primary-50 disabled:opacity-30"
+                  aria-label={`${CARD_LABELS[key]}を下へ`}
+                >
+                  <ArrowDown size={16} />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {mutation.isError && (
+        <ErrorText>
+          {mutation.error instanceof Error
+            ? mutation.error.message
+            : "保存に失敗しました"}
+        </ErrorText>
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+          キャンセル
+        </Button>
+        <Button onClick={handleSave} disabled={mutation.isPending}>
+          <Check size={16} />
+          {mutation.isPending ? "保存中..." : "保存"}
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+// 保存済みの cardOrder を基に、並び替え対象キーの順序を確定する。
+// 未知キーは無視し、欠落キーは既定順序の末尾に補完する。
+function buildOrder(savedOrder: string[]): DashboardCardKey[] {
+  const orderable = new Set<DashboardCardKey>(ORDERABLE_CARD_KEYS);
+  const result: DashboardCardKey[] = [];
+  for (const key of savedOrder) {
+    if (orderable.has(key as DashboardCardKey) && !result.includes(key as DashboardCardKey)) {
+      result.push(key as DashboardCardKey);
+    }
+  }
+  for (const key of ORDERABLE_CARD_KEYS) {
+    if (!result.includes(key)) result.push(key);
+  }
+  return result;
+}

--- a/frontend/app/components/expenses/BudgetCard.tsx
+++ b/frontend/app/components/expenses/BudgetCard.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
-import { PiggyBank, Pencil, Check, X } from "lucide-react";
-import type { Budget, ExpenseSummary } from "@/lib/types";
+import React, { useMemo, useState } from "react";
+import { PiggyBank, Pencil, Check, X, Bell, BellOff } from "lucide-react";
+import type { Budget, CategoryBudget, ExpenseSummary } from "@/lib/types";
 import { Card } from "@/components/ui";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { EXPENSE_CATEGORIES } from "@/components/expenses/ExpenseForm";
 
 const currency = new Intl.NumberFormat("ja-JP", {
   style: "currency",
@@ -12,11 +13,17 @@ const currency = new Intl.NumberFormat("ja-JP", {
 
 const MONTH_LABELS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"];
 
+export interface BudgetSavePayload {
+  monthlyAmount: number;
+  alertEnabled: boolean;
+  categories: CategoryBudget[];
+}
+
 interface BudgetCardProps {
   budget: Budget | undefined;
   summary: ExpenseSummary | undefined;
   isLoading: boolean;
-  onSave: (monthlyAmount: number) => void;
+  onSave: (payload: BudgetSavePayload) => void;
 }
 
 export const BudgetCard: React.FC<BudgetCardProps> = ({
@@ -26,8 +33,19 @@ export const BudgetCard: React.FC<BudgetCardProps> = ({
   onSave,
 }) => {
   const monthly = budget?.monthlyAmount ?? 0;
+  const alertEnabled = budget?.alertEnabled ?? false;
+
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(String(monthly));
+  const [alert, setAlert] = useState(alertEnabled);
+  // カテゴリ別予算の編集状態（カテゴリ値 -> 入力文字列）
+  const [catValues, setCatValues] = useState<Record<string, string>>({});
+
+  const budgetCatMap = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const c of budget?.categories ?? []) m.set(c.category, c.monthlyAmount);
+    return m;
+  }, [budget?.categories]);
 
   if (isLoading) {
     return (
@@ -39,13 +57,30 @@ export const BudgetCard: React.FC<BudgetCardProps> = ({
 
   const startEdit = () => {
     setValue(String(monthly));
+    setAlert(alertEnabled);
+    const initial: Record<string, string> = {};
+    for (const c of EXPENSE_CATEGORIES) {
+      const amt = budgetCatMap.get(c.value) ?? 0;
+      initial[c.value] = amt > 0 ? String(amt) : "";
+    }
+    setCatValues(initial);
     setEditing(true);
   };
 
   const save = () => {
     const n = Number(value);
     if (!Number.isFinite(n) || n < 0) return;
-    onSave(Math.floor(n));
+
+    const categories: CategoryBudget[] = [];
+    for (const c of EXPENSE_CATEGORIES) {
+      const raw = catValues[c.value] ?? "";
+      if (raw === "") continue;
+      const cn = Number(raw);
+      if (!Number.isFinite(cn) || cn <= 0) continue;
+      categories.push({ category: c.value, monthlyAmount: Math.floor(cn) });
+    }
+
+    onSave({ monthlyAmount: Math.floor(n), alertEnabled: alert, categories });
     setEditing(false);
   };
 
@@ -56,6 +91,12 @@ export const BudgetCard: React.FC<BudgetCardProps> = ({
   const annualBudget = monthly * 12;
   const annualSpent = summary?.total ?? 0;
   const annualRatio = annualBudget > 0 ? Math.min(annualSpent / annualBudget, 1) : 0;
+
+  // カテゴリ別の年間使用額（summary.byCategory）
+  const byCategory = summary?.byCategory ?? {};
+
+  const categoryBudgets = budget?.categories ?? [];
+  const hasCategoryBudgets = categoryBudgets.length > 0;
 
   return (
     <Card className="space-y-4">
@@ -70,85 +111,211 @@ export const BudgetCard: React.FC<BudgetCardProps> = ({
             className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-ink-500 transition hover:bg-ink-400/10 hover:text-ink-700"
           >
             <Pencil size={13} />
-            {monthly > 0 ? "変更" : "設定"}
+            {monthly > 0 || hasCategoryBudgets ? "変更" : "設定"}
           </button>
         )}
       </div>
 
       {editing ? (
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-ink-500">¥</span>
-          <input
-            type="number"
-            min={0}
-            step={1000}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            className="w-36 rounded-xl border border-ink-400/30 bg-white px-3 py-2 text-sm text-ink-800 outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
-            autoFocus
-          />
-          <span className="text-sm text-ink-500">/ 月</span>
+        <div className="space-y-4">
+          {/* 総額の月次予算 */}
+          <div>
+            <p className="mb-1.5 text-xs font-semibold text-ink-600">総額の月次予算</p>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-ink-500">¥</span>
+              <input
+                type="number"
+                min={0}
+                step={1000}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                className="w-36 rounded-xl border border-ink-400/30 bg-white px-3 py-2 text-sm text-ink-800 outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+                autoFocus
+              />
+              <span className="text-sm text-ink-500">/ 月</span>
+            </div>
+          </div>
+
+          {/* アラート有効トグル */}
           <button
-            onClick={save}
-            className="ml-auto flex h-8 w-8 items-center justify-center rounded-full bg-primary text-white hover:bg-primary-dark"
-            aria-label="保存"
+            type="button"
+            onClick={() => setAlert((v) => !v)}
+            className="flex w-full items-center justify-between rounded-xl border border-ink-400/20 bg-white px-3 py-2 text-left transition hover:border-primary/40"
+            aria-pressed={alert}
           >
-            <Check size={16} />
+            <span className="flex items-center gap-2 text-sm text-ink-700">
+              {alert ? (
+                <Bell size={15} className="text-primary" />
+              ) : (
+                <BellOff size={15} className="text-ink-400" />
+              )}
+              予算超過アラート
+            </span>
+            <span
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition ${
+                alert ? "bg-primary" : "bg-ink-400/30"
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition ${
+                  alert ? "translate-x-4" : "translate-x-1"
+                }`}
+              />
+            </span>
           </button>
-          <button
-            onClick={() => setEditing(false)}
-            className="flex h-8 w-8 items-center justify-center rounded-full bg-ink-400/10 text-ink-600 hover:bg-ink-400/20"
-            aria-label="キャンセル"
-          >
-            <X size={16} />
-          </button>
+
+          {/* カテゴリ別予算 */}
+          <div>
+            <p className="mb-1.5 text-xs font-semibold text-ink-600">
+              カテゴリ別予算（任意 / 月）
+            </p>
+            <div className="space-y-2">
+              {EXPENSE_CATEGORIES.map((c) => (
+                <div key={c.value} className="flex items-center gap-2">
+                  <span className="flex-1 text-sm text-ink-700">{c.label}</span>
+                  <span className="text-sm text-ink-500">¥</span>
+                  <input
+                    type="number"
+                    min={0}
+                    step={1000}
+                    value={catValues[c.value] ?? ""}
+                    onChange={(e) =>
+                      setCatValues((prev) => ({ ...prev, [c.value]: e.target.value }))
+                    }
+                    placeholder="0"
+                    className="w-28 rounded-xl border border-ink-400/30 bg-white px-3 py-1.5 text-sm text-ink-800 outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={save}
+              className="flex items-center gap-1 rounded-full bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-dark"
+            >
+              <Check size={15} />
+              保存
+            </button>
+            <button
+              onClick={() => setEditing(false)}
+              className="flex items-center gap-1 rounded-full bg-ink-400/10 px-3 py-1.5 text-sm text-ink-600 hover:bg-ink-400/20"
+            >
+              <X size={15} />
+              キャンセル
+            </button>
+          </div>
         </div>
-      ) : monthly === 0 ? (
+      ) : monthly === 0 && !hasCategoryBudgets ? (
         <p className="text-sm text-ink-500">
           月次予算を設定すると、月別の医療費が予算内かどうかを可視化できます。
         </p>
       ) : (
         <>
-          <div className="flex items-baseline justify-between">
-            <span className="text-2xl font-bold text-ink-800">{currency.format(monthly)}</span>
-            <span className="text-xs text-ink-500">/ 月</span>
-          </div>
+          {monthly > 0 && (
+            <>
+              <div className="flex items-baseline justify-between">
+                <span className="text-2xl font-bold text-ink-800">
+                  {currency.format(monthly)}
+                </span>
+                <span className="flex items-center gap-2 text-xs text-ink-500">
+                  {alertEnabled ? (
+                    <span className="flex items-center gap-1 text-primary">
+                      <Bell size={12} />
+                      アラートON
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 text-ink-400">
+                      <BellOff size={12} />
+                      アラートOFF
+                    </span>
+                  )}
+                  <span>/ 月</span>
+                </span>
+              </div>
 
-          {/* 年間予算の消化 */}
-          <div className="space-y-1">
-            <div className="flex items-center justify-between text-xs text-ink-500">
-              <span>{summary?.year}年の消化（年間予算 {currency.format(annualBudget)}）</span>
-              <span>{Math.round(annualRatio * 100)}%</span>
-            </div>
-            <div className="h-2.5 w-full overflow-hidden rounded-full bg-ink-400/10">
-              <div
-                className={`h-full rounded-full ${annualSpent > annualBudget ? "bg-red-400" : "bg-primary"}`}
-                style={{ width: `${Math.round(annualRatio * 100)}%` }}
-              />
-            </div>
-          </div>
+              {/* 年間予算の消化 */}
+              <div className="space-y-1">
+                <div className="flex items-center justify-between text-xs text-ink-500">
+                  <span>
+                    {summary?.year}年の消化（年間予算 {currency.format(annualBudget)}）
+                  </span>
+                  <span>{Math.round(annualRatio * 100)}%</span>
+                </div>
+                <div className="h-2.5 w-full overflow-hidden rounded-full bg-ink-400/10">
+                  <div
+                    className={`h-full rounded-full ${
+                      annualSpent > annualBudget ? "bg-red-400" : "bg-primary"
+                    }`}
+                    style={{ width: `${Math.round(annualRatio * 100)}%` }}
+                  />
+                </div>
+              </div>
 
-          {/* 月別バー（予算超過は赤） */}
-          <div>
-            <p className="mb-1.5 text-xs font-semibold text-ink-600">月別の支出（赤=予算超過）</p>
-            <div className="flex items-end gap-1" style={{ height: 72 }}>
-              {MONTH_LABELS.map((label, i) => {
-                const spend = byMonth.get(i + 1) ?? 0;
-                const h = Math.round((spend / maxSpend) * 60);
-                const over = spend > monthly;
-                return (
-                  <div key={label} className="flex flex-1 flex-col items-center gap-1">
-                    <div
-                      className={`w-full rounded-t ${over ? "bg-red-400" : "bg-primary/70"}`}
-                      style={{ height: `${Math.max(h, spend > 0 ? 3 : 0)}px` }}
-                      title={`${label}月: ${currency.format(spend)}`}
-                    />
-                    <span className="text-[9px] text-ink-400">{label}</span>
-                  </div>
-                );
-              })}
+              {/* 月別バー（予算超過は赤） */}
+              <div>
+                <p className="mb-1.5 text-xs font-semibold text-ink-600">
+                  月別の支出（赤=予算超過）
+                </p>
+                <div className="flex items-end gap-1" style={{ height: 72 }}>
+                  {MONTH_LABELS.map((label, i) => {
+                    const spend = byMonth.get(i + 1) ?? 0;
+                    const h = Math.round((spend / maxSpend) * 60);
+                    const over = spend > monthly;
+                    return (
+                      <div key={label} className="flex flex-1 flex-col items-center gap-1">
+                        <div
+                          className={`w-full rounded-t ${over ? "bg-red-400" : "bg-primary/70"}`}
+                          style={{ height: `${Math.max(h, spend > 0 ? 3 : 0)}px` }}
+                          title={`${label}月: ${currency.format(spend)}`}
+                        />
+                        <span className="text-[9px] text-ink-400">{label}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* カテゴリ別予算の一覧（今年の使用額を併記） */}
+          {hasCategoryBudgets && (
+            <div>
+              <p className="mb-1.5 text-xs font-semibold text-ink-600">
+                カテゴリ別予算（{summary?.year}年の使用額）
+              </p>
+              <div className="space-y-2">
+                {categoryBudgets.map((cb) => {
+                  const label =
+                    EXPENSE_CATEGORIES.find((c) => c.value === cb.category)?.label ??
+                    cb.category;
+                  const used = byCategory[cb.category] ?? 0;
+                  // カテゴリ別の年間予算 = 月次 * 12
+                  const annualCatBudget = cb.monthlyAmount * 12;
+                  const ratio =
+                    annualCatBudget > 0 ? Math.min(used / annualCatBudget, 1) : 0;
+                  const over = annualCatBudget > 0 && used > annualCatBudget;
+                  return (
+                    <div key={cb.category} className="space-y-1">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-ink-700">{label}</span>
+                        <span className="text-ink-500">
+                          {currency.format(used)} / {currency.format(annualCatBudget)}
+                        </span>
+                      </div>
+                      <div className="h-2 w-full overflow-hidden rounded-full bg-ink-400/10">
+                        <div
+                          className={`h-full rounded-full ${over ? "bg-red-400" : "bg-accent"}`}
+                          style={{ width: `${Math.round(ratio * 100)}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
-          </div>
+          )}
         </>
       )}
     </Card>

--- a/frontend/app/components/medications/InteractionWarning.tsx
+++ b/frontend/app/components/medications/InteractionWarning.tsx
@@ -1,0 +1,106 @@
+import { AlertTriangle, Info, ShieldCheck } from "lucide-react";
+import {
+  INTERACTION_DISCLAIMER,
+  type InteractionLevel,
+  type InteractionWarning as InteractionWarningItem,
+} from "@/lib/interactions";
+
+interface InteractionWarningProps {
+  warnings: InteractionWarningItem[];
+}
+
+const LEVEL_STYLES: Record<
+  InteractionLevel,
+  { container: string; title: string; detail: string; chip: string; iconColor: string }
+> = {
+  danger: {
+    container: "border-red-200 bg-red-50",
+    title: "text-red-700",
+    detail: "text-red-600",
+    chip: "bg-red-100 text-red-700",
+    iconColor: "text-red-500",
+  },
+  warning: {
+    container: "border-amber-200 bg-amber-50",
+    title: "text-amber-700",
+    detail: "text-amber-600",
+    chip: "bg-amber-100 text-amber-700",
+    iconColor: "text-amber-500",
+  },
+  info: {
+    container: "border-primary-200 bg-primary-50",
+    title: "text-primary-700",
+    detail: "text-primary-700/80",
+    chip: "bg-primary-100 text-primary-700",
+    iconColor: "text-primary-500",
+  },
+};
+
+const LEVEL_LABEL: Record<InteractionLevel, string> = {
+  danger: "要注意",
+  warning: "注意",
+  info: "参考",
+};
+
+function LevelIcon({ level, className }: { level: InteractionLevel; className?: string }) {
+  if (level === "info") return <Info size={16} className={className} />;
+  return <AlertTriangle size={16} className={className} />;
+}
+
+export function InteractionWarning({ warnings }: InteractionWarningProps) {
+  if (warnings.length === 0) {
+    return (
+      <div className="rounded-2xl border border-ink-400/10 bg-white p-4 shadow-soft">
+        <div className="flex items-center gap-2">
+          <ShieldCheck size={16} className="text-primary-500 shrink-0" />
+          <p className="text-sm text-ink-500">重大な飲み合わせは検出されませんでした</p>
+        </div>
+        <p className="mt-2 text-xs text-ink-400">{INTERACTION_DISCLAIMER}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {warnings.map((warning, index) => {
+        const styles = LEVEL_STYLES[warning.level];
+        return (
+          <div
+            key={`${warning.title}-${index}`}
+            className={`rounded-2xl border p-4 shadow-soft ${styles.container}`}
+          >
+            <div className="flex items-start gap-2">
+              <LevelIcon level={warning.level} className={`mt-0.5 shrink-0 ${styles.iconColor}`} />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs font-semibold ${styles.chip}`}
+                  >
+                    {LEVEL_LABEL[warning.level]}
+                  </span>
+                  <h3 className={`text-sm font-semibold ${styles.title}`}>{warning.title}</h3>
+                </div>
+                <p className={`mt-1.5 text-xs leading-relaxed ${styles.detail}`}>
+                  {warning.detail}
+                </p>
+                {warning.drugs.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {warning.drugs.map((drug) => (
+                      <span
+                        key={drug}
+                        className="rounded-full bg-white/70 px-2 py-0.5 text-xs text-ink-600 border border-ink-400/10"
+                      >
+                        {drug}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      <p className="px-1 text-xs text-ink-400">{INTERACTION_DISCLAIMER}</p>
+    </div>
+  );
+}

--- a/frontend/app/lib/interactions.ts
+++ b/frontend/app/lib/interactions.ts
@@ -1,0 +1,316 @@
+// 薬の飲み合わせ(相互作用)簡易チェック
+// 外部APIは使わず、薬剤名のキーワード一致ベースの静的ルールセットで判定する。
+// 医療的な正確性を保証するものではなく、あくまで注意喚起のための簡易チェックである。
+
+export type InteractionLevel = "info" | "warning" | "danger";
+
+export interface InteractionWarning {
+  level: InteractionLevel;
+  title: string;
+  detail: string;
+  drugs: string[];
+}
+
+/** 免責文言 */
+export const INTERACTION_DISCLAIMER =
+  "本チェックは簡易的なものです。実際の服用は必ず医師・薬剤師にご相談ください。";
+
+/**
+ * 相互作用ルール。
+ * groups の各配列のうち「いずれか1つ以上」がそれぞれマッチした場合に警告を出す。
+ * 例: groups: [["ワルファリン"], ["アスピリン", "イブプロフェン"]] は
+ *     ワルファリン系 かつ (アスピリン系 または イブプロフェン系) が同時に存在する場合に発火する。
+ */
+interface InteractionRule {
+  level: InteractionLevel;
+  title: string;
+  detail: string;
+  groups: string[][];
+}
+
+// キーワードは小文字化して部分一致で判定する
+const RULES: InteractionRule[] = [
+  {
+    level: "danger",
+    title: "ワルファリンと解熱鎮痛薬(NSAIDs)の併用",
+    detail:
+      "ワルファリン(抗凝固薬)とNSAIDs・アスピリンを併用すると、出血のリスクが高まる可能性があります。",
+    groups: [
+      ["ワルファリン", "warfarin", "ワーファリン"],
+      [
+        "アスピリン",
+        "aspirin",
+        "イブプロフェン",
+        "ibuprofen",
+        "ロキソプロフェン",
+        "loxoprofen",
+        "ロキソニン",
+        "ジクロフェナク",
+        "diclofenac",
+        "ボルタレン",
+        "nsaid",
+        "ナプロキセン",
+        "naproxen",
+      ],
+    ],
+  },
+  {
+    level: "warning",
+    title: "ワルファリンとビタミンK(納豆など)",
+    detail:
+      "ワルファリンの効果はビタミンKによって弱まります。納豆・青汁・クロレラ・ビタミンKサプリは避けるのが一般的です。",
+    groups: [
+      ["ワルファリン", "warfarin", "ワーファリン"],
+      ["納豆", "ビタミンk", "vitamin k", "青汁", "クロレラ", "vitamink"],
+    ],
+  },
+  {
+    level: "danger",
+    title: "MAO阻害薬と他の抗うつ薬・特定薬剤の併用",
+    detail:
+      "MAO阻害薬とSSRI・SNRI・三環系抗うつ薬などの併用は、セロトニン症候群など重篤な反応を起こす可能性があります。",
+    groups: [
+      ["mao阻害", "mao阻害薬", "maoi", "セレギリン", "selegiline", "エフピー"],
+      [
+        "ssri",
+        "snri",
+        "セルトラリン",
+        "sertraline",
+        "パロキセチン",
+        "paroxetine",
+        "フルボキサミン",
+        "fluvoxamine",
+        "デュロキセチン",
+        "duloxetine",
+        "三環系",
+        "イミプラミン",
+        "imipramine",
+        "ペチジン",
+        "pethidine",
+        "トラマドール",
+        "tramadol",
+      ],
+    ],
+  },
+  {
+    level: "danger",
+    title: "複数のNSAIDsの併用",
+    detail:
+      "複数の解熱鎮痛薬(NSAIDs)を併用すると、胃腸障害や腎機能障害のリスクが高まる可能性があります。",
+    groups: [
+      [
+        "アスピリン",
+        "aspirin",
+        "イブプロフェン",
+        "ibuprofen",
+        "ロキソプロフェン",
+        "loxoprofen",
+        "ロキソニン",
+        "ジクロフェナク",
+        "diclofenac",
+        "ボルタレン",
+        "ナプロキセン",
+        "naproxen",
+        "セレコキシブ",
+        "celecoxib",
+      ],
+      [
+        "アスピリン",
+        "aspirin",
+        "イブプロフェン",
+        "ibuprofen",
+        "ロキソプロフェン",
+        "loxoprofen",
+        "ロキソニン",
+        "ジクロフェナク",
+        "diclofenac",
+        "ボルタレン",
+        "ナプロキセン",
+        "naproxen",
+        "セレコキシブ",
+        "celecoxib",
+      ],
+    ],
+  },
+  {
+    level: "warning",
+    title: "グレープフルーツと一部の降圧薬・脂質異常症薬",
+    detail:
+      "グレープフルーツ(ジュース)は一部のカルシウム拮抗薬やスタチンの血中濃度を上げ、副作用が出やすくなる可能性があります。",
+    groups: [
+      ["グレープフルーツ", "grapefruit"],
+      [
+        "アムロジピン",
+        "amlodipine",
+        "ニフェジピン",
+        "nifedipine",
+        "アゼルニジピン",
+        "ベニジピン",
+        "アトルバスタチン",
+        "atorvastatin",
+        "シンバスタチン",
+        "simvastatin",
+        "スタチン",
+        "statin",
+      ],
+    ],
+  },
+  {
+    level: "warning",
+    title: "テトラサイクリン系・ニューキノロン系とカルシウム・鉄剤",
+    detail:
+      "抗菌薬(テトラサイクリン系・ニューキノロン系)はカルシウムや鉄・マグネシウムと結合し、効果が弱まる可能性があります。時間をずらして服用します。",
+    groups: [
+      [
+        "テトラサイクリン",
+        "tetracycline",
+        "ミノサイクリン",
+        "minocycline",
+        "ドキシサイクリン",
+        "doxycycline",
+        "レボフロキサシン",
+        "levofloxacin",
+        "シプロフロキサシン",
+        "ciprofloxacin",
+        "クラビット",
+        "ニューキノロン",
+      ],
+      ["カルシウム", "calcium", "鉄剤", "鉄", "iron", "マグネシウム", "magnesium", "制酸"],
+    ],
+  },
+  {
+    level: "warning",
+    title: "カリウム保持性利尿薬・ACE阻害薬とカリウム",
+    detail:
+      "ACE阻害薬・ARB・カリウム保持性利尿薬とカリウム製剤の併用は、高カリウム血症のリスクがあります。",
+    groups: [
+      [
+        "スピロノラクトン",
+        "spironolactone",
+        "ace阻害",
+        "エナラプリル",
+        "enalapril",
+        "arb",
+        "ロサルタン",
+        "losartan",
+        "カンデサルタン",
+        "candesartan",
+      ],
+      ["カリウム", "potassium", "アスパラk", "塩化カリウム"],
+    ],
+  },
+  {
+    level: "info",
+    title: "アルコールと中枢神経抑制薬・睡眠薬",
+    detail:
+      "睡眠薬・抗不安薬・抗ヒスタミン薬とアルコールの併用は、過度の眠気や呼吸抑制を招くことがあります。",
+    groups: [
+      [
+        "睡眠薬",
+        "ベンゾジアゼピン",
+        "benzodiazepine",
+        "ゾルピデム",
+        "zolpidem",
+        "マイスリー",
+        "ブロチゾラム",
+        "デパス",
+        "エチゾラム",
+        "抗ヒスタミン",
+      ],
+      ["アルコール", "alcohol", "お酒"],
+    ],
+  },
+  {
+    level: "info",
+    title: "メトトレキサートとNSAIDs",
+    detail:
+      "メトトレキサートとNSAIDsの併用は、メトトレキサートの血中濃度を上げ、副作用が強まる可能性があります。",
+    groups: [
+      ["メトトレキサート", "methotrexate", "リウマトレックス"],
+      [
+        "アスピリン",
+        "aspirin",
+        "イブプロフェン",
+        "ibuprofen",
+        "ロキソプロフェン",
+        "loxoprofen",
+        "ロキソニン",
+        "nsaid",
+      ],
+    ],
+  },
+];
+
+function normalize(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, "");
+}
+
+/** ルールの1グループに対し、マッチした薬剤名(元の名前)を返す */
+function matchGroup(group: string[], meds: { name: string; normalized: string }[]): string[] {
+  const matched: string[] = [];
+  for (const med of meds) {
+    if (group.some((kw) => med.normalized.includes(normalize(kw)))) {
+      matched.push(med.name);
+    }
+  }
+  return matched;
+}
+
+/**
+ * 飲み合わせをチェックする。
+ * - 静的ルールセットによる相互作用の検出
+ * - 同名薬の重複登録の検出
+ */
+export function checkInteractions(meds: { name: string }[]): InteractionWarning[] {
+  const warnings: InteractionWarning[] = [];
+
+  const prepared = meds
+    .filter((m) => m.name && m.name.trim().length > 0)
+    .map((m) => ({ name: m.name, normalized: normalize(m.name) }));
+
+  // --- 同名薬の重複検出 ---
+  const seen = new Map<string, string[]>();
+  for (const m of prepared) {
+    const list = seen.get(m.normalized) ?? [];
+    list.push(m.name);
+    seen.set(m.normalized, list);
+  }
+  for (const [, names] of seen) {
+    if (names.length >= 2) {
+      warnings.push({
+        level: "warning",
+        title: "同じ薬が重複して登録されています",
+        detail:
+          "同一の薬が複数登録されています。二重服用にならないよう、登録内容をご確認ください。",
+        drugs: [...new Set(names)],
+      });
+    }
+  }
+
+  // --- 相互作用ルールの判定 ---
+  for (const rule of RULES) {
+    // 各グループでマッチした薬剤名を取得
+    const matchedPerGroup = rule.groups.map((g) => matchGroup(g, prepared));
+
+    // すべてのグループが少なくとも1件マッチする必要がある
+    if (matchedPerGroup.some((m) => m.length === 0)) continue;
+
+    // 同一グループ内の自己マッチ(NSAIDs同士など)の場合、最低2剤必要
+    const allMatched = matchedPerGroup.flat();
+    const uniqueDrugs = [...new Set(allMatched)];
+    if (uniqueDrugs.length < 2) continue;
+
+    warnings.push({
+      level: rule.level,
+      title: rule.title,
+      detail: rule.detail,
+      drugs: uniqueDrugs,
+    });
+  }
+
+  // 重大度の高い順に並べる
+  const order: Record<InteractionLevel, number> = { danger: 0, warning: 1, info: 2 };
+  warnings.sort((a, b) => order[a.level] - order[b.level]);
+
+  return warnings;
+}

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -34,13 +34,39 @@ export interface MonthlyTotal {
   total: number;
 }
 
+// カテゴリ別の月次予算
+export interface CategoryBudget {
+  category: string;
+  monthlyAmount: number;
+}
+
 // 医療費の月次予算（ユーザー単位のパーソナライズ）
 export interface Budget {
   id: string;
   userId: string;
   monthlyAmount: number;
+  alertEnabled: boolean;
+  lastAlertedMonth: string | null;
+  categories: CategoryBudget[];
   createdAt: string;
   updatedAt: string;
+}
+
+// 予算超過判定の結果
+export interface BudgetAlertStatus {
+  overBudget: boolean;
+  monthTotal: number;
+  monthlyAmount: number;
+  overCategories: string[];
+  emailSent: boolean;
+}
+
+// ダッシュボードのパーソナライズ設定
+export interface DashboardPreference {
+  userId: string;
+  hiddenCards: string[];
+  cardOrder: string[];
+  defaultMemberId: string | null;
 }
 
 export interface ExpenseSummary {

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -8,6 +8,9 @@ export default [
   route("forgot-password", "routes/forgot-password.tsx"),
   route("reset-password", "routes/reset-password.tsx"),
 
+  // 医師共有用の印刷最適化レポート（サイドバー等を出さない独立ページ）
+  route("members/:memberId/report", "routes/members.$memberId.report.tsx"),
+
   // 認証済みレイアウト配下
   layout("routes/_authed.tsx", [
     index("routes/home.tsx"),

--- a/frontend/app/routes/expenses.tsx
+++ b/frontend/app/routes/expenses.tsx
@@ -1,19 +1,38 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Download, Plus, X } from "lucide-react";
+import { AlertTriangle, Download, Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
-import type { Budget, Expense, ExpenseSummary, Member } from "@/lib/types";
+import type {
+  Budget,
+  BudgetAlertStatus,
+  Expense,
+  ExpenseSummary,
+  Member,
+} from "@/lib/types";
 import { SectionTitle } from "@/components/shared/SectionTitle";
 import { MemberFilter } from "@/components/shared/MemberFilter";
-import { ExpenseForm, type ExpenseFormData } from "@/components/expenses/ExpenseForm";
+import {
+  ExpenseForm,
+  EXPENSE_CATEGORIES,
+  type ExpenseFormData,
+} from "@/components/expenses/ExpenseForm";
 import {
   ExpenseList,
   type UpdateExpenseInput,
 } from "@/components/expenses/ExpenseList";
 import { ExpenseSummaryCard } from "@/components/expenses/ExpenseSummaryCard";
-import { BudgetCard } from "@/components/expenses/BudgetCard";
+import {
+  BudgetCard,
+  type BudgetSavePayload,
+} from "@/components/expenses/BudgetCard";
 
 const YEAR_OPTIONS_COUNT = 5;
+
+const currency = new Intl.NumberFormat("ja-JP", {
+  style: "currency",
+  currency: "JPY",
+  maximumFractionDigits: 0,
+});
 
 export default function Expenses() {
   const qc = useQueryClient();
@@ -53,9 +72,18 @@ export default function Expenses() {
   });
 
   const saveBudgetMutation = useMutation({
-    mutationFn: (monthlyAmount: number) =>
-      api.put<Budget>("/budget", { monthlyAmount }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["budget"] }),
+    mutationFn: (payload: BudgetSavePayload) =>
+      api.put<Budget>("/budget", payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["budget"] });
+      qc.invalidateQueries({ queryKey: ["budget", "alert"] });
+    },
+  });
+
+  // ページ表示時に予算超過を判定（メールアラート連動）
+  const { data: alertStatus } = useQuery({
+    queryKey: ["budget", "alert"],
+    queryFn: () => api.post<BudgetAlertStatus>("/budget/alert"),
   });
 
   const invalidateAll = () => {
@@ -133,11 +161,39 @@ export default function Expenses() {
     URL.revokeObjectURL(url);
   };
 
+  const categoryLabel = (value: string): string =>
+    EXPENSE_CATEGORIES.find((c) => c.value === value)?.label ?? value;
+
   return (
     <div className="space-y-5">
       <SectionTitle accentColor="primary" size="lg">
         医療費・家計
       </SectionTitle>
+
+      {alertStatus?.overBudget && (
+        <div className="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 p-4 text-red-700">
+          <AlertTriangle size={20} className="mt-0.5 shrink-0 text-red-500" />
+          <div className="space-y-1">
+            <p className="text-sm font-bold">今月の医療費が予算を超えています</p>
+            <p className="text-xs text-red-600">
+              今月の支出 {currency.format(alertStatus.monthTotal)} / 予算{" "}
+              {currency.format(alertStatus.monthlyAmount)}
+            </p>
+            {alertStatus.overCategories.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 pt-1">
+                {alertStatus.overCategories.map((cat) => (
+                  <span
+                    key={cat}
+                    className="rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-medium text-red-700"
+                  >
+                    {categoryLabel(cat)}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="flex items-center gap-2">
         <label htmlFor="expense-year" className="text-sm font-medium text-ink-600">
@@ -172,7 +228,7 @@ export default function Expenses() {
         budget={budget}
         summary={summary}
         isLoading={budgetLoading}
-        onSave={(amount) => saveBudgetMutation.mutate(amount)}
+        onSave={(payload) => saveBudgetMutation.mutate(payload)}
       />
 
       <MemberFilter

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,4 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { SlidersHorizontal } from "lucide-react";
+import { api } from "@/lib/api";
+import type { DashboardPreference } from "@/lib/types";
 import { useAuth } from "@/lib/auth";
 import { useDashboardData, useMarkRecord, type MissedDose } from "@/hooks/dashboard";
 import { GreetingCard } from "@/components/dashboard/GreetingCard";
@@ -8,8 +12,34 @@ import { TodayScheduleList } from "@/components/dashboard/TodayScheduleList";
 import { StockAlertList } from "@/components/dashboard/StockAlertList";
 import { AdherenceStatsCard } from "@/components/dashboard/AdherenceStatsCard";
 import { UpcomingAppointments } from "@/components/dashboard/UpcomingAppointments";
+import {
+  DashboardSettings,
+  ORDERABLE_CARD_KEYS,
+  type DashboardCardKey,
+} from "@/components/dashboard/DashboardSettings";
 import { MemberFilter } from "@/components/shared/MemberFilter";
 import { SectionTitle } from "@/components/shared/SectionTitle";
+
+const EMPTY_PREFERENCE: DashboardPreference = {
+  userId: "",
+  hiddenCards: [],
+  cardOrder: [],
+  defaultMemberId: null,
+};
+
+// 保存済み cardOrder を並び替え対象キーの確定順序に解決する。
+function resolveCardOrder(savedOrder: string[]): DashboardCardKey[] {
+  const orderable = new Set<DashboardCardKey>(ORDERABLE_CARD_KEYS);
+  const result: DashboardCardKey[] = [];
+  for (const key of savedOrder) {
+    const k = key as DashboardCardKey;
+    if (orderable.has(k) && !result.includes(k)) result.push(k);
+  }
+  for (const key of ORDERABLE_CARD_KEYS) {
+    if (!result.includes(key)) result.push(key);
+  }
+  return result;
+}
 
 function buildTakenAtISO(date: string, scheduledTime: string): string {
   return new Date(`${date}T${scheduledTime}:00+09:00`).toISOString();
@@ -35,6 +65,32 @@ export default function Home() {
 
   const markRecord = useMarkRecord();
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [showSettings, setShowSettings] = useState(false);
+  // defaultMemberId の初期反映は一度だけ行い、以降のユーザー操作を上書きしない
+  const [defaultApplied, setDefaultApplied] = useState(false);
+
+  const { data: preference = EMPTY_PREFERENCE } = useQuery({
+    queryKey: ["dashboard-preferences"],
+    queryFn: () => api.get<DashboardPreference>("/dashboard-preferences"),
+    enabled: !!userId,
+  });
+
+  const hiddenCards = useMemo(
+    () => new Set(preference.hiddenCards),
+    [preference.hiddenCards],
+  );
+  const cardOrder = useMemo(
+    () => resolveCardOrder(preference.cardOrder),
+    [preference.cardOrder],
+  );
+
+  useEffect(() => {
+    if (defaultApplied) return;
+    if (preference.defaultMemberId) {
+      setSelectedMemberId(preference.defaultMemberId);
+    }
+    setDefaultApplied(true);
+  }, [preference.defaultMemberId, defaultApplied]);
 
   const handleMarkCompleted = useCallback(
     async (scheduleId: string, options?: { takenAt?: string; notes?: string }) => {
@@ -111,46 +167,86 @@ export default function Home() {
     [members],
   );
 
+  const bottomCards: Record<DashboardCardKey, ReactNode> = {
+    weeklySummary: <></>,
+    missedDoses: <></>,
+    todaySchedule: <></>,
+    stockAlerts: <StockAlertList alerts={stockAlerts} isLoading={stockLoading} />,
+    adherence: <AdherenceStatsCard stats={adherenceStats} isLoading={adherenceLoading} />,
+    upcomingAppointments: (
+      <UpcomingAppointments appointments={appointments} isLoading={appointmentsLoading} />
+    ),
+  };
+
   return (
     <div className="space-y-0">
+      <div className="mb-3 flex items-center justify-end">
+        <button
+          onClick={() => setShowSettings((v) => !v)}
+          className="flex items-center gap-1.5 rounded-xl bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 transition hover:bg-primary-100"
+          aria-expanded={showSettings}
+        >
+          <SlidersHorizontal size={16} />
+          表示設定
+        </button>
+      </div>
+
+      {showSettings && (
+        <div className="mb-4">
+          <DashboardSettings
+            preference={preference}
+            members={members}
+            onClose={() => setShowSettings(false)}
+          />
+        </div>
+      )}
+
       <GreetingCard
         displayName={user?.displayName ?? ""}
         weeklyRate={adherenceStats?.overall.weeklyRate}
       />
 
-      <WeeklySummaryCard schedules={todaySchedules} isLoading={todayLoading} />
+      {!hiddenCards.has("weeklySummary") && (
+        <WeeklySummaryCard schedules={todaySchedules} isLoading={todayLoading} />
+      )}
 
-      <MissedDosesAlert
-        missedDoses={missedDoses}
-        isLoading={missedLoading}
-        onMarkAsTaken={handleMarkMissedAsTaken}
-        onMarkMultipleAsTaken={handleMarkMultipleMissedAsTaken}
-      />
-
-      <SectionTitle accentColor="primary" size="lg">
-        今日の予定
-      </SectionTitle>
-      <div className="mb-4">
-        <MemberFilter
-          members={memberOptions}
-          selectedMemberId={selectedMemberId}
-          onSelect={setSelectedMemberId}
+      {!hiddenCards.has("missedDoses") && (
+        <MissedDosesAlert
+          missedDoses={missedDoses}
+          isLoading={missedLoading}
+          onMarkAsTaken={handleMarkMissedAsTaken}
+          onMarkMultipleAsTaken={handleMarkMultipleMissedAsTaken}
         />
-      </div>
-      <TodayScheduleList
-        schedules={filteredSchedules}
-        isLoading={todayLoading}
-        onMarkCompleted={handleMarkCompleted}
-        onMarkMultipleCompleted={handleMarkMultipleCompleted}
-        hasMembers={members.length > 0}
-      />
+      )}
+
+      {!hiddenCards.has("todaySchedule") && (
+        <>
+          <SectionTitle accentColor="primary" size="lg">
+            今日の予定
+          </SectionTitle>
+          <div className="mb-4">
+            <MemberFilter
+              members={memberOptions}
+              selectedMemberId={selectedMemberId}
+              onSelect={setSelectedMemberId}
+            />
+          </div>
+          <TodayScheduleList
+            schedules={filteredSchedules}
+            isLoading={todayLoading}
+            onMarkCompleted={handleMarkCompleted}
+            onMarkMultipleCompleted={handleMarkMultipleCompleted}
+            hasMembers={members.length > 0}
+          />
+        </>
+      )}
 
       <div className="mt-6 grid items-start gap-4 md:grid-cols-2">
-        <StockAlertList alerts={stockAlerts} isLoading={stockLoading} />
-
-        <AdherenceStatsCard stats={adherenceStats} isLoading={adherenceLoading} />
-
-        <UpcomingAppointments appointments={appointments} isLoading={appointmentsLoading} />
+        {cardOrder
+          .filter((key) => !hiddenCards.has(key))
+          .map((key) => (
+            <div key={key}>{bottomCards[key]}</div>
+          ))}
       </div>
     </div>
   );

--- a/frontend/app/routes/medications.tsx
+++ b/frontend/app/routes/medications.tsx
@@ -2,9 +2,11 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { api } from "@/lib/api";
-import type { Member } from "@/lib/types";
+import type { Medication, Member } from "@/lib/types";
 import { CategoryFilter, type MedicationCategory } from "@/components/shared/CategoryFilter";
 import { MemberMedications } from "@/components/medications/MemberMedications";
+import { InteractionWarning } from "@/components/medications/InteractionWarning";
+import { checkInteractions } from "@/lib/interactions";
 
 export default function Medications() {
   const [selectedCategory, setSelectedCategory] = useState<MedicationCategory | null>(null);
@@ -14,13 +16,30 @@ export default function Medications() {
     queryFn: () => api.get<Member[]>("/members"),
   });
 
+  const { data: allMedications = [] } = useQuery({
+    queryKey: ["medications"],
+    queryFn: () => api.get<Medication[]>("/medications"),
+  });
+
   const hasMembers = useMemo(() => members.length > 0, [members]);
+
+  const interactionWarnings = useMemo(
+    () =>
+      checkInteractions(
+        allMedications.filter((m) => m.isActive).map((m) => ({ name: m.name })),
+      ),
+    [allMedications],
+  );
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold text-ink-800 tracking-wide">お薬</h1>
       </div>
+
+      {!isLoading && hasMembers && (
+        <InteractionWarning warnings={interactionWarnings} />
+      )}
 
       {!isLoading && hasMembers && (
         <CategoryFilter selectedCategory={selectedCategory} onSelect={setSelectedCategory} />

--- a/frontend/app/routes/members.$memberId.report.tsx
+++ b/frontend/app/routes/members.$memberId.report.tsx
@@ -1,0 +1,318 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useParams } from "react-router";
+import { ChevronLeft, Printer } from "lucide-react";
+import { api } from "@/lib/api";
+import { useRequireAuth } from "@/lib/auth";
+import type {
+  Member,
+  Medication,
+  Allergy,
+  Vaccination,
+  Examination,
+  Appointment,
+} from "@/lib/types";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+
+const memberTypeLabels: Record<string, string> = {
+  human: "家族",
+  pet: "ペット",
+};
+
+const severityLabels: Record<string, string> = {
+  mild: "軽度",
+  moderate: "中等度",
+  severe: "重度",
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "-";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "-";
+  return d.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function calcAge(birthDate: string | null): string {
+  if (!birthDate) return "-";
+  const d = new Date(birthDate);
+  if (Number.isNaN(d.getTime())) return "-";
+  const now = new Date();
+  let age = now.getFullYear() - d.getFullYear();
+  const m = now.getMonth() - d.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < d.getDate())) age -= 1;
+  return `${age}歳`;
+}
+
+export default function MemberReport() {
+  const { memberId } = useParams();
+  const { user, loading: authLoading } = useRequireAuth();
+
+  const { data: member, isLoading: memberLoading } = useQuery({
+    queryKey: ["members", memberId],
+    queryFn: () => api.get<Member>(`/members/${memberId}`),
+    enabled: !!memberId && !!user,
+    retry: false,
+  });
+
+  const { data: medications = [], isLoading: medsLoading } = useQuery({
+    queryKey: ["members", memberId, "medications"],
+    queryFn: () => api.get<Medication[]>(`/members/${memberId}/medications`),
+    enabled: !!memberId && !!user,
+  });
+
+  const { data: allergies = [] } = useQuery({
+    queryKey: ["allergies"],
+    queryFn: () => api.get<Allergy[]>("/allergies"),
+    enabled: !!user,
+  });
+
+  const { data: vaccinations = [] } = useQuery({
+    queryKey: ["vaccinations"],
+    queryFn: () => api.get<Vaccination[]>("/vaccinations"),
+    enabled: !!user,
+  });
+
+  const { data: examinations = [] } = useQuery({
+    queryKey: ["examinations"],
+    queryFn: () => api.get<Examination[]>("/examinations"),
+    enabled: !!user,
+  });
+
+  const { data: appointments = [] } = useQuery({
+    queryKey: ["appointments"],
+    queryFn: () => api.get<Appointment[]>("/appointments"),
+    enabled: !!user,
+  });
+
+  if (authLoading || (user && (memberLoading || medsLoading))) {
+    return <LoadingSpinner />;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  if (!member) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center p-6">
+        <div className="text-center space-y-4">
+          <p className="text-ink-600">メンバーが見つかりませんでした。</p>
+          <Link to="/members" className="text-primary hover:underline">
+            メンバー一覧へ戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const memberAllergies = allergies.filter((a) => a.memberId === member.id);
+  const memberVaccinations = [...vaccinations]
+    .filter((v) => v.memberId === member.id)
+    .sort(
+      (a, b) =>
+        new Date(b.vaccinatedAt).getTime() - new Date(a.vaccinatedAt).getTime(),
+    );
+  const memberExaminations = [...examinations]
+    .filter((e) => e.memberId === member.id)
+    .sort(
+      (a, b) =>
+        new Date(b.examinedAt).getTime() - new Date(a.examinedAt).getTime(),
+    );
+  const memberAppointments = [...appointments]
+    .filter((a) => a.memberId === member.id)
+    .sort(
+      (a, b) =>
+        new Date(b.appointmentDate).getTime() -
+        new Date(a.appointmentDate).getTime(),
+    )
+    .slice(0, 5);
+  const activeMedications = medications.filter((m) => m.isActive);
+
+  const typeLabel = memberTypeLabels[member.memberType] ?? member.memberType;
+
+  return (
+    <div className="min-h-screen bg-white text-ink-800">
+      <style>{`@media print { .print\\:hidden { display:none !important } @page { margin: 16mm } }`}</style>
+
+      <div className="mx-auto max-w-3xl p-6 print:p-0">
+        <div className="flex items-center justify-between mb-6 print:hidden">
+          <Link
+            to={`/members/${member.id}`}
+            className="inline-flex items-center space-x-1 text-sm text-ink-500 hover:text-ink-700 transition-colors"
+          >
+            <ChevronLeft size={16} />
+            <span>戻る</span>
+          </Link>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="inline-flex items-center space-x-2 px-4 py-2 bg-primary text-white text-sm rounded-xl hover:bg-primary-dark transition-colors"
+          >
+            <Printer size={16} />
+            <span>印刷 / PDF保存</span>
+          </button>
+        </div>
+
+        <header className="border-b border-ink-400/20 pb-4 mb-6">
+          <h1 className="text-2xl font-bold">医師共有用サマリー</h1>
+          <p className="text-sm text-ink-500 mt-1">
+            作成日: {formatDate(new Date().toISOString())}
+          </p>
+        </header>
+
+        <section className="mb-8">
+          <h2 className="text-base font-bold border-l-4 border-primary pl-2 mb-3">
+            基本情報
+          </h2>
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+            <div className="flex">
+              <dt className="w-24 text-ink-500">氏名</dt>
+              <dd className="font-medium">{member.name}</dd>
+            </div>
+            <div className="flex">
+              <dt className="w-24 text-ink-500">種別</dt>
+              <dd className="font-medium">
+                {typeLabel}
+                {member.petType ? `（${member.petType}）` : ""}
+              </dd>
+            </div>
+            <div className="flex">
+              <dt className="w-24 text-ink-500">生年月日</dt>
+              <dd className="font-medium">{formatDate(member.birthDate)}</dd>
+            </div>
+            <div className="flex">
+              <dt className="w-24 text-ink-500">年齢</dt>
+              <dd className="font-medium">{calcAge(member.birthDate)}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base font-bold border-l-4 border-primary pl-2 mb-3">
+            服用中の薬
+          </h2>
+          {activeMedications.length === 0 ? (
+            <p className="text-sm text-ink-500">服用中の薬はありません。</p>
+          ) : (
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-ink-400/20 text-left text-ink-500">
+                  <th className="py-1.5 pr-3 font-medium">薬の名前</th>
+                  <th className="py-1.5 pr-3 font-medium">用量</th>
+                  <th className="py-1.5 font-medium">頻度</th>
+                </tr>
+              </thead>
+              <tbody>
+                {activeMedications.map((m) => (
+                  <tr key={m.id} className="border-b border-ink-400/10">
+                    <td className="py-1.5 pr-3">{m.name}</td>
+                    <td className="py-1.5 pr-3">{m.dosageAmount ?? "-"}</td>
+                    <td className="py-1.5">{m.frequency ?? "-"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base font-bold border-l-4 border-primary pl-2 mb-3">
+            アレルギー
+          </h2>
+          {memberAllergies.length === 0 ? (
+            <p className="text-sm text-ink-500">登録されているアレルギーはありません。</p>
+          ) : (
+            <ul className="space-y-1.5 text-sm">
+              {memberAllergies.map((a) => (
+                <li key={a.id} className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="font-medium">{a.allergenName}</span>
+                  <span className="text-ink-500">
+                    （{severityLabels[a.severity] ?? a.severity}）
+                  </span>
+                  {a.symptoms ? (
+                    <span className="text-ink-500">{a.symptoms}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base font-bold border-l-4 border-primary pl-2 mb-3">
+            予防接種歴
+          </h2>
+          {memberVaccinations.length === 0 ? (
+            <p className="text-sm text-ink-500">予防接種の記録はありません。</p>
+          ) : (
+            <ul className="space-y-1.5 text-sm">
+              {memberVaccinations.map((v) => (
+                <li key={v.id} className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="text-ink-500 w-32 shrink-0">
+                    {formatDate(v.vaccinatedAt)}
+                  </span>
+                  <span className="font-medium">{v.vaccineName}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base font-bold border-l-4 border-primary pl-2 mb-3">
+            検査歴
+          </h2>
+          {memberExaminations.length === 0 ? (
+            <p className="text-sm text-ink-500">検査の記録はありません。</p>
+          ) : (
+            <ul className="space-y-1.5 text-sm">
+              {memberExaminations.map((e) => (
+                <li key={e.id} className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="text-ink-500 w-32 shrink-0">
+                    {formatDate(e.examinedAt)}
+                  </span>
+                  <span className="font-medium">{e.examinationType}</span>
+                  {e.notes ? (
+                    <span className="text-ink-500">{e.notes}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-base font-bold border-l-4 border-primary pl-2 mb-3">
+            直近の通院
+          </h2>
+          {memberAppointments.length === 0 ? (
+            <p className="text-sm text-ink-500">通院の記録はありません。</p>
+          ) : (
+            <ul className="space-y-1.5 text-sm">
+              {memberAppointments.map((a) => (
+                <li key={a.id} className="flex flex-wrap items-baseline gap-x-2">
+                  <span className="text-ink-500 w-32 shrink-0">
+                    {formatDate(a.appointmentDate)}
+                  </span>
+                  <span className="font-medium">
+                    {a.appointmentType ?? "通院"}
+                  </span>
+                  {a.description ? (
+                    <span className="text-ink-500">{a.description}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <footer className="border-t border-ink-400/20 pt-3 mt-8 text-xs text-ink-400">
+          <p>本サマリーは HealthFamily で作成されました。</p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes/members.$memberId.tsx
+++ b/frontend/app/routes/members.$memberId.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, Navigate, useParams } from "react-router";
-import { Pill, Plus, X, ChevronLeft } from "lucide-react";
+import { Pill, Plus, X, ChevronLeft, FileText } from "lucide-react";
 import { api } from "@/lib/api";
 import type {
   Member,
@@ -119,13 +119,22 @@ export default function MemberDetail() {
               <p className="text-sm text-ink-500">{typeLabel}</p>
             </div>
           </div>
-          <Link
-            to={`/members/${member.id}/medications`}
-            className="flex items-center space-x-1 px-3 py-1.5 bg-primary text-white text-sm rounded-xl hover:bg-primary-dark transition-colors"
-          >
-            <Pill size={16} />
-            <span>お薬管理</span>
-          </Link>
+          <div className="flex items-center space-x-2">
+            <Link
+              to={`/members/${member.id}/report`}
+              className="flex items-center space-x-1 px-3 py-1.5 bg-primary-50 text-primary text-sm rounded-xl hover:bg-primary-100 transition-colors"
+            >
+              <FileText size={16} />
+              <span>医師共有用サマリー</span>
+            </Link>
+            <Link
+              to={`/members/${member.id}/medications`}
+              className="flex items-center space-x-1 px-3 py-1.5 bg-primary text-white text-sm rounded-xl hover:bg-primary-dark transition-colors"
+            >
+              <Pill size={16} />
+              <span>お薬管理</span>
+            </Link>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
### バックエンド（クリーンアーキテクチャ / 生SQL）
- migration `0004`: `Budget` 拡張(`alertEnabled`/`lastAlertedMonth`)、`CategoryBudget`、`DashboardPreference`（既存DBに no-op）
- `GET/PUT /budget` をカテゴリ別＋アラート設定対応に拡張、`POST /budget/alert`（当月の総額/カテゴリ別超過を判定、有効かつ当月未通知ならメール通知し重複防止）
- `GET/PUT /dashboard-preferences`
- バリデーションガード（負の予算は保存不可）、メールは Resend(best-effort)

### フロントエンド
- **カテゴリ別予算UI** ＋ 予算超過の警告バナー（`/expenses`）
- **ダッシュボード個人化**: カード表示/非表示・既定メンバー・並び順を保存（`/dashboard-preferences`）
- **医師共有PDF**: 印刷最適化レポート `/members/:id/report`（window.print でPDF保存、サイドバー無しの独立ページ）
- **飲み合わせ簡易チェック**: 静的ルールセット＋重複薬検出、免責文言つき（`/medications`）

backend `build`/`vet`/`test`・frontend `typecheck`/`build` 通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 月次予算の超過アラート機能を追加。カテゴリ別の予算設定と超過判定が可能に
  * ダッシュボードのカード表示・非表示と並び順を自由にカスタマイズできるように
  * お薬の飲み合わせ注意情報を自動検出・表示
  * メンバーの医学情報をまとめた医師共有用レポートを生成・印刷可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->