### PR TITLE
feat(backend-java): Spring Boot で Medication 集約をDDDで実装

### DIFF
--- a/backend-java/.gitattributes
+++ b/backend-java/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/backend-java/.gitignore
+++ b/backend-java/.gitignore
@@ -1,0 +1,36 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Local ###
+.env

--- a/backend-java/.mvn/wrapper/maven-wrapper.properties
+++ b/backend-java/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/backend-java/mvnw
+++ b/backend-java/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/backend-java/mvnw.cmd
+++ b/backend-java/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>4.1.0</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>app.healthfamily</groupId>
+	<artifactId>healthfamily-api</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>healthfamily-api</name>
+	<description/>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>25</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/backend-java/src/main/java/app/healthfamily/HealthfamilyApiApplication.java
+++ b/backend-java/src/main/java/app/healthfamily/HealthfamilyApiApplication.java
@@ -1,0 +1,13 @@
+package app.healthfamily;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class HealthfamilyApiApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(HealthfamilyApiApplication.class, args);
+	}
+
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/DoseTaken.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/DoseTaken.java
@@ -1,0 +1,41 @@
+package app.healthfamily.medication.domain;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * 服用が成立したことを表す。
+ *
+ * <p>{@link Medication#take} の戻り値。集約が「何が起きたか」を返し、
+ * それを永続化するのはアプリケーション層の仕事とする。
+ * ドメイン層はリポジトリを呼ばない。
+ *
+ * @param medicationId   服用した薬
+ * @param memberID       対象メンバー（薬から導出するので呼び出し側が指定する必要はない）
+ * @param userId         所有ユーザー
+ * @param takenAt        服用時刻
+ * @param dosageAmount   服用量。薬に設定がなければ空
+ * @param remainingStock 服用後の残数。残数を管理していない薬なら空
+ */
+public record DoseTaken(
+        String medicationId,
+        String memberID,
+        String userId,
+        Instant takenAt,
+        Optional<String> dosageAmount,
+        Optional<StockQuantity> remainingStock) {
+
+    public DoseTaken {
+        if (medicationId == null || medicationId.isBlank()) {
+            throw new IllegalArgumentException("medicationId is required");
+        }
+        if (takenAt == null) {
+            throw new IllegalArgumentException("takenAt is required");
+        }
+    }
+
+    /** 残数を管理していて、かつ服用後に 0 になったか。 */
+    public boolean depletedStock() {
+        return remainingStock.map(StockQuantity::isEmpty).orElse(false);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/DosingInterval.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/DosingInterval.java
@@ -1,0 +1,42 @@
+package app.healthfamily.medication.domain;
+
+import app.healthfamily.shared.DomainException;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * 頓服薬の最短服用間隔。
+ *
+ * <p>「前回から 4 時間空けること」という医療上の制約を表す。
+ * Go 版では {@code IntervalHours *int} が保存されているだけで、
+ * この制約を強制するコードはどこにも存在しなかった。
+ */
+public record DosingInterval(int hours) {
+
+    public DosingInterval {
+        if (hours <= 0) {
+            throw DomainException.validation("服用間隔は 1 時間以上で指定してください");
+        }
+        if (hours > 24 * 7) {
+            throw DomainException.validation("服用間隔は 168 時間（7日）以内で指定してください");
+        }
+    }
+
+    public static DosingInterval ofHours(int hours) {
+        return new DosingInterval(hours);
+    }
+
+    public Duration duration() {
+        return Duration.ofHours(hours);
+    }
+
+    /** 前回服用時刻から、次に服用できる時刻を求める。 */
+    public Instant nextAvailableAfter(Instant lastTakenAt) {
+        return lastTakenAt.plus(duration());
+    }
+
+    /** その時刻に服用してよいか。境界（ちょうど間隔ぶん経過）は服用可とする。 */
+    public boolean allowsTakingAt(Instant now, Instant lastTakenAt) {
+        return !now.isBefore(nextAvailableAfter(lastTakenAt));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/Medication.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/Medication.java
@@ -1,0 +1,266 @@
+package app.healthfamily.medication.domain;
+
+import app.healthfamily.shared.DomainException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+/**
+ * 薬の集約ルート。
+ *
+ * <p>服薬記録（MedicationRecord）は件数が無制限に増えるため、この集約には含めない。
+ * 前回服用時刻が必要な操作では、アプリケーション層が読み出して引数で渡す。
+ * 集約を小さく保つための意図的な設計。
+ *
+ * <p>状態を変えられるのはこのクラスのメソッド経由だけで、setter は公開しない。
+ */
+public class Medication {
+
+    private final String id;
+    private final String userId;
+    private final String memberId;
+    private final String name;
+    private final MedicationCategory category;
+    private final MedicationStatus status;
+    private final String dosageAmount;
+    private final LocalDate stockAlertDate;
+    private final DosingInterval interval;
+
+    private StockQuantity stock;
+
+    private Medication(Builder b) {
+        if (b.id == null || b.id.isBlank()) {
+            throw DomainException.validation("薬のIDは必須です");
+        }
+        if (b.userId == null || b.userId.isBlank()) {
+            throw DomainException.validation("所有ユーザーは必須です");
+        }
+        if (b.name == null || b.name.isBlank()) {
+            throw DomainException.validation("薬の名前は必須です");
+        }
+        this.id = b.id;
+        this.userId = b.userId;
+        this.memberId = b.memberId;
+        this.name = b.name;
+        this.category = b.category == null ? MedicationCategory.REGULAR : b.category;
+        this.status = b.status == null ? MedicationStatus.ACTIVE : b.status;
+        this.dosageAmount = b.dosageAmount;
+        this.stockAlertDate = b.stockAlertDate;
+        this.interval = b.interval;
+        this.stock = b.stock;
+    }
+
+    // --- 振る舞い ---------------------------------------------------------
+
+    /**
+     * 1 回ぶん服用したことを記録する。
+     *
+     * <p>ここで守る不変条件は 3 つ。
+     * <ol>
+     *   <li>服用中（active）の薬でなければ記録できない</li>
+     *   <li>間隔を強制する種別なら、前回服用から所定の時間が経っていること</li>
+     *   <li>残数を管理している薬なら、残数が 1 以上あり、記録すると 1 減ること</li>
+     * </ol>
+     *
+     * <p>Go 版ではこのいずれも実装されておらず、記録を作るだけで残数は減らなかった。
+     *
+     * @param now          服用時刻
+     * @param lastTakenAt  前回服用時刻。初回なら空
+     */
+    public DoseTaken take(Instant now, Optional<Instant> lastTakenAt) {
+        if (now == null) {
+            throw new IllegalArgumentException("now is required");
+        }
+        if (!status.allowsTaking()) {
+            throw DomainException.conflict(
+                    status == MedicationStatus.PAUSED
+                            ? "休薬中の薬は服用を記録できません"
+                            : "中止した薬は服用を記録できません");
+        }
+        requireIntervalElapsed(now, lastTakenAt);
+
+        Optional<StockQuantity> remaining = Optional.empty();
+        if (stock != null) {
+            stock = stock.consumeOne();
+            remaining = Optional.of(stock);
+        }
+        return new DoseTaken(
+                id, memberId, userId, now, Optional.ofNullable(dosageAmount), remaining);
+    }
+
+    private void requireIntervalElapsed(Instant now, Optional<Instant> lastTakenAt) {
+        if (!category.enforcesInterval() || interval == null) {
+            return;
+        }
+        Optional<Instant> last = lastTakenAt == null ? Optional.empty() : lastTakenAt;
+        if (last.isEmpty()) {
+            return;
+        }
+        if (!interval.allowsTakingAt(now, last.get())) {
+            long minutes = ChronoUnit.MINUTES.between(now, interval.nextAvailableAfter(last.get()));
+            throw DomainException.conflict(
+                    "前回の服用から %d 時間空ける必要があります。あと %d 分お待ちください"
+                            .formatted(interval.hours(), Math.max(minutes, 1)));
+        }
+    }
+
+    /**
+     * 次に服用できる時刻。間隔を強制しない薬、または初回なら空を返す。
+     */
+    public Optional<Instant> nextAvailableAt(Optional<Instant> lastTakenAt) {
+        if (!category.enforcesInterval() || interval == null || lastTakenAt.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(interval.nextAvailableAfter(lastTakenAt.get()));
+    }
+
+    /**
+     * 残数が少ないか。
+     *
+     * <p>アラート日までの残り日数より残数が少なければ「少ない」と判定する。
+     * フロントの computeIsLowStock からそのまま移してきた規則で、
+     * アラート日を過ぎている場合は false を返す（期限超過は別の表示で扱っているため）。
+     */
+    public boolean isLowStock(LocalDate today) {
+        if (stock == null || stockAlertDate == null) {
+            return false;
+        }
+        long daysUntilAlert = ChronoUnit.DAYS.between(today, stockAlertDate);
+        if (daysUntilAlert <= 0) {
+            return false;
+        }
+        return stock.isBelow(daysUntilAlert);
+    }
+
+    /** 指定ユーザーの所有物か。 */
+    public boolean ownedBy(String candidateUserId) {
+        return userId.equals(candidateUserId);
+    }
+
+    /** 所有者でなければ例外を投げる。 */
+    public void requireOwnedBy(String candidateUserId) {
+        if (!ownedBy(candidateUserId)) {
+            throw DomainException.forbidden("この薬にアクセスする権限がありません");
+        }
+    }
+
+    // --- 参照 -------------------------------------------------------------
+
+    public String id() {
+        return id;
+    }
+
+    public String userId() {
+        return userId;
+    }
+
+    public String memberId() {
+        return memberId;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public MedicationCategory category() {
+        return category;
+    }
+
+    public MedicationStatus status() {
+        return status;
+    }
+
+    public Optional<StockQuantity> stock() {
+        return Optional.ofNullable(stock);
+    }
+
+    public Optional<DosingInterval> interval() {
+        return Optional.ofNullable(interval);
+    }
+
+    public Optional<LocalDate> stockAlertDate() {
+        return Optional.ofNullable(stockAlertDate);
+    }
+
+    public Optional<String> dosageAmount() {
+        return Optional.ofNullable(dosageAmount);
+    }
+
+    // --- 再構築 -----------------------------------------------------------
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * 永続化層からの再構築とテスト用の組み立てを担う。
+     * ドメインの制約はコンストラクタ側でまとめて検証する。
+     */
+    public static final class Builder {
+        private String id;
+        private String userId;
+        private String memberId;
+        private String name;
+        private MedicationCategory category;
+        private MedicationStatus status;
+        private String dosageAmount;
+        private LocalDate stockAlertDate;
+        private DosingInterval interval;
+        private StockQuantity stock;
+
+        public Builder id(String v) {
+            this.id = v;
+            return this;
+        }
+
+        public Builder userId(String v) {
+            this.userId = v;
+            return this;
+        }
+
+        public Builder memberId(String v) {
+            this.memberId = v;
+            return this;
+        }
+
+        public Builder name(String v) {
+            this.name = v;
+            return this;
+        }
+
+        public Builder category(MedicationCategory v) {
+            this.category = v;
+            return this;
+        }
+
+        public Builder status(MedicationStatus v) {
+            this.status = v;
+            return this;
+        }
+
+        public Builder dosageAmount(String v) {
+            this.dosageAmount = v;
+            return this;
+        }
+
+        public Builder stockAlertDate(LocalDate v) {
+            this.stockAlertDate = v;
+            return this;
+        }
+
+        public Builder interval(DosingInterval v) {
+            this.interval = v;
+            return this;
+        }
+
+        public Builder stock(StockQuantity v) {
+            this.stock = v;
+            return this;
+        }
+
+        public Medication build() {
+            return new Medication(this);
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationCategory.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationCategory.java
@@ -1,0 +1,48 @@
+package app.healthfamily.medication.domain;
+
+import app.healthfamily.shared.DomainException;
+import java.util.Arrays;
+
+/**
+ * 薬の種別。DB に実在する値だけを列挙している。
+ *
+ * <p>{@link #PRN} は頓服（pro re nata）。服用間隔の制約が効くのはこの種別だけで、
+ * 定時薬はスケジュールに従うため間隔判定の対象外とする。
+ */
+public enum MedicationCategory {
+
+    /** 定時薬 */
+    REGULAR("regular", false),
+    /** 頓服薬 */
+    PRN("prn", true),
+    /** 吸入薬 */
+    INHALER("inhaler", true),
+    /** 点眼薬 */
+    EYE_DROPS("eye_drops", true),
+    /** サプリメント */
+    SUPPLEMENT("supplement", false);
+
+    private final String code;
+    private final boolean intervalEnforced;
+
+    MedicationCategory(String code, boolean intervalEnforced) {
+        this.code = code;
+        this.intervalEnforced = intervalEnforced;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    /** この種別で服用間隔を強制するか。 */
+    public boolean enforcesInterval() {
+        return intervalEnforced;
+    }
+
+    public static MedicationCategory fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(c -> c.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> DomainException.validation("不明な薬の種別です: " + code));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationStatus.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationStatus.java
@@ -1,0 +1,37 @@
+package app.healthfamily.medication.domain;
+
+import app.healthfamily.shared.DomainException;
+import java.util.Arrays;
+
+/** 薬の服用状態。DB に実在する値だけを列挙している。 */
+public enum MedicationStatus {
+
+    /** 服用中 */
+    ACTIVE("active"),
+    /** 休薬中 */
+    PAUSED("paused"),
+    /** 中止 */
+    STOPPED("stopped");
+
+    private final String code;
+
+    MedicationStatus(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    /** 服用を記録してよい状態か。 */
+    public boolean allowsTaking() {
+        return this == ACTIVE;
+    }
+
+    public static MedicationStatus fromCode(String code) {
+        return Arrays.stream(values())
+                .filter(s -> s.code.equals(code))
+                .findFirst()
+                .orElseThrow(() -> DomainException.validation("不明な服用状態です: " + code));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/StockQuantity.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/StockQuantity.java
@@ -1,0 +1,40 @@
+package app.healthfamily.medication.domain;
+
+import app.healthfamily.shared.DomainException;
+
+/**
+ * 薬の残数。
+ *
+ * <p>「負の残数」という状態をコンストラクタで潰しているので、この型を持ち回る限り
+ * 残数が負になることはない。Go 版では {@code *int} をそのまま扱っていたため、
+ * 負値を弾く責任がどこにもなかった。
+ */
+public record StockQuantity(int value) {
+
+    public StockQuantity {
+        if (value < 0) {
+            throw DomainException.validation("残数に負の値は指定できません");
+        }
+    }
+
+    public static StockQuantity of(int value) {
+        return new StockQuantity(value);
+    }
+
+    public boolean isEmpty() {
+        return value == 0;
+    }
+
+    /** 1 回ぶん減らす。残数が 0 のときは不変条件違反として拒否する。 */
+    public StockQuantity consumeOne() {
+        if (isEmpty()) {
+            throw DomainException.conflict("残数が 0 のため服用を記録できません");
+        }
+        return new StockQuantity(value - 1);
+    }
+
+    /** 指定した日数ぶんを下回っているか。残数アラートの判定に使う。 */
+    public boolean isBelow(long days) {
+        return value < days;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/shared/DomainException.java
+++ b/backend-java/src/main/java/app/healthfamily/shared/DomainException.java
@@ -1,0 +1,59 @@
+package app.healthfamily.shared;
+
+/**
+ * ドメイン層が投げる例外。
+ *
+ * <p>HTTP のステータスコードはここでは決めない。web 層の例外ハンドラが対応付ける。
+ * ドメインが「見つからない」「権限がない」までを表現し、それが 404 なのか 403 なのかは
+ * 外側の関心事とする。
+ */
+public sealed class DomainException extends RuntimeException {
+
+    private DomainException(String message) {
+        super(message);
+    }
+
+    /** 対象が存在しない。 */
+    public static final class NotFound extends DomainException {
+        public NotFound(String subject) {
+            super(subject + "が見つかりません");
+        }
+    }
+
+    /** 対象は存在するが、操作する権限がない。 */
+    public static final class Forbidden extends DomainException {
+        public Forbidden(String message) {
+            super(message);
+        }
+    }
+
+    /** 入力値がドメインの制約を満たさない。 */
+    public static final class Validation extends DomainException {
+        public Validation(String message) {
+            super(message);
+        }
+    }
+
+    /** 現在の状態では、その操作を実行できない（不変条件違反）。 */
+    public static final class Conflict extends DomainException {
+        public Conflict(String message) {
+            super(message);
+        }
+    }
+
+    public static NotFound notFound(String subject) {
+        return new NotFound(subject);
+    }
+
+    public static Forbidden forbidden(String message) {
+        return new Forbidden(message);
+    }
+
+    public static Validation validation(String message) {
+        return new Validation(message);
+    }
+
+    public static Conflict conflict(String message) {
+        return new Conflict(message);
+    }
+}

--- a/backend-java/src/main/resources/application.properties
+++ b/backend-java/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=healthfamily-api

--- a/backend-java/src/test/java/app/healthfamily/HealthfamilyApiApplicationTests.java
+++ b/backend-java/src/test/java/app/healthfamily/HealthfamilyApiApplicationTests.java
@@ -1,0 +1,13 @@
+package app.healthfamily;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class HealthfamilyApiApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/backend-java/src/test/java/app/healthfamily/medication/domain/MedicationTest.java
+++ b/backend-java/src/test/java/app/healthfamily/medication/domain/MedicationTest.java
@@ -1,0 +1,270 @@
+package app.healthfamily.medication.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.shared.DomainException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Medication 集約")
+class MedicationTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-04T12:00:00Z");
+
+    private static Medication.Builder prn() {
+        return Medication.builder()
+                .id("med-1")
+                .userId("user-1")
+                .memberId("member-1")
+                .name("ロキソニン")
+                .category(MedicationCategory.PRN)
+                .status(MedicationStatus.ACTIVE)
+                .interval(DosingInterval.ofHours(4));
+    }
+
+    private static Medication.Builder regular() {
+        return Medication.builder()
+                .id("med-2")
+                .userId("user-1")
+                .memberId("member-1")
+                .name("血圧の薬")
+                .category(MedicationCategory.REGULAR)
+                .status(MedicationStatus.ACTIVE);
+    }
+
+    @Nested
+    @DisplayName("服用の記録")
+    class Take {
+
+        @Test
+        @DisplayName("初回は前回服用時刻がなくても服用できる")
+        void firstDoseIsAllowed() {
+            var med = prn().build();
+
+            var taken = med.take(NOW, Optional.empty());
+
+            assertThat(taken.medicationId()).isEqualTo("med-1");
+            assertThat(taken.takenAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("休薬中の薬は服用を記録できない")
+        void pausedMedicationRejectsTaking() {
+            var med = prn().status(MedicationStatus.PAUSED).build();
+
+            assertThatThrownBy(() -> med.take(NOW, Optional.empty()))
+                    .isInstanceOf(DomainException.Conflict.class)
+                    .hasMessageContaining("休薬中");
+        }
+
+        @Test
+        @DisplayName("中止した薬は服用を記録できない")
+        void stoppedMedicationRejectsTaking() {
+            var med = prn().status(MedicationStatus.STOPPED).build();
+
+            assertThatThrownBy(() -> med.take(NOW, Optional.empty()))
+                    .isInstanceOf(DomainException.Conflict.class)
+                    .hasMessageContaining("中止");
+        }
+
+        @Test
+        @DisplayName("頓服薬は服用間隔が空いていないと記録できない")
+        void prnRejectsTakingWithinInterval() {
+            var med = prn().build();
+            var lastTaken = NOW.minus(Duration.ofHours(3));
+
+            assertThatThrownBy(() -> med.take(NOW, Optional.of(lastTaken)))
+                    .isInstanceOf(DomainException.Conflict.class)
+                    .hasMessageContaining("4 時間")
+                    .hasMessageContaining("60 分");
+        }
+
+        @Test
+        @DisplayName("ちょうど服用間隔ぶん経過していれば服用できる")
+        void prnAllowsTakingExactlyAtInterval() {
+            var med = prn().build();
+            var lastTaken = NOW.minus(Duration.ofHours(4));
+
+            var taken = med.take(NOW, Optional.of(lastTaken));
+
+            assertThat(taken.takenAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("定時薬は服用間隔の制約を受けない")
+        void regularIgnoresInterval() {
+            var med = regular().interval(DosingInterval.ofHours(4)).build();
+            var lastTaken = NOW.minus(Duration.ofMinutes(1));
+
+            var taken = med.take(NOW, Optional.of(lastTaken));
+
+            assertThat(taken.takenAt()).isEqualTo(NOW);
+        }
+
+        @Test
+        @DisplayName("残数を管理していれば服用で 1 減る")
+        void takingDecrementsStock() {
+            var med = prn().stock(StockQuantity.of(3)).build();
+
+            var taken = med.take(NOW, Optional.empty());
+
+            assertThat(taken.remainingStock()).contains(StockQuantity.of(2));
+            assertThat(med.stock()).contains(StockQuantity.of(2));
+        }
+
+        @Test
+        @DisplayName("残数が 0 なら服用を記録できない")
+        void takingWithEmptyStockIsRejected() {
+            var med = prn().stock(StockQuantity.of(0)).build();
+
+            assertThatThrownBy(() -> med.take(NOW, Optional.empty()))
+                    .isInstanceOf(DomainException.Conflict.class)
+                    .hasMessageContaining("残数が 0");
+        }
+
+        @Test
+        @DisplayName("残数を管理していない薬は残数が空のまま服用できる")
+        void takingWithoutStockTracking() {
+            var med = prn().build();
+
+            var taken = med.take(NOW, Optional.empty());
+
+            assertThat(taken.remainingStock()).isEmpty();
+            assertThat(taken.depletedStock()).isFalse();
+        }
+
+        @Test
+        @DisplayName("最後の 1 錠を服用すると残数切れが分かる")
+        void lastDoseReportsDepletion() {
+            var med = prn().stock(StockQuantity.of(1)).build();
+
+            var taken = med.take(NOW, Optional.empty());
+
+            assertThat(taken.depletedStock()).isTrue();
+        }
+
+        @Test
+        @DisplayName("服用量は薬の設定から引き継がれる")
+        void dosageIsCarriedOver() {
+            var med = prn().dosageAmount("1錠").build();
+
+            assertThat(med.take(NOW, Optional.empty()).dosageAmount()).contains("1錠");
+        }
+    }
+
+    @Nested
+    @DisplayName("次回服用可能時刻")
+    class NextAvailable {
+
+        @Test
+        @DisplayName("頓服薬は前回服用時刻から間隔ぶん後になる")
+        void prnReturnsNextTime() {
+            var med = prn().build();
+            var lastTaken = NOW.minus(Duration.ofHours(1));
+
+            assertThat(med.nextAvailableAt(Optional.of(lastTaken)))
+                    .contains(lastTaken.plus(Duration.ofHours(4)));
+        }
+
+        @Test
+        @DisplayName("初回は算出できない")
+        void firstDoseHasNoNextTime() {
+            assertThat(prn().build().nextAvailableAt(Optional.empty())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("定時薬は算出しない")
+        void regularHasNoNextTime() {
+            var med = regular().interval(DosingInterval.ofHours(4)).build();
+
+            assertThat(med.nextAvailableAt(Optional.of(NOW))).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("残数アラート")
+    class LowStock {
+
+        private static final LocalDate TODAY = LocalDate.of(2026, 8, 4);
+
+        @Test
+        @DisplayName("アラート日までの残り日数より残数が少なければ少ないと判定する")
+        void belowRemainingDaysIsLow() {
+            var med = prn().stock(StockQuantity.of(3)).stockAlertDate(TODAY.plusDays(10)).build();
+
+            assertThat(med.isLowStock(TODAY)).isTrue();
+        }
+
+        @Test
+        @DisplayName("残り日数以上の残数があれば少なくない")
+        void enoughStockIsNotLow() {
+            var med = prn().stock(StockQuantity.of(30)).stockAlertDate(TODAY.plusDays(10)).build();
+
+            assertThat(med.isLowStock(TODAY)).isFalse();
+        }
+
+        @Test
+        @DisplayName("残数を管理していなければ判定しない")
+        void withoutStockIsNotLow() {
+            assertThat(prn().stockAlertDate(TODAY.plusDays(10)).build().isLowStock(TODAY)).isFalse();
+        }
+
+        @Test
+        @DisplayName("アラート日が未設定なら判定しない")
+        void withoutAlertDateIsNotLow() {
+            assertThat(prn().stock(StockQuantity.of(1)).build().isLowStock(TODAY)).isFalse();
+        }
+
+        @Test
+        @DisplayName("アラート日を過ぎていれば判定しない（期限超過は別扱い）")
+        void pastAlertDateIsNotLow() {
+            var med = prn().stock(StockQuantity.of(1)).stockAlertDate(TODAY.minusDays(1)).build();
+
+            assertThat(med.isLowStock(TODAY)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("所有権")
+    class Ownership {
+
+        @Test
+        @DisplayName("所有者なら通る")
+        void ownerPasses() {
+            prn().build().requireOwnedBy("user-1");
+        }
+
+        @Test
+        @DisplayName("所有者でなければ拒否する")
+        void nonOwnerIsRejected() {
+            assertThatThrownBy(() -> prn().build().requireOwnedBy("user-2"))
+                    .isInstanceOf(DomainException.Forbidden.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("組み立て時の検証")
+    class Construction {
+
+        @Test
+        @DisplayName("名前は必須")
+        void nameIsRequired() {
+            assertThatThrownBy(() -> prn().name(" ").build())
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("名前は必須");
+        }
+
+        @Test
+        @DisplayName("所有ユーザーは必須")
+        void userIsRequired() {
+            assertThatThrownBy(() -> prn().userId(null).build())
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/medication/domain/ValueObjectTest.java
+++ b/backend-java/src/test/java/app/healthfamily/medication/domain/ValueObjectTest.java
@@ -1,0 +1,129 @@
+package app.healthfamily.medication.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.shared.DomainException;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("値オブジェクト")
+class ValueObjectTest {
+
+    @Nested
+    @DisplayName("StockQuantity")
+    class Stock {
+
+        @Test
+        @DisplayName("負の残数は作れない")
+        void negativeIsRejected() {
+            assertThatThrownBy(() -> StockQuantity.of(-1))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("負の値");
+        }
+
+        @Test
+        @DisplayName("1 消費すると 1 減る")
+        void consumeOneDecrements() {
+            assertThat(StockQuantity.of(5).consumeOne()).isEqualTo(StockQuantity.of(4));
+        }
+
+        @Test
+        @DisplayName("0 からは消費できない")
+        void consumeFromEmptyIsRejected() {
+            assertThatThrownBy(() -> StockQuantity.of(0).consumeOne())
+                    .isInstanceOf(DomainException.Conflict.class);
+        }
+
+        @Test
+        @DisplayName("消費しても元の値は変わらない（不変）")
+        void isImmutable() {
+            var original = StockQuantity.of(5);
+            original.consumeOne();
+            assertThat(original.value()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("残り日数との比較")
+        void comparesWithDays() {
+            assertThat(StockQuantity.of(3).isBelow(10)).isTrue();
+            assertThat(StockQuantity.of(10).isBelow(10)).isFalse();
+            assertThat(StockQuantity.of(30).isBelow(10)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("DosingInterval")
+    class Interval {
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, 169})
+        @DisplayName("範囲外の間隔は作れない")
+        void outOfRangeIsRejected(int hours) {
+            assertThatThrownBy(() -> DosingInterval.ofHours(hours))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+
+        @Test
+        @DisplayName("次に服用できる時刻を求められる")
+        void computesNextAvailable() {
+            var last = Instant.parse("2026-08-04T09:00:00Z");
+
+            assertThat(DosingInterval.ofHours(6).nextAvailableAfter(last))
+                    .isEqualTo(Instant.parse("2026-08-04T15:00:00Z"));
+        }
+
+        @Test
+        @DisplayName("間隔ちょうどは服用可、1 秒でも手前は不可")
+        void boundaryIsInclusive() {
+            var last = Instant.parse("2026-08-04T09:00:00Z");
+            var interval = DosingInterval.ofHours(4);
+            var exactly = last.plus(Duration.ofHours(4));
+
+            assertThat(interval.allowsTakingAt(exactly, last)).isTrue();
+            assertThat(interval.allowsTakingAt(exactly.minusSeconds(1), last)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("コード変換")
+    class Codes {
+
+        @Test
+        @DisplayName("DB に入っている種別をすべて解釈できる")
+        void allStoredCategoriesParse() {
+            for (var code : new String[] {"regular", "prn", "inhaler", "eye_drops", "supplement"}) {
+                assertThat(MedicationCategory.fromCode(code).code()).isEqualTo(code);
+            }
+        }
+
+        @Test
+        @DisplayName("間隔を強制するのは頓服・吸入・点眼")
+        void intervalEnforcedCategories() {
+            assertThat(MedicationCategory.PRN.enforcesInterval()).isTrue();
+            assertThat(MedicationCategory.INHALER.enforcesInterval()).isTrue();
+            assertThat(MedicationCategory.EYE_DROPS.enforcesInterval()).isTrue();
+            assertThat(MedicationCategory.REGULAR.enforcesInterval()).isFalse();
+            assertThat(MedicationCategory.SUPPLEMENT.enforcesInterval()).isFalse();
+        }
+
+        @Test
+        @DisplayName("DB に入っている状態をすべて解釈できる")
+        void allStoredStatusesParse() {
+            assertThat(MedicationStatus.fromCode("active").allowsTaking()).isTrue();
+            assertThat(MedicationStatus.fromCode("paused").allowsTaking()).isFalse();
+        }
+
+        @Test
+        @DisplayName("未知のコードは弾く")
+        void unknownCodeIsRejected() {
+            assertThatThrownBy(() -> MedicationCategory.fromCode("unknown"))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `backend-java/` に Java 25 + Spring Boot 4.1.0 のプロジェクトを追加（Go 版と並存させ、段階的に移す）
- Medication を集約ルートとして実装し、Go 版に存在しなかったドメイン不変条件を `Medication.take()` に閉じ込めた
  - 休薬中・中止の薬は服用を記録できない
  - 頓服・吸入・点眼は前回服用から所定時間が経つまで拒否する
  - 残数を管理している薬は服用で 1 減り、0 なら拒否する（Go 版では記録を作るだけで残数が減らなかった）
- 値オブジェクト `StockQuantity` / `DosingInterval` で、負の残数と範囲外の服用間隔を型で禁止
- `MedicationCategory` / `MedicationStatus` は DB に実在する値のみを列挙
- 服薬記録は件数が無制限に増えるため集約に含めず、前回服用時刻は引数で受け取る設計
- ドメイン層のテスト 37 件

現時点ではドメイン層のみで、永続化・REST 層は未実装。Go 版が本番を提供したままで、動作への影響はない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 薬の登録情報、服用状態、服用間隔、用量、在庫を管理できる基盤を追加しました。
  * 服用可能時間や在庫消費、在庫切れ・低在庫の判定に対応しました。
  * 薬のカテゴリ、服用状態、所有者の検証を追加しました。
  * アプリケーションの稼働状態を確認できる基盤を整備しました。

* **品質改善**
  * 入力値や状態の不整合を検証し、適切なエラーとして扱えるようにしました。
  * 薬の服用・在庫管理に関する自動テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->