### PR TITLE
fix(backend): Medication.status/Examination.imageDataカラム欠損で薬・検査APIが500になる問題を修正

### DIFF
--- a/backend/migrations/0007_add_missing_columns.sql
+++ b/backend/migrations/0007_add_missing_columns.sql
@@ -1,0 +1,20 @@
+-- 本番DBは旧Prisma時代に作成されたテーブルを引き継いでおり、
+-- 0001 の CREATE TABLE IF NOT EXISTS は既存テーブルに対して no-op になる。
+-- そのため 0001 に後から追記されたカラムが本番に存在しない (SQLSTATE 42703)。
+-- 不足カラムはここで ALTER TABLE により補う。
+
+-- Medication.status: 服用状況 (active / paused / discontinued)
+-- カラム新設時のみ、既存の isActive=FALSE を paused として引き継ぐ
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'Medication' AND column_name = 'status'
+    ) THEN
+        ALTER TABLE "Medication" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'active';
+        UPDATE "Medication" SET "status" = 'paused' WHERE "isActive" = FALSE;
+    END IF;
+END $$;
+
+-- Examination.imageData: 検査画像 (base64)
+ALTER TABLE "Examination" ADD COLUMN IF NOT EXISTS "imageData" TEXT;

--- a/frontend/app/components/medications/MemberMedications.tsx
+++ b/frontend/app/components/medications/MemberMedications.tsx
@@ -291,6 +291,11 @@ export function MemberMedications({ member, categoryFilter }: MemberMedicationsP
             onSubmit={(data) => createMedication.mutate(data)}
             onCancel={() => setShowAddForm(false)}
           />
+          {createMedication.isError && (
+            <p className="mt-2 text-sm text-red-600" role="alert">
+              追加できませんでした: {createMedication.error.message}
+            </p>
+          )}
         </div>
       )}
 
@@ -349,6 +354,11 @@ export function MemberMedications({ member, categoryFilter }: MemberMedicationsP
             initialData={editingMed}
             onCancel={() => setEditingMed(null)}
           />
+          {updateMedication.isError && (
+            <p className="mt-2 text-sm text-red-600" role="alert">
+              更新できませんでした: {updateMedication.error.message}
+            </p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- 本番DBは旧Prisma時代のテーブルを引き継いでおり、`0001_init.sql` の `CREATE TABLE IF NOT EXISTS` が no-op のため、後から0001に追記された `Medication.status` / `Examination.imageData` が本番に存在せず、薬・検査系エンドポイントが全て500 (SQLSTATE 42703) になっていた
- `0007_add_missing_columns.sql` を追加: `ADD COLUMN IF NOT EXISTS` で不足カラムを補完。status新設時のみ既存の `isActive=FALSE` を `paused` にバックフィル（DOブロックで再起動時の再実行から保護）
- 本番相当スキーマのローカルPostgresで、初回適用・二重適用の冪等性・再適用時に手動変更が上書きされないことを検証済み
- ダッシュボードの薬追加/編集フォーム (`MemberMedications`) にエラー表示を追加（従来は失敗しても無反応のサイレント失敗だった）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 既存データベースで一部の項目が不足している場合でも、薬剤情報や検査情報を正しく扱えるようになりました。
  * 追加・更新時に失敗した場合、画面上に赤いエラーメッセージが表示されるようになりました。
  * 既存の薬剤データについて、状態が欠けている場合の補完と整合性の修正を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->