### PR TITLE
feat: 処方箋OCR / 医療費CSV取込 / 電子処方箋連携

### DIFF
--- a/backend/internal/domain/entity/entities_ext.go
+++ b/backend/internal/domain/entity/entities_ext.go
@@ -139,6 +139,7 @@ type Prescription struct {
 	PrescribedAt     time.Time  `json:"prescribedAt"`
 	ExpiresAt        *time.Time `json:"expiresAt"`
 	PharmacyName     *string    `json:"pharmacyName"`
+	ElectronicCode   *string    `json:"electronicCode"` // 電子処方箋の引換番号/アクセスコード
 	Notes            *string    `json:"notes"`
 	CreatedAt        time.Time  `json:"createdAt"`
 }

--- a/backend/internal/domain/repository/repository_ext.go
+++ b/backend/internal/domain/repository/repository_ext.go
@@ -295,6 +295,7 @@ type CreatePrescriptionInput struct {
 	PrescribedAt     time.Time
 	ExpiresAt        *time.Time
 	PharmacyName     *string
+	ElectronicCode   *string
 	Notes            *string
 }
 
@@ -304,6 +305,7 @@ type UpdatePrescriptionInput struct {
 	PrescribedAt     *time.Time
 	ExpiresAt        *time.Time
 	PharmacyName     *string
+	ElectronicCode   *string
 	Notes            *string
 }
 

--- a/backend/internal/infrastructure/persistence/prescription_repository.go
+++ b/backend/internal/infrastructure/persistence/prescription_repository.go
@@ -20,11 +20,11 @@ func NewPrescriptionRepository(db *database.DB) *PrescriptionRepository {
 	return &PrescriptionRepository{db: db}
 }
 
-const prescriptionColumns = `"id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt", "expiresAt", "pharmacyName", "notes", "createdAt"`
+const prescriptionColumns = `"id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt", "expiresAt", "pharmacyName", "electronicCode", "notes", "createdAt"`
 
 func scanPrescription(row pgx.Row) (*entity.Prescription, error) {
 	var p entity.Prescription
-	err := row.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.Notes, &p.CreatedAt)
+	err := row.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.ElectronicCode, &p.Notes, &p.CreatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -44,7 +44,7 @@ func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]ent
 	list := make([]entity.Prescription, 0)
 	for rows.Next() {
 		var p entity.Prescription
-		if err := rows.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.Notes, &p.CreatedAt); err != nil {
+		if err := rows.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.ElectronicCode, &p.Notes, &p.CreatedAt); err != nil {
 			return nil, err
 		}
 		list = append(list, p)
@@ -60,10 +60,10 @@ func (r *PrescriptionRepository) FindByID(ctx context.Context, id string) (*enti
 func (r *PrescriptionRepository) Create(ctx context.Context, in repository.CreatePrescriptionInput) (*entity.Prescription, error) {
 	id := auth.NewID()
 	row := r.db.Pool.QueryRow(ctx,
-		`INSERT INTO "Prescription" ("id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt", "expiresAt", "pharmacyName", "notes", "createdAt")
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, now())
+		`INSERT INTO "Prescription" ("id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt", "expiresAt", "pharmacyName", "electronicCode", "notes", "createdAt")
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, now())
 		 RETURNING `+prescriptionColumns,
-		id, in.UserID, in.MemberID, in.PrescriptionName, in.PrescribedBy, in.PrescribedAt, in.ExpiresAt, in.PharmacyName, in.Notes)
+		id, in.UserID, in.MemberID, in.PrescriptionName, in.PrescribedBy, in.PrescribedAt, in.ExpiresAt, in.PharmacyName, in.ElectronicCode, in.Notes)
 	return scanPrescription(row)
 }
 
@@ -75,10 +75,11 @@ func (r *PrescriptionRepository) Update(ctx context.Context, id string, in repos
 			"prescribedAt" = COALESCE($4, "prescribedAt"),
 			"expiresAt" = COALESCE($5, "expiresAt"),
 			"pharmacyName" = COALESCE($6, "pharmacyName"),
-			"notes" = COALESCE($7, "notes")
+			"electronicCode" = COALESCE($7, "electronicCode"),
+			"notes" = COALESCE($8, "notes")
 		 WHERE "id"=$1
 		 RETURNING `+prescriptionColumns,
-		id, in.PrescriptionName, in.PrescribedBy, in.PrescribedAt, in.ExpiresAt, in.PharmacyName, in.Notes)
+		id, in.PrescriptionName, in.PrescribedBy, in.PrescribedAt, in.ExpiresAt, in.PharmacyName, in.ElectronicCode, in.Notes)
 	return scanPrescription(row)
 }
 

--- a/backend/internal/interface/handler/expense_handler.go
+++ b/backend/internal/interface/handler/expense_handler.go
@@ -124,6 +124,55 @@ func (h *ExpenseHandler) Update(c *gin.Context) {
 	response.Success(c, e)
 }
 
+type importExpenseRow struct {
+	MemberID     *string `json:"memberId"`
+	Category     string  `json:"category"`
+	Amount       int     `json:"amount"`
+	Description  *string `json:"description"`
+	ExpenseDate  string  `json:"expenseDate"`
+	IsDeductible *bool   `json:"isDeductible"`
+}
+
+type importExpensesRequest struct {
+	Expenses []importExpenseRow `json:"expenses" binding:"required"`
+}
+
+// Import は CSV/医療費通知から変換した支出を一括登録する。
+func (h *ExpenseHandler) Import(c *gin.Context) {
+	userID := middleware.UserID(c)
+	var req importExpensesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, 400, "取込データが正しくありません")
+		return
+	}
+	inputs := make([]repository.CreateExpenseInput, 0, len(req.Expenses))
+	for _, row := range req.Expenses {
+		date := parseDate(&row.ExpenseDate)
+		if date == nil {
+			continue // 日付不正はスキップ
+		}
+		deductible := true
+		if row.IsDeductible != nil {
+			deductible = *row.IsDeductible
+		}
+		inputs = append(inputs, repository.CreateExpenseInput{
+			UserID:       userID,
+			MemberID:     row.MemberID,
+			Category:     row.Category,
+			Amount:       row.Amount,
+			Description:  row.Description,
+			ExpenseDate:  *date,
+			IsDeductible: deductible,
+		})
+	}
+	imported, skipped, err := h.uc.ImportMany(c.Request.Context(), inputs)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Created(c, gin.H{"imported": imported, "skipped": skipped})
+}
+
 func (h *ExpenseHandler) Delete(c *gin.Context) {
 	userID := middleware.UserID(c)
 	if err := h.uc.Delete(c.Request.Context(), userID, c.Param("expenseId")); err != nil {

--- a/backend/internal/interface/handler/prescription_handler.go
+++ b/backend/internal/interface/handler/prescription_handler.go
@@ -44,6 +44,7 @@ type createPrescriptionRequest struct {
 	PrescribedAt     *string `json:"prescribedAt" binding:"required"`
 	ExpiresAt        *string `json:"expiresAt"`
 	PharmacyName     *string `json:"pharmacyName"`
+	ElectronicCode   *string `json:"electronicCode"`
 	Notes            *string `json:"notes"`
 }
 
@@ -67,6 +68,7 @@ func (h *PrescriptionHandler) Create(c *gin.Context) {
 		PrescribedAt:     *prescribedAt,
 		ExpiresAt:        parseDate(req.ExpiresAt),
 		PharmacyName:     req.PharmacyName,
+		ElectronicCode:   req.ElectronicCode,
 		Notes:            req.Notes,
 	})
 	if err != nil {
@@ -82,6 +84,7 @@ type updatePrescriptionRequest struct {
 	PrescribedAt     *string `json:"prescribedAt"`
 	ExpiresAt        *string `json:"expiresAt"`
 	PharmacyName     *string `json:"pharmacyName"`
+	ElectronicCode   *string `json:"electronicCode"`
 	Notes            *string `json:"notes"`
 }
 
@@ -98,6 +101,7 @@ func (h *PrescriptionHandler) Update(c *gin.Context) {
 		PrescribedAt:     parseDate(req.PrescribedAt),
 		ExpiresAt:        parseDate(req.ExpiresAt),
 		PharmacyName:     req.PharmacyName,
+		ElectronicCode:   req.ElectronicCode,
 		Notes:            req.Notes,
 	})
 	if err != nil {

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -95,6 +95,7 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 		authed.GET("/expenses", h.Expense.List)
 		authed.GET("/expenses/summary", h.Expense.Summary)
 		authed.POST("/expenses", h.Expense.Create)
+		authed.POST("/expenses/import", h.Expense.Import)
 		authed.PATCH("/expenses/:expenseId", h.Expense.Update)
 		authed.DELETE("/expenses/:expenseId", h.Expense.Delete)
 

--- a/backend/internal/usecase/expense_usecase.go
+++ b/backend/internal/usecase/expense_usecase.go
@@ -115,6 +115,26 @@ func (uc *ExpenseUsecase) Create(ctx context.Context, in repository.CreateExpens
 	return uc.expenses.Create(ctx, in)
 }
 
+// ImportMany は複数の支出を一括登録する（CSV/医療費通知の取込用）。
+// 不正な行はスキップし、登録件数とスキップ件数を返す。
+func (uc *ExpenseUsecase) ImportMany(ctx context.Context, inputs []repository.CreateExpenseInput) (imported int, skipped int, err error) {
+	for _, in := range inputs {
+		if in.Amount <= 0 || !validExpenseCategories[in.Category] || in.ExpenseDate.IsZero() {
+			skipped++
+			continue
+		}
+		if e := uc.ensureMemberOwner(ctx, in.UserID, in.MemberID); e != nil {
+			skipped++
+			continue
+		}
+		if _, e := uc.expenses.Create(ctx, in); e != nil {
+			return imported, skipped, e
+		}
+		imported++
+	}
+	return imported, skipped, nil
+}
+
 // Update は所有権確認と、指定された項目のみの検証を行う。
 func (uc *ExpenseUsecase) Update(ctx context.Context, userID, id string, in repository.UpdateExpenseInput) (*entity.Expense, error) {
 	if _, err := uc.ensureOwner(ctx, userID, id); err != nil {

--- a/backend/migrations/0005_prescription_electronic_code.sql
+++ b/backend/migrations/0005_prescription_electronic_code.sql
@@ -1,0 +1,2 @@
+-- 電子処方箋の引換番号/アクセスコードを処方箋に保持。既存DBに安全な no-op。
+ALTER TABLE "Prescription" ADD COLUMN IF NOT EXISTS "electronicCode" TEXT;

--- a/frontend/app/components/expenses/ExpenseImport.tsx
+++ b/frontend/app/components/expenses/ExpenseImport.tsx
@@ -1,0 +1,317 @@
+import { useRef, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { FileUp, Upload } from "lucide-react";
+import { api } from "@/lib/api";
+import { Button, ErrorText } from "@/components/ui";
+import { getExpenseCategoryLabel } from "@/lib/categories";
+
+interface ImportExpense {
+  memberId: string | null;
+  category: string;
+  amount: number;
+  description?: string;
+  expenseDate: string;
+  isDeductible?: boolean;
+}
+
+interface ImportResult {
+  imported: number;
+  skipped: number;
+}
+
+interface ExpenseImportProps {
+  onImported: () => void;
+}
+
+// CSV の1行を簡易パース（ダブルクォート/エスケープ対応, カンマ区切り）
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      result.push(cur);
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  result.push(cur);
+  return result.map((c) => c.trim());
+}
+
+// CSV全体を行に分割（クォート内の改行も許容）
+function splitCsvRows(text: string): string[] {
+  const rows: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '"') {
+      if (inQuotes && text[i + 1] === '"') {
+        cur += '""';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+        cur += ch;
+      }
+    } else if ((ch === "\n" || ch === "\r") && !inQuotes) {
+      if (ch === "\r" && text[i + 1] === "\n") i++;
+      if (cur.length > 0) rows.push(cur);
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.length > 0) rows.push(cur);
+  return rows;
+}
+
+// 医療費の区分（国税庁フォーム/当アプリエクスポート）→ カテゴリへの逆マッピング
+function divisionToCategory(division: string): string {
+  const d = division.replace(/\s/g, "");
+  if (!d) return "other";
+  if (/診療|治療|診察/.test(d)) return "hospital";
+  if (/医薬品|薬局|薬|処方/.test(d)) return "medication";
+  if (/介護/.test(d)) return "other";
+  if (/その他/.test(d)) return "other";
+  if (/保険/.test(d)) return "insurance";
+  if (/健診|検査|検診/.test(d)) return "checkup";
+  if (/通院|交通/.test(d)) return "transport";
+  if (/ペット/.test(d)) return "pet";
+  return "other";
+}
+
+// 金額文字列から数値を抽出（カンマ/円記号/全角を除去）
+function parseAmount(raw: string): number {
+  const normalized = raw
+    .replace(/[０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0))
+    .replace(/[,，\s¥￥円]/g, "");
+  const n = Number(normalized);
+  return Number.isFinite(n) ? Math.round(n) : NaN;
+}
+
+// 支払日を YYYY-MM-DD に正規化
+function parseDate(raw: string): string {
+  const t = raw
+    .replace(/[０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xfee0))
+    .trim();
+  // 2024-01-02 / 2024/1/2 / 2024.1.2 / 20240102 / 2024年1月2日
+  let m = t.match(/(\d{4})\D+(\d{1,2})\D+(\d{1,2})/);
+  if (!m) m = t.match(/(\d{4})(\d{2})(\d{2})/);
+  if (!m) return "";
+  const [, y, mo, d] = m;
+  return `${y}-${mo.padStart(2, "0")}-${d.padStart(2, "0")}`;
+}
+
+// ヘッダ名から列インデックスを探す（部分一致）
+function findCol(headers: string[], keywords: string[]): number {
+  for (let i = 0; i < headers.length; i++) {
+    const h = headers[i].replace(/\s/g, "");
+    if (keywords.some((k) => h.includes(k))) return i;
+  }
+  return -1;
+}
+
+function parseCsv(text: string): { rows: ImportExpense[]; errors: number } {
+  const lines = splitCsvRows(text).filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return { rows: [], errors: 0 };
+
+  const headers = parseCsvLine(lines[0]);
+  const personIdx = findCol(headers, ["医療を受けた人", "受けた人", "氏名", "名前", "人"]);
+  const payeeIdx = findCol(headers, ["支払先", "病院", "薬局", "支払", "内容", "摘要"]);
+  const divisionIdx = findCol(headers, ["区分", "種別", "カテゴリ"]);
+  const amountIdx = findCol(headers, ["支払った金額", "金額", "支払金額"]);
+  const dateIdx = findCol(headers, ["支払年月日", "支払日", "日付", "年月日", "日"]);
+  const deductibleIdx = findCol(headers, ["控除対象", "控除"]);
+
+  const rows: ImportExpense[] = [];
+  let errors = 0;
+
+  for (let i = 1; i < lines.length; i++) {
+    const cols = parseCsvLine(lines[i]);
+    if (cols.every((c) => c === "")) continue;
+
+    const amount = amountIdx >= 0 ? parseAmount(cols[amountIdx] ?? "") : NaN;
+    const expenseDate = dateIdx >= 0 ? parseDate(cols[dateIdx] ?? "") : "";
+
+    if (!Number.isFinite(amount) || amount <= 0 || !expenseDate) {
+      errors++;
+      continue;
+    }
+
+    const division = divisionIdx >= 0 ? (cols[divisionIdx] ?? "") : "";
+    const payee = payeeIdx >= 0 ? (cols[payeeIdx] ?? "").trim() : "";
+    const deductibleRaw = deductibleIdx >= 0 ? (cols[deductibleIdx] ?? "") : "";
+    const isDeductible = deductibleIdx >= 0 ? !/対象外|いいえ|no|false|×|✕/i.test(deductibleRaw) : true;
+
+    rows.push({
+      memberId: null,
+      category: divisionToCategory(division),
+      amount,
+      description: payee || undefined,
+      expenseDate,
+      isDeductible,
+    });
+  }
+
+  return { rows, errors };
+}
+
+export function ExpenseImport({ onImported }: ExpenseImportProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [fileName, setFileName] = useState<string>("");
+  const [parsed, setParsed] = useState<ImportExpense[]>([]);
+  const [parseErrors, setParseErrors] = useState(0);
+  const [parseMessage, setParseMessage] = useState<string>("");
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  const importMutation = useMutation({
+    mutationFn: (expenses: ImportExpense[]) =>
+      api.post<ImportResult>("/expenses/import", { expenses }),
+    onSuccess: (res) => {
+      setResult(res);
+      onImported();
+    },
+  });
+
+  const handleFile = async (file: File) => {
+    setResult(null);
+    setParseMessage("");
+    setFileName(file.name);
+    try {
+      const text = await file.text();
+      const { rows, errors } = parseCsv(text);
+      setParsed(rows);
+      setParseErrors(errors);
+      if (rows.length === 0) {
+        setParseMessage(
+          "取込可能な行が見つかりませんでした。ヘッダ行（金額・支払日など）があるCSVを選択してください。",
+        );
+      }
+    } catch {
+      setParsed([]);
+      setParseErrors(0);
+      setParseMessage("CSVの読み込みに失敗しました。");
+    }
+  };
+
+  const handleImport = () => {
+    if (parsed.length === 0) return;
+    importMutation.mutate(parsed);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <p className="text-sm font-bold text-ink-800">医療費CSVの取込</p>
+        <p className="text-xs text-ink-500">
+          マイナポータルの医療費通知や国税庁「医療費集計フォーム」、当アプリの明細書CSVを取り込めます。
+        </p>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".csv,text/csv"
+        className="hidden"
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) void handleFile(f);
+          e.target.value = "";
+        }}
+      />
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="ghost" onClick={() => fileInputRef.current?.click()}>
+          <FileUp size={16} />
+          CSVファイルを選択
+        </Button>
+        {fileName && <span className="text-xs text-ink-500">{fileName}</span>}
+      </div>
+
+      <ErrorText>{parseMessage}</ErrorText>
+
+      {parsed.length > 0 && !result && (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+            <span className="font-bold text-primary-700">
+              取込予定 {parsed.length}件
+            </span>
+            {parseErrors > 0 && (
+              <span className="text-xs text-amber-600">
+                （金額・日付が不正な {parseErrors}件 はスキップされます）
+              </span>
+            )}
+          </div>
+
+          <div className="max-h-64 overflow-auto rounded-xl border border-ink-400/15">
+            <table className="w-full text-left text-xs">
+              <thead className="sticky top-0 bg-primary-50 text-ink-600">
+                <tr>
+                  <th className="px-3 py-2 font-medium">支払日</th>
+                  <th className="px-3 py-2 font-medium">区分</th>
+                  <th className="px-3 py-2 font-medium">支払先</th>
+                  <th className="px-3 py-2 text-right font-medium">金額</th>
+                  <th className="px-3 py-2 font-medium">控除</th>
+                </tr>
+              </thead>
+              <tbody>
+                {parsed.map((row, i) => (
+                  <tr key={i} className="border-t border-ink-400/10">
+                    <td className="px-3 py-1.5 text-ink-700">{row.expenseDate}</td>
+                    <td className="px-3 py-1.5 text-ink-700">
+                      {getExpenseCategoryLabel(row.category)}
+                    </td>
+                    <td className="px-3 py-1.5 text-ink-600">
+                      {row.description ?? "-"}
+                    </td>
+                    <td className="px-3 py-1.5 text-right text-ink-800">
+                      {row.amount.toLocaleString()}円
+                    </td>
+                    <td className="px-3 py-1.5 text-ink-600">
+                      {row.isDeductible ? "対象" : "対象外"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <Button onClick={handleImport} disabled={importMutation.isPending}>
+            <Upload size={16} />
+            {importMutation.isPending ? "取込中..." : `${parsed.length}件を取り込む`}
+          </Button>
+
+          {importMutation.isError && (
+            <ErrorText>取込に失敗しました。時間をおいて再度お試しください。</ErrorText>
+          )}
+        </div>
+      )}
+
+      {result && (
+        <div className="rounded-xl border border-primary-200 bg-primary-50 p-4 text-sm">
+          <p className="font-bold text-primary-700">取込が完了しました</p>
+          <p className="mt-1 text-ink-700">
+            登録 {result.imported}件
+            {result.skipped > 0 && ` / スキップ ${result.skipped}件`}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/medications/MedicationForm.tsx
+++ b/frontend/app/components/medications/MedicationForm.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, ScanText } from "lucide-react";
 import type { Medication } from "@/lib/types";
 import type { MedicationCategory } from "@/lib/categories";
+import { OcrImport } from "./OcrImport";
 
 export type { MedicationCategory };
 
@@ -50,6 +51,7 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
     initialData?.instructions
   );
   const [showOptional, setShowOptional] = useState(isEditing && hasOptionalData);
+  const [showOcr, setShowOcr] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -83,9 +85,24 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label htmlFor="med-name" className="block text-sm font-medium text-ink-700 mb-1">
-          薬の名前
-        </label>
+        <div className="flex items-center justify-between mb-1">
+          <label htmlFor="med-name" className="block text-sm font-medium text-ink-700">
+            薬の名前
+          </label>
+          <button
+            type="button"
+            onClick={() => setShowOcr((v) => !v)}
+            aria-pressed={showOcr}
+            className={`flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium transition-colors ${
+              showOcr
+                ? "bg-primary-600 text-white"
+                : "bg-primary-50 text-primary-700 hover:bg-primary-100"
+            }`}
+          >
+            <ScanText size={14} />
+            画像から読み取り(OCR)
+          </button>
+        </div>
         <input
           id="med-name"
           type="text"
@@ -94,6 +111,11 @@ export const MedicationForm: React.FC<MedicationFormProps> = ({ onSubmit, initia
           className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500"
           placeholder="薬の名前を入力"
         />
+        {showOcr && (
+          <div className="mt-2">
+            <OcrImport onPick={(text) => setName(text)} />
+          </div>
+        )}
       </div>
 
       <div>

--- a/frontend/app/components/medications/OcrImport.tsx
+++ b/frontend/app/components/medications/OcrImport.tsx
@@ -1,0 +1,122 @@
+import { useRef, useState } from "react";
+import { Loader2, ImageUp, Info } from "lucide-react";
+import { Button, ErrorText } from "@/components/ui";
+
+interface OcrImportProps {
+  onPick: (text: string) => void;
+}
+
+export function OcrImport({ onPick }: OcrImportProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [lines, setLines] = useState<string[]>([]);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // 同じファイルを再選択できるよう値をリセット
+    e.target.value = "";
+    if (!file) return;
+
+    setError(null);
+    setLines([]);
+    setProgress(0);
+    setLoading(true);
+
+    try {
+      // tesseract.js は重いため遅延読込する
+      const Tesseract = await import("tesseract.js");
+      const worker = await Tesseract.createWorker("jpn+eng", undefined, {
+        logger: (m: { status: string; progress: number }) => {
+          if (m.status === "recognizing text") {
+            setProgress(Math.round(m.progress * 100));
+          }
+        },
+      });
+
+      try {
+        const { data } = await worker.recognize(file);
+        const text = data.text ?? "";
+        const parsed = text
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l.length > 0);
+        setLines(parsed);
+        if (parsed.length === 0) {
+          setError("文字を読み取れませんでした。別の画像でお試しください。");
+        }
+      } finally {
+        await worker.terminate();
+      }
+    } catch {
+      setError("画像の解析に失敗しました。もう一度お試しください。");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl border border-primary-200 bg-primary-50/40 p-3">
+      <div className="flex items-start gap-2 text-xs text-ink-500">
+        <Info size={14} className="mt-0.5 flex-shrink-0" />
+        <span>
+          簡易OCRのため精度は限定的です。読み取った文字は必ず内容をご確認ください。
+        </span>
+      </div>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFile}
+        className="hidden"
+      />
+
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => inputRef.current?.click()}
+        disabled={loading}
+        className="w-full"
+      >
+        {loading ? (
+          <>
+            <Loader2 size={16} className="animate-spin" />
+            解析中…{progress > 0 ? ` ${progress}%` : ""}
+          </>
+        ) : (
+          <>
+            <ImageUp size={16} />
+            画像を選択
+          </>
+        )}
+      </Button>
+
+      <ErrorText>{error}</ErrorText>
+
+      {lines.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-ink-700">読み取り結果（行を選んで薬名に使えます）</p>
+          <ul className="max-h-56 space-y-1 overflow-y-auto">
+            {lines.map((line, i) => (
+              <li
+                key={`${i}-${line}`}
+                className="flex items-center justify-between gap-2 rounded-lg bg-white px-3 py-2"
+              >
+                <span className="min-w-0 flex-1 break-all text-sm text-ink-800">{line}</span>
+                <button
+                  type="button"
+                  onClick={() => onPick(line)}
+                  className="flex-shrink-0 rounded-lg bg-primary-100 px-2.5 py-1 text-xs font-medium text-primary-700 transition-colors hover:bg-primary-200"
+                >
+                  これを薬名に使う
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/prescriptions/PrescriptionForm.tsx
+++ b/frontend/app/components/prescriptions/PrescriptionForm.tsx
@@ -8,6 +8,7 @@ export interface PrescriptionFormData {
   prescribedAt: string;
   expiresAt?: string;
   pharmacyName?: string;
+  electronicCode?: string;
   notes?: string;
 }
 
@@ -22,6 +23,7 @@ interface PrescriptionFormProps {
     prescribedAt: string;
     expiresAt?: string;
     pharmacyName?: string;
+    electronicCode?: string;
     notes?: string;
   };
 }
@@ -42,6 +44,7 @@ export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onS
   );
   const [expiresAt, setExpiresAt] = useState(toDateInput(initialData?.expiresAt));
   const [pharmacyName, setPharmacyName] = useState(initialData?.pharmacyName || "");
+  const [electronicCode, setElectronicCode] = useState(initialData?.electronicCode || "");
   const [notes, setNotes] = useState(initialData?.notes || "");
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -55,6 +58,7 @@ export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onS
       prescribedAt: new Date(prescribedAt).toISOString(),
       expiresAt: expiresAt ? new Date(expiresAt).toISOString() : undefined,
       pharmacyName: pharmacyName.trim() || undefined,
+      electronicCode: electronicCode.trim() || undefined,
       notes: notes.trim() || undefined,
     });
 
@@ -63,6 +67,7 @@ export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onS
       setPrescribedBy("");
       setExpiresAt("");
       setPharmacyName("");
+      setElectronicCode("");
       setNotes("");
     }
   };
@@ -157,6 +162,20 @@ export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onS
           onChange={(e) => setPharmacyName(e.target.value)}
           className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
           placeholder="例: 調剤薬局ABC"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="rx-ecode" className="block text-sm font-medium text-ink-700 mb-1">
+          電子処方箋コード/引換番号（任意）
+        </label>
+        <input
+          id="rx-ecode"
+          type="text"
+          value={electronicCode}
+          onChange={(e) => setElectronicCode(e.target.value)}
+          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          placeholder="例: 1234-5678-9012"
         />
       </div>
 

--- a/frontend/app/components/prescriptions/PrescriptionList.tsx
+++ b/frontend/app/components/prescriptions/PrescriptionList.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
-import { Pencil, Trash2, Check, X } from "lucide-react";
-import type { Prescription } from "@/lib/types";
+import { useMutation } from "@tanstack/react-query";
+import { Pencil, Trash2, Check, X, QrCode, PillBottle } from "lucide-react";
+import type { Medication, Prescription } from "@/lib/types";
+import { api } from "@/lib/api";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
 import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
@@ -54,10 +56,19 @@ interface PrescriptionCardProps {
 const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescription, onUpdate, onDelete }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isRegisterDialogOpen, setIsRegisterDialogOpen] = useState(false);
   const [editName, setEditName] = useState(prescription.prescriptionName);
   const [editDoctor, setEditDoctor] = useState(prescription.prescribedBy || "");
   const [editPharmacy, setEditPharmacy] = useState(prescription.pharmacyName || "");
   const [editNotes, setEditNotes] = useState(prescription.notes || "");
+
+  const registerMedicationMutation = useMutation({
+    mutationFn: () =>
+      api.post<Medication>("/medications", {
+        memberId: prescription.memberId,
+        name: prescription.prescriptionName,
+      }),
+  });
 
   const now = new Date();
   const expiresDate = prescription.expiresAt ? new Date(prescription.expiresAt) : null;
@@ -168,6 +179,29 @@ const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescrip
             {prescription.pharmacyName && <p>薬局: {prescription.pharmacyName}</p>}
             {prescription.notes && <p className="text-ink-400">{prescription.notes}</p>}
           </div>
+          {prescription.electronicCode && (
+            <div className="mt-2 inline-flex items-center gap-1.5 bg-primary-50 text-primary-700 px-2 py-1 rounded-md">
+              <QrCode size={14} className="flex-shrink-0" />
+              <span className="text-xs font-mono tracking-wide break-all">{prescription.electronicCode}</span>
+            </div>
+          )}
+          <div className="mt-2">
+            <button
+              type="button"
+              onClick={() => setIsRegisterDialogOpen(true)}
+              disabled={registerMedicationMutation.isPending}
+              className="inline-flex items-center gap-1 bg-primary-50 text-primary-700 px-2.5 py-1 rounded-lg text-xs font-medium hover:bg-primary-100 transition-colors disabled:opacity-50"
+            >
+              <PillBottle size={14} />
+              <span>{registerMedicationMutation.isPending ? "登録中..." : "この処方箋からお薬を登録"}</span>
+            </button>
+            {registerMedicationMutation.isSuccess && (
+              <p className="mt-1 text-xs text-primary-600">お薬を登録しました</p>
+            )}
+            {registerMedicationMutation.isError && (
+              <p className="mt-1 text-xs text-red-600">登録に失敗しました。もう一度お試しください</p>
+            )}
+          </div>
         </div>
         <div className="flex items-center space-x-1 flex-shrink-0">
           <button
@@ -196,6 +230,16 @@ const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescrip
         }}
         onCancel={() => setIsDeleteDialogOpen(false)}
         isDangerous
+      />
+      <ConfirmationDialog
+        title="お薬を登録"
+        message={`「${prescription.prescriptionName}」を服薬管理のお薬として登録しますか？`}
+        isOpen={isRegisterDialogOpen}
+        onConfirm={() => {
+          setIsRegisterDialogOpen(false);
+          registerMedicationMutation.mutate();
+        }}
+        onCancel={() => setIsRegisterDialogOpen(false)}
       />
     </div>
   );

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -289,6 +289,7 @@ export interface Prescription {
   prescribedAt: string;
   expiresAt: string | null;
   pharmacyName: string | null;
+  electronicCode: string | null;
   notes: string | null;
   createdAt: string;
 }

--- a/frontend/app/routes/expenses.tsx
+++ b/frontend/app/routes/expenses.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Download, Plus, X } from "lucide-react";
+import { AlertTriangle, Download, Plus, Upload, X } from "lucide-react";
 import { api } from "@/lib/api";
 import type {
   Budget,
@@ -24,6 +24,7 @@ import {
   BudgetCard,
   type BudgetSavePayload,
 } from "@/components/expenses/BudgetCard";
+import { ExpenseImport } from "@/components/expenses/ExpenseImport";
 import { getExpenseCategoryLabel } from "@/lib/categories";
 import { formatCurrency } from "@/lib/format";
 
@@ -36,6 +37,7 @@ export default function Expenses() {
   const [year, setYear] = useState<number>(currentYear);
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
+  const [showImport, setShowImport] = useState(false);
 
   const yearOptions = useMemo(
     () => Array.from({ length: YEAR_OPTIONS_COUNT }, (_, i) => currentYear - i),
@@ -206,15 +208,52 @@ export default function Expenses() {
           ))}
         </select>
         <button
+          onClick={() => setShowImport(true)}
+          className="ml-auto flex items-center gap-1.5 rounded-xl bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 transition hover:bg-primary-100"
+          title="医療費CSVを取り込む"
+        >
+          <Upload size={16} />
+          CSV取込
+        </button>
+        <button
           onClick={handleExportCsv}
           disabled={expenses.length === 0}
-          className="ml-auto flex items-center gap-1.5 rounded-xl bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 transition hover:bg-primary-100 disabled:opacity-50"
+          className="flex items-center gap-1.5 rounded-xl bg-primary-50 px-3 py-1.5 text-sm font-medium text-primary-700 transition hover:bg-primary-100 disabled:opacity-50"
           title="医療費控除の明細書(CSV)をダウンロード"
         >
           <Download size={16} />
           明細書CSV
         </button>
       </div>
+
+      {showImport && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-ink-900/40 p-0 sm:items-center sm:p-4"
+          onClick={() => setShowImport(false)}
+        >
+          <div
+            className="max-h-[90vh] w-full max-w-lg overflow-auto rounded-t-2xl bg-white p-5 shadow-card sm:rounded-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-base font-bold text-ink-800">医療費CSV取込</h3>
+              <button
+                onClick={() => setShowImport(false)}
+                className="rounded-lg p-1 text-ink-500 transition hover:bg-ink-400/10"
+                aria-label="閉じる"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <ExpenseImport
+              onImported={() => {
+                invalidateAll();
+                qc.invalidateQueries({ queryKey: ["budget", "alert"] });
+              }}
+            />
+          </div>
+        </div>
+      )}
 
       <ExpenseSummaryCard summary={summary} isLoading={summaryLoading} />
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.1.0",
+        "tesseract.js": "^5.1.1",
         "zod": "^3.23.8",
         "zustand": "^5.0.14"
       },
@@ -1696,6 +1697,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -2154,6 +2161,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.5.tgz",
+      "integrity": "sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2182,6 +2195,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2215,6 +2234,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/isbot": {
       "version": "5.1.43",
@@ -2376,6 +2401,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.48",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
@@ -2414,6 +2459,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/p-map": {
@@ -2779,6 +2833,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -3041,6 +3101,31 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-5.1.1.tgz",
+      "integrity": "sha512-lzVl/Ar3P3zhpUT31NjqeCo1f+D5+YfpZ5J62eo2S14QNVOmHBTtbchHm/YAbOOOzCegFnKf4B3Qih9LuldcYQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-electron": "^2.2.2",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^5.1.1",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.1.1.tgz",
+      "integrity": "sha512-KX3bYSU5iGcO1XJa+QGPbi+Zjo2qq6eBhNjSGR5E5q0JtzkoipJKOUQD7ph8kFyteCEfEQ0maWLu8MCXtvX5uQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -3124,6 +3209,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -3384,12 +3475,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.0",
+    "tesseract.js": "^5.1.1",
     "zod": "^3.23.8",
     "zustand": "^5.0.14"
   },


### PR DESCRIPTION
## Summary
competitor 調査の上位ギャップを、本来必要な外部連携(マイナポータルOAuth/HPKI/クラウドOCR)無しで**現スタック完結の実用版**として実装。
### バックエンド
- `Prescription.electronicCode`(電子処方箋の引換番号)を追加(migration `0005`)。`POST/PATCH /prescriptions` で受付。
- `POST /expenses/import`：医療費の一括取込(CSV/通知変換後)。不正行はスキップし `{imported, skipped}` を返す。
### フロントエンド
- **処方箋/お薬OCR**：`tesseract.js`(ブラウザOCR・遅延import)で処方箋/ラベル画像から文字認識→薬名入力を補助(精度限定の注記つき)。
- **医療費CSV取込**：国税庁「医療費集計フォーム」/自アプリCSVをパース→区分→カテゴリ逆マッピング→プレビュー→一括登録。
- **電子処方箋連携**：`electronicCode` の入力/表示＋「処方箋からお薬を登録」フローで服薬管理へ橋渡し。

backend `build`/`vet`/`test`・frontend `typecheck`/`build` 通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 電子処方箋コードの登録・編集に対応しました
  * 医療費のCSVファイル一括取込機能を追加しました
  * 薬の名前入力時にOCR読み取り機能が使用できるようになりました
  * 処方箋から薬を直接登録できるようになりました
  * 電子処方箋コードがある場合、QRコードが表示されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->