### PR TITLE
chore: 旧構成の残骸とSupabase CLI生成物をgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ backend/app
 frontend/node_modules/
 frontend/build/
 frontend/.react-router/
+
+# Supabase CLI のローカル生成物 (リンク情報など)
+/supabase/
+
+# 旧 Next.js 構成の残骸。現行のE2Eは frontend/e2e/ + frontend/playwright.config.ts
+# (CI も working-directory: frontend で実行している)
+/e2e/
+/playwright.config.ts
+/scripts/


### PR DESCRIPTION
## Summary

- ルート直下の `e2e/` `playwright.config.ts` `scripts/` を gitignore に追加。旧 Next.js 構成の残骸で、現行のE2Eは `frontend/e2e/` + `frontend/playwright.config.ts` (CI も `working-directory: frontend` で実行)
- Supabase CLI がローカル生成する `supabase/` を gitignore に追加
- いずれも先頭 `/` でリポジトリルート限定にし、`frontend/e2e/` が巻き添えで無視されないようにしている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Supabase CLIのローカル生成物や、旧構成に関連するテスト・スクリプトファイルが不要な変更として扱われるようになりました。
  * 対象となる除外ルールの説明コメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->