### PR TITLE
fix(frontend): 下部タブバーがメンバー系2ページにしか表示されない不整合を修正

### DIFF
--- a/frontend/app/components/shared/BottomNavigation.tsx
+++ b/frontend/app/components/shared/BottomNavigation.tsx
@@ -1,48 +1,47 @@
 import React from "react";
-import { Link } from "react-router";
+import { NavLink } from "react-router";
 import { Home, Pill, Calendar, Activity, Settings, type LucideIcon } from "lucide-react";
+import { clsx } from "clsx";
 
 interface NavItem {
   path: string;
   icon: LucideIcon;
   label: string;
+  end: boolean;
 }
 
 const navItems: NavItem[] = [
-  { path: "/", icon: Home, label: "ホーム" },
-  { path: "/medications", icon: Pill, label: "お薬" },
-  { path: "/health-logs", icon: Activity, label: "体調" },
-  { path: "/appointments", icon: Calendar, label: "通院" },
-  { path: "/settings", icon: Settings, label: "設定" },
+  { path: "/", icon: Home, label: "ホーム", end: true },
+  { path: "/medications", icon: Pill, label: "お薬", end: false },
+  { path: "/health-logs", icon: Activity, label: "体調", end: false },
+  { path: "/appointments", icon: Calendar, label: "通院", end: false },
+  { path: "/settings", icon: Settings, label: "設定", end: false },
 ];
 
-interface BottomNavigationProps {
-  activePath: string;
-}
-
-export const BottomNavigation: React.FC<BottomNavigationProps> = ({ activePath }) => {
+// スマホ専用の下部タブバー。PC(md以上)はサイドバーがあるため表示しない。
+export const BottomNavigation: React.FC = () => {
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 bg-white border-t border-primary-100 shadow-lg"
+      className="fixed bottom-0 left-0 right-0 z-10 border-t border-primary-100 bg-white shadow-lg md:hidden"
       aria-label="メインナビゲーション"
     >
-      <div className="max-w-md mx-auto flex justify-around py-2">
-        {navItems.map(({ path, icon, label }) => {
-          const isActive = activePath === path;
-          return (
-            <Link
-              key={path}
-              to={path}
-              {...(isActive && { "aria-current": "page" as const })}
-              className={`flex flex-col items-center text-xs transition-colors ${
-                isActive ? "text-primary-700 font-semibold" : "text-ink-400 hover:text-primary-600"
-              }`}
-            >
-              {React.createElement(icon, { size: 20, className: "mb-0.5" })}
-              {label}
-            </Link>
-          );
-        })}
+      <div className="mx-auto flex max-w-md justify-around py-2">
+        {navItems.map(({ path, icon, label, end }) => (
+          <NavLink
+            key={path}
+            to={path}
+            end={end}
+            className={({ isActive }) =>
+              clsx(
+                "flex flex-col items-center text-xs transition-colors",
+                isActive ? "font-semibold text-primary-700" : "text-ink-400 hover:text-primary-600",
+              )
+            }
+          >
+            {React.createElement(icon, { size: 20, className: "mb-0.5" })}
+            {label}
+          </NavLink>
+        ))}
       </div>
     </nav>
   );

--- a/frontend/app/routes/_authed.tsx
+++ b/frontend/app/routes/_authed.tsx
@@ -19,6 +19,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useAuth, useRequireAuth } from "@/lib/auth";
+import { BottomNavigation } from "@/components/shared/BottomNavigation";
 
 interface NavItem {
   to: string;
@@ -123,10 +124,13 @@ export default function AuthedLayout() {
           <span className="w-9" aria-hidden />
         </header>
 
-        <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-6 md:max-w-5xl md:px-8 md:py-8">
+        <main className="mx-auto w-full max-w-2xl flex-1 px-4 pt-6 pb-24 md:max-w-5xl md:px-8 md:py-8">
           <Outlet />
         </main>
       </div>
+
+      {/* ===== スマホ: 下部タブバー (全ページ共通、PCはサイドバーのため非表示) ===== */}
+      <BottomNavigation />
 
       {/* ===== スマホ: ハンバーガーメニュー(ドロワー) ===== */}
       {menuOpen && (

--- a/frontend/app/routes/members.$memberId.medications.tsx
+++ b/frontend/app/routes/members.$memberId.medications.tsx
@@ -6,7 +6,6 @@ import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/queryKeys";
 import type { Medication, Schedule } from "@/lib/types";
 import { Button, Card, ErrorText, Input } from "@/components/ui";
-import { BottomNavigation } from "@/components/shared/BottomNavigation";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { EmptyStatePrompt } from "@/components/shared/EmptyStatePrompt";
 
@@ -137,7 +136,7 @@ export default function MemberMedications() {
   };
 
   return (
-    <div className="min-h-screen pb-20">
+    <div className="min-h-screen">
       <header className="bg-gradient-header shadow-soft">
         <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
           <div className="flex items-center space-x-3">
@@ -348,8 +347,6 @@ export default function MemberMedications() {
           </div>
         )}
       </main>
-
-      <BottomNavigation activePath="/members" />
     </div>
   );
 }

--- a/frontend/app/routes/members.tsx
+++ b/frontend/app/routes/members.tsx
@@ -7,7 +7,6 @@ import type { Appointment, Member, MemberWithCounts } from "@/lib/types";
 import { MemberList } from "@/components/members/MemberList";
 import { MemberForm, type MemberFormData } from "@/components/members/MemberForm";
 import type { MemberSummary } from "@/components/members/MemberSummaryCard";
-import { BottomNavigation } from "@/components/shared/BottomNavigation";
 
 interface CreateMemberBody {
   name: string;
@@ -118,7 +117,7 @@ export default function Members() {
   };
 
   return (
-    <div className="min-h-screen pb-20">
+    <div className="min-h-screen">
       <header className="bg-gradient-header shadow-soft">
         <div className="max-w-md mx-auto px-4 py-3 flex justify-between items-center">
           <h1 className="text-xl font-bold text-ink-800 tracking-wide">メンバー</h1>
@@ -171,8 +170,6 @@ export default function Members() {
           summaries={summaries}
         />
       </main>
-
-      <BottomNavigation activePath="/members" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `BottomNavigation` (下部タブバー) が `members` 系2ページでのみ個別レンダリングされており、他ページには無い・PCではサイドバーと二重になる不整合があった
- `_authed.tsx` 共通レイアウトに移動し、認証済み全ページで統一表示。`md:hidden` によりPC(サイドバーあり)では非表示、モバイルのみ表示に変更
- アクティブ判定を `activePath` prop から `NavLink` の `isActive` に置き換え、現在地のハイライトが全ページで自動追従するよう改善
- タブバーとコンテンツの重なり防止のため共通 `<main>` にモバイル時 `pb-24` を付与し、個別ページの `pb-20` 対応を削除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイル画面で共通の下部ナビゲーションを表示するようになりました。
  * 現在表示中のページに応じて、ナビゲーション項目の選択状態が自動的に反映されます。

* **改善**
  * 下部ナビゲーション表示時も、ページ内容が隠れにくいレイアウトに調整しました。
  * 一部ページで重複して表示されていた下部ナビゲーションを整理しました。
  * デスクトップ画面では従来どおり下部ナビゲーションを非表示にします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->