### PR TITLE
feat: 処方明細/休薬中/OCR強化/CSVマッピング + ハンバーガーメニュー

### DIFF
--- a/backend/internal/domain/entity/entities_ext.go
+++ b/backend/internal/domain/entity/entities_ext.go
@@ -131,17 +131,29 @@ type EmergencyContact struct {
 
 // Prescription は処方箋
 type Prescription struct {
-	ID               string     `json:"id"`
-	UserID           string     `json:"userId"`
-	MemberID         string     `json:"memberId"`
-	PrescriptionName string     `json:"prescriptionName"`
-	PrescribedBy     *string    `json:"prescribedBy"`
-	PrescribedAt     time.Time  `json:"prescribedAt"`
-	ExpiresAt        *time.Time `json:"expiresAt"`
-	PharmacyName     *string    `json:"pharmacyName"`
-	ElectronicCode   *string    `json:"electronicCode"` // 電子処方箋の引換番号/アクセスコード
-	Notes            *string    `json:"notes"`
-	CreatedAt        time.Time  `json:"createdAt"`
+	ID               string             `json:"id"`
+	UserID           string             `json:"userId"`
+	MemberID         string             `json:"memberId"`
+	PrescriptionName string             `json:"prescriptionName"`
+	PrescribedBy     *string            `json:"prescribedBy"`
+	PrescribedAt     time.Time          `json:"prescribedAt"`
+	ExpiresAt        *time.Time         `json:"expiresAt"`
+	PharmacyName     *string            `json:"pharmacyName"`
+	ElectronicCode   *string            `json:"electronicCode"` // 電子処方箋の引換番号/アクセスコード
+	Notes            *string            `json:"notes"`
+	Items            []PrescriptionItem `json:"items"` // 処方明細（行データ）
+	CreatedAt        time.Time          `json:"createdAt"`
+}
+
+// PrescriptionItem は処方箋の1行（薬ごとの用量/頻度/日数）
+type PrescriptionItem struct {
+	ID             string  `json:"id"`
+	PrescriptionID string  `json:"prescriptionId"`
+	Name           string  `json:"name"`
+	Dosage         *string `json:"dosage"`
+	Frequency      *string `json:"frequency"`
+	Days           *int    `json:"days"`
+	SortOrder      int     `json:"sortOrder"`
 }
 
 // NotificationSetting は通知設定（user スコープ・UNIQUE）

--- a/backend/internal/domain/repository/repository_ext.go
+++ b/backend/internal/domain/repository/repository_ext.go
@@ -315,6 +315,7 @@ type PrescriptionRepository interface {
 	Create(ctx context.Context, in CreatePrescriptionInput) (*entity.Prescription, error)
 	Update(ctx context.Context, id string, in UpdatePrescriptionInput) (*entity.Prescription, error)
 	Delete(ctx context.Context, id string) error
+	ReplaceItems(ctx context.Context, prescriptionID string, items []entity.PrescriptionItem) error
 }
 
 // ---- NotificationSetting ----

--- a/backend/internal/infrastructure/persistence/prescription_repository.go
+++ b/backend/internal/infrastructure/persistence/prescription_repository.go
@@ -49,12 +49,98 @@ func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]ent
 		}
 		list = append(list, p)
 	}
-	return list, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// 明細をまとめて取得して各処方箋へ割り当て（N+1回避）
+	ids := make([]string, len(list))
+	for i := range list {
+		ids[i] = list[i].ID
+		list[i].Items = []entity.PrescriptionItem{}
+	}
+	if len(ids) > 0 {
+		itemRows, err := r.db.Pool.Query(ctx,
+			`SELECT "id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder"
+			 FROM "PrescriptionItem" WHERE "prescriptionId" = ANY($1) ORDER BY "sortOrder", "createdAt"`, ids)
+		if err != nil {
+			return nil, err
+		}
+		defer itemRows.Close()
+		byPid := map[string]int{}
+		for i := range list {
+			byPid[list[i].ID] = i
+		}
+		for itemRows.Next() {
+			var it entity.PrescriptionItem
+			if err := itemRows.Scan(&it.ID, &it.PrescriptionID, &it.Name, &it.Dosage, &it.Frequency, &it.Days, &it.SortOrder); err != nil {
+				return nil, err
+			}
+			if idx, ok := byPid[it.PrescriptionID]; ok {
+				list[idx].Items = append(list[idx].Items, it)
+			}
+		}
+		if err := itemRows.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return list, nil
+}
+
+func (r *PrescriptionRepository) loadItems(ctx context.Context, prescriptionID string) ([]entity.PrescriptionItem, error) {
+	rows, err := r.db.Pool.Query(ctx,
+		`SELECT "id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder"
+		 FROM "PrescriptionItem" WHERE "prescriptionId"=$1 ORDER BY "sortOrder", "createdAt"`, prescriptionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := make([]entity.PrescriptionItem, 0)
+	for rows.Next() {
+		var it entity.PrescriptionItem
+		if err := rows.Scan(&it.ID, &it.PrescriptionID, &it.Name, &it.Dosage, &it.Frequency, &it.Days, &it.SortOrder); err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	return items, rows.Err()
 }
 
 func (r *PrescriptionRepository) FindByID(ctx context.Context, id string) (*entity.Prescription, error) {
 	row := r.db.Pool.QueryRow(ctx, `SELECT `+prescriptionColumns+` FROM "Prescription" WHERE "id"=$1`, id)
-	return scanPrescription(row)
+	p, err := scanPrescription(row)
+	if err != nil || p == nil {
+		return p, err
+	}
+	items, err := r.loadItems(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	p.Items = items
+	return p, nil
+}
+
+// ReplaceItems は処方明細を指定内容で置き換える。
+func (r *PrescriptionRepository) ReplaceItems(ctx context.Context, prescriptionID string, items []entity.PrescriptionItem) error {
+	tx, err := r.db.Pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	if _, err := tx.Exec(ctx, `DELETE FROM "PrescriptionItem" WHERE "prescriptionId"=$1`, prescriptionID); err != nil {
+		return err
+	}
+	for i, it := range items {
+		if it.Name == "" {
+			continue
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO "PrescriptionItem" ("id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder", "createdAt")
+			 VALUES ($1,$2,$3,$4,$5,$6,$7, now())`,
+			auth.NewID(), prescriptionID, it.Name, it.Dosage, it.Frequency, it.Days, i); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
 }
 
 func (r *PrescriptionRepository) Create(ctx context.Context, in repository.CreatePrescriptionInput) (*entity.Prescription, error) {

--- a/backend/internal/infrastructure/persistence/schedule_repository.go
+++ b/backend/internal/infrastructure/persistence/schedule_repository.go
@@ -117,6 +117,8 @@ func (r *ScheduleRepository) GetTodaySchedules(ctx context.Context, userID strin
 		 JOIN "Member" mem ON mem."id" = s."memberId"
 		 WHERE s."userId" = $1
 		   AND s."isEnabled" = TRUE
+		   AND m."isActive" = TRUE
+		   AND m."status" NOT IN ('paused', 'discontinued')
 		   AND (array_length(s."daysOfWeek", 1) IS NULL OR $2 = ANY(s."daysOfWeek"))
 		 ORDER BY s."scheduledTime" ASC`,
 		userID, weekday, dayStart, dayEnd)

--- a/backend/internal/interface/handler/prescription_handler.go
+++ b/backend/internal/interface/handler/prescription_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"healthfamily/internal/domain/entity"
 	"healthfamily/internal/domain/repository"
 	"healthfamily/internal/interface/middleware"
 	"healthfamily/internal/pkg/response"
@@ -109,6 +110,50 @@ func (h *PrescriptionHandler) Update(c *gin.Context) {
 		return
 	}
 	response.Success(c, v)
+}
+
+type prescriptionItemReq struct {
+	Name      string  `json:"name"`
+	Dosage    *string `json:"dosage"`
+	Frequency *string `json:"frequency"`
+	Days      *int    `json:"days"`
+}
+
+type setItemsRequest struct {
+	Items []prescriptionItemReq `json:"items"`
+}
+
+// SetItems は処方明細を置き換える。
+func (h *PrescriptionHandler) SetItems(c *gin.Context) {
+	userID := middleware.UserID(c)
+	var req setItemsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, 400, "明細の内容が正しくありません")
+		return
+	}
+	items := make([]entity.PrescriptionItem, 0, len(req.Items))
+	for _, it := range req.Items {
+		items = append(items, entity.PrescriptionItem{
+			Name: it.Name, Dosage: it.Dosage, Frequency: it.Frequency, Days: it.Days,
+		})
+	}
+	p, err := h.uc.SetItems(c.Request.Context(), userID, c.Param("prescriptionId"), items)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, p)
+}
+
+// Dispense は処方明細から服薬管理を一括作成する。
+func (h *PrescriptionHandler) Dispense(c *gin.Context) {
+	userID := middleware.UserID(c)
+	meds, err := h.uc.Dispense(c.Request.Context(), userID, c.Param("prescriptionId"))
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Created(c, meds)
 }
 
 func (h *PrescriptionHandler) Delete(c *gin.Context) {

--- a/backend/internal/interface/router/routes_ext.go
+++ b/backend/internal/interface/router/routes_ext.go
@@ -97,12 +97,14 @@ func RegisterExtraRoutes(authed *gin.RouterGroup, db *database.DB) {
 	authed.DELETE("/emergency-contacts/:contactId", contactH.Delete)
 
 	// --- Prescription ---
-	prescriptionH := handler.NewPrescriptionHandler(usecase.NewPrescriptionUsecase(persistence.NewPrescriptionRepository(db), memberRepo))
+	prescriptionH := handler.NewPrescriptionHandler(usecase.NewPrescriptionUsecase(persistence.NewPrescriptionRepository(db), memberRepo, persistence.NewMedicationRepository(db)))
 	authed.GET("/prescriptions", prescriptionH.List)
 	authed.POST("/prescriptions", prescriptionH.Create)
 	authed.GET("/prescriptions/:prescriptionId", prescriptionH.Get)
 	authed.PATCH("/prescriptions/:prescriptionId", prescriptionH.Update)
 	authed.DELETE("/prescriptions/:prescriptionId", prescriptionH.Delete)
+	authed.PUT("/prescriptions/:prescriptionId/items", prescriptionH.SetItems)
+	authed.POST("/prescriptions/:prescriptionId/dispense", prescriptionH.Dispense)
 
 	// --- NotificationSetting ---
 	notifH := handler.NewNotificationSettingHandler(usecase.NewNotificationSettingUsecase(persistence.NewNotificationSettingRepository(db)))

--- a/backend/internal/usecase/prescription_usecase.go
+++ b/backend/internal/usecase/prescription_usecase.go
@@ -10,12 +10,13 @@ import (
 
 // PrescriptionUsecase は処方箋のビジネスロジック
 type PrescriptionUsecase struct {
-	repo    repository.PrescriptionRepository
-	members repository.MemberRepository
+	repo        repository.PrescriptionRepository
+	members     repository.MemberRepository
+	medications repository.MedicationRepository
 }
 
-func NewPrescriptionUsecase(repo repository.PrescriptionRepository, members repository.MemberRepository) *PrescriptionUsecase {
-	return &PrescriptionUsecase{repo: repo, members: members}
+func NewPrescriptionUsecase(repo repository.PrescriptionRepository, members repository.MemberRepository, medications repository.MedicationRepository) *PrescriptionUsecase {
+	return &PrescriptionUsecase{repo: repo, members: members, medications: medications}
 }
 
 func (uc *PrescriptionUsecase) ensureOwner(ctx context.Context, userID, id string) (*entity.Prescription, error) {
@@ -59,4 +60,47 @@ func (uc *PrescriptionUsecase) Delete(ctx context.Context, userID, id string) er
 		return err
 	}
 	return uc.repo.Delete(ctx, id)
+}
+
+// SetItems は処方明細(行データ)を置き換える。
+func (uc *PrescriptionUsecase) SetItems(ctx context.Context, userID, id string, items []entity.PrescriptionItem) (*entity.Prescription, error) {
+	if _, err := uc.ensureOwner(ctx, userID, id); err != nil {
+		return nil, err
+	}
+	for _, it := range items {
+		if it.Name == "" {
+			return nil, domain.NewValidation("薬の名前は必須です")
+		}
+	}
+	if err := uc.repo.ReplaceItems(ctx, id, items); err != nil {
+		return nil, err
+	}
+	return uc.repo.FindByID(ctx, id)
+}
+
+// Dispense は処方明細から服薬管理(Medication)を一括作成する(電子処方箋→調剤の橋渡し)。
+func (uc *PrescriptionUsecase) Dispense(ctx context.Context, userID, id string) ([]entity.Medication, error) {
+	p, err := uc.ensureOwner(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Items) == 0 {
+		return nil, domain.NewValidation("処方明細がありません")
+	}
+	created := make([]entity.Medication, 0, len(p.Items))
+	for _, it := range p.Items {
+		m, err := uc.medications.Create(ctx, repository.CreateMedicationInput{
+			UserID:       userID,
+			MemberID:     p.MemberID,
+			Name:         it.Name,
+			Category:     "regular",
+			DosageAmount: it.Dosage,
+			Frequency:    it.Frequency,
+		})
+		if err != nil {
+			return nil, err
+		}
+		created = append(created, *m)
+	}
+	return created, nil
 }

--- a/backend/migrations/0006_prescription_items.sql
+++ b/backend/migrations/0006_prescription_items.sql
@@ -1,0 +1,12 @@
+-- 処方明細（処方箋の行データ：薬ごとの用量/頻度/日数）。既存DBに安全な no-op。
+CREATE TABLE IF NOT EXISTS "PrescriptionItem" (
+    "id"             TEXT PRIMARY KEY,
+    "prescriptionId" TEXT NOT NULL REFERENCES "Prescription"("id") ON DELETE CASCADE,
+    "name"           TEXT NOT NULL,
+    "dosage"         TEXT,
+    "frequency"      TEXT,
+    "days"           INTEGER,
+    "sortOrder"      INTEGER NOT NULL DEFAULT 0,
+    "createdAt"      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS "PrescriptionItem_prescriptionId_idx" ON "PrescriptionItem"("prescriptionId");

--- a/frontend/app/components/expenses/ExpenseImport.tsx
+++ b/frontend/app/components/expenses/ExpenseImport.tsx
@@ -1,9 +1,9 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { FileUp, Upload } from "lucide-react";
 import { api } from "@/lib/api";
 import { Button, ErrorText } from "@/components/ui";
-import { getExpenseCategoryLabel } from "@/lib/categories";
+import { EXPENSE_CATEGORIES, getExpenseCategoryLabel } from "@/lib/categories";
 
 interface ImportExpense {
   memberId: string | null;
@@ -22,6 +22,53 @@ interface ImportResult {
 interface ExpenseImportProps {
   onImported: () => void;
 }
+
+// マッピング対象の項目
+type TargetField = "description" | "category" | "amount" | "expenseDate" | "isDeductible";
+
+interface TargetDef {
+  key: TargetField;
+  label: string;
+  required: boolean;
+  // ヘッダ名から自動推定するためのキーワード（部分一致）
+  keywords: string[];
+}
+
+const TARGET_FIELDS: TargetDef[] = [
+  {
+    key: "amount",
+    label: "金額",
+    required: true,
+    keywords: ["支払った金額", "金額", "支払金額", "医療費", "費用", "amount"],
+  },
+  {
+    key: "expenseDate",
+    label: "支払日",
+    required: true,
+    keywords: ["支払年月日", "支払日", "日付", "年月日", "date", "日"],
+  },
+  {
+    key: "category",
+    label: "医療費の区分",
+    required: false,
+    keywords: ["区分", "種別", "カテゴリ", "category"],
+  },
+  {
+    key: "description",
+    label: "支払先",
+    required: false,
+    keywords: ["支払先", "病院", "薬局", "支払", "内容", "摘要", "名称"],
+  },
+  {
+    key: "isDeductible",
+    label: "控除対象（任意）",
+    required: false,
+    keywords: ["控除対象", "控除"],
+  },
+];
+
+// 未割当を表す番兵値
+const UNMAPPED = -1;
 
 // CSV の1行を簡易パース（ダブルクォート/エスケープ対応, カンマ区切り）
 function parseCsvLine(line: string): string[] {
@@ -81,12 +128,19 @@ function splitCsvRows(text: string): string[] {
   return rows;
 }
 
+// 既知のカテゴリ値集合（妥当性チェック用）
+const VALID_CATEGORIES = new Set<string>(EXPENSE_CATEGORIES.map((c) => c.value));
+
 // 医療費の区分（国税庁フォーム/当アプリエクスポート）→ カテゴリへの逆マッピング
 function divisionToCategory(division: string): string {
   const d = division.replace(/\s/g, "");
   if (!d) return "other";
+  // 既にカテゴリ値そのものが入っているケース（当アプリのエクスポート等）
+  if (VALID_CATEGORIES.has(d)) return d;
   if (/診療|治療|診察/.test(d)) return "hospital";
-  if (/医薬品|薬局|薬|処方/.test(d)) return "medication";
+  if (/医薬品|処方/.test(d)) return "medication";
+  if (/薬局/.test(d)) return "pharmacy";
+  if (/薬/.test(d)) return "medication";
   if (/介護/.test(d)) return "other";
   if (/その他/.test(d)) return "other";
   if (/保険/.test(d)) return "insurance";
@@ -118,50 +172,81 @@ function parseDate(raw: string): string {
   return `${y}-${mo.padStart(2, "0")}-${d.padStart(2, "0")}`;
 }
 
-// ヘッダ名から列インデックスを探す（部分一致）
-function findCol(headers: string[], keywords: string[]): number {
-  for (let i = 0; i < headers.length; i++) {
-    const h = headers[i].replace(/\s/g, "");
-    if (keywords.some((k) => h.includes(k))) return i;
+// ヘッダ名からターゲット項目への初期マッピングを推定
+function inferMapping(headers: string[]): Record<TargetField, number> {
+  const norm = headers.map((h) => h.replace(/\s/g, ""));
+  const used = new Set<number>();
+  const mapping = {} as Record<TargetField, number>;
+  for (const field of TARGET_FIELDS) {
+    let found = UNMAPPED;
+    for (let i = 0; i < norm.length; i++) {
+      if (used.has(i)) continue;
+      if (field.keywords.some((k) => norm[i].includes(k))) {
+        found = i;
+        break;
+      }
+    }
+    if (found !== UNMAPPED) used.add(found);
+    mapping[field.key] = found;
   }
-  return -1;
+  return mapping;
 }
 
-function parseCsv(text: string): { rows: ImportExpense[]; errors: number } {
+interface ParsedCsv {
+  headers: string[];
+  rows: string[][];
+}
+
+function parseCsv(text: string): ParsedCsv {
   const lines = splitCsvRows(text).filter((l) => l.trim().length > 0);
-  if (lines.length === 0) return { rows: [], errors: 0 };
-
+  if (lines.length === 0) return { headers: [], rows: [] };
   const headers = parseCsvLine(lines[0]);
-  const personIdx = findCol(headers, ["医療を受けた人", "受けた人", "氏名", "名前", "人"]);
-  const payeeIdx = findCol(headers, ["支払先", "病院", "薬局", "支払", "内容", "摘要"]);
-  const divisionIdx = findCol(headers, ["区分", "種別", "カテゴリ"]);
-  const amountIdx = findCol(headers, ["支払った金額", "金額", "支払金額"]);
-  const dateIdx = findCol(headers, ["支払年月日", "支払日", "日付", "年月日", "日"]);
-  const deductibleIdx = findCol(headers, ["控除対象", "控除"]);
-
-  const rows: ImportExpense[] = [];
-  let errors = 0;
-
+  const rows: string[][] = [];
   for (let i = 1; i < lines.length; i++) {
     const cols = parseCsvLine(lines[i]);
     if (cols.every((c) => c === "")) continue;
+    rows.push(cols);
+  }
+  return { headers, rows };
+}
 
-    const amount = amountIdx >= 0 ? parseAmount(cols[amountIdx] ?? "") : NaN;
-    const expenseDate = dateIdx >= 0 ? parseDate(cols[dateIdx] ?? "") : "";
+// マッピングを適用して取込行へ変換。不正行はスキップしつつ件数を返す。
+function applyMapping(
+  csv: ParsedCsv,
+  mapping: Record<TargetField, number>,
+): { rows: ImportExpense[]; skipped: number } {
+  const result: ImportExpense[] = [];
+  let skipped = 0;
+
+  const at = (cols: string[], idx: number): string =>
+    idx >= 0 ? (cols[idx] ?? "") : "";
+
+  for (const cols of csv.rows) {
+    const amount =
+      mapping.amount >= 0 ? parseAmount(at(cols, mapping.amount)) : NaN;
+    const expenseDate =
+      mapping.expenseDate >= 0 ? parseDate(at(cols, mapping.expenseDate)) : "";
 
     if (!Number.isFinite(amount) || amount <= 0 || !expenseDate) {
-      errors++;
+      skipped++;
       continue;
     }
 
-    const division = divisionIdx >= 0 ? (cols[divisionIdx] ?? "") : "";
-    const payee = payeeIdx >= 0 ? (cols[payeeIdx] ?? "").trim() : "";
-    const deductibleRaw = deductibleIdx >= 0 ? (cols[deductibleIdx] ?? "") : "";
-    const isDeductible = deductibleIdx >= 0 ? !/対象外|いいえ|no|false|×|✕/i.test(deductibleRaw) : true;
+    const division = at(cols, mapping.category);
+    let category = divisionToCategory(division);
+    if (!VALID_CATEGORIES.has(category)) category = "other";
 
-    rows.push({
+    const payee = at(cols, mapping.description).trim();
+
+    const deductibleRaw = at(cols, mapping.isDeductible);
+    const isDeductible =
+      mapping.isDeductible >= 0
+        ? !/対象外|いいえ|no|false|×|✕/i.test(deductibleRaw)
+        : true;
+
+    result.push({
       memberId: null,
-      category: divisionToCategory(division),
+      category,
       amount,
       description: payee || undefined,
       expenseDate,
@@ -169,16 +254,22 @@ function parseCsv(text: string): { rows: ImportExpense[]; errors: number } {
     });
   }
 
-  return { rows, errors };
+  return { rows: result, skipped };
 }
 
 export function ExpenseImport({ onImported }: ExpenseImportProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [fileName, setFileName] = useState<string>("");
-  const [parsed, setParsed] = useState<ImportExpense[]>([]);
-  const [parseErrors, setParseErrors] = useState(0);
+  const [csv, setCsv] = useState<ParsedCsv | null>(null);
+  const [mapping, setMapping] = useState<Record<TargetField, number> | null>(null);
   const [parseMessage, setParseMessage] = useState<string>("");
   const [result, setResult] = useState<ImportResult | null>(null);
+
+  // 現在のマッピングからプレビュー行を導出
+  const preview = useMemo(() => {
+    if (!csv || !mapping) return { rows: [] as ImportExpense[], skipped: 0 };
+    return applyMapping(csv, mapping);
+  }, [csv, mapping]);
 
   const importMutation = useMutation({
     mutationFn: (expenses: ImportExpense[]) =>
@@ -195,25 +286,36 @@ export function ExpenseImport({ onImported }: ExpenseImportProps) {
     setFileName(file.name);
     try {
       const text = await file.text();
-      const { rows, errors } = parseCsv(text);
-      setParsed(rows);
-      setParseErrors(errors);
-      if (rows.length === 0) {
+      const parsed = parseCsv(text);
+      if (parsed.headers.length === 0 || parsed.rows.length === 0) {
+        setCsv(null);
+        setMapping(null);
         setParseMessage(
           "取込可能な行が見つかりませんでした。ヘッダ行（金額・支払日など）があるCSVを選択してください。",
         );
+        return;
       }
+      setCsv(parsed);
+      setMapping(inferMapping(parsed.headers));
     } catch {
-      setParsed([]);
-      setParseErrors(0);
+      setCsv(null);
+      setMapping(null);
       setParseMessage("CSVの読み込みに失敗しました。");
     }
   };
 
-  const handleImport = () => {
-    if (parsed.length === 0) return;
-    importMutation.mutate(parsed);
+  const updateMapping = (field: TargetField, value: number) => {
+    setMapping((prev) => (prev ? { ...prev, [field]: value } : prev));
   };
+
+  const handleImport = () => {
+    if (preview.rows.length === 0) return;
+    importMutation.mutate(preview.rows);
+  };
+
+  const requiredUnmapped =
+    !!mapping &&
+    TARGET_FIELDS.some((f) => f.required && mapping[f.key] === UNMAPPED);
 
   return (
     <div className="space-y-4">
@@ -246,59 +348,110 @@ export function ExpenseImport({ onImported }: ExpenseImportProps) {
 
       <ErrorText>{parseMessage}</ErrorText>
 
-      {parsed.length > 0 && !result && (
-        <div className="space-y-3">
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-            <span className="font-bold text-primary-700">
-              取込予定 {parsed.length}件
-            </span>
-            {parseErrors > 0 && (
-              <span className="text-xs text-amber-600">
-                （金額・日付が不正な {parseErrors}件 はスキップされます）
-              </span>
-            )}
+      {csv && mapping && !result && (
+        <div className="space-y-4">
+          {/* 列マッピングUI */}
+          <div className="space-y-2">
+            <p className="text-xs font-bold text-ink-700">列の割り当て</p>
+            <p className="text-xs text-ink-500">
+              CSVのどの列をどの項目として取り込むか選択してください。
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {TARGET_FIELDS.map((field) => (
+                <label key={field.key} className="block space-y-1">
+                  <span className="text-xs font-medium text-ink-600">
+                    {field.label}
+                    {field.required && <span className="text-red-500"> *</span>}
+                  </span>
+                  <select
+                    value={mapping[field.key]}
+                    onChange={(e) =>
+                      updateMapping(field.key, Number(e.target.value))
+                    }
+                    className="w-full rounded-xl border border-ink-400/30 bg-white px-3 py-2 text-sm text-ink-800 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  >
+                    <option value={UNMAPPED}>（未割当）</option>
+                    {csv.headers.map((h, i) => (
+                      <option key={i} value={i}>
+                        {h || `列${i + 1}`}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ))}
+            </div>
           </div>
 
-          <div className="max-h-64 overflow-auto rounded-xl border border-ink-400/15">
-            <table className="w-full text-left text-xs">
-              <thead className="sticky top-0 bg-primary-50 text-ink-600">
-                <tr>
-                  <th className="px-3 py-2 font-medium">支払日</th>
-                  <th className="px-3 py-2 font-medium">区分</th>
-                  <th className="px-3 py-2 font-medium">支払先</th>
-                  <th className="px-3 py-2 text-right font-medium">金額</th>
-                  <th className="px-3 py-2 font-medium">控除</th>
-                </tr>
-              </thead>
-              <tbody>
-                {parsed.map((row, i) => (
-                  <tr key={i} className="border-t border-ink-400/10">
-                    <td className="px-3 py-1.5 text-ink-700">{row.expenseDate}</td>
-                    <td className="px-3 py-1.5 text-ink-700">
-                      {getExpenseCategoryLabel(row.category)}
-                    </td>
-                    <td className="px-3 py-1.5 text-ink-600">
-                      {row.description ?? "-"}
-                    </td>
-                    <td className="px-3 py-1.5 text-right text-ink-800">
-                      {row.amount.toLocaleString()}円
-                    </td>
-                    <td className="px-3 py-1.5 text-ink-600">
-                      {row.isDeductible ? "対象" : "対象外"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          {requiredUnmapped ? (
+            <ErrorText>
+              金額・支払日は必須です。割り当てる列を選択してください。
+            </ErrorText>
+          ) : (
+            <>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+                <span className="font-bold text-primary-700">
+                  取込予定 {preview.rows.length}件
+                </span>
+                {preview.skipped > 0 && (
+                  <span className="text-xs text-amber-600">
+                    （金額・日付が不正な {preview.skipped}件 はスキップされます）
+                  </span>
+                )}
+              </div>
 
-          <Button onClick={handleImport} disabled={importMutation.isPending}>
-            <Upload size={16} />
-            {importMutation.isPending ? "取込中..." : `${parsed.length}件を取り込む`}
-          </Button>
+              {preview.rows.length > 0 && (
+                <div className="max-h-64 overflow-auto rounded-xl border border-ink-400/15">
+                  <table className="w-full text-left text-xs">
+                    <thead className="sticky top-0 bg-primary-50 text-ink-600">
+                      <tr>
+                        <th className="px-3 py-2 font-medium">支払日</th>
+                        <th className="px-3 py-2 font-medium">区分</th>
+                        <th className="px-3 py-2 font-medium">支払先</th>
+                        <th className="px-3 py-2 text-right font-medium">金額</th>
+                        <th className="px-3 py-2 font-medium">控除</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {preview.rows.map((row, i) => (
+                        <tr key={i} className="border-t border-ink-400/10">
+                          <td className="px-3 py-1.5 text-ink-700">
+                            {row.expenseDate}
+                          </td>
+                          <td className="px-3 py-1.5 text-ink-700">
+                            {getExpenseCategoryLabel(row.category)}
+                          </td>
+                          <td className="px-3 py-1.5 text-ink-600">
+                            {row.description ?? "-"}
+                          </td>
+                          <td className="px-3 py-1.5 text-right text-ink-800">
+                            {row.amount.toLocaleString()}円
+                          </td>
+                          <td className="px-3 py-1.5 text-ink-600">
+                            {row.isDeductible ? "対象" : "対象外"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
 
-          {importMutation.isError && (
-            <ErrorText>取込に失敗しました。時間をおいて再度お試しください。</ErrorText>
+              <Button
+                onClick={handleImport}
+                disabled={importMutation.isPending || preview.rows.length === 0}
+              >
+                <Upload size={16} />
+                {importMutation.isPending
+                  ? "取込中..."
+                  : `${preview.rows.length}件を取り込む`}
+              </Button>
+
+              {importMutation.isError && (
+                <ErrorText>
+                  取込に失敗しました。時間をおいて再度お試しください。
+                </ErrorText>
+              )}
+            </>
           )}
         </div>
       )}

--- a/frontend/app/components/medications/MedicationList.tsx
+++ b/frontend/app/components/medications/MedicationList.tsx
@@ -30,6 +30,7 @@ interface MedicationListProps {
   onMarkPastTaken?: (medicationId: string, takenAt: string) => Promise<void>;
   onEdit?: (medication: Medication) => void;
   onReorder?: (medicationIds: string[]) => Promise<void>;
+  onChangeStatus?: (medicationId: string, status: "active" | "paused") => Promise<void>;
   scheduleMap?: MedicationScheduleMap;
   scheduleEditUrl?: string;
 }
@@ -42,6 +43,7 @@ export const MedicationList: React.FC<MedicationListProps> = ({
   onMarkPastTaken,
   onEdit,
   onReorder,
+  onChangeStatus,
   scheduleMap,
   scheduleEditUrl,
 }) => {
@@ -116,6 +118,7 @@ export const MedicationList: React.FC<MedicationListProps> = ({
           onMarkTaken={onMarkTaken}
           onMarkPastTaken={onMarkPastTaken}
           onEdit={onEdit}
+          onChangeStatus={onChangeStatus}
           onMoveUp={onReorder && index > 0 ? () => handleMove(index, "up") : undefined}
           onMoveDown={onReorder && index < localOrder.length - 1 ? () => handleMove(index, "down") : undefined}
           schedules={scheduleMap?.[vm.medication.id]}
@@ -132,6 +135,7 @@ export interface MedicationCardProps {
   onMarkTaken?: (medicationId: string) => Promise<void>;
   onMarkPastTaken?: (medicationId: string, takenAt: string) => Promise<void>;
   onEdit?: (medication: Medication) => void;
+  onChangeStatus?: (medicationId: string, status: "active" | "paused") => Promise<void>;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   schedules?: MedicationScheduleInfo[];
@@ -145,6 +149,7 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
     onMarkTaken,
     onMarkPastTaken,
     onEdit,
+    onChangeStatus,
     onMoveUp,
     onMoveDown,
     schedules,
@@ -153,6 +158,19 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
     const { medication, isLowStock, displayInfo } = viewModel;
     const [isTaken, setIsTaken] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isStatusSubmitting, setIsStatusSubmitting] = useState(false);
+    const isPaused = medication.status === "paused";
+    const isDiscontinued = medication.status === "discontinued";
+
+    const handleChangeStatus = async (status: "active" | "paused") => {
+      if (!onChangeStatus || isStatusSubmitting) return;
+      setIsStatusSubmitting(true);
+      try {
+        await onChangeStatus(medication.id, status);
+      } finally {
+        setIsStatusSubmitting(false);
+      }
+    };
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
     const [isPastRecordOpen, setIsPastRecordOpen] = useState(false);
     const [pastDate, setPastDate] = useState("");
@@ -189,8 +207,14 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
       }
     };
 
+    const isDimmed = isPaused || isDiscontinued;
+
     return (
-      <div className="bg-white rounded-lg shadow-md p-4 border border-primary-100">
+      <div
+        className={`bg-white rounded-lg shadow-md p-4 border border-primary-100${
+          isDimmed ? " opacity-60" : ""
+        }`}
+      >
         <div className="flex items-center justify-between">
           {(onMoveUp || onMoveDown) && (
             <div className="flex flex-col mr-2 -my-1">
@@ -220,13 +244,15 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
             <div className="flex items-center flex-wrap gap-x-2 gap-y-1">
               <Pill size={20} className="text-primary-600" />
               <p className="font-semibold text-ink-800">{displayInfo.name}</p>
-              {medication.status === "paused" && (
-                <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-bold border border-red-300">
-                  休薬
+              {isPaused && (
+                <span className="px-2 py-0.5 bg-amber-100 text-amber-700 text-xs rounded-full font-bold border border-amber-300">
+                  休薬中
                 </span>
               )}
-              {medication.status === "discontinued" && (
-                <span className="px-2 py-0.5 bg-red-600 text-white text-xs rounded-full font-bold">中止</span>
+              {isDiscontinued && (
+                <span className="px-2 py-0.5 bg-ink-100 text-ink-600 text-xs rounded-full font-bold border border-ink-200">
+                  中止
+                </span>
               )}
               {isLowStock && (
                 <span className="px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full font-medium">
@@ -280,6 +306,20 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
                   {isSubmitting ? "記録中..." : "飲んだ"}
                 </button>
               ))}
+            {onChangeStatus && !isDiscontinued && (
+              <button
+                onClick={() => handleChangeStatus(isPaused ? "active" : "paused")}
+                disabled={isStatusSubmitting}
+                className={`text-sm px-3 py-1 rounded-full font-medium transition-colors disabled:opacity-50 ${
+                  isPaused
+                    ? "bg-primary-500 text-white hover:bg-primary-600"
+                    : "bg-amber-100 text-amber-700 hover:bg-amber-200"
+                }`}
+                aria-label={isPaused ? "再開する" : "休薬する"}
+              >
+                {isStatusSubmitting ? "変更中..." : isPaused ? "再開する" : "休薬する"}
+              </button>
+            )}
             <button
               onClick={() => setIsDeleteDialogOpen(true)}
               className="text-red-500 hover:text-red-700 text-sm px-3 py-1 rounded-md hover:bg-red-50 transition-colors"

--- a/frontend/app/components/medications/OcrImport.tsx
+++ b/frontend/app/components/medications/OcrImport.tsx
@@ -1,17 +1,100 @@
-import { useRef, useState } from "react";
-import { Loader2, ImageUp, Info } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Loader2, ImageUp, Info, Crop, Sliders } from "lucide-react";
 import { Button, ErrorText } from "@/components/ui";
 
 interface OcrImportProps {
   onPick: (text: string) => void;
 }
 
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+// 表示用キャンバスの最大幅（縮小して扱いやすくする）
+const MAX_PREVIEW_WIDTH = 360;
+// 二値化のしきい値（0-255）
+const BINARY_THRESHOLD = 140;
+// コントラスト強調係数
+const CONTRAST = 1.4;
+
 export function OcrImport({ onPick }: OcrImportProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const previewCanvasRef = useRef<HTMLCanvasElement>(null);
+  // 元画像（原寸）を保持しておき、OCR時に再描画する
+  const imageRef = useRef<HTMLImageElement | null>(null);
+  // ドラッグ開始座標（プレビュー座標系）
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [lines, setLines] = useState<string[]>([]);
+
+  const [hasImage, setHasImage] = useState(false);
+  const [preprocess, setPreprocess] = useState(true);
+  // プレビュー座標系での選択矩形（null = 全体）
+  const [selection, setSelection] = useState<Rect | null>(null);
+  // 現在ドラッグ中の矩形（描画用）
+  const [dragRect, setDragRect] = useState<Rect | null>(null);
+
+  // プレビューを再描画（前処理ON/OFFの反映）
+  useEffect(() => {
+    drawPreview();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasImage, preprocess]);
+
+  const applyPreprocess = (ctx: CanvasRenderingContext2D, w: number, h: number) => {
+    const imageData = ctx.getImageData(0, 0, w, h);
+    const d = imageData.data;
+    for (let i = 0; i < d.length; i += 4) {
+      // グレースケール化（輝度）
+      const gray = d[i] * 0.299 + d[i + 1] * 0.587 + d[i + 2] * 0.114;
+      // コントラスト強調（中央128基準）
+      let v = (gray - 128) * CONTRAST + 128;
+      // 簡易二値化
+      v = v >= BINARY_THRESHOLD ? 255 : 0;
+      d[i] = v;
+      d[i + 1] = v;
+      d[i + 2] = v;
+    }
+    ctx.putImageData(imageData, 0, 0);
+  };
+
+  const drawPreview = () => {
+    const img = imageRef.current;
+    const canvas = previewCanvasRef.current;
+    if (!img || !canvas) return;
+
+    const scale = Math.min(1, MAX_PREVIEW_WIDTH / img.naturalWidth);
+    const w = Math.max(1, Math.round(img.naturalWidth * scale));
+    const h = Math.max(1, Math.round(img.naturalHeight * scale));
+    canvas.width = w;
+    canvas.height = h;
+
+    const ctx = canvas.getContext("2d", { willReadFrequently: true });
+    if (!ctx) return;
+    ctx.clearRect(0, 0, w, h);
+    ctx.drawImage(img, 0, 0, w, h);
+    if (preprocess) applyPreprocess(ctx, w, h);
+  };
+
+  const loadImage = (file: File) =>
+    new Promise<HTMLImageElement>((resolve, reject) => {
+      const url = URL.createObjectURL(file);
+      const img = new Image();
+      img.onload = () => {
+        URL.revokeObjectURL(url);
+        resolve(img);
+      };
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        reject(new Error("image load failed"));
+      };
+      img.src = url;
+    });
 
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -22,9 +105,125 @@ export function OcrImport({ onPick }: OcrImportProps) {
     setError(null);
     setLines([]);
     setProgress(0);
+    setSelection(null);
+    setDragRect(null);
+
+    try {
+      const img = await loadImage(file);
+      imageRef.current = img;
+      setHasImage(true);
+      // hasImage 変更で useEffect により drawPreview が走る
+    } catch {
+      setError("画像の読み込みに失敗しました。別の画像でお試しください。");
+    }
+  };
+
+  // プレビュー座標を取得（マウス/タッチ共通の pointer events）
+  const getCanvasPoint = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = previewCanvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+    return {
+      x: Math.max(0, Math.min(canvas.width, x)),
+      y: Math.max(0, Math.min(canvas.height, y)),
+    };
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!hasImage || loading) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const p = getCanvasPoint(e);
+    dragStartRef.current = p;
+    setDragRect({ x: p.x, y: p.y, w: 0, h: 0 });
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const start = dragStartRef.current;
+    if (!start) return;
+    const p = getCanvasPoint(e);
+    setDragRect({
+      x: Math.min(start.x, p.x),
+      y: Math.min(start.y, p.y),
+      w: Math.abs(p.x - start.x),
+      h: Math.abs(p.y - start.y),
+    });
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const start = dragStartRef.current;
+    dragStartRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    if (!start || !dragRect) {
+      setDragRect(null);
+      return;
+    }
+    // 小さすぎる選択は無効（全体扱い）
+    if (dragRect.w >= 8 && dragRect.h >= 8) {
+      setSelection(dragRect);
+    } else {
+      setSelection(null);
+    }
+    setDragRect(null);
+  };
+
+  const resetSelection = () => {
+    setSelection(null);
+    setDragRect(null);
+  };
+
+  // OCR対象のキャンバスを原寸ベースで生成し dataURL を返す
+  const buildOcrDataUrl = (): string | null => {
+    const img = imageRef.current;
+    const preview = previewCanvasRef.current;
+    if (!img || !preview) return null;
+
+    // プレビュー座標 → 原寸座標へ変換
+    const ratioX = img.naturalWidth / preview.width;
+    const ratioY = img.naturalHeight / preview.height;
+
+    let sx = 0;
+    let sy = 0;
+    let sw = img.naturalWidth;
+    let sh = img.naturalHeight;
+    if (selection) {
+      sx = Math.round(selection.x * ratioX);
+      sy = Math.round(selection.y * ratioY);
+      sw = Math.round(selection.w * ratioX);
+      sh = Math.round(selection.h * ratioY);
+    }
+    sw = Math.max(1, sw);
+    sh = Math.max(1, sh);
+
+    const out = document.createElement("canvas");
+    out.width = sw;
+    out.height = sh;
+    const ctx = out.getContext("2d", { willReadFrequently: true });
+    if (!ctx) return null;
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
+    if (preprocess) applyPreprocess(ctx, sw, sh);
+    return out.toDataURL("image/png");
+  };
+
+  const runOcr = async () => {
+    if (!hasImage) return;
+    setError(null);
+    setLines([]);
+    setProgress(0);
     setLoading(true);
 
     try {
+      const dataUrl = buildOcrDataUrl();
+      if (!dataUrl) {
+        setError("画像の準備に失敗しました。もう一度お試しください。");
+        return;
+      }
+
       // tesseract.js は重いため遅延読込する
       const Tesseract = await import("tesseract.js");
       const worker = await Tesseract.createWorker("jpn+eng", undefined, {
@@ -36,7 +235,7 @@ export function OcrImport({ onPick }: OcrImportProps) {
       });
 
       try {
-        const { data } = await worker.recognize(file);
+        const { data } = await worker.recognize(dataUrl);
         const text = data.text ?? "";
         const parsed = text
           .split("\n")
@@ -55,6 +254,9 @@ export function OcrImport({ onPick }: OcrImportProps) {
       setLoading(false);
     }
   };
+
+  // 描画する矩形（ドラッグ中優先、なければ確定選択）
+  const overlay = dragRect ?? selection;
 
   return (
     <div className="space-y-3 rounded-xl border border-primary-200 bg-primary-50/40 p-3">
@@ -80,18 +282,83 @@ export function OcrImport({ onPick }: OcrImportProps) {
         disabled={loading}
         className="w-full"
       >
-        {loading ? (
-          <>
-            <Loader2 size={16} className="animate-spin" />
-            解析中…{progress > 0 ? ` ${progress}%` : ""}
-          </>
-        ) : (
-          <>
-            <ImageUp size={16} />
-            画像を選択
-          </>
-        )}
+        <ImageUp size={16} />
+        {hasImage ? "別の画像を選択" : "画像を選択"}
       </Button>
+
+      {hasImage && (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setPreprocess((v) => !v)}
+              disabled={loading}
+              className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+                preprocess
+                  ? "bg-primary-100 text-primary-700 hover:bg-primary-200"
+                  : "bg-white text-ink-600 hover:bg-ink-50"
+              }`}
+            >
+              <Sliders size={14} />
+              前処理 {preprocess ? "ON" : "OFF"}
+            </button>
+            <button
+              type="button"
+              onClick={resetSelection}
+              disabled={loading || !selection}
+              className="flex items-center gap-1.5 rounded-lg bg-white px-2.5 py-1 text-xs font-medium text-ink-600 transition-colors hover:bg-ink-50 disabled:opacity-50"
+            >
+              <Crop size={14} />
+              選択範囲をリセット
+            </button>
+          </div>
+
+          <p className="text-xs text-ink-500">
+            画像上をドラッグして読み取り範囲を選択できます（未選択時は全体を対象）。
+          </p>
+
+          <div className="relative inline-block max-w-full overflow-hidden rounded-lg border border-ink-200 bg-white">
+            <canvas
+              ref={previewCanvasRef}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerUp}
+              className="block max-w-full touch-none cursor-crosshair select-none"
+            />
+            {overlay && overlay.w > 0 && overlay.h > 0 && previewCanvasRef.current && (
+              <div
+                className="pointer-events-none absolute border-2 border-primary-500 bg-primary-500/10"
+                style={{
+                  left: `${(overlay.x / previewCanvasRef.current.width) * 100}%`,
+                  top: `${(overlay.y / previewCanvasRef.current.height) * 100}%`,
+                  width: `${(overlay.w / previewCanvasRef.current.width) * 100}%`,
+                  height: `${(overlay.h / previewCanvasRef.current.height) * 100}%`,
+                }}
+              />
+            )}
+          </div>
+
+          <Button
+            type="button"
+            onClick={runOcr}
+            disabled={loading}
+            className="w-full"
+          >
+            {loading ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                解析中…{progress > 0 ? ` ${progress}%` : ""}
+              </>
+            ) : (
+              <>
+                <ImageUp size={16} />
+                この内容で読み取る
+              </>
+            )}
+          </Button>
+        </div>
+      )}
 
       <ErrorText>{error}</ErrorText>
 

--- a/frontend/app/components/prescriptions/PrescriptionList.tsx
+++ b/frontend/app/components/prescriptions/PrescriptionList.tsx
@@ -1,12 +1,28 @@
 import React, { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
-import { Pencil, Trash2, Check, X, QrCode, PillBottle } from "lucide-react";
-import type { Medication, Prescription } from "@/lib/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Pencil, Trash2, Check, X, QrCode, PillBottle, Plus, ListChecks } from "lucide-react";
+import type { Medication, Prescription, PrescriptionItem } from "@/lib/types";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/queryKeys";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
 import { ConfirmationDialog } from "@/components/shared/ConfirmationDialog";
 import { formatDateShort } from "@/lib/format";
+
+// 処方明細の編集用ローカル行（入力中は文字列で保持し、保存時に整形する）
+interface ItemDraft {
+  name: string;
+  dosage: string;
+  frequency: string;
+  days: string;
+}
+
+interface SaveItemsPayload {
+  name: string;
+  dosage?: string;
+  frequency?: string;
+  days?: number;
+}
 
 export type PrescriptionWithMember = Prescription & { memberName?: string };
 
@@ -53,14 +69,26 @@ interface PrescriptionCardProps {
   onDelete: (id: string) => void;
 }
 
+const itemToDraft = (item: PrescriptionItem): ItemDraft => ({
+  name: item.name,
+  dosage: item.dosage ?? "",
+  frequency: item.frequency ?? "",
+  days: item.days != null ? String(item.days) : "",
+});
+
 const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescription, onUpdate, onDelete }) => {
+  const queryClient = useQueryClient();
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isRegisterDialogOpen, setIsRegisterDialogOpen] = useState(false);
+  const [isDispenseDialogOpen, setIsDispenseDialogOpen] = useState(false);
   const [editName, setEditName] = useState(prescription.prescriptionName);
   const [editDoctor, setEditDoctor] = useState(prescription.prescribedBy || "");
   const [editPharmacy, setEditPharmacy] = useState(prescription.pharmacyName || "");
   const [editNotes, setEditNotes] = useState(prescription.notes || "");
+
+  const [isEditingItems, setIsEditingItems] = useState(false);
+  const [itemDrafts, setItemDrafts] = useState<ItemDraft[]>([]);
 
   const registerMedicationMutation = useMutation({
     mutationFn: () =>
@@ -69,6 +97,54 @@ const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescrip
         name: prescription.prescriptionName,
       }),
   });
+
+  const saveItemsMutation = useMutation({
+    mutationFn: (items: SaveItemsPayload[]) =>
+      api.put<Prescription>(`/prescriptions/${prescription.id}/items`, { items }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.prescriptions.all });
+      setIsEditingItems(false);
+    },
+  });
+
+  const dispenseMutation = useMutation({
+    mutationFn: () => api.post<Medication[]>(`/prescriptions/${prescription.id}/dispense`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.medications.all });
+    },
+  });
+
+  const startEditingItems = () => {
+    const drafts = prescription.items.length > 0 ? prescription.items.map(itemToDraft) : [{ name: "", dosage: "", frequency: "", days: "" }];
+    setItemDrafts(drafts);
+    setIsEditingItems(true);
+  };
+
+  const updateItemDraft = (index: number, field: keyof ItemDraft, value: string) => {
+    setItemDrafts((prev) => prev.map((d, i) => (i === index ? { ...d, [field]: value } : d)));
+  };
+
+  const addItemDraft = () => {
+    setItemDrafts((prev) => [...prev, { name: "", dosage: "", frequency: "", days: "" }]);
+  };
+
+  const removeItemDraft = (index: number) => {
+    setItemDrafts((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const validItemDrafts = itemDrafts.filter((d) => d.name.trim() !== "");
+
+  const handleSaveItems = () => {
+    const items: SaveItemsPayload[] = validItemDrafts.map((d) => {
+      const payload: SaveItemsPayload = { name: d.name.trim() };
+      if (d.dosage.trim()) payload.dosage = d.dosage.trim();
+      if (d.frequency.trim()) payload.frequency = d.frequency.trim();
+      const daysNum = Number(d.days.trim());
+      if (d.days.trim() && Number.isFinite(daysNum)) payload.days = daysNum;
+      return payload;
+    });
+    saveItemsMutation.mutate(items);
+  };
 
   const now = new Date();
   const expiresDate = prescription.expiresAt ? new Date(prescription.expiresAt) : null;
@@ -185,6 +261,154 @@ const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescrip
               <span className="text-xs font-mono tracking-wide break-all">{prescription.electronicCode}</span>
             </div>
           )}
+
+          {/* 処方明細セクション */}
+          <div className="mt-3 border-t border-primary-100 pt-2">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-medium text-ink-700">処方明細</p>
+              {!isEditingItems && (
+                <button
+                  type="button"
+                  onClick={startEditingItems}
+                  className="inline-flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 transition-colors"
+                >
+                  <Pencil size={12} />
+                  <span>明細を編集</span>
+                </button>
+              )}
+            </div>
+
+            {!isEditingItems && (
+              <>
+                {prescription.items.length === 0 ? (
+                  <p className="mt-1 text-xs text-ink-400">明細はまだ登録されていません</p>
+                ) : (
+                  <ul className="mt-1 space-y-1">
+                    {prescription.items.map((item) => (
+                      <li key={item.id} className="text-xs text-ink-600">
+                        <span className="font-medium text-ink-700">{item.name}</span>
+                        {(item.dosage || item.frequency || item.days != null) && (
+                          <span className="text-ink-400">
+                            {" "}
+                            {[item.dosage, item.frequency, item.days != null ? `${item.days}日分` : null]
+                              .filter(Boolean)
+                              .join(" / ")}
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {prescription.items.length > 0 && (
+                  <div className="mt-2">
+                    <button
+                      type="button"
+                      onClick={() => setIsDispenseDialogOpen(true)}
+                      disabled={dispenseMutation.isPending}
+                      className="inline-flex items-center gap-1 bg-primary text-white px-2.5 py-1 rounded-lg text-xs font-medium hover:bg-primary-dark transition-colors disabled:opacity-50"
+                    >
+                      <ListChecks size={14} />
+                      <span>{dispenseMutation.isPending ? "登録中..." : "この処方明細からお薬を登録"}</span>
+                    </button>
+                    {dispenseMutation.isSuccess && (
+                      <p className="mt-1 text-xs text-primary-600">
+                        {dispenseMutation.data.length}件のお薬を登録しました
+                      </p>
+                    )}
+                    {dispenseMutation.isError && (
+                      <p className="mt-1 text-xs text-red-600">登録に失敗しました。もう一度お試しください</p>
+                    )}
+                  </div>
+                )}
+              </>
+            )}
+
+            {isEditingItems && (
+              <div className="mt-2 space-y-2">
+                {itemDrafts.map((draft, index) => (
+                  <div key={index} className="rounded-lg border border-primary-200 p-2 space-y-1.5">
+                    <div className="flex items-start gap-1.5">
+                      <input
+                        type="text"
+                        value={draft.name}
+                        onChange={(e) => updateItemDraft(index, "name", e.target.value)}
+                        placeholder="薬名（必須）"
+                        className="flex-1 px-2 py-1 border border-primary-200 rounded text-xs focus:ring-2 focus:ring-primary-500"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeItemDraft(index)}
+                        className="text-ink-400 hover:text-red-500 p-1 transition-colors flex-shrink-0"
+                        aria-label="明細行を削除"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                    <div className="grid grid-cols-3 gap-1.5">
+                      <input
+                        type="text"
+                        value={draft.dosage}
+                        onChange={(e) => updateItemDraft(index, "dosage", e.target.value)}
+                        placeholder="用量"
+                        className="px-2 py-1 border border-primary-200 rounded text-xs focus:ring-2 focus:ring-primary-500"
+                      />
+                      <input
+                        type="text"
+                        value={draft.frequency}
+                        onChange={(e) => updateItemDraft(index, "frequency", e.target.value)}
+                        placeholder="頻度"
+                        className="px-2 py-1 border border-primary-200 rounded text-xs focus:ring-2 focus:ring-primary-500"
+                      />
+                      <input
+                        type="number"
+                        min={0}
+                        value={draft.days}
+                        onChange={(e) => updateItemDraft(index, "days", e.target.value)}
+                        placeholder="日数"
+                        className="px-2 py-1 border border-primary-200 rounded text-xs focus:ring-2 focus:ring-primary-500"
+                      />
+                    </div>
+                  </div>
+                ))}
+
+                <button
+                  type="button"
+                  onClick={addItemDraft}
+                  className="inline-flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 transition-colors"
+                >
+                  <Plus size={14} />
+                  <span>明細行を追加</span>
+                </button>
+
+                {saveItemsMutation.isError && (
+                  <p className="text-xs text-red-600">保存に失敗しました。もう一度お試しください</p>
+                )}
+
+                <div className="flex gap-2 pt-1">
+                  <button
+                    type="button"
+                    onClick={handleSaveItems}
+                    disabled={saveItemsMutation.isPending}
+                    className="flex-1 flex items-center justify-center gap-1 bg-primary text-white py-1.5 rounded-lg text-xs hover:bg-primary-dark transition-colors disabled:opacity-50"
+                  >
+                    <Check size={14} />
+                    <span>{saveItemsMutation.isPending ? "保存中..." : "明細を保存"}</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setIsEditingItems(false)}
+                    disabled={saveItemsMutation.isPending}
+                    className="flex-1 flex items-center justify-center gap-1 bg-primary-50 text-ink-700 py-1.5 rounded-lg text-xs hover:bg-primary-100 transition-colors disabled:opacity-50"
+                  >
+                    <X size={14} />
+                    <span>キャンセル</span>
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+
           <div className="mt-2">
             <button
               type="button"
@@ -240,6 +464,16 @@ const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescrip
           registerMedicationMutation.mutate();
         }}
         onCancel={() => setIsRegisterDialogOpen(false)}
+      />
+      <ConfirmationDialog
+        title="明細からお薬を登録"
+        message={`「${prescription.prescriptionName}」の処方明細（${prescription.items.length}件）から服薬管理のお薬を一括登録しますか？`}
+        isOpen={isDispenseDialogOpen}
+        onConfirm={() => {
+          setIsDispenseDialogOpen(false);
+          dispenseMutation.mutate();
+        }}
+        onCancel={() => setIsDispenseDialogOpen(false)}
       />
     </div>
   );

--- a/frontend/app/hooks/dashboard.ts
+++ b/frontend/app/hooks/dashboard.ts
@@ -308,6 +308,8 @@ export function useDashboardData(userId: string | null) {
         if (recordedKeys.has(`${dateKey}-${s.id}`)) continue;
 
         const med = medMap.get(s.medicationId);
+        // 休薬中・中止の薬は飲み忘れ集計から除外する (status が active 以外)
+        if (med && med.status !== "active") continue;
         result.push({
           date: dateKey,
           scheduleId: s.id,
@@ -444,6 +446,24 @@ export interface MarkRecordInput {
   scheduleId: string;
   takenAt?: string;
   notes?: string;
+}
+
+export type MedicationStatus = "active" | "paused" | "discontinued";
+
+/**
+ * 薬のステータス(休薬中トグル等)を変更し、関連クエリを無効化する。
+ */
+export function useUpdateMedicationStatus() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ medicationId, status }: { medicationId: string; status: MedicationStatus }) =>
+      api.patch<Medication>(`/medications/${medicationId}`, { status }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.medications.all });
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.today });
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
+    },
+  });
 }
 
 /**

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -291,7 +291,19 @@ export interface Prescription {
   pharmacyName: string | null;
   electronicCode: string | null;
   notes: string | null;
+  items: PrescriptionItem[];
   createdAt: string;
+}
+
+// 処方明細（処方箋の行データ）
+export interface PrescriptionItem {
+  id: string;
+  prescriptionId: string;
+  name: string;
+  dosage: string | null;
+  frequency: string | null;
+  days: number | null;
+  sortOrder: number;
 }
 
 export interface NotificationSetting {

--- a/frontend/app/routes/_authed.tsx
+++ b/frontend/app/routes/_authed.tsx
@@ -41,11 +41,6 @@ const navItems: NavItem[] = [
   { to: "/guide", label: "使い方ガイド", icon: BookOpen, end: false },
 ];
 
-// ボトムナビ(スマホ)は主要5項目。それ以外はハンバーガーメニューから。
-const bottomNavItems = navItems.filter((n) =>
-  ["/", "/medications", "/health-logs", "/appointments", "/settings"].includes(n.to),
-);
-
 function Brand() {
   return (
     <div className="flex items-center gap-2 font-bold text-ink-800">
@@ -128,7 +123,7 @@ export default function AuthedLayout() {
           <span className="w-9" aria-hidden />
         </header>
 
-        <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-6 pb-28 md:max-w-5xl md:px-8 md:py-8 md:pb-10">
+        <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-6 md:max-w-5xl md:px-8 md:py-8">
           <Outlet />
         </main>
       </div>
@@ -171,38 +166,6 @@ export default function AuthedLayout() {
         </div>
       )}
 
-      {/* ===== スマホ: ボトムナビ(主要5) ===== */}
-      <nav className="fixed inset-x-0 bottom-0 z-10 mx-auto max-w-2xl border-t border-ink-400/10 bg-white/90 px-2 pb-[env(safe-area-inset-bottom)] backdrop-blur-md md:hidden">
-        <div className="flex justify-around py-2">
-          {bottomNavItems.map(({ to, label, icon: Icon, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              className={({ isActive }) =>
-                clsx(
-                  "flex flex-1 flex-col items-center gap-1 rounded-xl py-1.5 text-[11px] font-medium transition",
-                  isActive ? "text-primary" : "text-ink-400 hover:text-ink-600",
-                )
-              }
-            >
-              {({ isActive }) => (
-                <>
-                  <span
-                    className={clsx(
-                      "flex h-9 w-12 items-center justify-center rounded-full transition",
-                      isActive && "bg-primary-50",
-                    )}
-                  >
-                    <Icon className="h-5 w-5" />
-                  </span>
-                  {label}
-                </>
-              )}
-            </NavLink>
-          ))}
-        </div>
-      </nav>
     </div>
   );
 }

--- a/frontend/app/routes/_authed.tsx
+++ b/frontend/app/routes/_authed.tsx
@@ -1,17 +1,21 @@
+import { useState } from "react";
 import { NavLink, Outlet } from "react-router";
 import { clsx } from "clsx";
 import {
   Activity,
+  BookOpen,
   Building2,
   Calendar,
   HeartPulse,
   History,
   Home,
   LogOut,
+  Menu,
   Pill,
   Settings,
   Users,
   Wallet,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { useAuth, useRequireAuth } from "@/lib/auth";
@@ -23,7 +27,7 @@ interface NavItem {
   end: boolean;
 }
 
-// サイドバー(PC)はフル項目、ボトムナビ(スマホ)は主要5項目
+// 全機能の一覧（PCサイドバー / モバイルのハンバーガーメニューで使用）
 const navItems: NavItem[] = [
   { to: "/", label: "ホーム", icon: Home, end: true },
   { to: "/members", label: "メンバー", icon: Users, end: false },
@@ -31,11 +35,13 @@ const navItems: NavItem[] = [
   { to: "/health-logs", label: "体調", icon: Activity, end: false },
   { to: "/appointments", label: "通院", icon: Calendar, end: false },
   { to: "/hospitals", label: "病院", icon: Building2, end: false },
-  { to: "/expenses", label: "医療費", icon: Wallet, end: false },
+  { to: "/expenses", label: "医療費・家計", icon: Wallet, end: false },
   { to: "/history", label: "履歴", icon: History, end: false },
   { to: "/settings", label: "設定", icon: Settings, end: false },
+  { to: "/guide", label: "使い方ガイド", icon: BookOpen, end: false },
 ];
 
+// ボトムナビ(スマホ)は主要5項目。それ以外はハンバーガーメニューから。
 const bottomNavItems = navItems.filter((n) =>
   ["/", "/medications", "/health-logs", "/appointments", "/settings"].includes(n.to),
 );
@@ -51,9 +57,32 @@ function Brand() {
   );
 }
 
+function SidebarNavLink({ item, onClick }: { item: NavItem; onClick?: () => void }) {
+  const { to, label, icon: Icon, end } = item;
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      onClick={onClick}
+      className={({ isActive }) =>
+        clsx(
+          "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition",
+          isActive
+            ? "bg-primary-50 text-primary"
+            : "text-ink-600 hover:bg-ink-400/5 hover:text-ink-800",
+        )
+      }
+    >
+      <Icon className="h-5 w-5 shrink-0" />
+      {label}
+    </NavLink>
+  );
+}
+
 export default function AuthedLayout() {
   const { user, loading } = useRequireAuth();
   const { logout } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   if (loading || !user) {
     return (
@@ -70,24 +99,9 @@ export default function AuthedLayout() {
         <div className="px-2">
           <Brand />
         </div>
-        <nav className="mt-8 flex flex-1 flex-col gap-1">
-          {navItems.map(({ to, label, icon: Icon, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              className={({ isActive }) =>
-                clsx(
-                  "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition",
-                  isActive
-                    ? "bg-primary-50 text-primary"
-                    : "text-ink-600 hover:bg-ink-400/5 hover:text-ink-800",
-                )
-              }
-            >
-              <Icon className="h-5 w-5 shrink-0" />
-              {label}
-            </NavLink>
+        <nav className="mt-8 flex flex-1 flex-col gap-1 overflow-y-auto">
+          {navItems.map((item) => (
+            <SidebarNavLink key={item.to} item={item} />
           ))}
         </nav>
         <button
@@ -101,16 +115,17 @@ export default function AuthedLayout() {
 
       {/* ===== コンテンツ ===== */}
       <div className="flex min-h-screen flex-1 flex-col md:pl-60">
-        {/* スマホ: ヘッダー */}
-        <header className="sticky top-0 z-10 flex items-center justify-between border-b border-ink-400/10 bg-white/80 px-4 py-3 backdrop-blur-md md:hidden">
-          <Brand />
+        {/* スマホ: ヘッダー(ハンバーガー + ブランド) */}
+        <header className="sticky top-0 z-10 flex items-center justify-between border-b border-ink-400/10 bg-white/80 px-3 py-3 backdrop-blur-md md:hidden">
           <button
-            onClick={logout}
-            className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm text-ink-500 transition hover:bg-ink-400/10 hover:text-ink-700"
+            onClick={() => setMenuOpen(true)}
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-ink-700 transition hover:bg-ink-400/10"
+            aria-label="メニューを開く"
           >
-            <LogOut className="h-4 w-4" />
-            ログアウト
+            <Menu className="h-6 w-6" />
           </button>
+          <Brand />
+          <span className="w-9" aria-hidden />
         </header>
 
         <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-6 pb-28 md:max-w-5xl md:px-8 md:py-8 md:pb-10">
@@ -118,7 +133,45 @@ export default function AuthedLayout() {
         </main>
       </div>
 
-      {/* ===== スマホ: ボトムナビ ===== */}
+      {/* ===== スマホ: ハンバーガーメニュー(ドロワー) ===== */}
+      {menuOpen && (
+        <div className="fixed inset-0 z-40 md:hidden">
+          <div
+            className="absolute inset-0 bg-ink-800/40 backdrop-blur-sm"
+            onClick={() => setMenuOpen(false)}
+            aria-hidden
+          />
+          <div className="absolute inset-y-0 left-0 flex w-72 max-w-[85%] flex-col bg-white px-4 py-5 shadow-card">
+            <div className="flex items-center justify-between px-2">
+              <Brand />
+              <button
+                onClick={() => setMenuOpen(false)}
+                className="flex h-9 w-9 items-center justify-center rounded-xl text-ink-600 transition hover:bg-ink-400/10"
+                aria-label="メニューを閉じる"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <nav className="mt-6 flex flex-1 flex-col gap-1 overflow-y-auto">
+              {navItems.map((item) => (
+                <SidebarNavLink key={item.to} item={item} onClick={() => setMenuOpen(false)} />
+              ))}
+            </nav>
+            <button
+              onClick={() => {
+                setMenuOpen(false);
+                logout();
+              }}
+              className="mt-2 flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium text-ink-500 transition hover:bg-ink-400/5 hover:text-ink-700"
+            >
+              <LogOut className="h-5 w-5" />
+              ログアウト
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ===== スマホ: ボトムナビ(主要5) ===== */}
       <nav className="fixed inset-x-0 bottom-0 z-10 mx-auto max-w-2xl border-t border-ink-400/10 bg-white/90 px-2 pb-[env(safe-area-inset-bottom)] backdrop-blur-md md:hidden">
         <div className="flex justify-around py-2">
           {bottomNavItems.map(({ to, label, icon: Icon, end }) => (


### PR DESCRIPTION
## Summary
### バックエンド
- **処方明細(行データ)**: `PrescriptionItem`(migration 0006)、`Prescription.items[]` 同梱。`PUT /prescriptions/:id/items`(明細置換)、`POST /prescriptions/:id/dispense`(明細→お薬一括登録=調剤)。
- **休薬中**: `GET /schedules/today` が `status` paused/discontinued の薬を自動除外。
### フロントエンド
- **OCR精度向上**: Canvas前処理(グレースケール/二値化)＋ドラッグ領域指定(クロップ)。
- **CSV取込マッピングUI**: ヘッダ自動推定＋手動列割当→プレビュー→一括取込。
- **処方明細UI**: 明細の追加/削除/保存＋「明細からお薬を登録」。
- **休薬トグル**: 薬の休薬/再開、ダッシュボード集計も休薬を除外。
- **ハンバーガーメニュー**: 全機能ドロワーを追加し、モバイルで新機能(医療費/履歴/病院/メンバー/ガイド等)へ到達可能に。

backend `build`/`vet`/`test`・frontend `typecheck`/`build` 通過。