### PR TITLE
refactor: 直近追加コードの清掃(挙動不変)

### DIFF
--- a/backend/internal/infrastructure/persistence/prescription_repository.go
+++ b/backend/internal/infrastructure/persistence/prescription_repository.go
@@ -22,6 +22,21 @@ func NewPrescriptionRepository(db *database.DB) *PrescriptionRepository {
 
 const prescriptionColumns = `"id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt", "expiresAt", "pharmacyName", "electronicCode", "notes", "createdAt"`
 
+const prescriptionItemColumns = `"id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder"`
+
+// scanPrescriptionItems は prescriptionItemColumns 順の行群を PrescriptionItem に変換する。
+func scanPrescriptionItems(rows pgx.Rows) ([]entity.PrescriptionItem, error) {
+	items := make([]entity.PrescriptionItem, 0)
+	for rows.Next() {
+		var it entity.PrescriptionItem
+		if err := rows.Scan(&it.ID, &it.PrescriptionID, &it.Name, &it.Dosage, &it.Frequency, &it.Days, &it.SortOrder); err != nil {
+			return nil, err
+		}
+		items = append(items, it)
+	}
+	return items, rows.Err()
+}
+
 func scanPrescription(row pgx.Row) (*entity.Prescription, error) {
 	var p entity.Prescription
 	err := row.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.ElectronicCode, &p.Notes, &p.CreatedAt)
@@ -60,27 +75,24 @@ func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]ent
 	}
 	if len(ids) > 0 {
 		itemRows, err := r.db.Pool.Query(ctx,
-			`SELECT "id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder"
+			`SELECT `+prescriptionItemColumns+`
 			 FROM "PrescriptionItem" WHERE "prescriptionId" = ANY($1) ORDER BY "sortOrder", "createdAt"`, ids)
 		if err != nil {
 			return nil, err
 		}
 		defer itemRows.Close()
+		items, err := scanPrescriptionItems(itemRows)
+		if err != nil {
+			return nil, err
+		}
 		byPid := map[string]int{}
 		for i := range list {
 			byPid[list[i].ID] = i
 		}
-		for itemRows.Next() {
-			var it entity.PrescriptionItem
-			if err := itemRows.Scan(&it.ID, &it.PrescriptionID, &it.Name, &it.Dosage, &it.Frequency, &it.Days, &it.SortOrder); err != nil {
-				return nil, err
-			}
+		for _, it := range items {
 			if idx, ok := byPid[it.PrescriptionID]; ok {
 				list[idx].Items = append(list[idx].Items, it)
 			}
-		}
-		if err := itemRows.Err(); err != nil {
-			return nil, err
 		}
 	}
 	return list, nil
@@ -88,21 +100,13 @@ func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]ent
 
 func (r *PrescriptionRepository) loadItems(ctx context.Context, prescriptionID string) ([]entity.PrescriptionItem, error) {
 	rows, err := r.db.Pool.Query(ctx,
-		`SELECT "id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder"
+		`SELECT `+prescriptionItemColumns+`
 		 FROM "PrescriptionItem" WHERE "prescriptionId"=$1 ORDER BY "sortOrder", "createdAt"`, prescriptionID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := make([]entity.PrescriptionItem, 0)
-	for rows.Next() {
-		var it entity.PrescriptionItem
-		if err := rows.Scan(&it.ID, &it.PrescriptionID, &it.Name, &it.Dosage, &it.Frequency, &it.Days, &it.SortOrder); err != nil {
-			return nil, err
-		}
-		items = append(items, it)
-	}
-	return items, rows.Err()
+	return scanPrescriptionItems(rows)
 }
 
 func (r *PrescriptionRepository) FindByID(ctx context.Context, id string) (*entity.Prescription, error) {

--- a/frontend/app/hooks/dashboard.ts
+++ b/frontend/app/hooks/dashboard.ts
@@ -81,7 +81,7 @@ interface ScheduleLike {
   isEnabled: boolean;
 }
 
-function isActiveOnDay(s: ScheduleLike, scheduledTime: string, date: Date): boolean {
+function isActiveOnDay(s: ScheduleLike, date: Date): boolean {
   if (!s.isEnabled) return false;
   if (s.intervalDays === -1) return false;
   if (s.intervalDays && s.intervalDays > 0 && s.startDate) {
@@ -304,7 +304,7 @@ export function useDashboardData(userId: string | null) {
 
       for (const s of allSchedules) {
         if (!s.isEnabled) continue;
-        if (!isActiveOnDay(s, s.scheduledTime, target)) continue;
+        if (!isActiveOnDay(s, target)) continue;
         if (recordedKeys.has(`${dateKey}-${s.id}`)) continue;
 
         const med = medMap.get(s.medicationId);


### PR DESCRIPTION
## Summary
- **backend**: 処方明細(PrescriptionItem)のSELECT列を定数化＋`scanPrescriptionItems`ヘルパーを抽出し、`List`/`loadItems` の重複を除去。
- **frontend**: `dashboard.ts` の未使用引数を除去。
- 直近追加コードは既に共通ユーティリティ(`@/lib/format`/`@/lib/categories`/`@/lib/queryKeys`)を使用しており、変更は最小限。
- 挙動/API/UI 不変。gofmt/build/vet/test・typecheck/build 全通過。