### PR TITLE
feat(backend-java): 服用の記録を実DBまで通し、トランザクション境界を確立する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
       - run: go vet ./...
       - run: go test ./...
 
+  backend-java:
+    name: Backend (Spring Boot)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend-java
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      # 統合テストは Testcontainers で PostgreSQL を起動する。
+      # ubuntu-latest には Docker が同梱されているため追加のセットアップは不要。
+      - run: ./mvnw -B --no-transfer-progress verify
+
   frontend:
     name: Frontend (React Router)
     runs-on: ubuntu-latest
@@ -37,5 +54,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - run: npm run lint
       - run: npm run typecheck
       - run: npm run build

--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -72,13 +72,51 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers-bom</artifactId>
+				<version>2.0.5</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<!-- *IT は Testcontainers を使う統合テスト。既定の命名規約から外れるため明示する -->
+					<includes>
+						<include>**/*Test.java</include>
+						<include>**/*IT.java</include>
+					</includes>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/backend-java/src/main/java/app/healthfamily/medication/application/TakeMedicationUseCase.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/application/TakeMedicationUseCase.java
@@ -1,0 +1,77 @@
+package app.healthfamily.medication.application;
+
+import app.healthfamily.medication.domain.DoseTaken;
+import app.healthfamily.medication.domain.Medication;
+import app.healthfamily.medication.domain.MedicationRecord;
+import app.healthfamily.medication.domain.MedicationRecordRepository;
+import app.healthfamily.medication.domain.MedicationRepository;
+import app.healthfamily.shared.DomainException;
+import java.time.Clock;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 「薬を服用した」を記録するユースケース。
+ *
+ * <p>このクラスの仕事は 4 つだけで、判断はすべて集約に任せている。
+ *
+ * <ol>
+ *   <li>集約と、判断に必要な外部の値（前回服用時刻）を読み出す</li>
+ *   <li>所有権を確認する</li>
+ *   <li>集約のメソッドを呼ぶ</li>
+ *   <li>結果を書き戻す</li>
+ * </ol>
+ *
+ * <p>残数の減算と記録の追加は <b>1 つのトランザクション</b>にまとまっている。
+ * Go 版はトランザクションがリポジトリの内側にしかなく、ユースケースが
+ * 複数リポジトリをまたげなかったため、この原子性を確保できなかった。
+ */
+@Service
+public class TakeMedicationUseCase {
+
+    private final MedicationRepository medications;
+    private final MedicationRecordRepository records;
+    private final Clock clock;
+
+    public TakeMedicationUseCase(
+            MedicationRepository medications, MedicationRecordRepository records, Clock clock) {
+        this.medications = medications;
+        this.records = records;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public MedicationRecord execute(Command command) {
+        Medication medication =
+                medications
+                        .findById(command.medicationId())
+                        .orElseThrow(() -> DomainException.notFound("薬"));
+        medication.requireOwnedBy(command.userId());
+
+        Optional<java.time.Instant> lastTakenAt =
+                records.findLastTakenAt(command.medicationId());
+
+        DoseTaken taken = medication.take(clock.instant(), lastTakenAt);
+
+        medications.save(medication);
+        MedicationRecord record =
+                MedicationRecord.from(UUID.randomUUID().toString(), taken, command.notes());
+        records.append(record);
+        return record;
+    }
+
+    /** @param notes 任意のメモ。未指定なら null */
+    public record Command(String userId, String medicationId, String notes) {
+
+        public Command {
+            if (userId == null || userId.isBlank()) {
+                throw DomainException.validation("ユーザーIDは必須です");
+            }
+            if (medicationId == null || medicationId.isBlank()) {
+                throw DomainException.validation("薬のIDは必須です");
+            }
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRecord.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRecord.java
@@ -1,0 +1,35 @@
+package app.healthfamily.medication.domain;
+
+import java.time.Instant;
+
+/**
+ * 服薬記録。
+ *
+ * <p>Medication 集約とは別のライフサイクルを持つ（件数が無制限に増える）ため、
+ * 独立した集約として扱う。参照は ID のみで、オブジェクト参照は持たせない。
+ *
+ * @param scheduleId 定時薬のスケジュールに紐づく場合のみ。頓服では null
+ */
+public record MedicationRecord(
+        String id,
+        String medicationId,
+        String memberId,
+        String userId,
+        String scheduleId,
+        Instant takenAt,
+        String dosageAmount,
+        String notes) {
+
+    /** {@link DoseTaken} から、まだ採番されていない記録を組み立てる。 */
+    public static MedicationRecord from(String id, DoseTaken taken, String notes) {
+        return new MedicationRecord(
+                id,
+                taken.medicationId(),
+                taken.memberID(),
+                taken.userId(),
+                null,
+                taken.takenAt(),
+                taken.dosageAmount().orElse(null),
+                notes);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRecordRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRecordRepository.java
@@ -1,0 +1,19 @@
+package app.healthfamily.medication.domain;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/** 服薬記録の永続化ポート。 */
+public interface MedicationRecordRepository {
+
+    /**
+     * その薬の直近の服用時刻。まだ一度も服用していなければ空。
+     *
+     * <p>服用間隔の判定に使う。集約に記録を含めない代わりに、
+     * 必要な一点だけをここから取り出してアプリケーション層が集約へ渡す。
+     */
+    Optional<Instant> findLastTakenAt(String medicationId);
+
+    /** 記録を1件追加する。 */
+    void append(MedicationRecord record);
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRepository.java
@@ -1,0 +1,17 @@
+package app.healthfamily.medication.domain;
+
+import java.util.Optional;
+
+/**
+ * Medication 集約の永続化ポート。
+ *
+ * <p>ドメイン層に interface を置き、実装を infrastructure に置くことで、
+ * 依存の向きを外から内へ保つ。ドメインは JDBC も SQL も知らない。
+ */
+public interface MedicationRepository {
+
+    Optional<Medication> findById(String medicationId);
+
+    /** 集約の現在の状態を書き戻す。 */
+    void save(Medication medication);
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/infrastructure/JdbcMedicationRecordRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/infrastructure/JdbcMedicationRecordRepository.java
@@ -1,0 +1,61 @@
+package app.healthfamily.medication.infrastructure;
+
+import app.healthfamily.medication.domain.MedicationRecord;
+import app.healthfamily.medication.domain.MedicationRecordRepository;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+/** 服薬記録の JDBC 実装。 */
+@Repository
+public class JdbcMedicationRecordRepository implements MedicationRecordRepository {
+
+    private static final String SELECT_LAST_TAKEN_AT =
+            """
+            SELECT "takenAt"
+              FROM "MedicationRecord"
+             WHERE "medicationId" = :medicationId
+             ORDER BY "takenAt" DESC
+             LIMIT 1
+            """;
+
+    private static final String INSERT =
+            """
+            INSERT INTO "MedicationRecord"
+                   (id, "medicationId", "memberId", "userId", "scheduleId",
+                    "takenAt", "dosageAmount", notes)
+            VALUES (:id, :medicationId, :memberId, :userId, :scheduleId,
+                    :takenAt, :dosageAmount, :notes)
+            """;
+
+    private final JdbcClient jdbc;
+
+    public JdbcMedicationRecordRepository(JdbcClient jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public Optional<Instant> findLastTakenAt(String medicationId) {
+        return jdbc.sql(SELECT_LAST_TAKEN_AT)
+                .param("medicationId", medicationId)
+                .query(OffsetDateTime.class)
+                .optional()
+                .map(OffsetDateTime::toInstant);
+    }
+
+    @Override
+    public void append(MedicationRecord record) {
+        jdbc.sql(INSERT)
+                .param("id", record.id())
+                .param("medicationId", record.medicationId())
+                .param("memberId", record.memberId())
+                .param("userId", record.userId())
+                .param("scheduleId", record.scheduleId())
+                .param("takenAt", OffsetDateTime.ofInstant(record.takenAt(), java.time.ZoneOffset.UTC))
+                .param("dosageAmount", record.dosageAmount())
+                .param("notes", record.notes())
+                .update();
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/infrastructure/JdbcMedicationRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/infrastructure/JdbcMedicationRepository.java
@@ -1,0 +1,98 @@
+package app.healthfamily.medication.infrastructure;
+
+import app.healthfamily.medication.domain.DosingInterval;
+import app.healthfamily.medication.domain.Medication;
+import app.healthfamily.medication.domain.MedicationCategory;
+import app.healthfamily.medication.domain.MedicationRepository;
+import app.healthfamily.medication.domain.MedicationStatus;
+import app.healthfamily.medication.domain.StockQuantity;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Medication 集約の JDBC 実装。
+ *
+ * <p>テーブルは Go 版と共有しているため、列名は Prisma 由来のキャメルケースのまま。
+ * 引用符が必須な点に注意。
+ */
+@Repository
+public class JdbcMedicationRepository implements MedicationRepository {
+
+    private static final String SELECT_BY_ID =
+            """
+            SELECT id, "memberId", "userId", name, category, "dosageAmount",
+                   "stockQuantity", "stockAlertDate", "intervalHours", status
+              FROM "Medication"
+             WHERE id = :id
+            """;
+
+    private static final String UPDATE_STOCK =
+            """
+            UPDATE "Medication"
+               SET "stockQuantity" = :stock,
+                   "updatedAt"     = now()
+             WHERE id = :id
+            """;
+
+    private final JdbcClient jdbc;
+
+    public JdbcMedicationRepository(JdbcClient jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public Optional<Medication> findById(String medicationId) {
+        return jdbc.sql(SELECT_BY_ID)
+                .param("id", medicationId)
+                .query(JdbcMedicationRepository::toAggregate)
+                .optional();
+    }
+
+    @Override
+    public void save(Medication medication) {
+        jdbc.sql(UPDATE_STOCK)
+                .param("stock", medication.stock().map(StockQuantity::value).orElse(null))
+                .param("id", medication.id())
+                .update();
+    }
+
+    /**
+     * 行から集約を再構築する。
+     *
+     * <p>{@code stockAlertDate} は timestamptz だが、実データは UTC の 0 時ちょうどで
+     * 「日付」として書かれている。書かれ方に合わせて UTC で日付へ落とす。
+     */
+    private static Medication toAggregate(ResultSet rs, int rowNum) throws SQLException {
+        var builder =
+                Medication.builder()
+                        .id(rs.getString("id"))
+                        .userId(rs.getString("userId"))
+                        .memberId(rs.getString("memberId"))
+                        .name(rs.getString("name"))
+                        .category(MedicationCategory.fromCode(rs.getString("category")))
+                        .status(MedicationStatus.fromCode(rs.getString("status")))
+                        .dosageAmount(rs.getString("dosageAmount"));
+
+        int stock = rs.getInt("stockQuantity");
+        if (!rs.wasNull()) {
+            builder.stock(StockQuantity.of(stock));
+        }
+
+        int intervalHours = rs.getInt("intervalHours");
+        if (!rs.wasNull()) {
+            builder.interval(DosingInterval.ofHours(intervalHours));
+        }
+
+        OffsetDateTime alertAt = rs.getObject("stockAlertDate", OffsetDateTime.class);
+        if (alertAt != null) {
+            builder.stockAlertDate(alertAt.atZoneSameInstant(ZoneOffset.UTC).toLocalDate());
+        }
+
+        return builder.build();
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/shared/ClockConfig.java
+++ b/backend-java/src/main/java/app/healthfamily/shared/ClockConfig.java
@@ -1,0 +1,22 @@
+package app.healthfamily.shared;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 時刻の供給元。
+ *
+ * <p>ドメインとユースケースは {@code Instant.now()} を直接呼ばず、この Clock から受け取る。
+ * テストで固定時刻に差し替えられるようにするため。
+ * フロントの computeIsLowStock が端末の時計に依存していた問題を、
+ * バックエンドでは最初から避けておく。
+ */
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/medication/application/TakeMedicationUseCaseIT.java
+++ b/backend-java/src/test/java/app/healthfamily/medication/application/TakeMedicationUseCaseIT.java
@@ -1,0 +1,247 @@
+package app.healthfamily.medication.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.shared.DomainException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * 実際の PostgreSQL に対して「服用の記録」を通す統合テスト。
+ *
+ * <p>いちばん確かめたいのは、残数の減算と記録の追加が
+ * <b>1 つのトランザクションにまとまっているか</b>。
+ * 集約が服用を拒否したとき、残数だけ減って記録が無い、あるいはその逆が
+ * 起きないことを検証する。
+ */
+@SpringBootTest
+@Testcontainers
+@Import(TakeMedicationUseCaseIT.FixedClockConfig.class)
+@DisplayName("服用の記録（実DB）")
+class TakeMedicationUseCaseIT {
+
+    private static final Instant NOW = Instant.parse("2026-08-15T12:00:00Z");
+
+    @Container
+    @SuppressWarnings("resource")
+    static PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>("postgres:17")
+                    .withInitScript("db/medication-schema.sql");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+
+    /**
+     * ユースケースが参照する時刻を固定する。
+     *
+     * <p>本番の ClockConfig と Bean 名が衝突しないよう別名にし、
+     * {@code @Primary} で注入側の優先度を上げている。
+     */
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired TakeMedicationUseCase useCase;
+    @Autowired JdbcClient jdbc;
+
+    @BeforeEach
+    void resetFixtures() {
+        jdbc.sql("TRUNCATE \"MedicationRecord\", \"Medication\", \"Member\", \"User\" CASCADE")
+                .update();
+        jdbc.sql(
+                        """
+                        INSERT INTO "User" (id, email, password, "displayName", "updatedAt")
+                        VALUES ('user-1', 'owner@example.test', 'x', '所有者', now()),
+                               ('user-2', 'other@example.test', 'x', '別人',   now())
+                        """)
+                .update();
+        jdbc.sql(
+                        """
+                        INSERT INTO "Member" (id, "userId", name, "memberType", "updatedAt")
+                        VALUES ('member-1', 'user-1', '本人', 'human', now())
+                        """)
+                .update();
+    }
+
+    private void insertMedication(
+            String id, String category, String status, Integer stock, Integer intervalHours) {
+        jdbc.sql(
+                        """
+                        INSERT INTO "Medication"
+                               (id, "memberId", "userId", name, category, status,
+                                "stockQuantity", "intervalHours", "dosageAmount", "updatedAt")
+                        VALUES (:id, 'member-1', 'user-1', 'ロキソニン', :category, :status,
+                                :stock, :interval, '1錠', now())
+                        """)
+                .param("id", id)
+                .param("category", category)
+                .param("status", status)
+                .param("stock", stock)
+                .param("interval", intervalHours)
+                .update();
+    }
+
+    private void insertRecord(String medicationId, Instant takenAt) {
+        jdbc.sql(
+                        """
+                        INSERT INTO "MedicationRecord"
+                               (id, "medicationId", "memberId", "userId", "takenAt")
+                        VALUES (gen_random_uuid()::text, :med, 'member-1', 'user-1', :at)
+                        """)
+                .param("med", medicationId)
+                .param("at", OffsetDateTime.ofInstant(takenAt, ZoneOffset.UTC))
+                .update();
+    }
+
+    private Integer stockOf(String id) {
+        return jdbc.sql("SELECT \"stockQuantity\" FROM \"Medication\" WHERE id = :id")
+                .param("id", id)
+                .query(Integer.class)
+                .optional()
+                .orElse(null);
+    }
+
+    private long recordCount(String medicationId) {
+        return jdbc.sql("SELECT count(*) FROM \"MedicationRecord\" WHERE \"medicationId\" = :id")
+                .param("id", medicationId)
+                .query(Long.class)
+                .single();
+    }
+
+    @Test
+    @DisplayName("服用すると残数が減り、記録が1件増える")
+    void takingDecrementsStockAndAppendsRecord() {
+        insertMedication("med-1", "prn", "active", 10, 4);
+
+        var record = useCase.execute(new TakeMedicationUseCase.Command("user-1", "med-1", "頭痛"));
+
+        assertThat(stockOf("med-1")).isEqualTo(9);
+        assertThat(recordCount("med-1")).isEqualTo(1);
+        assertThat(record.takenAt()).isEqualTo(NOW);
+        assertThat(record.dosageAmount()).isEqualTo("1錠");
+        assertThat(record.notes()).isEqualTo("頭痛");
+    }
+
+    @Test
+    @DisplayName("服用間隔が空いていなければ、残数も記録も変わらない")
+    void intervalViolationLeavesNothingBehind() {
+        insertMedication("med-2", "prn", "active", 10, 4);
+        insertRecord("med-2", NOW.minus(Duration.ofHours(3)));
+
+        assertThatThrownBy(
+                        () ->
+                                useCase.execute(
+                                        new TakeMedicationUseCase.Command("user-1", "med-2", null)))
+                .isInstanceOf(DomainException.Conflict.class)
+                .hasMessageContaining("4 時間");
+
+        assertThat(stockOf("med-2")).isEqualTo(10);
+        assertThat(recordCount("med-2")).isEqualTo(1); // 事前に入れた1件のみ
+    }
+
+    @Test
+    @DisplayName("残数が0なら、記録は作られない")
+    void emptyStockLeavesNothingBehind() {
+        insertMedication("med-3", "prn", "active", 0, null);
+
+        assertThatThrownBy(
+                        () ->
+                                useCase.execute(
+                                        new TakeMedicationUseCase.Command("user-1", "med-3", null)))
+                .isInstanceOf(DomainException.Conflict.class);
+
+        assertThat(stockOf("med-3")).isZero();
+        assertThat(recordCount("med-3")).isZero();
+    }
+
+    @Test
+    @DisplayName("休薬中の薬は記録できない")
+    void pausedMedicationIsRejected() {
+        insertMedication("med-4", "prn", "paused", 10, null);
+
+        assertThatThrownBy(
+                        () ->
+                                useCase.execute(
+                                        new TakeMedicationUseCase.Command("user-1", "med-4", null)))
+                .isInstanceOf(DomainException.Conflict.class)
+                .hasMessageContaining("休薬中");
+
+        assertThat(stockOf("med-4")).isEqualTo(10);
+        assertThat(recordCount("med-4")).isZero();
+    }
+
+    @Test
+    @DisplayName("他人の薬は操作できない")
+    void otherUsersMedicationIsForbidden() {
+        insertMedication("med-5", "prn", "active", 10, null);
+
+        assertThatThrownBy(
+                        () ->
+                                useCase.execute(
+                                        new TakeMedicationUseCase.Command("user-2", "med-5", null)))
+                .isInstanceOf(DomainException.Forbidden.class);
+
+        assertThat(recordCount("med-5")).isZero();
+    }
+
+    @Test
+    @DisplayName("存在しない薬は見つからない")
+    void unknownMedicationIsNotFound() {
+        assertThatThrownBy(
+                        () ->
+                                useCase.execute(
+                                        new TakeMedicationUseCase.Command("user-1", "missing", null)))
+                .isInstanceOf(DomainException.NotFound.class);
+    }
+
+    @Test
+    @DisplayName("残数を管理していない薬も服用できる")
+    void medicationWithoutStockCanBeTaken() {
+        insertMedication("med-6", "regular", "active", null, null);
+
+        useCase.execute(new TakeMedicationUseCase.Command("user-1", "med-6", null));
+
+        assertThat(stockOf("med-6")).isNull();
+        assertThat(recordCount("med-6")).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("間隔ぶん経過していれば服用できる")
+    void takingAfterIntervalSucceeds() {
+        insertMedication("med-7", "prn", "active", 5, 4);
+        insertRecord("med-7", NOW.minus(Duration.ofHours(4)));
+
+        useCase.execute(new TakeMedicationUseCase.Command("user-1", "med-7", null));
+
+        assertThat(stockOf("med-7")).isEqualTo(4);
+        assertThat(recordCount("med-7")).isEqualTo(2);
+    }
+}

--- a/backend-java/src/test/resources/db/medication-schema.sql
+++ b/backend-java/src/test/resources/db/medication-schema.sql
@@ -1,0 +1,83 @@
+CREATE TABLE public."Medication" (
+    id text NOT NULL,
+    "memberId" text NOT NULL,
+    "userId" text NOT NULL,
+    name text NOT NULL,
+    category text DEFAULT 'regular'::text NOT NULL,
+    "dosageAmount" text,
+    frequency text,
+    "stockQuantity" integer,
+    "stockAlertDate" timestamp with time zone,
+    "intervalHours" integer,
+    instructions text,
+    "displayOrder" integer DEFAULT 0 NOT NULL,
+    "isActive" boolean DEFAULT true NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    "createdAt" timestamp with time zone DEFAULT now() NOT NULL,
+    "updatedAt" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE TABLE public."MedicationRecord" (
+    id text NOT NULL,
+    "memberId" text NOT NULL,
+    "medicationId" text NOT NULL,
+    "userId" text NOT NULL,
+    "scheduleId" text,
+    "takenAt" timestamp with time zone DEFAULT now() NOT NULL,
+    notes text,
+    "dosageAmount" text
+);
+CREATE TABLE public."Member" (
+    id text NOT NULL,
+    "userId" text NOT NULL,
+    "memberType" text DEFAULT 'human'::text NOT NULL,
+    name text NOT NULL,
+    "petType" text,
+    "photoUrl" text,
+    "birthDate" timestamp with time zone,
+    notes text,
+    "createdAt" timestamp with time zone DEFAULT now() NOT NULL,
+    "updatedAt" timestamp with time zone DEFAULT now() NOT NULL
+);
+CREATE TABLE public."User" (
+    id text NOT NULL,
+    email text NOT NULL,
+    password text NOT NULL,
+    "displayName" text,
+    "characterType" text DEFAULT 'cat'::text NOT NULL,
+    "characterName" text,
+    "emailVerified" boolean DEFAULT false NOT NULL,
+    "verificationCode" text,
+    "verificationExpiry" timestamp with time zone,
+    "verificationAttempts" integer DEFAULT 0 NOT NULL,
+    "resetCode" text,
+    "resetCodeExpiry" timestamp with time zone,
+    "createdAt" timestamp with time zone DEFAULT now() NOT NULL,
+    "updatedAt" timestamp with time zone DEFAULT now() NOT NULL,
+    "googleId" text
+);
+ALTER TABLE ONLY public."MedicationRecord"
+    ADD CONSTRAINT "MedicationRecord_pkey" PRIMARY KEY (id);
+ALTER TABLE ONLY public."Medication"
+    ADD CONSTRAINT "Medication_pkey" PRIMARY KEY (id);
+ALTER TABLE ONLY public."Member"
+    ADD CONSTRAINT "Member_pkey" PRIMARY KEY (id);
+ALTER TABLE ONLY public."User"
+    ADD CONSTRAINT "User_email_key" UNIQUE (email);
+ALTER TABLE ONLY public."User"
+    ADD CONSTRAINT "User_pkey" PRIMARY KEY (id);
+CREATE INDEX "MedicationRecord_memberId_idx" ON public."MedicationRecord" USING btree ("memberId");
+CREATE INDEX "MedicationRecord_userId_idx" ON public."MedicationRecord" USING btree ("userId");
+CREATE INDEX "Medication_memberId_idx" ON public."Medication" USING btree ("memberId");
+CREATE INDEX "Medication_userId_idx" ON public."Medication" USING btree ("userId");
+CREATE INDEX "Member_userId_idx" ON public."Member" USING btree ("userId");
+CREATE UNIQUE INDEX "User_googleId_key" ON public."User" USING btree ("googleId");
+ALTER TABLE ONLY public."MedicationRecord"
+    ADD CONSTRAINT "MedicationRecord_medicationId_fkey" FOREIGN KEY ("medicationId") REFERENCES public."Medication"(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public."MedicationRecord"
+    ADD CONSTRAINT "MedicationRecord_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES public."Member"(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public."MedicationRecord"
+    ADD CONSTRAINT "MedicationRecord_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public."Medication"
+    ADD CONSTRAINT "Medication_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES public."Member"(id) ON DELETE CASCADE;
+ALTER TABLE ONLY public."Member"
+    ADD CONSTRAINT "Member_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."User"(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary

前 PR で作った Medication 集約の不変条件を、実際の PostgreSQL に対して機能させる縦一本を通した。

- `MedicationRepository` / `MedicationRecordRepository` のポートをドメインに置き、`JdbcClient` による実装を infrastructure に置いた（依存の向きは外から内）
- `TakeMedicationUseCase` を `@Transactional` にし、**残数の減算と記録の追加を1つの原子的操作**にした
  - Go 版はトランザクションがリポジトリの内側にしかなく、ユースケースが複数リポジトリをまたげなかった
- `Clock` を Bean 化し、ドメインとユースケースが直接 `now()` を呼ばないようにした（フロントの `computeIsLowStock` が端末の時計に依存していた問題をバックエンドでは避ける）
- Testcontainers による統合テスト8件。とくに **「集約が服用を拒否したとき、残数も記録も変化しない」** ことを検証している
- テスト用スキーマは実 DB から `pg_dump` で切り出したもの（`User` / `Member` / `Medication` / `MedicationRecord`）
- CI に Spring Boot のジョブを追加。あわせてフロントの `lint` も CI で実行するようにした（前 PR で導入したが未実行だったため）

テスト **45件（ドメイン 37 + 実DB統合 8）** すべて通過。REST 層は未実装のため、本番の動作には影響しない。

## 次にやること

- JWT 認証と REST エンドポイント（`POST /api/medications/{id}/take`）
- `isLowStock` を使った残数アラートの照会系