### PR TITLE
refactor(frontend): 汎用useResourceフックでCRUD集約(挙動/UI不変)

### DIFF
--- a/frontend/app/hooks/health-logs.ts
+++ b/frontend/app/hooks/health-logs.ts
@@ -1,6 +1,7 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/queryKeys";
+import { useResource } from "@/lib/useResource";
 import type {
   BodyMeasurement,
   HealthLog,
@@ -283,14 +284,13 @@ export interface CreateHealthLogInput {
 }
 
 export function useHealthLogs(members: Member[] | undefined) {
-  const qc = useQueryClient();
-
-  const query = useQuery({
+  const { items, isLoading, create, remove } = useResource<HealthLog>({
     queryKey: queryKeys.healthLogs.all,
-    queryFn: () => api.get<HealthLog[]>("/health-logs"),
+    listPath: "/health-logs",
+    basePath: "/health-logs",
   });
 
-  const logs: HealthLogView[] = (query.data ?? []).map((h) => ({
+  const logs: HealthLogView[] = items.map((h) => ({
     id: h.id,
     memberId: h.memberId,
     memberName: memberNameOf(members, h.memberId),
@@ -302,30 +302,19 @@ export function useHealthLogs(members: Member[] | undefined) {
 
   const groups = groupByDate(logs);
 
-  const createMutation = useMutation({
-    mutationFn: (input: CreateHealthLogInput) =>
-      api.post<HealthLog>("/health-logs", {
+  return {
+    logs,
+    groups,
+    isLoading,
+    createLog: (input: CreateHealthLogInput) =>
+      create.mutateAsync({
         memberId: input.memberId,
         conditionLevel: input.conditionLevel,
         symptoms: input.symptoms,
         notes: input.notes,
         recordedAt: new Date().toISOString(),
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.healthLogs.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/health-logs/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.healthLogs.all }),
-  });
-
-  return {
-    logs,
-    groups,
-    isLoading: query.isLoading,
-    createLog: (input: CreateHealthLogInput) =>
-      createMutation.mutateAsync(input),
-    deleteLog: (id: string) => deleteMutation.mutateAsync(id),
+    deleteLog: (id: string) => remove.mutateAsync(id),
   };
 }
 
@@ -337,14 +326,13 @@ export interface CreateTemperatureInput {
 }
 
 export function useTemperatureRecords(members: Member[] | undefined) {
-  const qc = useQueryClient();
-
-  const query = useQuery({
+  const { items, isLoading, create, remove } = useResource<TemperatureRecord>({
     queryKey: queryKeys.temperatureRecords.all,
-    queryFn: () => api.get<TemperatureRecord[]>("/temperature-records"),
+    listPath: "/temperature-records",
+    basePath: "/temperature-records",
   });
 
-  const records: TemperatureRecordView[] = (query.data ?? [])
+  const records: TemperatureRecordView[] = items
     .map((r) => ({
       id: r.id,
       memberId: r.memberId,
@@ -355,30 +343,17 @@ export function useTemperatureRecords(members: Member[] | undefined) {
     }))
     .sort((a, b) => b.measuredAt.getTime() - a.measuredAt.getTime());
 
-  const createMutation = useMutation({
-    mutationFn: (input: CreateTemperatureInput) =>
-      api.post<TemperatureRecord>("/temperature-records", {
+  return {
+    records,
+    isLoading,
+    createRecord: (input: CreateTemperatureInput) =>
+      create.mutateAsync({
         memberId: input.memberId,
         temperature: input.temperature,
         measuredAt: input.measuredAt,
         notes: input.notes,
       }),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.temperatureRecords.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/temperature-records/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.temperatureRecords.all }),
-  });
-
-  return {
-    records,
-    isLoading: query.isLoading,
-    createRecord: (input: CreateTemperatureInput) =>
-      createMutation.mutateAsync(input),
-    deleteRecord: (id: string) => deleteMutation.mutateAsync(id),
+    deleteRecord: (id: string) => remove.mutateAsync(id),
   };
 }
 
@@ -397,14 +372,17 @@ export interface UpdateBodyMeasurementInput {
 }
 
 export function useBodyMeasurements(members: Member[] | undefined) {
-  const qc = useQueryClient();
-
-  const query = useQuery({
+  const { items, isLoading, create, update, remove } = useResource<
+    BodyMeasurement,
+    unknown,
+    UpdateBodyMeasurementInput
+  >({
     queryKey: queryKeys.bodyMeasurements.all,
-    queryFn: () => api.get<BodyMeasurement[]>("/body-measurements"),
+    listPath: "/body-measurements",
+    basePath: "/body-measurements",
   });
 
-  const measurements: BodyMeasurementView[] = (query.data ?? [])
+  const measurements: BodyMeasurementView[] = items
     .map((m) => ({
       id: m.id,
       memberId: m.memberId,
@@ -419,48 +397,23 @@ export function useBodyMeasurements(members: Member[] | undefined) {
         new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime(),
     );
 
-  const createMutation = useMutation({
-    mutationFn: (input: CreateBodyMeasurementInput) =>
-      api.post<BodyMeasurement>("/body-measurements", {
+  return {
+    measurements,
+    isLoading,
+    createMeasurement: (input: CreateBodyMeasurementInput) =>
+      create.mutateAsync({
         memberId: input.memberId,
         weight: input.weight,
         height: input.height,
         recordedAt: new Date(input.recordedAt).toISOString(),
         notes: input.notes,
       }),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.bodyMeasurements.all }),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({
-      id,
-      input,
-    }: {
-      id: string;
-      input: UpdateBodyMeasurementInput;
-    }) => api.patch<BodyMeasurement>(`/body-measurements/${id}`, input),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.bodyMeasurements.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/body-measurements/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.bodyMeasurements.all }),
-  });
-
-  return {
-    measurements,
-    isLoading: query.isLoading,
-    createMeasurement: (input: CreateBodyMeasurementInput) =>
-      createMutation.mutateAsync(input),
     updateMeasurement: async (
       id: string,
       input: UpdateBodyMeasurementInput,
     ): Promise<void> => {
-      await updateMutation.mutateAsync({ id, input });
+      await update.mutateAsync({ id, input });
     },
-    deleteMeasurement: (id: string) => deleteMutation.mutateAsync(id),
+    deleteMeasurement: (id: string) => remove.mutateAsync(id),
   };
 }

--- a/frontend/app/lib/useResource.ts
+++ b/frontend/app/lib/useResource.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+/**
+ * 汎用CRUDリソースフック。
+ *
+ * 各画面に散在していた「一覧取得(useQuery) + create/update/delete(useMutation) +
+ * 成功時の invalidateQueries」というボイラープレートを一箇所に集約する。
+ *
+ * 重要:
+ * - queryKey は呼び出し側で既存と「バイト等価」の配列を渡すこと
+ *   (queryKeys ファクトリの .all 等をそのまま渡す)。
+ * - listPath / basePath は既存のエンドポイントと厳密一致させること。
+ *   作成は POST basePath、更新は PATCH `${basePath}/${id}`、削除は DELETE `${basePath}/${id}`。
+ * - invalidate は一覧キーの invalidateQueries を行う。React Query のプレフィックス一致に
+ *   依存しているため、既存挙動と同じキーを渡す限り無効化範囲も同一になる。
+ */
+export interface ResourceConfig {
+  /** 一覧のクエリキー(既存と同一配列を渡す) */
+  queryKey: readonly unknown[];
+  /** 一覧取得パス。例 "/hospitals" */
+  listPath: string;
+  /** 作成 POST basePath、更新/削除は `${basePath}/${id}`。例 "/hospitals" */
+  basePath: string;
+  /** 追加で無効化するキー(任意) */
+  invalidateKeys?: readonly (readonly unknown[])[];
+}
+
+export function useResource<T, C = unknown, U = unknown>(cfg: ResourceConfig) {
+  const qc = useQueryClient();
+
+  const list = useQuery({
+    queryKey: cfg.queryKey,
+    queryFn: () => api.get<T[]>(cfg.listPath),
+  });
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: cfg.queryKey });
+    cfg.invalidateKeys?.forEach((k) => qc.invalidateQueries({ queryKey: k }));
+  };
+
+  const create = useMutation({
+    mutationFn: (body: C) => api.post<T>(cfg.basePath, body),
+    onSuccess: invalidate,
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, input }: { id: string; input: U }) =>
+      api.patch<T>(`${cfg.basePath}/${id}`, input),
+    onSuccess: invalidate,
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => api.delete(`${cfg.basePath}/${id}`),
+    onSuccess: invalidate,
+  });
+
+  return {
+    list,
+    items: list.data ?? [],
+    isLoading: list.isLoading,
+    create,
+    update,
+    remove,
+    invalidate,
+  };
+}

--- a/frontend/app/routes/appointments.tsx
+++ b/frontend/app/routes/appointments.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { MapPin, Plus, X } from "lucide-react";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/queryKeys";
+import { useResource } from "@/lib/useResource";
 import type { Appointment, Hospital, Member } from "@/lib/types";
 import { TabSwitch } from "@/components/shared/TabSwitch";
 import { MiniCalendar } from "@/components/appointments/MiniCalendar";
@@ -15,7 +16,6 @@ import {
 } from "@/components/appointments/AppointmentList";
 
 export default function Appointments() {
-  const qc = useQueryClient();
   const [showForm, setShowForm] = useState(false);
   const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
   const [activeTab, setActiveTab] = useState<AppointmentFilter>("upcoming");
@@ -27,9 +27,16 @@ export default function Appointments() {
     queryFn: () => api.get<Member[]>("/members"),
   });
 
-  const { data: appointments = [], isLoading } = useQuery({
+  const {
+    items: appointments,
+    isLoading,
+    create: createMutation,
+    update: updateMutation,
+    remove: deleteMutation,
+  } = useResource<Appointment>({
     queryKey: queryKeys.appointments.all,
-    queryFn: () => api.get<Appointment[]>("/appointments"),
+    listPath: "/appointments",
+    basePath: "/appointments",
   });
 
   const { data: hospitals = [] } = useQuery({
@@ -57,44 +64,17 @@ export default function Appointments() {
     [counts],
   );
 
-  const createMutation = useMutation({
-    mutationFn: (data: AppointmentFormData) =>
-      api.post<Appointment>("/appointments", {
+  const handleCreate = (data: AppointmentFormData) => {
+    createMutation.mutate(
+      {
         memberId: data.memberId,
         hospitalId: data.hospitalId,
         appointmentDate: new Date(data.appointmentDate).toISOString(),
         type: data.type,
         notes: data.notes,
-      }),
-    onSuccess: () => {
-      setShowForm(false);
-      qc.invalidateQueries({ queryKey: queryKeys.appointments.all });
-    },
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: AppointmentFormData }) =>
-      api.patch<Appointment>(`/appointments/${id}`, {
-        appointmentDate: new Date(data.appointmentDate).toISOString(),
-        hospitalId: data.hospitalId,
-        type: data.type,
-        notes: data.notes,
-      }),
-    onSuccess: () => {
-      setEditingAppointment(null);
-      qc.invalidateQueries({ queryKey: queryKeys.appointments.all });
-    },
-    onError: () => setUpdateError("更新に失敗しました。もう一度お試しください。"),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/appointments/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.appointments.all }),
-  });
-
-  const handleCreate = (data: AppointmentFormData) => {
-    createMutation.mutate(data);
+      },
+      { onSuccess: () => setShowForm(false) },
+    );
   };
 
   const handleEdit = (appointment: Appointment) => {
@@ -112,7 +92,22 @@ export default function Appointments() {
   const handleUpdate = (data: AppointmentFormData) => {
     if (!editingAppointment) return;
     setUpdateError(null);
-    updateMutation.mutate({ id: editingAppointment.id, data });
+    updateMutation.mutate(
+      {
+        id: editingAppointment.id,
+        input: {
+          appointmentDate: new Date(data.appointmentDate).toISOString(),
+          hospitalId: data.hospitalId,
+          type: data.type,
+          notes: data.notes,
+        },
+      },
+      {
+        onSuccess: () => setEditingAppointment(null),
+        onError: () =>
+          setUpdateError("更新に失敗しました。もう一度お試しください。"),
+      },
+    );
   };
 
   const handleCancelEdit = () => {

--- a/frontend/app/routes/hospitals.tsx
+++ b/frontend/app/routes/hospitals.tsx
@@ -1,60 +1,48 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import { ArrowLeft, Plus, X } from "lucide-react";
-import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/queryKeys";
+import { useResource } from "@/lib/useResource";
 import type { Hospital } from "@/lib/types";
 import { HospitalList, type UpdateHospitalInput } from "@/components/hospitals/HospitalList";
 import { HospitalForm, type HospitalFormData } from "@/components/hospitals/HospitalForm";
 
 export default function Hospitals() {
   const navigate = useNavigate();
-  const qc = useQueryClient();
   const [showForm, setShowForm] = useState(false);
 
-  const { data: hospitals = [], isLoading } = useQuery({
+  const {
+    items: hospitals,
+    isLoading,
+    create,
+    update,
+    remove,
+  } = useResource<Hospital, Partial<HospitalFormData>, UpdateHospitalInput>({
     queryKey: queryKeys.hospitals.all,
-    queryFn: () => api.get<Hospital[]>("/hospitals"),
+    listPath: "/hospitals",
+    basePath: "/hospitals",
   });
 
-  const createMutation = useMutation({
-    mutationFn: (data: HospitalFormData) =>
-      api.post<Hospital>("/hospitals", {
+  const handleCreate = (data: HospitalFormData) => {
+    create.mutate(
+      {
         name: data.name,
         address: data.address,
         phone: data.phone,
         department: data.department,
         doctorName: data.doctorName,
         notes: data.notes,
-      }),
-    onSuccess: () => {
-      setShowForm(false);
-      qc.invalidateQueries({ queryKey: queryKeys.hospitals.all });
-    },
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdateHospitalInput }) =>
-      api.patch<Hospital>(`/hospitals/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hospitals.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/hospitals/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.hospitals.all }),
-  });
-
-  const handleCreate = (data: HospitalFormData) => {
-    createMutation.mutate(data);
+      },
+      { onSuccess: () => setShowForm(false) },
+    );
   };
 
   const handleUpdate = async (hospitalId: string, input: UpdateHospitalInput) => {
-    await updateMutation.mutateAsync({ id: hospitalId, input });
+    await update.mutateAsync({ id: hospitalId, input });
   };
 
   const handleDelete = (hospitalId: string) => {
-    deleteMutation.mutate(hospitalId);
+    remove.mutate(hospitalId);
   };
 
   return (

--- a/frontend/app/routes/members.$memberId.tsx
+++ b/frontend/app/routes/members.$memberId.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link, Navigate, useParams } from "react-router";
 import { Pill, Plus, X, ChevronLeft, FileText } from "lucide-react";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/queryKeys";
+import { useResource } from "@/lib/useResource";
 import type {
   Member,
   Allergy,
@@ -71,7 +72,6 @@ const memberTypeLabels: Record<string, string> = {
 
 export default function MemberDetail() {
   const { memberId } = useParams();
-  const qc = useQueryClient();
   const [activeTab, setActiveTab] = useState<TabKey>("allergies");
 
   const {
@@ -156,30 +156,27 @@ export default function MemberDetail() {
       </div>
 
       {activeTab === "allergies" && (
-        <AllergiesSection member={member} members={members} qc={qc} />
+        <AllergiesSection member={member} members={members} />
       )}
       {activeTab === "vaccinations" && (
-        <VaccinationsSection member={member} members={members} qc={qc} />
+        <VaccinationsSection member={member} members={members} />
       )}
       {activeTab === "examinations" && (
-        <ExaminationsSection member={member} members={members} qc={qc} />
+        <ExaminationsSection member={member} members={members} />
       )}
       {activeTab === "insurances" && (
-        <InsurancesSection member={member} members={members} qc={qc} />
+        <InsurancesSection member={member} members={members} />
       )}
       {activeTab === "prescriptions" && (
-        <PrescriptionsSection member={member} members={members} qc={qc} />
+        <PrescriptionsSection member={member} members={members} />
       )}
     </div>
   );
 }
 
-type QueryClientType = ReturnType<typeof useQueryClient>;
-
 interface SectionProps {
   member: Member;
   members: Member[];
-  qc: QueryClientType;
 }
 
 function SectionHeader({
@@ -213,28 +210,19 @@ function FormWrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
-function AllergiesSection({ member, members, qc }: SectionProps) {
+function AllergiesSection({ member, members }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
-  const { data: allergies = [], isLoading } = useQuery({
+  const {
+    items: allergies,
+    isLoading,
+    create,
+    update,
+    remove,
+  } = useResource<Allergy, AllergyFormData, UpdateAllergyInput>({
     queryKey: queryKeys.allergies.all,
-    queryFn: () => api.get<Allergy[]>("/allergies"),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: (data: AllergyFormData) => api.post<Allergy>("/allergies", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.allergies.all }),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdateAllergyInput }) =>
-      api.patch<Allergy>(`/allergies/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.allergies.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/allergies/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.allergies.all }),
+    listPath: "/allergies",
+    basePath: "/allergies",
   });
 
   const items: AllergyWithMember[] = allergies
@@ -242,16 +230,16 @@ function AllergiesSection({ member, members, qc }: SectionProps) {
     .map((a) => ({ ...a, memberName: member.name }));
 
   const handleCreate = async (data: AllergyFormData) => {
-    await createMutation.mutateAsync(data);
+    await create.mutateAsync(data);
     setShowForm(false);
   };
 
   const handleUpdate = async (id: string, input: UpdateAllergyInput) => {
-    await updateMutation.mutateAsync({ id, input });
+    await update.mutateAsync({ id, input });
   };
 
   const handleDelete = (id: string) => {
-    deleteMutation.mutate(id);
+    remove.mutate(id);
   };
 
   return (
@@ -267,31 +255,19 @@ function AllergiesSection({ member, members, qc }: SectionProps) {
   );
 }
 
-function VaccinationsSection({ member, members, qc }: SectionProps) {
+function VaccinationsSection({ member, members }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
-  const { data: vaccinations = [], isLoading } = useQuery({
+  const {
+    items: vaccinations,
+    isLoading,
+    create,
+    update,
+    remove,
+  } = useResource<Vaccination, VaccinationFormData, UpdateVaccinationInput>({
     queryKey: queryKeys.vaccinations.all,
-    queryFn: () => api.get<Vaccination[]>("/vaccinations"),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: (data: VaccinationFormData) => api.post<Vaccination>("/vaccinations", data),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.vaccinations.all }),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdateVaccinationInput }) =>
-      api.patch<Vaccination>(`/vaccinations/${id}`, input),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.vaccinations.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/vaccinations/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.vaccinations.all }),
+    listPath: "/vaccinations",
+    basePath: "/vaccinations",
   });
 
   const items: VaccinationWithMember[] = vaccinations
@@ -299,16 +275,16 @@ function VaccinationsSection({ member, members, qc }: SectionProps) {
     .map((v) => ({ ...v, memberName: member.name }));
 
   const handleCreate = async (data: VaccinationFormData) => {
-    await createMutation.mutateAsync(data);
+    await create.mutateAsync(data);
     setShowForm(false);
   };
 
   const handleUpdate = async (id: string, input: UpdateVaccinationInput) => {
-    await updateMutation.mutateAsync({ id, input });
+    await update.mutateAsync({ id, input });
   };
 
   const handleDelete = (id: string) => {
-    deleteMutation.mutate(id);
+    remove.mutate(id);
   };
 
   return (
@@ -329,31 +305,19 @@ function VaccinationsSection({ member, members, qc }: SectionProps) {
   );
 }
 
-function ExaminationsSection({ member, members, qc }: SectionProps) {
+function ExaminationsSection({ member, members }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
-  const { data: examinations = [], isLoading } = useQuery({
+  const {
+    items: examinations,
+    isLoading,
+    create,
+    update,
+    remove,
+  } = useResource<Examination, ExaminationFormData, UpdateExaminationInput>({
     queryKey: queryKeys.examinations.all,
-    queryFn: () => api.get<Examination[]>("/examinations"),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: (data: ExaminationFormData) => api.post<Examination>("/examinations", data),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.examinations.all }),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdateExaminationInput }) =>
-      api.patch<Examination>(`/examinations/${id}`, input),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.examinations.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/examinations/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.examinations.all }),
+    listPath: "/examinations",
+    basePath: "/examinations",
   });
 
   const items: ExaminationWithMember[] = examinations
@@ -361,16 +325,16 @@ function ExaminationsSection({ member, members, qc }: SectionProps) {
     .map((e) => ({ ...e, memberName: member.name }));
 
   const handleCreate = async (data: ExaminationFormData) => {
-    await createMutation.mutateAsync(data);
+    await create.mutateAsync(data);
     setShowForm(false);
   };
 
   const handleUpdate = async (id: string, input: UpdateExaminationInput) => {
-    await updateMutation.mutateAsync({ id, input });
+    await update.mutateAsync({ id, input });
   };
 
   const handleDelete = (id: string) => {
-    deleteMutation.mutate(id);
+    remove.mutate(id);
   };
 
   return (
@@ -391,28 +355,19 @@ function ExaminationsSection({ member, members, qc }: SectionProps) {
   );
 }
 
-function InsurancesSection({ member, members, qc }: SectionProps) {
+function InsurancesSection({ member, members }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
-  const { data: insurances = [], isLoading } = useQuery({
+  const {
+    items: insurances,
+    isLoading,
+    create,
+    update,
+    remove,
+  } = useResource<Insurance, InsuranceFormData, UpdateInsuranceInput>({
     queryKey: queryKeys.insurances.all,
-    queryFn: () => api.get<Insurance[]>("/insurances"),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: (data: InsuranceFormData) => api.post<Insurance>("/insurances", data),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.insurances.all }),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdateInsuranceInput }) =>
-      api.patch<Insurance>(`/insurances/${id}`, input),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.insurances.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/insurances/${id}`),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.insurances.all }),
+    listPath: "/insurances",
+    basePath: "/insurances",
   });
 
   const items: InsuranceWithMember[] = insurances
@@ -420,16 +375,16 @@ function InsurancesSection({ member, members, qc }: SectionProps) {
     .map((i) => ({ ...i, memberName: member.name }));
 
   const handleCreate = async (data: InsuranceFormData) => {
-    await createMutation.mutateAsync(data);
+    await create.mutateAsync(data);
     setShowForm(false);
   };
 
   const handleUpdate = async (id: string, input: UpdateInsuranceInput) => {
-    await updateMutation.mutateAsync({ id, input });
+    await update.mutateAsync({ id, input });
   };
 
   const handleDelete = (id: string) => {
-    deleteMutation.mutate(id);
+    remove.mutate(id);
   };
 
   return (
@@ -450,31 +405,19 @@ function InsurancesSection({ member, members, qc }: SectionProps) {
   );
 }
 
-function PrescriptionsSection({ member, members, qc }: SectionProps) {
+function PrescriptionsSection({ member, members }: SectionProps) {
   const [showForm, setShowForm] = useState(false);
 
-  const { data: prescriptions = [], isLoading } = useQuery({
+  const {
+    items: prescriptions,
+    isLoading,
+    create,
+    update,
+    remove,
+  } = useResource<Prescription, PrescriptionFormData, UpdatePrescriptionInput>({
     queryKey: queryKeys.prescriptions.all,
-    queryFn: () => api.get<Prescription[]>("/prescriptions"),
-  });
-
-  const createMutation = useMutation({
-    mutationFn: (data: PrescriptionFormData) => api.post<Prescription>("/prescriptions", data),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.prescriptions.all }),
-  });
-
-  const updateMutation = useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdatePrescriptionInput }) =>
-      api.patch<Prescription>(`/prescriptions/${id}`, input),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.prescriptions.all }),
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (id: string) => api.delete(`/prescriptions/${id}`),
-    onSuccess: () =>
-      qc.invalidateQueries({ queryKey: queryKeys.prescriptions.all }),
+    listPath: "/prescriptions",
+    basePath: "/prescriptions",
   });
 
   const items: PrescriptionWithMember[] = prescriptions
@@ -482,16 +425,16 @@ function PrescriptionsSection({ member, members, qc }: SectionProps) {
     .map((p) => ({ ...p, memberName: member.name }));
 
   const handleCreate = async (data: PrescriptionFormData) => {
-    await createMutation.mutateAsync(data);
+    await create.mutateAsync(data);
     setShowForm(false);
   };
 
   const handleUpdate = async (id: string, input: UpdatePrescriptionInput) => {
-    await updateMutation.mutateAsync({ id, input });
+    await update.mutateAsync({ id, input });
   };
 
   const handleDelete = (id: string) => {
-    deleteMutation.mutate(id);
+    remove.mutate(id);
   };
 
   return (


### PR DESCRIPTION
## Summary
- `app/lib/useResource.ts` を新設し、散在していた 一覧+create/update/delete+invalidate のreact-queryボイラープレートを集約。
- members詳細の医療記録5セクション・hospitals・appointments・health-logs(体調/体温/身体測定)を置換。
- queryKey はバイト等価維持（prefix無効化保持）、パス/リクエスト/可視UI/文言は不変。
- typecheck/build/e2e(11件) 通過。