### PR TITLE
refactor(frontend): React Queryキーを queryKeys ファクトリに安全集約

### DIFF
--- a/frontend/app/components/dashboard/DashboardSettings.tsx
+++ b/frontend/app/components/dashboard/DashboardSettings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowDown, ArrowUp, Check, Eye, EyeOff, X } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { DashboardPreference, Member } from "@/lib/types";
 import { Button, Card, ErrorText } from "@/components/ui";
 
@@ -67,7 +68,7 @@ export function DashboardSettings({ preference, members, onClose }: DashboardSet
       defaultMemberId: string | null;
     }) => api.put<DashboardPreference>("/dashboard-preferences", input),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["dashboard-preferences"] });
+      qc.invalidateQueries({ queryKey: queryKeys.dashboardPreferences.all });
       onClose();
     },
   });

--- a/frontend/app/components/medications/MemberMedications.tsx
+++ b/frontend/app/components/medications/MemberMedications.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Clock, X, Check } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { Medication, Member, Schedule } from "@/lib/types";
 import { MemberIcon, type MemberType, type PetType } from "@/components/shared/MemberIcon";
 import {
@@ -89,17 +90,19 @@ export function MemberMedications({ member, categoryFilter }: MemberMedicationsP
   const addFormRef = useRef<HTMLDivElement>(null);
 
   const { data: medications = [], isLoading } = useQuery({
-    queryKey: ["medications", member.id],
+    queryKey: queryKeys.medications.byMember(member.id),
     queryFn: () => api.get<Medication[]>(`/members/${member.id}/medications`),
   });
 
   const { data: schedules = [] } = useQuery({
-    queryKey: ["schedules"],
+    queryKey: queryKeys.schedules.all,
     queryFn: () => api.get<Schedule[]>("/schedules"),
   });
 
-  const invalidateMeds = () => qc.invalidateQueries({ queryKey: ["medications", member.id] });
-  const invalidateSchedules = () => qc.invalidateQueries({ queryKey: ["schedules"] });
+  const invalidateMeds = () =>
+    qc.invalidateQueries({ queryKey: queryKeys.medications.byMember(member.id) });
+  const invalidateSchedules = () =>
+    qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
 
   const createMedication = useMutation({
     mutationFn: (data: MedicationFormData) =>

--- a/frontend/app/hooks/dashboard.ts
+++ b/frontend/app/hooks/dashboard.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type {
   Appointment,
   Hospital,
@@ -208,39 +209,39 @@ export function useDashboardData(userId: string | null) {
   const enabled = !!userId;
 
   const todayQuery = useQuery({
-    queryKey: ["schedules", "today"],
+    queryKey: queryKeys.schedules.today,
     queryFn: () => api.get<TodaySchedule[]>("/schedules/today"),
     enabled,
   });
   const schedulesQuery = useQuery({
-    queryKey: ["schedules"],
+    queryKey: queryKeys.schedules.all,
     queryFn: () => api.get<Schedule[]>("/schedules"),
     enabled,
   });
   // ダッシュボードの集計は週次/月次のみ。全件ではなく直近40日に絞って取得する。
   // (invalidateQueries({queryKey:["records"]}) はプレフィックス一致でこのキーも無効化する)
   const recordsQuery = useQuery({
-    queryKey: ["records", "window", 40],
+    queryKey: queryKeys.records.window(40),
     queryFn: () => api.get<MedicationRecord[]>("/records?days=40"),
     enabled,
   });
   const medicationsQuery = useQuery({
-    queryKey: ["medications"],
+    queryKey: queryKeys.medications.all,
     queryFn: () => api.get<Medication[]>("/medications"),
     enabled,
   });
   const membersQuery = useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<Member[]>("/members"),
     enabled,
   });
   const appointmentsQuery = useQuery({
-    queryKey: ["appointments"],
+    queryKey: queryKeys.appointments.all,
     queryFn: () => api.get<Appointment[]>("/appointments"),
     enabled,
   });
   const hospitalsQuery = useQuery({
-    queryKey: ["hospitals"],
+    queryKey: queryKeys.hospitals.all,
     queryFn: () => api.get<Hospital[]>("/hospitals"),
     enabled,
   });
@@ -460,8 +461,8 @@ export function useMarkRecord() {
         ...(input.notes ? { notes: input.notes } : {}),
       }),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["schedules", "today"] });
-      qc.invalidateQueries({ queryKey: ["records"] });
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.today });
+      qc.invalidateQueries({ queryKey: queryKeys.records.all });
     },
   });
 }

--- a/frontend/app/hooks/health-logs.ts
+++ b/frontend/app/hooks/health-logs.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type {
   BodyMeasurement,
   HealthLog,
@@ -269,7 +270,7 @@ function memberNameOf(members: Member[] | undefined, memberId: string): string {
 
 export function useMembersQuery() {
   return useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<Member[]>("/members"),
   });
 }
@@ -285,7 +286,7 @@ export function useHealthLogs(members: Member[] | undefined) {
   const qc = useQueryClient();
 
   const query = useQuery({
-    queryKey: ["health-logs"],
+    queryKey: queryKeys.healthLogs.all,
     queryFn: () => api.get<HealthLog[]>("/health-logs"),
   });
 
@@ -310,12 +311,12 @@ export function useHealthLogs(members: Member[] | undefined) {
         notes: input.notes,
         recordedAt: new Date().toISOString(),
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["health-logs"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.healthLogs.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/health-logs/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["health-logs"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.healthLogs.all }),
   });
 
   return {
@@ -339,7 +340,7 @@ export function useTemperatureRecords(members: Member[] | undefined) {
   const qc = useQueryClient();
 
   const query = useQuery({
-    queryKey: ["temperature-records"],
+    queryKey: queryKeys.temperatureRecords.all,
     queryFn: () => api.get<TemperatureRecord[]>("/temperature-records"),
   });
 
@@ -362,12 +363,14 @@ export function useTemperatureRecords(members: Member[] | undefined) {
         measuredAt: input.measuredAt,
         notes: input.notes,
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["temperature-records"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.temperatureRecords.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/temperature-records/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["temperature-records"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.temperatureRecords.all }),
   });
 
   return {
@@ -397,7 +400,7 @@ export function useBodyMeasurements(members: Member[] | undefined) {
   const qc = useQueryClient();
 
   const query = useQuery({
-    queryKey: ["body-measurements"],
+    queryKey: queryKeys.bodyMeasurements.all,
     queryFn: () => api.get<BodyMeasurement[]>("/body-measurements"),
   });
 
@@ -425,7 +428,8 @@ export function useBodyMeasurements(members: Member[] | undefined) {
         recordedAt: new Date(input.recordedAt).toISOString(),
         notes: input.notes,
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["body-measurements"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.bodyMeasurements.all }),
   });
 
   const updateMutation = useMutation({
@@ -436,12 +440,14 @@ export function useBodyMeasurements(members: Member[] | undefined) {
       id: string;
       input: UpdateBodyMeasurementInput;
     }) => api.patch<BodyMeasurement>(`/body-measurements/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["body-measurements"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.bodyMeasurements.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/body-measurements/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["body-measurements"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.bodyMeasurements.all }),
   });
 
   return {

--- a/frontend/app/hooks/history.ts
+++ b/frontend/app/hooks/history.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { MedicationRecord, Member, Medication, HealthLog } from "@/lib/types";
 
 /** 表示用に氏名・薬名を付与した服薬記録 */
@@ -85,22 +86,22 @@ export function useMedicationHistory(): UseMedicationHistoryResult {
   const qc = useQueryClient();
 
   const { data: rawRecords, isLoading: recordsLoading } = useQuery({
-    queryKey: ["records"],
+    queryKey: queryKeys.records.all,
     queryFn: () => api.get<MedicationRecord[]>("/records"),
   });
 
   const { data: members } = useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<Member[]>("/members"),
   });
 
   const { data: medications } = useQuery({
-    queryKey: ["medications"],
+    queryKey: queryKeys.medications.all,
     queryFn: () => api.get<Medication[]>("/medications"),
   });
 
   const { data: healthLogs } = useQuery({
-    queryKey: ["health-logs"],
+    queryKey: queryKeys.healthLogs.all,
     queryFn: () => api.get<HealthLog[]>("/health-logs"),
   });
 
@@ -124,12 +125,12 @@ export function useMedicationHistory(): UseMedicationHistoryResult {
 
   const deleteMutation = useMutation({
     mutationFn: (recordId: string) => api.delete(`/records/${recordId}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["records"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.records.all }),
   });
 
   const createMutation = useMutation({
     mutationFn: (input: CreateRecordInput) => api.post("/records", input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["records"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.records.all }),
   });
 
   return {

--- a/frontend/app/lib/queryKeys.ts
+++ b/frontend/app/lib/queryKeys.ts
@@ -1,0 +1,85 @@
+/**
+ * React Query キーの一元管理ファクトリ。
+ *
+ * 重要: キャッシュと無効化(invalidateQueries)はキー配列の「要素・順序の完全一致」と
+ * 「プレフィックス一致」に依存している。
+ * 例: invalidateQueries({ queryKey: queryKeys.records.all }) は ["records"] となり、
+ *     ["records", "window", 40] をプレフィックス一致で無効化する。
+ *
+ * したがって、各メンバーは既存のリテラル配列とバイト単位で同一の配列を返す必要がある。
+ * 変更時はキーの要素・順序を絶対に変えないこと。
+ */
+export const queryKeys = {
+  members: {
+    all: ["members"] as const,
+    // memberId は useParams() 由来で string | undefined になり得る。
+    // 既存リテラル ["members", memberId] の挙動を完全一致で維持するため undefined も許容する。
+    detail: (memberId: string | undefined) => ["members", memberId] as const,
+    medications: (memberId: string | undefined) =>
+      ["members", memberId, "medications"] as const,
+  },
+  medications: {
+    all: ["medications"] as const,
+    byMember: (memberId: string) => ["medications", memberId] as const,
+  },
+  schedules: {
+    all: ["schedules"] as const,
+    today: ["schedules", "today"] as const,
+  },
+  records: {
+    all: ["records"] as const,
+    window: (limit: number) => ["records", "window", limit] as const,
+  },
+  expenses: {
+    all: ["expenses"] as const,
+    list: (year: number, memberId: string | null) =>
+      ["expenses", year, memberId] as const,
+    summary: (year: number) => ["expenses", "summary", year] as const,
+  },
+  budget: {
+    all: ["budget"] as const,
+    alert: ["budget", "alert"] as const,
+  },
+  dashboardPreferences: {
+    all: ["dashboard-preferences"] as const,
+  },
+  notificationSettings: {
+    all: ["notification-settings"] as const,
+  },
+  users: {
+    me: ["users", "me"] as const,
+  },
+  hospitals: {
+    all: ["hospitals"] as const,
+  },
+  appointments: {
+    all: ["appointments"] as const,
+  },
+  healthLogs: {
+    all: ["health-logs"] as const,
+  },
+  vaccinations: {
+    all: ["vaccinations"] as const,
+  },
+  examinations: {
+    all: ["examinations"] as const,
+  },
+  insurances: {
+    all: ["insurances"] as const,
+  },
+  allergies: {
+    all: ["allergies"] as const,
+  },
+  bodyMeasurements: {
+    all: ["body-measurements"] as const,
+  },
+  temperatureRecords: {
+    all: ["temperature-records"] as const,
+  },
+  emergencyContacts: {
+    all: ["emergency-contacts"] as const,
+  },
+  prescriptions: {
+    all: ["prescriptions"] as const,
+  },
+} as const;

--- a/frontend/app/routes/appointments.tsx
+++ b/frontend/app/routes/appointments.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { MapPin, Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { Appointment, Hospital, Member } from "@/lib/types";
 import { TabSwitch } from "@/components/shared/TabSwitch";
 import { MiniCalendar } from "@/components/appointments/MiniCalendar";
@@ -22,17 +23,17 @@ export default function Appointments() {
   const editFormRef = useRef<HTMLDivElement>(null);
 
   const { data: members = [], isLoading: membersLoading } = useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<Member[]>("/members"),
   });
 
   const { data: appointments = [], isLoading } = useQuery({
-    queryKey: ["appointments"],
+    queryKey: queryKeys.appointments.all,
     queryFn: () => api.get<Appointment[]>("/appointments"),
   });
 
   const { data: hospitals = [] } = useQuery({
-    queryKey: ["hospitals"],
+    queryKey: queryKeys.hospitals.all,
     queryFn: () => api.get<Hospital[]>("/hospitals"),
   });
 
@@ -67,7 +68,7 @@ export default function Appointments() {
       }),
     onSuccess: () => {
       setShowForm(false);
-      qc.invalidateQueries({ queryKey: ["appointments"] });
+      qc.invalidateQueries({ queryKey: queryKeys.appointments.all });
     },
   });
 
@@ -81,14 +82,15 @@ export default function Appointments() {
       }),
     onSuccess: () => {
       setEditingAppointment(null);
-      qc.invalidateQueries({ queryKey: ["appointments"] });
+      qc.invalidateQueries({ queryKey: queryKeys.appointments.all });
     },
     onError: () => setUpdateError("更新に失敗しました。もう一度お試しください。"),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/appointments/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["appointments"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.appointments.all }),
   });
 
   const handleCreate = (data: AppointmentFormData) => {

--- a/frontend/app/routes/expenses.tsx
+++ b/frontend/app/routes/expenses.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Download, Plus, Upload, X } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type {
   Budget,
   BudgetAlertStatus,
@@ -45,12 +46,12 @@ export default function Expenses() {
   );
 
   const { data: members = [] } = useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<Member[]>("/members"),
   });
 
   const { data: expenses = [], isLoading: expensesLoading } = useQuery({
-    queryKey: ["expenses", year, selectedMemberId],
+    queryKey: queryKeys.expenses.list(year, selectedMemberId),
     queryFn: () => {
       const params = new URLSearchParams({ year: String(year) });
       if (selectedMemberId) params.set("memberId", selectedMemberId);
@@ -59,12 +60,12 @@ export default function Expenses() {
   });
 
   const { data: summary, isLoading: summaryLoading } = useQuery({
-    queryKey: ["expenses", "summary", year],
+    queryKey: queryKeys.expenses.summary(year),
     queryFn: () => api.get<ExpenseSummary>(`/expenses/summary?year=${year}`),
   });
 
   const { data: budget, isLoading: budgetLoading } = useQuery({
-    queryKey: ["budget"],
+    queryKey: queryKeys.budget.all,
     queryFn: () => api.get<Budget>("/budget"),
   });
 
@@ -72,20 +73,20 @@ export default function Expenses() {
     mutationFn: (payload: BudgetSavePayload) =>
       api.put<Budget>("/budget", payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["budget"] });
-      qc.invalidateQueries({ queryKey: ["budget", "alert"] });
+      qc.invalidateQueries({ queryKey: queryKeys.budget.all });
+      qc.invalidateQueries({ queryKey: queryKeys.budget.alert });
     },
   });
 
   // ページ表示時に予算超過を判定（メールアラート連動）
   const { data: alertStatus } = useQuery({
-    queryKey: ["budget", "alert"],
+    queryKey: queryKeys.budget.alert,
     queryFn: () => api.post<BudgetAlertStatus>("/budget/alert"),
   });
 
   const invalidateAll = () => {
-    qc.invalidateQueries({ queryKey: ["expenses"] });
-    qc.invalidateQueries({ queryKey: ["expenses", "summary", year] });
+    qc.invalidateQueries({ queryKey: queryKeys.expenses.all });
+    qc.invalidateQueries({ queryKey: queryKeys.expenses.summary(year) });
   };
 
   const createMutation = useMutation({
@@ -248,7 +249,7 @@ export default function Expenses() {
             <ExpenseImport
               onImported={() => {
                 invalidateAll();
-                qc.invalidateQueries({ queryKey: ["budget", "alert"] });
+                qc.invalidateQueries({ queryKey: queryKeys.budget.alert });
               }}
             />
           </div>

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react
 import { useQuery } from "@tanstack/react-query";
 import { SlidersHorizontal } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { DashboardPreference } from "@/lib/types";
 import { useAuth } from "@/lib/auth";
 import { useDashboardData, useMarkRecord, type MissedDose } from "@/hooks/dashboard";
@@ -70,7 +71,7 @@ export default function Home() {
   const [defaultApplied, setDefaultApplied] = useState(false);
 
   const { data: preference = EMPTY_PREFERENCE } = useQuery({
-    queryKey: ["dashboard-preferences"],
+    queryKey: queryKeys.dashboardPreferences.all,
     queryFn: () => api.get<DashboardPreference>("/dashboard-preferences"),
     enabled: !!userId,
   });

--- a/frontend/app/routes/hospitals.tsx
+++ b/frontend/app/routes/hospitals.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import { ArrowLeft, Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { Hospital } from "@/lib/types";
 import { HospitalList, type UpdateHospitalInput } from "@/components/hospitals/HospitalList";
 import { HospitalForm, type HospitalFormData } from "@/components/hospitals/HospitalForm";
@@ -13,7 +14,7 @@ export default function Hospitals() {
   const [showForm, setShowForm] = useState(false);
 
   const { data: hospitals = [], isLoading } = useQuery({
-    queryKey: ["hospitals"],
+    queryKey: queryKeys.hospitals.all,
     queryFn: () => api.get<Hospital[]>("/hospitals"),
   });
 
@@ -29,19 +30,19 @@ export default function Hospitals() {
       }),
     onSuccess: () => {
       setShowForm(false);
-      qc.invalidateQueries({ queryKey: ["hospitals"] });
+      qc.invalidateQueries({ queryKey: queryKeys.hospitals.all });
     },
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateHospitalInput }) =>
       api.patch<Hospital>(`/hospitals/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["hospitals"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hospitals.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/hospitals/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["hospitals"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hospitals.all }),
   });
 
   const handleCreate = (data: HospitalFormData) => {

--- a/frontend/app/routes/medications.tsx
+++ b/frontend/app/routes/medications.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { Medication, Member } from "@/lib/types";
 import { CategoryFilter, type MedicationCategory } from "@/components/shared/CategoryFilter";
 import { MemberMedications } from "@/components/medications/MemberMedications";
@@ -12,12 +13,12 @@ export default function Medications() {
   const [selectedCategory, setSelectedCategory] = useState<MedicationCategory | null>(null);
 
   const { data: members = [], isLoading } = useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<Member[]>("/members"),
   });
 
   const { data: allMedications = [] } = useQuery({
-    queryKey: ["medications"],
+    queryKey: queryKeys.medications.all,
     queryFn: () => api.get<Medication[]>("/medications"),
   });
 

--- a/frontend/app/routes/members.$memberId.medications.tsx
+++ b/frontend/app/routes/members.$memberId.medications.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router";
 import { ArrowLeft, Plus, X, Clock, Pill, Trash2 } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { Medication, Schedule } from "@/lib/types";
 import { Button, Card, ErrorText, Input } from "@/components/ui";
 import { BottomNavigation } from "@/components/shared/BottomNavigation";
@@ -54,13 +55,13 @@ export default function MemberMedications() {
   const [scheduleError, setScheduleError] = useState<string | null>(null);
 
   const { data: medications = [], isLoading } = useQuery({
-    queryKey: ["members", memberId, "medications"],
+    queryKey: queryKeys.members.medications(memberId),
     queryFn: () => api.get<Medication[]>(`/members/${memberId}/medications`),
     enabled: !!memberId,
   });
 
   const { data: allSchedules = [], isLoading: schedulesLoading } = useQuery({
-    queryKey: ["schedules"],
+    queryKey: queryKeys.schedules.all,
     queryFn: () => api.get<Schedule[]>("/schedules"),
   });
 
@@ -81,8 +82,8 @@ export default function MemberMedications() {
       setMedInstructions("");
       setMedError(null);
       setShowMedForm(false);
-      qc.invalidateQueries({ queryKey: ["members", memberId, "medications"] });
-      qc.invalidateQueries({ queryKey: ["medications"] });
+      qc.invalidateQueries({ queryKey: queryKeys.members.medications(memberId) });
+      qc.invalidateQueries({ queryKey: queryKeys.medications.all });
     },
     onError: (e: Error) => setMedError(e.message),
   });
@@ -90,8 +91,8 @@ export default function MemberMedications() {
   const deleteMedMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/medications/${id}`),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["members", memberId, "medications"] });
-      qc.invalidateQueries({ queryKey: ["medications"] });
+      qc.invalidateQueries({ queryKey: queryKeys.members.medications(memberId) });
+      qc.invalidateQueries({ queryKey: queryKeys.medications.all });
     },
   });
 
@@ -102,14 +103,14 @@ export default function MemberMedications() {
       setScheduledTime("08:00");
       setReminderMinutes("10");
       setScheduleError(null);
-      qc.invalidateQueries({ queryKey: ["schedules"] });
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
     },
     onError: (e: Error) => setScheduleError(e.message),
   });
 
   const deleteScheduleMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/schedules/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["schedules"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.schedules.all }),
   });
 
   const handleCreateMedication = () => {

--- a/frontend/app/routes/members.$memberId.report.tsx
+++ b/frontend/app/routes/members.$memberId.report.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link, useParams } from "react-router";
 import { ChevronLeft, Printer } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import { useRequireAuth } from "@/lib/auth";
 import type {
   Member,
@@ -51,38 +52,38 @@ export default function MemberReport() {
   const { user, loading: authLoading } = useRequireAuth();
 
   const { data: member, isLoading: memberLoading } = useQuery({
-    queryKey: ["members", memberId],
+    queryKey: queryKeys.members.detail(memberId),
     queryFn: () => api.get<Member>(`/members/${memberId}`),
     enabled: !!memberId && !!user,
     retry: false,
   });
 
   const { data: medications = [], isLoading: medsLoading } = useQuery({
-    queryKey: ["members", memberId, "medications"],
+    queryKey: queryKeys.members.medications(memberId),
     queryFn: () => api.get<Medication[]>(`/members/${memberId}/medications`),
     enabled: !!memberId && !!user,
   });
 
   const { data: allergies = [] } = useQuery({
-    queryKey: ["allergies"],
+    queryKey: queryKeys.allergies.all,
     queryFn: () => api.get<Allergy[]>("/allergies"),
     enabled: !!user,
   });
 
   const { data: vaccinations = [] } = useQuery({
-    queryKey: ["vaccinations"],
+    queryKey: queryKeys.vaccinations.all,
     queryFn: () => api.get<Vaccination[]>("/vaccinations"),
     enabled: !!user,
   });
 
   const { data: examinations = [] } = useQuery({
-    queryKey: ["examinations"],
+    queryKey: queryKeys.examinations.all,
     queryFn: () => api.get<Examination[]>("/examinations"),
     enabled: !!user,
   });
 
   const { data: appointments = [] } = useQuery({
-    queryKey: ["appointments"],
+    queryKey: queryKeys.appointments.all,
     queryFn: () => api.get<Appointment[]>("/appointments"),
     enabled: !!user,
   });

--- a/frontend/app/routes/members.$memberId.tsx
+++ b/frontend/app/routes/members.$memberId.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, Navigate, useParams } from "react-router";
 import { Pill, Plus, X, ChevronLeft, FileText } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type {
   Member,
   Allergy,
@@ -78,7 +79,7 @@ export default function MemberDetail() {
     isLoading: memberLoading,
     isError: memberError,
   } = useQuery({
-    queryKey: ["members", memberId],
+    queryKey: queryKeys.members.detail(memberId),
     queryFn: () => api.get<Member>(`/members/${memberId}`),
     enabled: !!memberId,
     retry: false,
@@ -216,24 +217,24 @@ function AllergiesSection({ member, members, qc }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
   const { data: allergies = [], isLoading } = useQuery({
-    queryKey: ["allergies"],
+    queryKey: queryKeys.allergies.all,
     queryFn: () => api.get<Allergy[]>("/allergies"),
   });
 
   const createMutation = useMutation({
     mutationFn: (data: AllergyFormData) => api.post<Allergy>("/allergies", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["allergies"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.allergies.all }),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateAllergyInput }) =>
       api.patch<Allergy>(`/allergies/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["allergies"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.allergies.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/allergies/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["allergies"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.allergies.all }),
   });
 
   const items: AllergyWithMember[] = allergies
@@ -270,24 +271,27 @@ function VaccinationsSection({ member, members, qc }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
   const { data: vaccinations = [], isLoading } = useQuery({
-    queryKey: ["vaccinations"],
+    queryKey: queryKeys.vaccinations.all,
     queryFn: () => api.get<Vaccination[]>("/vaccinations"),
   });
 
   const createMutation = useMutation({
     mutationFn: (data: VaccinationFormData) => api.post<Vaccination>("/vaccinations", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["vaccinations"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.vaccinations.all }),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateVaccinationInput }) =>
       api.patch<Vaccination>(`/vaccinations/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["vaccinations"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.vaccinations.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/vaccinations/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["vaccinations"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.vaccinations.all }),
   });
 
   const items: VaccinationWithMember[] = vaccinations
@@ -329,24 +333,27 @@ function ExaminationsSection({ member, members, qc }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
   const { data: examinations = [], isLoading } = useQuery({
-    queryKey: ["examinations"],
+    queryKey: queryKeys.examinations.all,
     queryFn: () => api.get<Examination[]>("/examinations"),
   });
 
   const createMutation = useMutation({
     mutationFn: (data: ExaminationFormData) => api.post<Examination>("/examinations", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["examinations"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.examinations.all }),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateExaminationInput }) =>
       api.patch<Examination>(`/examinations/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["examinations"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.examinations.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/examinations/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["examinations"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.examinations.all }),
   });
 
   const items: ExaminationWithMember[] = examinations
@@ -388,24 +395,24 @@ function InsurancesSection({ member, members, qc }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
   const { data: insurances = [], isLoading } = useQuery({
-    queryKey: ["insurances"],
+    queryKey: queryKeys.insurances.all,
     queryFn: () => api.get<Insurance[]>("/insurances"),
   });
 
   const createMutation = useMutation({
     mutationFn: (data: InsuranceFormData) => api.post<Insurance>("/insurances", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["insurances"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.insurances.all }),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateInsuranceInput }) =>
       api.patch<Insurance>(`/insurances/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["insurances"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.insurances.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/insurances/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["insurances"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.insurances.all }),
   });
 
   const items: InsuranceWithMember[] = insurances
@@ -447,24 +454,27 @@ function PrescriptionsSection({ member, members, qc }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
   const { data: prescriptions = [], isLoading } = useQuery({
-    queryKey: ["prescriptions"],
+    queryKey: queryKeys.prescriptions.all,
     queryFn: () => api.get<Prescription[]>("/prescriptions"),
   });
 
   const createMutation = useMutation({
     mutationFn: (data: PrescriptionFormData) => api.post<Prescription>("/prescriptions", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["prescriptions"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.prescriptions.all }),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdatePrescriptionInput }) =>
       api.patch<Prescription>(`/prescriptions/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["prescriptions"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.prescriptions.all }),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/prescriptions/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["prescriptions"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.prescriptions.all }),
   });
 
   const items: PrescriptionWithMember[] = prescriptions

--- a/frontend/app/routes/members.tsx
+++ b/frontend/app/routes/members.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { Appointment, Member, MemberWithCounts } from "@/lib/types";
 import { MemberList } from "@/components/members/MemberList";
 import { MemberForm, type MemberFormData } from "@/components/members/MemberForm";
@@ -30,12 +31,12 @@ export default function Members() {
 
   // サーバ集計の /members/summary を使用（全medications取得＋クライアント集計のN+1を解消）
   const { data: members = [], isLoading } = useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<MemberWithCounts[]>("/members/summary"),
   });
 
   const { data: appointments = [] } = useQuery({
-    queryKey: ["appointments"],
+    queryKey: queryKeys.appointments.all,
     queryFn: () => api.get<Appointment[]>("/appointments"),
   });
 
@@ -66,7 +67,7 @@ export default function Members() {
     mutationFn: (body: CreateMemberBody) => api.post<Member>("/members", body),
     onSuccess: () => {
       setShowForm(false);
-      qc.invalidateQueries({ queryKey: ["members"] });
+      qc.invalidateQueries({ queryKey: queryKeys.members.all });
     },
   });
 
@@ -75,13 +76,13 @@ export default function Members() {
       api.patch<Member>(`/members/${id}`, body),
     onSuccess: () => {
       setEditingMember(null);
-      qc.invalidateQueries({ queryKey: ["members"] });
+      qc.invalidateQueries({ queryKey: queryKeys.members.all });
     },
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/members/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["members"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.members.all }),
   });
 
   const handleCreate = (data: MemberFormData) => {

--- a/frontend/app/routes/settings.notifications.tsx
+++ b/frontend/app/routes/settings.notifications.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { ArrowLeft } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import type { NotificationSetting } from "@/lib/types";
 import {
   NotificationSettingsForm,
@@ -12,14 +13,15 @@ export default function NotificationSettingsPage() {
   const qc = useQueryClient();
 
   const { data: setting = null, isLoading, error } = useQuery({
-    queryKey: ["notification-settings"],
+    queryKey: queryKeys.notificationSettings.all,
     queryFn: () => api.get<NotificationSetting>("/notification-settings"),
   });
 
   const updateMutation = useMutation({
     mutationFn: (input: UpdateNotificationSettingInput) =>
       api.put<NotificationSetting>("/notification-settings", input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["notification-settings"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.notificationSettings.all }),
   });
 
   const handleSave = async (input: UpdateNotificationSettingInput) => {

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "react-router";
 import { LogOut, Pencil, Check, X, Plus, Phone, Bell, ChevronRight, HelpCircle } from "lucide-react";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import { useAuth } from "@/lib/auth";
 import type { User, Member, EmergencyContact } from "@/lib/types";
 import { CharacterSelector } from "@/components/character/CharacterSelector";
@@ -23,17 +24,17 @@ export default function Settings() {
   const { user, logout } = useAuth();
 
   const { data: profile } = useQuery({
-    queryKey: ["users", "me"],
+    queryKey: queryKeys.users.me,
     queryFn: () => api.get<User>("/users/me"),
   });
 
   const { data: members = [], isLoading: membersLoading } = useQuery({
-    queryKey: ["members"],
+    queryKey: queryKeys.members.all,
     queryFn: () => api.get<Member[]>("/members"),
   });
 
   const { data: contacts = [], isLoading: contactsLoading } = useQuery({
-    queryKey: ["emergency-contacts"],
+    queryKey: queryKeys.emergencyContacts.all,
     queryFn: () => api.get<EmergencyContact[]>("/emergency-contacts"),
   });
 
@@ -49,24 +50,27 @@ export default function Settings() {
 
   const updateProfileMutation = useMutation({
     mutationFn: (input: { displayName: string }) => api.patch<User>("/users/me", input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["users", "me"] }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.users.me }),
   });
 
   const createContactMutation = useMutation({
     mutationFn: (data: EmergencyContactFormData) =>
       api.post<EmergencyContact>("/emergency-contacts", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["emergency-contacts"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.emergencyContacts.all }),
   });
 
   const updateContactMutation = useMutation({
     mutationFn: ({ id, input }: { id: string; input: UpdateEmergencyContactInput }) =>
       api.patch<EmergencyContact>(`/emergency-contacts/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["emergency-contacts"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.emergencyContacts.all }),
   });
 
   const deleteContactMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/emergency-contacts/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["emergency-contacts"] }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.emergencyContacts.all }),
   });
 
   const contactsWithMember: EmergencyContactWithMember[] = contacts.map((c) => ({


### PR DESCRIPTION
## Summary
- `app/lib/queryKeys.ts` ファクトリを新設し、散在していた React Query キー(全14ファイル/約120箇所)を集約。
- **挙動不変を厳守**: 生成キー配列は従来と完全同一(順序/値)。prefix 無効化用の `.all` 基底キーを用意し、`invalidateQueries(records.all)` が `["records","window",40]` を無効化する等の挙動を維持。
- `useParams` 由来の `string|undefined` を保持し配列同一性を担保。
- 生キーリテラル残存ゼロ、`typecheck`/`build` 通過。