### PR TITLE
fix(backend): updatedAtのDB DEFAULT欠損でUser/Member/Medicationの新規作成が500になる問題を修正

### DIFF
--- a/backend/migrations/0008_add_missing_column_defaults.sql
+++ b/backend/migrations/0008_add_missing_column_defaults.sql
@@ -1,0 +1,13 @@
+-- 旧Prisma時代に作成された本番テーブルは、@updatedAt がクライアント側更新のため
+-- "updatedAt" に DB DEFAULT が存在しない (0001 の DEFAULT now() は既存テーブルに no-op)。
+-- GORM モデルは `default:now()` タグにより INSERT 時に updatedAt を省略して DB 既定値に
+-- 委ねるため、DEFAULT が無いと NOT NULL 制約違反 (SQLSTATE 23502) で新規作成が失敗する。
+-- ALTER COLUMN SET DEFAULT は冪等 (毎起動の再実行で同値を再設定するだけ)。
+
+ALTER TABLE "User"       ALTER COLUMN "updatedAt"  SET DEFAULT now();
+ALTER TABLE "Member"     ALTER COLUMN "updatedAt"  SET DEFAULT now();
+ALTER TABLE "Medication" ALTER COLUMN "updatedAt"  SET DEFAULT now();
+
+-- 配列カラムの DEFAULT '{}' も同様に本番へ未反映だったため補正
+ALTER TABLE "HealthLog"  ALTER COLUMN "symptoms"   SET DEFAULT '{}';
+ALTER TABLE "Schedule"   ALTER COLUMN "daysOfWeek" SET DEFAULT '{}';


### PR DESCRIPTION
## Summary
- #1150 でSELECT系は復旧したが、新規作成(INSERT)が `null value in column "updatedAt" violates not-null constraint` (SQLSTATE 23502) で失敗していた
- 旧Prisma時代の本番テーブルは `@updatedAt` がクライアント側更新のため `updatedAt` にDB DEFAULTが無く、GORMモデルの `default:now()` タグ（INSERT時にカラム省略しDB既定値に委ねる）と噛み合わず新規作成が全滅していた
- 本番DBのinformation_schemaとマイグレーション定義の全カラムDEFAULT突き合わせで欠損5件を特定: `User.updatedAt` / `Member.updatedAt` / `Medication.updatedAt` (NOT NULL、新規作成を破壊) と `HealthLog.symptoms` / `Schedule.daysOfWeek` の `'{}'`
- `0008_add_missing_column_defaults.sql` で `ALTER COLUMN ... SET DEFAULT` を適用（冪等）。本番相当スキーマのローカルPostgresでエラー再現→修正後INSERT成功→二重適用の冪等性を検証済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 一部のレコード作成時に発生していた `updatedAt` の必須値不足によるエラーを解消しました。
  * 配列項目の初期値が未設定だったケースを補正し、保存時の不具合を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->