### PR TITLE
feat(backend-java): Google ログインを認可コードグラント + PKCE で実装する

### DIFF
--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -44,6 +44,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc</artifactId>
 		</dependency>
 
@@ -70,6 +78,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend-java/src/main/java/app/healthfamily/auth/application/SignInWithGoogleUseCase.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/application/SignInWithGoogleUseCase.java
@@ -1,0 +1,77 @@
+package app.healthfamily.auth.application;
+
+import app.healthfamily.auth.domain.AccessTokenIssuer;
+import app.healthfamily.auth.domain.AuthorizationCodeGrant;
+import app.healthfamily.auth.domain.GoogleIdentity;
+import app.healthfamily.auth.domain.GoogleTokenExchanger;
+import app.healthfamily.auth.domain.User;
+import app.healthfamily.auth.domain.UserRepository;
+import java.time.Clock;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 認可コードグラントで Google ログインを完了させるユースケース。
+ *
+ * <p>アカウントの解決順は 3 段階で、Go 版と揃えている。
+ *
+ * <ol>
+ *   <li><b>googleId 一致</b>：すでに紐付け済み。そのままログイン</li>
+ *   <li><b>メール一致</b>：パスワード登録済みのユーザーに Google を紐付ける</li>
+ *   <li><b>どちらも無い</b>：新規作成</li>
+ * </ol>
+ *
+ * <p>2 と 3 は Google 側でメールの所有確認が済んでいる場合にのみ許可する。
+ * 未確認のメールで紐付けを許すと、他人のメールアドレスを名乗って
+ * 既存アカウントを乗っ取れてしまう。
+ */
+@Service
+public class SignInWithGoogleUseCase {
+
+    private final GoogleTokenExchanger exchanger;
+    private final UserRepository users;
+    private final AccessTokenIssuer tokens;
+    private final Clock clock;
+
+    public SignInWithGoogleUseCase(
+            GoogleTokenExchanger exchanger,
+            UserRepository users,
+            AccessTokenIssuer tokens,
+            Clock clock) {
+        this.exchanger = exchanger;
+        this.users = users;
+        this.tokens = tokens;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public Result execute(AuthorizationCodeGrant grant) {
+        GoogleIdentity identity = exchanger.exchange(grant);
+        User user = resolve(identity);
+        return new Result(tokens.issue(user, clock.instant()), user);
+    }
+
+    private User resolve(GoogleIdentity identity) {
+        var linked = users.findByGoogleId(identity.subject());
+        if (linked.isPresent()) {
+            return linked.get();
+        }
+
+        identity.requireVerifiedEmail();
+
+        var byEmail = users.findByEmail(identity.email());
+        if (byEmail.isPresent()) {
+            User existing = byEmail.get();
+            existing.linkGoogle(identity);
+            users.update(existing);
+            return existing;
+        }
+
+        User created = User.registerFromGoogle(UUID.randomUUID().toString(), identity);
+        users.create(created);
+        return created;
+    }
+
+    public record Result(String accessToken, User user) {}
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/domain/AccessTokenIssuer.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/domain/AccessTokenIssuer.java
@@ -1,0 +1,15 @@
+package app.healthfamily.auth.domain;
+
+import java.time.Instant;
+
+/**
+ * 自アプリのアクセストークンを発行するポート。
+ *
+ * <p>Google から受け取ったトークンをそのまま API 認証に使い回さない。
+ * ID トークンは「ログインしたのが誰か」を伝えるためのもので、
+ * リソースアクセスの権限を表すものではないため。
+ */
+public interface AccessTokenIssuer {
+
+    String issue(User user, Instant now);
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/domain/AuthorizationCodeGrant.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/domain/AuthorizationCodeGrant.java
@@ -1,0 +1,43 @@
+package app.healthfamily.auth.domain;
+
+import app.healthfamily.shared.DomainException;
+
+/**
+ * 認可コードグラントで受け取った、トークン交換に必要な一式。
+ *
+ * <p>SPA は公開クライアントで client_secret を安全に保持できないため、
+ * <b>PKCE の code_verifier を必須</b>にしている（RFC 7636）。
+ * 認可コードを盗まれても、合言葉の本体を知らない攻撃者はトークンを取得できない。
+ *
+ * <p>従来の Google Identity Services は ID トークンをブラウザへ直接渡す方式で、
+ * 実質インプリシットに近い。認可コードグラントへ移す目的はここにある。
+ *
+ * @param code 認可サーバーが発行した認可コード。一度しか使えない
+ * @param codeVerifier 認可リクエスト時に作った合言葉の本体（43〜128 文字）
+ * @param redirectUri 認可リクエストと完全一致していなければならない
+ */
+public record AuthorizationCodeGrant(String code, String codeVerifier, String redirectUri) {
+
+    private static final int VERIFIER_MIN = 43;
+    private static final int VERIFIER_MAX = 128;
+
+    public AuthorizationCodeGrant {
+        if (code == null || code.isBlank()) {
+            throw DomainException.validation("認可コードは必須です");
+        }
+        if (codeVerifier == null || codeVerifier.isBlank()) {
+            throw DomainException.validation("code_verifier は必須です");
+        }
+        if (codeVerifier.length() < VERIFIER_MIN || codeVerifier.length() > VERIFIER_MAX) {
+            throw DomainException.validation(
+                    "code_verifier は %d〜%d 文字である必要があります".formatted(VERIFIER_MIN, VERIFIER_MAX));
+        }
+        if (!codeVerifier.matches("[A-Za-z0-9\\-._~]+")) {
+            throw DomainException.validation(
+                    "code_verifier に使用できない文字が含まれています");
+        }
+        if (redirectUri == null || redirectUri.isBlank()) {
+            throw DomainException.validation("redirect_uri は必須です");
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/domain/GoogleIdentity.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/domain/GoogleIdentity.java
@@ -1,0 +1,43 @@
+package app.healthfamily.auth.domain;
+
+import app.healthfamily.shared.DomainException;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * 検証済みの Google ID トークンから取り出した本人情報。
+ *
+ * <p>ここに到達している時点で、署名・iss・aud・exp の検証は済んでいる前提。
+ * 未検証のトークンからこの型を作ってはならない。
+ *
+ * @param subject Google の安定したユーザー識別子。メールアドレスと違い変わらないため、
+ *     アカウントの紐付けはこちらで行う
+ */
+public record GoogleIdentity(String subject, String email, boolean emailVerified, String name) {
+
+    public GoogleIdentity {
+        if (subject == null || subject.isBlank()) {
+            throw DomainException.validation("Google の sub が取得できませんでした");
+        }
+        if (email == null || email.isBlank()) {
+            throw DomainException.validation("Google のメールアドレスが取得できませんでした");
+        }
+        email = email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    public Optional<String> displayName() {
+        return Optional.ofNullable(name).filter(n -> !n.isBlank());
+    }
+
+    /**
+     * このアカウントで既存ユーザーへの紐付けや新規作成を許してよいか。
+     *
+     * <p>Google 側でメールの所有確認が済んでいない場合に許すと、
+     * 他人のメールアドレスを名乗って既存アカウントを乗っ取れてしまう。
+     */
+    public void requireVerifiedEmail() {
+        if (!emailVerified) {
+            throw DomainException.forbidden("Googleアカウントのメールアドレスが確認されていません");
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/domain/GoogleTokenExchanger.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/domain/GoogleTokenExchanger.java
@@ -1,0 +1,17 @@
+package app.healthfamily.auth.domain;
+
+/**
+ * 認可コードを ID トークンに交換し、その中身を検証するポート。
+ *
+ * <p>ドメインは「交換して検証済みの本人情報が得られる」ことだけを知っていればよく、
+ * HTTP も JWKS も知らない。テストでは差し替える。
+ */
+public interface GoogleTokenExchanger {
+
+    /**
+     * 認可コードを ID トークンに交換し、署名と各クレームを検証して本人情報を返す。
+     *
+     * @throws app.healthfamily.shared.DomainException.Validation 交換または検証に失敗した場合
+     */
+    GoogleIdentity exchange(AuthorizationCodeGrant grant);
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/domain/User.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/domain/User.java
@@ -1,0 +1,129 @@
+package app.healthfamily.auth.domain;
+
+import app.healthfamily.shared.DomainException;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * 利用者の集約ルート。
+ *
+ * <p>Google ログイン専用ユーザーはパスワードを空文字で保持する。
+ * bcrypt の検証は空ハッシュに対して必ず失敗するため、パスワードログインは成立しない。
+ * Go 版と同じ扱いにして、両バックエンドが同じ行を読めるようにしている。
+ */
+public class User {
+
+    /** Google ログイン専用ユーザーのパスワード列。ログイン不能であることを表す */
+    public static final String NO_PASSWORD = "";
+
+    private static final String DEFAULT_CHARACTER = "cat";
+
+    private final String id;
+    private final String email;
+    private final String password;
+    private final String characterType;
+
+    private String displayName;
+    private String googleId;
+    private boolean emailVerified;
+
+    private User(
+            String id,
+            String email,
+            String password,
+            String displayName,
+            String characterType,
+            String googleId,
+            boolean emailVerified) {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("ユーザーIDは必須です");
+        }
+        if (email == null || email.isBlank()) {
+            throw DomainException.validation("メールアドレスは必須です");
+        }
+        this.id = id;
+        this.email = email.trim().toLowerCase(Locale.ROOT);
+        this.password = password == null ? NO_PASSWORD : password;
+        this.displayName = displayName;
+        this.characterType = characterType == null ? DEFAULT_CHARACTER : characterType;
+        this.googleId = googleId;
+        this.emailVerified = emailVerified;
+    }
+
+    /** 永続化層からの再構築。 */
+    public static User reconstitute(
+            String id,
+            String email,
+            String password,
+            String displayName,
+            String characterType,
+            String googleId,
+            boolean emailVerified) {
+        return new User(id, email, password, displayName, characterType, googleId, emailVerified);
+    }
+
+    /**
+     * Google アカウントから新規登録する。
+     *
+     * <p>Google 側でメールの所有確認が済んでいることが前提なので、
+     * こちらでの確認メールは不要。最初から確認済みとして作る。
+     */
+    public static User registerFromGoogle(String id, GoogleIdentity identity) {
+        identity.requireVerifiedEmail();
+        return new User(
+                id,
+                identity.email(),
+                NO_PASSWORD,
+                identity.displayName().orElse(null),
+                DEFAULT_CHARACTER,
+                identity.subject(),
+                true);
+    }
+
+    /**
+     * 既存アカウントに Google アカウントを紐付ける。
+     *
+     * <p>すでに別の Google アカウントが紐付いている場合は拒否する。
+     * 同じメールアドレスを持つ別の Google アカウントによる乗っ取りを防ぐため。
+     */
+    public void linkGoogle(GoogleIdentity identity) {
+        identity.requireVerifiedEmail();
+        if (googleId != null && !googleId.equals(identity.subject())) {
+            throw DomainException.conflict(
+                    "このメールアドレスには別のGoogleアカウントが紐付いています");
+        }
+        this.googleId = identity.subject();
+        this.emailVerified = true;
+        if (displayName == null || displayName.isBlank()) {
+            identity.displayName().ifPresent(n -> this.displayName = n);
+        }
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String email() {
+        return email;
+    }
+
+    public String password() {
+        return password;
+    }
+
+    public String characterType() {
+        return characterType;
+    }
+
+    public Optional<String> displayName() {
+        return Optional.ofNullable(displayName);
+    }
+
+    public Optional<String> googleId() {
+        return Optional.ofNullable(googleId);
+    }
+
+    public boolean emailVerified() {
+        return emailVerified;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/domain/UserRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/domain/UserRepository.java
@@ -1,0 +1,15 @@
+package app.healthfamily.auth.domain;
+
+import java.util.Optional;
+
+/** 利用者の永続化ポート。 */
+public interface UserRepository {
+
+    Optional<User> findByGoogleId(String googleId);
+
+    Optional<User> findByEmail(String email);
+
+    void create(User user);
+
+    void update(User user);
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/infrastructure/GoogleOidcProperties.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/infrastructure/GoogleOidcProperties.java
@@ -1,0 +1,40 @@
+package app.healthfamily.auth.infrastructure;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Google OIDC の設定。
+ *
+ * @param clientId 認可リクエストと ID トークンの aud に使う
+ * @param clientSecret バックエンドは秘密を保持できるので機密クライアントとして扱う。
+ *     SPA 単体では持てないため、トークン交換をバックエンドに寄せている
+ * @param tokenUri トークンエンドポイント
+ * @param jwkSetUri ID トークンの署名検証に使う公開鍵の配布元
+ * @param issuers 許容する iss。Google は 2 種類の表記を返しうる
+ */
+@ConfigurationProperties(prefix = "healthfamily.google-oidc")
+public record GoogleOidcProperties(
+        String clientId,
+        String clientSecret,
+        String tokenUri,
+        String jwkSetUri,
+        List<String> issuers) {
+
+    public GoogleOidcProperties {
+        if (tokenUri == null || tokenUri.isBlank()) {
+            tokenUri = "https://oauth2.googleapis.com/token";
+        }
+        if (jwkSetUri == null || jwkSetUri.isBlank()) {
+            jwkSetUri = "https://www.googleapis.com/oauth2/v3/certs";
+        }
+        if (issuers == null || issuers.isEmpty()) {
+            issuers = List.of("https://accounts.google.com", "accounts.google.com");
+        }
+    }
+
+    /** clientId が未設定なら Google ログインは無効とする。 */
+    public boolean enabled() {
+        return clientId != null && !clientId.isBlank();
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/infrastructure/GoogleOidcTokenExchanger.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/infrastructure/GoogleOidcTokenExchanger.java
@@ -1,0 +1,112 @@
+package app.healthfamily.auth.infrastructure;
+
+import app.healthfamily.auth.domain.AuthorizationCodeGrant;
+import app.healthfamily.auth.domain.GoogleIdentity;
+import app.healthfamily.auth.domain.GoogleTokenExchanger;
+import app.healthfamily.shared.DomainException;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 認可コードを Google のトークンエンドポイントで交換し、ID トークンを検証する。
+ *
+ * <p>交換は <b>バックエンドから</b> 行う。ブラウザには認可コードしか渡らず、
+ * client_secret も ID トークンも JavaScript から触れない。
+ * これが Google Identity Services の ID トークン直接受け取りとの決定的な違い。
+ *
+ * <p>PKCE の code_verifier も同時に送る。認可コードを盗まれても、
+ * 合言葉の本体を知らない攻撃者はトークンを取得できない（RFC 7636）。
+ */
+@Component
+public class GoogleOidcTokenExchanger implements GoogleTokenExchanger {
+
+    private static final Logger log = LoggerFactory.getLogger(GoogleOidcTokenExchanger.class);
+
+    private final RestClient restClient;
+    private final JwtDecoder idTokenDecoder;
+    private final GoogleOidcProperties properties;
+
+    public GoogleOidcTokenExchanger(
+            @Qualifier("googleRestClient") RestClient restClient,
+            @Qualifier("googleIdTokenDecoder") JwtDecoder googleIdTokenDecoder,
+            GoogleOidcProperties properties) {
+        this.restClient = restClient;
+        this.idTokenDecoder = googleIdTokenDecoder;
+        this.properties = properties;
+    }
+
+    @Override
+    public GoogleIdentity exchange(AuthorizationCodeGrant grant) {
+        if (!properties.enabled()) {
+            throw DomainException.validation("Googleログインは現在利用できません");
+        }
+        String idToken = requestIdToken(grant);
+        return toIdentity(verify(idToken));
+    }
+
+    private String requestIdToken(AuthorizationCodeGrant grant) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "authorization_code");
+        form.add("code", grant.code());
+        form.add("code_verifier", grant.codeVerifier());
+        form.add("redirect_uri", grant.redirectUri());
+        form.add("client_id", properties.clientId());
+        if (properties.clientSecret() != null && !properties.clientSecret().isBlank()) {
+            form.add("client_secret", properties.clientSecret());
+        }
+
+        Map<?, ?> body;
+        try {
+            body =
+                    restClient
+                            .post()
+                            .uri(properties.tokenUri())
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .body(form)
+                            .retrieve()
+                            .body(Map.class);
+        } catch (RestClientException e) {
+            // 認可コードの使い回し・期限切れ・code_verifier 不一致はすべてここに来る。
+            // 詳細を利用者へ返すと攻撃の手がかりになるため、ログにだけ残す
+            log.warn("Google のトークン交換に失敗しました", e);
+            throw DomainException.validation("Google認証に失敗しました");
+        }
+
+        Object idToken = body == null ? null : body.get("id_token");
+        if (!(idToken instanceof String token) || token.isBlank()) {
+            log.warn("トークンレスポンスに id_token が含まれていません");
+            throw DomainException.validation("Google認証に失敗しました");
+        }
+        return token;
+    }
+
+    /** 署名・iss・aud・exp を検証する。ここを省くと偽造トークンを受け入れてしまう。 */
+    private Jwt verify(String idToken) {
+        try {
+            return idTokenDecoder.decode(idToken);
+        } catch (JwtException e) {
+            log.warn("ID トークンの検証に失敗しました", e);
+            throw DomainException.validation("Google認証に失敗しました");
+        }
+    }
+
+    private GoogleIdentity toIdentity(Jwt jwt) {
+        Object emailVerified = jwt.getClaim("email_verified");
+        return new GoogleIdentity(
+                jwt.getSubject(),
+                jwt.getClaimAsString("email"),
+                Boolean.TRUE.equals(emailVerified) || "true".equals(String.valueOf(emailVerified)),
+                jwt.getClaimAsString("name"));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/infrastructure/HmacAccessTokenIssuer.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/infrastructure/HmacAccessTokenIssuer.java
@@ -1,0 +1,60 @@
+package app.healthfamily.auth.infrastructure;
+
+import app.healthfamily.auth.domain.AccessTokenIssuer;
+import app.healthfamily.auth.domain.User;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * 自アプリのアクセストークンを HS256 で発行する。
+ *
+ * <p>クレームの形と有効期限は Go 版と一致させてある（uid / email / sub、7 日）。
+ * 移行中は両方のバックエンドが同じトークンを受け付けられる必要があるため。
+ */
+@Component
+public class HmacAccessTokenIssuer implements AccessTokenIssuer {
+
+    /** Go 版の main.go と同じ 7 日 */
+    static final Duration TTL = Duration.ofDays(7);
+
+    private final byte[] secret;
+
+    public HmacAccessTokenIssuer(@Value("${healthfamily.jwt.secret}") String secret) {
+        byte[] bytes = secret.getBytes(StandardCharsets.UTF_8);
+        if (bytes.length < 32) {
+            // HS256 の鍵はハッシュ出力長 (256bit) 以上が必要 (RFC 7518)
+            throw new IllegalStateException(
+                    "healthfamily.jwt.secret は 32 バイト以上である必要があります");
+        }
+        this.secret = bytes;
+    }
+
+    @Override
+    public String issue(User user, Instant now) {
+        var claims =
+                new JWTClaimsSet.Builder()
+                        .subject(user.id())
+                        .claim("uid", user.id())
+                        .claim("email", user.email())
+                        .issueTime(Date.from(now))
+                        .expirationTime(Date.from(now.plus(TTL)))
+                        .build();
+        var jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
+        try {
+            jwt.sign(new MACSigner(secret));
+        } catch (JOSEException e) {
+            throw new IllegalStateException("アクセストークンの署名に失敗しました", e);
+        }
+        return jwt.serialize();
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/infrastructure/JdbcUserRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/infrastructure/JdbcUserRepository.java
@@ -1,0 +1,89 @@
+package app.healthfamily.auth.infrastructure;
+
+import app.healthfamily.auth.domain.User;
+import app.healthfamily.auth.domain.UserRepository;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Locale;
+import java.util.Optional;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+/** 利用者の JDBC 実装。テーブルは Go 版と共有している。 */
+@Repository
+public class JdbcUserRepository implements UserRepository {
+
+    private static final String COLUMNS =
+            "id, email, password, \"displayName\", \"characterType\", \"googleId\", \"emailVerified\"";
+
+    private final JdbcClient jdbc;
+
+    public JdbcUserRepository(JdbcClient jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public Optional<User> findByGoogleId(String googleId) {
+        return jdbc.sql("SELECT " + COLUMNS + " FROM \"User\" WHERE \"googleId\" = :googleId")
+                .param("googleId", googleId)
+                .query(JdbcUserRepository::toUser)
+                .optional();
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return jdbc.sql("SELECT " + COLUMNS + " FROM \"User\" WHERE email = :email")
+                .param("email", email.trim().toLowerCase(Locale.ROOT))
+                .query(JdbcUserRepository::toUser)
+                .optional();
+    }
+
+    @Override
+    public void create(User user) {
+        jdbc.sql(
+                        """
+                        INSERT INTO "User"
+                               (id, email, password, "displayName", "characterType",
+                                "googleId", "emailVerified", "updatedAt")
+                        VALUES (:id, :email, :password, :displayName, :characterType,
+                                :googleId, :emailVerified, now())
+                        """)
+                .param("id", user.id())
+                .param("email", user.email())
+                .param("password", user.password())
+                .param("displayName", user.displayName().orElse(null))
+                .param("characterType", user.characterType())
+                .param("googleId", user.googleId().orElse(null))
+                .param("emailVerified", user.emailVerified())
+                .update();
+    }
+
+    @Override
+    public void update(User user) {
+        jdbc.sql(
+                        """
+                        UPDATE "User"
+                           SET "displayName"   = :displayName,
+                               "googleId"      = :googleId,
+                               "emailVerified" = :emailVerified,
+                               "updatedAt"     = now()
+                         WHERE id = :id
+                        """)
+                .param("displayName", user.displayName().orElse(null))
+                .param("googleId", user.googleId().orElse(null))
+                .param("emailVerified", user.emailVerified())
+                .param("id", user.id())
+                .update();
+    }
+
+    private static User toUser(ResultSet rs, int rowNum) throws SQLException {
+        return User.reconstitute(
+                rs.getString("id"),
+                rs.getString("email"),
+                rs.getString("password"),
+                rs.getString("displayName"),
+                rs.getString("characterType"),
+                rs.getString("googleId"),
+                rs.getBoolean("emailVerified"));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/infrastructure/JwtDecoderConfig.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/infrastructure/JwtDecoderConfig.java
@@ -1,0 +1,114 @@
+package app.healthfamily.auth.infrastructure;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+/**
+ * 2 種類の JWT デコーダを組み立てる。
+ *
+ * <ul>
+ *   <li><b>googleIdTokenDecoder</b>：Google の ID トークン (RS256)。公開鍵は JWKS から取得する</li>
+ *   <li><b>appJwtDecoder</b>：自アプリのアクセストークン (HS256)。Go 版と同じ共有鍵</li>
+ * </ul>
+ *
+ * <p>この 2 つは役割がまったく違う。ID トークンは「ログインしたのが誰か」を一度だけ確かめるもので、
+ * API のアクセス制御には自アプリのトークンを使う。
+ */
+@Configuration
+@EnableConfigurationProperties(GoogleOidcProperties.class)
+public class JwtDecoderConfig {
+
+    /** Google の ID トークン検証用。署名・iss・aud・exp をすべて検証する。 */
+    @Bean
+    public JwtDecoder googleIdTokenDecoder(GoogleOidcProperties properties) {
+        NimbusJwtDecoder decoder =
+                NimbusJwtDecoder.withJwkSetUri(properties.jwkSetUri())
+                        .jwsAlgorithm(org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS256)
+                        .build();
+        decoder.setJwtValidator(
+                new DelegatingValidator(
+                        new JwtTimestampValidator(),
+                        issuerValidator(properties),
+                        audienceValidator(properties)));
+        return decoder;
+    }
+
+    /** 自アプリのアクセストークン検証用。 */
+    @Bean
+    public JwtDecoder appJwtDecoder(@Value("${healthfamily.jwt.secret}") String secret) {
+        var key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        NimbusJwtDecoder decoder =
+                NimbusJwtDecoder.withSecretKey(key)
+                        .macAlgorithm(org.springframework.security.oauth2.jose.jws.MacAlgorithm.HS256)
+                        .build();
+        // Go 版は iss / aud を入れていないため、期限のみ検証する
+        decoder.setJwtValidator(JwtValidators.createDefault());
+        return decoder;
+    }
+
+    /** Google は iss を 2 通りの表記で返しうるので、どちらも許容する。 */
+    private static OAuth2TokenValidator<Jwt> issuerValidator(GoogleOidcProperties properties) {
+        return jwt ->
+                properties.issuers().contains(jwt.getIssuer() == null ? null : jwt.getIssuer().toString())
+                        ? OAuth2TokenValidatorResult.success()
+                        : OAuth2TokenValidatorResult.failure(
+                                new OAuth2Error(
+                                        "invalid_issuer",
+                                        "iss が期待する発行者と一致しません",
+                                        null));
+    }
+
+    /** aud が自分の client_id でないトークンは、他所向けに発行されたもの。受け入れてはならない。 */
+    private static OAuth2TokenValidator<Jwt> audienceValidator(GoogleOidcProperties properties) {
+        return jwt ->
+                jwt.getAudience() != null && jwt.getAudience().contains(properties.clientId())
+                        ? OAuth2TokenValidatorResult.success()
+                        : OAuth2TokenValidatorResult.failure(
+                                new OAuth2Error(
+                                        "invalid_audience",
+                                        "aud が自分の client_id と一致しません",
+                                        null));
+    }
+
+    /** 検証器をまとめて適用する。1 つでも失敗したら不合格。 */
+    private record DelegatingValidator(OAuth2TokenValidator<Jwt>... validators)
+            implements OAuth2TokenValidator<Jwt> {
+
+        @SafeVarargs
+        private DelegatingValidator {}
+
+        @Override
+        public OAuth2TokenValidatorResult validate(Jwt token) {
+            for (OAuth2TokenValidator<Jwt> validator : validators) {
+                OAuth2TokenValidatorResult result = validator.validate(token);
+                if (result.hasErrors()) {
+                    return result;
+                }
+            }
+            return OAuth2TokenValidatorResult.success();
+        }
+    }
+
+    /** Google のトークンエンドポイントを叩く HTTP クライアント。 */
+    @Bean
+    public org.springframework.web.client.RestClient googleRestClient() {
+        return org.springframework.web.client.RestClient.create();
+    }
+
+    /** JwtClaimNames を参照しておくことで、クレーム名の定数を明示する */
+    static final String SUBJECT_CLAIM = JwtClaimNames.SUB;
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/infrastructure/SecurityConfig.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/infrastructure/SecurityConfig.java
@@ -1,0 +1,61 @@
+package app.healthfamily.auth.infrastructure;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * API の認可設定。
+ *
+ * <p>状態を持たない JWT 認証なので、セッションも CSRF トークンも使わない。
+ * 認証は Authorization ヘッダの Bearer トークンだけで行う。
+ */
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(
+            HttpSecurity http, @Qualifier("appJwtDecoder") JwtDecoder appJwtDecoder)
+            throws Exception {
+        return http
+                // Cookie を使わないため CSRF の攻撃面がない
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(
+                        auth ->
+                                auth
+                                        // ログイン導線とヘルスチェックのみ認証不要
+                                        .requestMatchers("/api/auth/**")
+                                        .permitAll()
+                                        .requestMatchers(HttpMethod.GET, "/actuator/health")
+                                        .permitAll()
+                                        .anyRequest()
+                                        .authenticated())
+                .oauth2ResourceServer(
+                        oauth2 ->
+                                oauth2.jwt(
+                                        jwt ->
+                                                jwt.decoder(appJwtDecoder)
+                                                        .jwtAuthenticationConverter(
+                                                                converter())))
+                .build();
+    }
+
+    /**
+     * トークンの主体をユーザーIDにする。
+     *
+     * <p>Go 版は uid クレームを使っているが、sub にも同じ値が入っているため
+     * 標準の sub をそのまま principal 名として扱う。
+     */
+    private static JwtAuthenticationConverter converter() {
+        var converter = new JwtAuthenticationConverter();
+        converter.setPrincipalClaimName("sub");
+        return converter;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/auth/web/AuthController.java
+++ b/backend-java/src/main/java/app/healthfamily/auth/web/AuthController.java
@@ -1,0 +1,66 @@
+package app.healthfamily.auth.web;
+
+import app.healthfamily.auth.application.SignInWithGoogleUseCase;
+import app.healthfamily.auth.domain.AuthorizationCodeGrant;
+import app.healthfamily.auth.domain.User;
+import app.healthfamily.shared.web.ApiResponse;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 認可コードグラントのコールバックを受ける。
+ *
+ * <p>ブラウザは Google から認可コードだけを受け取り、それをここへ渡す。
+ * <b>ID トークンもリフレッシュトークンもブラウザには渡らない。</b>
+ * トークン交換はサーバー間通信で行われる。
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final SignInWithGoogleUseCase signInWithGoogle;
+
+    public AuthController(SignInWithGoogleUseCase signInWithGoogle) {
+        this.signInWithGoogle = signInWithGoogle;
+    }
+
+    @PostMapping("/google/callback")
+    public ApiResponse<SignInResponse> googleCallback(
+            @jakarta.validation.Valid @RequestBody GoogleCallbackRequest request) {
+        var result =
+                signInWithGoogle.execute(
+                        new AuthorizationCodeGrant(
+                                request.code(), request.codeVerifier(), request.redirectUri()));
+        return ApiResponse.ok(SignInResponse.of(result));
+    }
+
+    /**
+     * @param codeVerifier PKCE の合言葉の本体。ブラウザが認可リクエスト前に生成し、
+     *     ハッシュだけを Google へ預けてある
+     */
+    public record GoogleCallbackRequest(
+            @NotBlank String code, @NotBlank String codeVerifier, @NotBlank String redirectUri) {}
+
+    public record SignInResponse(String token, UserResponse user) {
+
+        static SignInResponse of(SignInWithGoogleUseCase.Result result) {
+            return new SignInResponse(result.accessToken(), UserResponse.of(result.user()));
+        }
+    }
+
+    public record UserResponse(
+            String id, String email, String displayName, String characterType, boolean emailVerified) {
+
+        static UserResponse of(User user) {
+            return new UserResponse(
+                    user.id(),
+                    user.email(),
+                    user.displayName().orElse(null),
+                    user.characterType(),
+                    user.emailVerified());
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/shared/web/ApiResponse.java
+++ b/backend-java/src/main/java/app/healthfamily/shared/web/ApiResponse.java
@@ -1,0 +1,21 @@
+package app.healthfamily.shared.web;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * API のレスポンス形式。
+ *
+ * <p>{@code { success, data?, error? }} は Next.js 版から続く形で、
+ * Go 版・フロントともにこれを前提にしている。移行中も変えない。
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(boolean success, T data, String error) {
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> failure(String message) {
+        return new ApiResponse<>(false, null, message);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/shared/web/DomainExceptionHandler.java
+++ b/backend-java/src/main/java/app/healthfamily/shared/web/DomainExceptionHandler.java
@@ -1,0 +1,53 @@
+package app.healthfamily.shared.web;
+
+import app.healthfamily.shared.DomainException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * ドメイン例外を HTTP ステータスへ対応付ける。
+ *
+ * <p>対応は Go 版の HandleDomainError と揃えている。
+ * ドメイン層は HTTP を知らず、この 1 箇所だけが両者を橋渡しする。
+ */
+@RestControllerAdvice
+public class DomainExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(DomainExceptionHandler.class);
+
+    @ExceptionHandler(DomainException.NotFound.class)
+    public ResponseEntity<ApiResponse<Void>> notFound(DomainException.NotFound e) {
+        return respond(HttpStatus.NOT_FOUND, e);
+    }
+
+    @ExceptionHandler(DomainException.Forbidden.class)
+    public ResponseEntity<ApiResponse<Void>> forbidden(DomainException.Forbidden e) {
+        return respond(HttpStatus.FORBIDDEN, e);
+    }
+
+    @ExceptionHandler(DomainException.Validation.class)
+    public ResponseEntity<ApiResponse<Void>> validation(DomainException.Validation e) {
+        return respond(HttpStatus.BAD_REQUEST, e);
+    }
+
+    @ExceptionHandler(DomainException.Conflict.class)
+    public ResponseEntity<ApiResponse<Void>> conflict(DomainException.Conflict e) {
+        return respond(HttpStatus.CONFLICT, e);
+    }
+
+    /** 想定外の例外は中身を返さない。内部構造の手がかりを与えないため。 */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> unexpected(Exception e) {
+        log.error("想定外のエラー", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.failure("サーバーエラーが発生しました"));
+    }
+
+    private static ResponseEntity<ApiResponse<Void>> respond(HttpStatus status, DomainException e) {
+        return ResponseEntity.status(status).body(ApiResponse.failure(e.getMessage()));
+    }
+}

--- a/backend-java/src/main/resources/application.properties
+++ b/backend-java/src/main/resources/application.properties
@@ -1,1 +1,19 @@
 spring.application.name=healthfamily-api
+
+# DB は Go 版と同じ Supabase (session pooler)。
+# pgx / JDBC ともに prepared statement を使うため transaction pooler (:6543) は使わない。
+spring.datasource.url=${DATABASE_JDBC_URL:}
+spring.datasource.username=${DATABASE_USER:}
+spring.datasource.password=${DATABASE_PASSWORD:}
+
+# 自アプリのアクセストークン署名鍵。Go 版と同じ値を使うことで、
+# 移行中はどちらのバックエンドでも同じトークンを検証できる。
+healthfamily.jwt.secret=${JWT_SECRET:}
+
+# Google OIDC (認可コードグラント + PKCE)
+# client-secret はバックエンドだけが保持する。SPA には渡さない。
+healthfamily.google-oidc.client-id=${GOOGLE_CLIENT_ID:}
+healthfamily.google-oidc.client-secret=${GOOGLE_CLIENT_SECRET:}
+
+management.endpoints.web.exposure.include=health
+management.endpoint.health.probes.enabled=true

--- a/backend-java/src/test/java/app/healthfamily/HealthfamilyApiApplicationTests.java
+++ b/backend-java/src/test/java/app/healthfamily/HealthfamilyApiApplicationTests.java
@@ -1,13 +1,16 @@
 package app.healthfamily;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
+/** アプリケーションコンテキストが実 DB 付きで起動することの煙テスト。 */
 @SpringBootTest
+@Import(TestcontainersConfiguration.class)
 class HealthfamilyApiApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    @DisplayName("コンテキストが起動する")
+    void contextLoads() {}
 }

--- a/backend-java/src/test/java/app/healthfamily/TestcontainersConfiguration.java
+++ b/backend-java/src/test/java/app/healthfamily/TestcontainersConfiguration.java
@@ -1,0 +1,26 @@
+package app.healthfamily;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * 統合テストで共有する PostgreSQL。
+ *
+ * <p>{@code @ServiceConnection} を付けると Spring Boot が接続情報を自動で流し込むため、
+ * テストごとに DynamicPropertySource を書く必要がない。
+ *
+ * <p>初期スキーマは実 DB から pg_dump で切り出したもの。
+ * 手書きすると本番との差異に気づけないため、必ず実物から起こす。
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+    @Bean
+    @ServiceConnection
+    @SuppressWarnings("resource")
+    PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>("postgres:17").withInitScript("db/medication-schema.sql");
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/auth/application/SignInWithGoogleUseCaseTest.java
+++ b/backend-java/src/test/java/app/healthfamily/auth/application/SignInWithGoogleUseCaseTest.java
@@ -1,0 +1,167 @@
+package app.healthfamily.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.auth.domain.AccessTokenIssuer;
+import app.healthfamily.auth.domain.AuthorizationCodeGrant;
+import app.healthfamily.auth.domain.GoogleIdentity;
+import app.healthfamily.auth.domain.GoogleTokenExchanger;
+import app.healthfamily.auth.domain.User;
+import app.healthfamily.auth.domain.UserRepository;
+import app.healthfamily.shared.DomainException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Google ログイン（認可コードグラント）")
+class SignInWithGoogleUseCaseTest {
+
+    private static final Instant NOW = Instant.parse("2026-08-15T12:00:00Z");
+    private static final AuthorizationCodeGrant GRANT =
+            new AuthorizationCodeGrant("code-1", "v".repeat(43), "https://app.example/callback");
+
+    /** 交換結果を差し替えられる偽物。HTTP も JWKS も出てこない */
+    private static final class StubExchanger implements GoogleTokenExchanger {
+        private GoogleIdentity identity;
+        private int calls;
+
+        @Override
+        public GoogleIdentity exchange(AuthorizationCodeGrant grant) {
+            calls++;
+            return identity;
+        }
+    }
+
+    private static final class InMemoryUsers implements UserRepository {
+        private final List<User> stored = new ArrayList<>();
+        private int creates;
+        private int updates;
+
+        @Override
+        public Optional<User> findByGoogleId(String googleId) {
+            return stored.stream().filter(u -> u.googleId().filter(googleId::equals).isPresent()).findFirst();
+        }
+
+        @Override
+        public Optional<User> findByEmail(String email) {
+            String normalized = email.trim().toLowerCase(Locale.ROOT);
+            return stored.stream().filter(u -> u.email().equals(normalized)).findFirst();
+        }
+
+        @Override
+        public void create(User user) {
+            creates++;
+            stored.add(user);
+        }
+
+        @Override
+        public void update(User user) {
+            updates++;
+        }
+    }
+
+    private StubExchanger exchanger;
+    private InMemoryUsers users;
+    private SignInWithGoogleUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        exchanger = new StubExchanger();
+        users = new InMemoryUsers();
+        AccessTokenIssuer issuer = (user, now) -> "token-for-" + user.id();
+        useCase =
+                new SignInWithGoogleUseCase(
+                        exchanger, users, issuer, Clock.fixed(NOW, ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("googleId が一致すれば、そのユーザーでログインする")
+    void resolvesByGoogleId() {
+        var existing =
+                User.reconstitute("user-1", "user@example.com", "", "既存", "cat", "sub-1", true);
+        users.stored.add(existing);
+        exchanger.identity = new GoogleIdentity("sub-1", "user@example.com", true, "Google の名前");
+
+        var result = useCase.execute(GRANT);
+
+        assertThat(result.user().id()).isEqualTo("user-1");
+        assertThat(result.accessToken()).isEqualTo("token-for-user-1");
+        assertThat(users.creates).isZero();
+        assertThat(users.updates).isZero();
+    }
+
+    @Test
+    @DisplayName("googleId が無くメールが一致すれば、既存アカウントに紐付ける")
+    void linksToExistingByEmail() {
+        var existing =
+                User.reconstitute("user-2", "user@example.com", "hashed", null, "cat", null, false);
+        users.stored.add(existing);
+        exchanger.identity = new GoogleIdentity("sub-2", "USER@example.com", true, "拓真");
+
+        var result = useCase.execute(GRANT);
+
+        assertThat(result.user().id()).isEqualTo("user-2");
+        assertThat(result.user().googleId()).contains("sub-2");
+        assertThat(result.user().emailVerified()).isTrue();
+        assertThat(users.updates).isEqualTo(1);
+        assertThat(users.creates).isZero();
+    }
+
+    @Test
+    @DisplayName("どちらも無ければ新規作成する")
+    void createsNewUser() {
+        exchanger.identity = new GoogleIdentity("sub-3", "new@example.com", true, "新規");
+
+        var result = useCase.execute(GRANT);
+
+        assertThat(result.user().email()).isEqualTo("new@example.com");
+        assertThat(result.user().googleId()).contains("sub-3");
+        assertThat(users.creates).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("メール未確認では、既存アカウントへの紐付けも新規作成もしない")
+    void unverifiedEmailCannotLinkOrCreate() {
+        users.stored.add(
+                User.reconstitute("user-4", "victim@example.com", "hashed", null, "cat", null, true));
+        exchanger.identity = new GoogleIdentity("attacker-sub", "victim@example.com", false, null);
+
+        assertThatThrownBy(() -> useCase.execute(GRANT))
+                .isInstanceOf(DomainException.Forbidden.class);
+
+        assertThat(users.creates).isZero();
+        assertThat(users.updates).isZero();
+    }
+
+    @Test
+    @DisplayName("すでに別の Google アカウントが紐付いたメールは奪えない")
+    void cannotHijackAccountLinkedToAnotherGoogleAccount() {
+        users.stored.add(
+                User.reconstitute(
+                        "user-5", "user@example.com", "", null, "cat", "legit-sub", true));
+        exchanger.identity = new GoogleIdentity("attacker-sub", "user@example.com", true, null);
+
+        assertThatThrownBy(() -> useCase.execute(GRANT))
+                .isInstanceOf(DomainException.Conflict.class);
+
+        assertThat(users.updates).isZero();
+    }
+
+    @Test
+    @DisplayName("トークン交換は1回だけ呼ばれる（認可コードは使い捨て）")
+    void exchangesExactlyOnce() {
+        exchanger.identity = new GoogleIdentity("sub-6", "once@example.com", true, null);
+
+        useCase.execute(GRANT);
+
+        assertThat(exchanger.calls).isEqualTo(1);
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/auth/domain/AuthDomainTest.java
+++ b/backend-java/src/test/java/app/healthfamily/auth/domain/AuthDomainTest.java
@@ -1,0 +1,188 @@
+package app.healthfamily.auth.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import app.healthfamily.shared.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("認証ドメイン")
+class AuthDomainTest {
+
+    private static final String VALID_VERIFIER = "a".repeat(43);
+
+    private static GoogleIdentity verified() {
+        return new GoogleIdentity("google-sub-1", "USER@Example.com ", true, "拓真");
+    }
+
+    private static GoogleIdentity unverified() {
+        return new GoogleIdentity("google-sub-2", "unverified@example.com", false, null);
+    }
+
+    @Nested
+    @DisplayName("AuthorizationCodeGrant")
+    class Grant {
+
+        @Test
+        @DisplayName("正常な値なら作れる")
+        void validGrant() {
+            var grant = new AuthorizationCodeGrant("code-1", VALID_VERIFIER, "https://app/callback");
+
+            assertThat(grant.code()).isEqualTo("code-1");
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {42, 129})
+        @DisplayName("code_verifier は 43〜128 文字でなければならない")
+        void verifierLengthIsEnforced(int length) {
+            assertThatThrownBy(
+                            () ->
+                                    new AuthorizationCodeGrant(
+                                            "code-1", "a".repeat(length), "https://app/callback"))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("43〜128");
+        }
+
+        @Test
+        @DisplayName("code_verifier に使えない文字は弾く")
+        void verifierCharsetIsEnforced() {
+            assertThatThrownBy(
+                            () ->
+                                    new AuthorizationCodeGrant(
+                                            "code-1", "+".repeat(43), "https://app/callback"))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("使用できない文字");
+        }
+
+        @Test
+        @DisplayName("code_verifier は必須。PKCE 無しの交換は認めない")
+        void verifierIsRequired() {
+            assertThatThrownBy(
+                            () -> new AuthorizationCodeGrant("code-1", null, "https://app/callback"))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("code_verifier");
+        }
+
+        @Test
+        @DisplayName("redirect_uri は必須")
+        void redirectUriIsRequired() {
+            assertThatThrownBy(() -> new AuthorizationCodeGrant("code-1", VALID_VERIFIER, " "))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("GoogleIdentity")
+    class Identity {
+
+        @Test
+        @DisplayName("メールアドレスは小文字に正規化される")
+        void emailIsNormalized() {
+            assertThat(verified().email()).isEqualTo("user@example.com");
+        }
+
+        @Test
+        @DisplayName("sub が無ければ作れない")
+        void subjectIsRequired() {
+            assertThatThrownBy(() -> new GoogleIdentity(" ", "a@example.com", true, null))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+
+        @Test
+        @DisplayName("メール未確認は拒否できる")
+        void unverifiedEmailIsRejected() {
+            assertThatThrownBy(() -> unverified().requireVerifiedEmail())
+                    .isInstanceOf(DomainException.Forbidden.class)
+                    .hasMessageContaining("確認されていません");
+        }
+    }
+
+    @Nested
+    @DisplayName("User")
+    class Users {
+
+        @Test
+        @DisplayName("Google から新規登録すると確認済みで作られる")
+        void registerFromGoogle() {
+            var user = User.registerFromGoogle("user-1", verified());
+
+            assertThat(user.email()).isEqualTo("user@example.com");
+            assertThat(user.googleId()).contains("google-sub-1");
+            assertThat(user.emailVerified()).isTrue();
+            assertThat(user.displayName()).contains("拓真");
+            assertThat(user.password()).isEqualTo(User.NO_PASSWORD);
+            assertThat(user.characterType()).isEqualTo("cat");
+        }
+
+        @Test
+        @DisplayName("メール未確認の Google アカウントでは新規登録できない")
+        void registerRequiresVerifiedEmail() {
+            assertThatThrownBy(() -> User.registerFromGoogle("user-1", unverified()))
+                    .isInstanceOf(DomainException.Forbidden.class);
+        }
+
+        @Test
+        @DisplayName("既存アカウントに Google を紐付けると確認済みになる")
+        void linkGoogleToExisting() {
+            var user =
+                    User.reconstitute(
+                            "user-1", "user@example.com", "hashed", null, "cat", null, false);
+
+            user.linkGoogle(verified());
+
+            assertThat(user.googleId()).contains("google-sub-1");
+            assertThat(user.emailVerified()).isTrue();
+            assertThat(user.displayName()).contains("拓真");
+        }
+
+        @Test
+        @DisplayName("表示名が既にあれば Google の名前で上書きしない")
+        void existingDisplayNameIsKept() {
+            var user =
+                    User.reconstitute(
+                            "user-1", "user@example.com", "hashed", "自分の名前", "cat", null, false);
+
+            user.linkGoogle(verified());
+
+            assertThat(user.displayName()).contains("自分の名前");
+        }
+
+        @Test
+        @DisplayName("同じ Google アカウントの再紐付けは何度でも通る")
+        void relinkingSameAccountIsIdempotent() {
+            var user =
+                    User.reconstitute(
+                            "user-1", "user@example.com", "", null, "cat", "google-sub-1", true);
+
+            assertThatCode(() -> user.linkGoogle(verified())).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("別の Google アカウントの紐付けは拒否する")
+        void linkingDifferentAccountIsRejected() {
+            var user =
+                    User.reconstitute(
+                            "user-1", "user@example.com", "", null, "cat", "another-sub", true);
+
+            assertThatThrownBy(() -> user.linkGoogle(verified()))
+                    .isInstanceOf(DomainException.Conflict.class)
+                    .hasMessageContaining("別のGoogleアカウント");
+        }
+
+        @Test
+        @DisplayName("メール未確認の Google アカウントは紐付けられない")
+        void linkRequiresVerifiedEmail() {
+            var user =
+                    User.reconstitute(
+                            "user-1", "unverified@example.com", "h", null, "cat", null, false);
+
+            assertThatThrownBy(() -> user.linkGoogle(unverified()))
+                    .isInstanceOf(DomainException.Forbidden.class);
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/auth/infrastructure/HmacAccessTokenIssuerTest.java
+++ b/backend-java/src/test/java/app/healthfamily/auth/infrastructure/HmacAccessTokenIssuerTest.java
@@ -1,0 +1,89 @@
+package app.healthfamily.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.auth.domain.User;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.crypto.MACVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 発行したトークンが Go 版と同じ形になっていることを確かめる。
+ * 移行中は両バックエンドが同じトークンを検証できる必要がある。
+ */
+@DisplayName("アクセストークンの発行")
+class HmacAccessTokenIssuerTest {
+
+    private static final String SECRET = "0123456789abcdef0123456789abcdef";
+    private static final Instant NOW = Instant.parse("2026-08-15T12:00:00Z");
+
+    private static User user() {
+        return User.reconstitute("user-1", "user@example.com", "", "拓真", "cat", "sub-1", true);
+    }
+
+    @Test
+    @DisplayName("Go 版と同じクレーム（uid / email / sub）を持つ")
+    void claimsMatchGoFormat() throws Exception {
+        var token = new HmacAccessTokenIssuer(SECRET).issue(user(), NOW);
+
+        var jwt = SignedJWT.parse(token);
+        var claims = jwt.getJWTClaimsSet();
+
+        assertThat(jwt.getHeader().getAlgorithm()).isEqualTo(JWSAlgorithm.HS256);
+        assertThat(claims.getStringClaim("uid")).isEqualTo("user-1");
+        assertThat(claims.getStringClaim("email")).isEqualTo("user@example.com");
+        assertThat(claims.getSubject()).isEqualTo("user-1");
+    }
+
+    @Test
+    @DisplayName("有効期限は 7 日")
+    void expiresInSevenDays() throws Exception {
+        var token = new HmacAccessTokenIssuer(SECRET).issue(user(), NOW);
+
+        var claims = SignedJWT.parse(token).getJWTClaimsSet();
+
+        assertThat(claims.getIssueTime().toInstant()).isEqualTo(NOW);
+        assertThat(claims.getExpirationTime().toInstant())
+                .isEqualTo(NOW.plus(HmacAccessTokenIssuer.TTL));
+    }
+
+    @Test
+    @DisplayName("同じ鍵で署名が検証できる")
+    void signatureVerifies() throws Exception {
+        var token = new HmacAccessTokenIssuer(SECRET).issue(user(), NOW);
+
+        var verified =
+                SignedJWT.parse(token)
+                        .verify(new MACVerifier(SECRET.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(verified).isTrue();
+    }
+
+    @Test
+    @DisplayName("別の鍵では検証に失敗する")
+    void wrongSecretFails() throws Exception {
+        var token = new HmacAccessTokenIssuer(SECRET).issue(user(), NOW);
+
+        var verified =
+                SignedJWT.parse(token)
+                        .verify(
+                                new MACVerifier(
+                                        "fedcba9876543210fedcba9876543210"
+                                                .getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(verified).isFalse();
+    }
+
+    @Test
+    @DisplayName("短すぎる鍵は起動時に弾く")
+    void shortSecretIsRejected() {
+        assertThatThrownBy(() -> new HmacAccessTokenIssuer("too-short"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("32 バイト以上");
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/auth/web/AuthControllerIT.java
+++ b/backend-java/src/test/java/app/healthfamily/auth/web/AuthControllerIT.java
@@ -1,0 +1,162 @@
+package app.healthfamily.auth.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.healthfamily.TestcontainersConfiguration;
+import app.healthfamily.auth.domain.AuthorizationCodeGrant;
+import app.healthfamily.auth.domain.GoogleIdentity;
+import app.healthfamily.auth.domain.GoogleTokenExchanger;
+import app.healthfamily.shared.DomainException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+
+/**
+ * 認可コードグラントのコールバックと、API の認可設定を検証する。
+ *
+ * <p>Google との通信は差し替える。ここで確かめたいのは HTTP の境界であって、
+ * Google が正しく応答するかではない。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({TestcontainersConfiguration.class, AuthControllerIT.StubExchangerConfig.class})
+@DisplayName("認証エンドポイント")
+class AuthControllerIT {
+
+    private static final String VERIFIER = "v".repeat(43);
+
+    /** 交換結果を差し替える。テストごとに identity を書き換えて使う */
+    static class StubExchanger implements GoogleTokenExchanger {
+        GoogleIdentity identity;
+        RuntimeException failure;
+
+        @Override
+        public GoogleIdentity exchange(AuthorizationCodeGrant grant) {
+            if (failure != null) {
+                throw failure;
+            }
+            return identity;
+        }
+    }
+
+    @TestConfiguration
+    static class StubExchangerConfig {
+        @Bean
+        @Primary
+        StubExchanger stubExchanger() {
+            return new StubExchanger();
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired StubExchanger exchanger;
+    @Autowired JdbcClient jdbc;
+
+    @BeforeEach
+    void reset() {
+        jdbc.sql("TRUNCATE \"MedicationRecord\", \"Medication\", \"Member\", \"User\" CASCADE")
+                .update();
+        exchanger.failure = null;
+        exchanger.identity = new GoogleIdentity("sub-1", "new@example.com", true, "拓真");
+    }
+
+    private String body(String code, String verifier, String redirectUri) {
+        return """
+               {"code":"%s","codeVerifier":"%s","redirectUri":"%s"}
+               """.formatted(code, verifier, redirectUri);
+    }
+
+    @Test
+    @DisplayName("認可コードを渡すとトークンとユーザーが返る")
+    void callbackIssuesToken() throws Exception {
+        mockMvc.perform(
+                        post("/api/auth/google/callback")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body("code-1", VERIFIER, "https://app.example/callback")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.token").isNotEmpty())
+                .andExpect(jsonPath("$.data.user.email").value("new@example.com"))
+                .andExpect(jsonPath("$.data.user.emailVerified").value(true));
+
+        Long saved =
+                jdbc.sql("SELECT count(*) FROM \"User\" WHERE \"googleId\" = 'sub-1'")
+                        .query(Long.class)
+                        .single();
+        assertThat(saved).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("ログイン導線は認証なしで到達できる")
+    void callbackIsPublic() throws Exception {
+        mockMvc.perform(
+                        post("/api/auth/google/callback")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body("code-1", VERIFIER, "https://app.example/callback")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("code_verifier が短すぎると 400 を返す")
+    void shortVerifierIsRejected() throws Exception {
+        mockMvc.perform(
+                        post("/api/auth/google/callback")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body("code-1", "short", "https://app.example/callback")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    @DisplayName("メール未確認の Google アカウントは 403")
+    void unverifiedEmailIsForbidden() throws Exception {
+        exchanger.identity = new GoogleIdentity("sub-2", "unverified@example.com", false, null);
+
+        mockMvc.perform(
+                        post("/api/auth/google/callback")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body("code-1", VERIFIER, "https://app.example/callback")))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").value(
+                        org.hamcrest.Matchers.containsString("確認されていません")));
+    }
+
+    @Test
+    @DisplayName("トークン交換に失敗しても、内部の詳細は返さない")
+    void exchangeFailureIsOpaque() throws Exception {
+        exchanger.failure = DomainException.validation("Google認証に失敗しました");
+
+        mockMvc.perform(
+                        post("/api/auth/google/callback")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body("stolen-code", VERIFIER, "https://app.example/callback")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Google認証に失敗しました"));
+    }
+
+    @Test
+    @DisplayName("保護された API はトークン無しでは 401")
+    void protectedEndpointRequiresToken() throws Exception {
+        mockMvc.perform(get("/api/medications")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("ヘルスチェックは認証不要")
+    void healthIsPublic() throws Exception {
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/medication/application/TakeMedicationUseCaseIT.java
+++ b/backend-java/src/test/java/app/healthfamily/medication/application/TakeMedicationUseCaseIT.java
@@ -19,11 +19,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * 実際の PostgreSQL に対して「服用の記録」を通す統合テスト。
@@ -34,25 +29,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * 起きないことを検証する。
  */
 @SpringBootTest
-@Testcontainers
-@Import(TakeMedicationUseCaseIT.FixedClockConfig.class)
+@Import({app.healthfamily.TestcontainersConfiguration.class, TakeMedicationUseCaseIT.FixedClockConfig.class})
 @DisplayName("服用の記録（実DB）")
 class TakeMedicationUseCaseIT {
 
     private static final Instant NOW = Instant.parse("2026-08-15T12:00:00Z");
-
-    @Container
-    @SuppressWarnings("resource")
-    static PostgreSQLContainer<?> postgres =
-            new PostgreSQLContainer<>("postgres:17")
-                    .withInitScript("db/medication-schema.sql");
-
-    @DynamicPropertySource
-    static void datasource(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-    }
 
     /**
      * ユースケースが参照する時刻を固定する。

--- a/backend-java/src/test/resources/application.properties
+++ b/backend-java/src/test/resources/application.properties
@@ -1,0 +1,11 @@
+# テスト用の設定。実際の秘密は含めない。
+# 32 バイト以上でないと HS256 の鍵として拒否される
+healthfamily.jwt.secret=test-secret-for-unit-tests-0123456789
+
+healthfamily.google-oidc.client-id=test-client-id.apps.googleusercontent.com
+healthfamily.google-oidc.client-secret=test-client-secret
+
+# DB 接続は Testcontainers が @ServiceConnection 経由で上書きする
+spring.datasource.url=
+spring.datasource.username=
+spring.datasource.password=


### PR DESCRIPTION
## Summary

従来の Google Identity Services は **ID トークンをブラウザへ直接渡す**方式で、実質インプリシットに近い。認可コードグラント + PKCE へ移した。

### フローの違い

| | 従来 (GSI) | 本 PR |
|---|---|---|
| ブラウザが受け取るもの | **ID トークン本体** | **認可コードのみ** |
| トークン交換 | 無し | **サーバー間通信** |
| client_secret | 使わない | バックエンドのみが保持 |
| PKCE | 無し | **必須** |

- PKCE の `code_verifier` を値オブジェクトで必須化（43〜128 文字・使用可能文字を強制、RFC 7636）
- ID トークンは JWKS で署名を検証し、**iss / aud / exp をすべて確認**する
- 自アプリのアクセストークンは HS256 で発行。クレーム（`uid` / `email` / `sub`）と有効期限 7 日を **Go 版と一致**させ、移行中は双方で検証できるようにした
- アカウント解決は `googleId` → メール → 新規作成 の順（Go 版と同じ）。メール未確認の Google アカウントでは紐付けも作成もしない
- **既に別の Google アカウントが紐付いたメールへの紐付けを拒否**する（Go 版には無かった。同一メールを名乗る乗っ取りを防ぐ）
- Spring Security をステートレス JWT 構成で導入。ログイン導線とヘルスチェック以外は認証必須
- ドメイン例外 → HTTP の対応と `{ success, data, error }` 形式を Go 版に合わせた
- Testcontainers 設定を `@ServiceConnection` で共有化

テスト **79件** すべて通過。フロントは Go 版に接続したままなので、本番の動作には影響しない。

## 未対応

フロントの認可リクエスト側（`code_challenge` 生成・リダイレクト・コールバック画面）は、Go から Java へ切り替えるタイミングで実装する。今変えると本番が壊れるため。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Google OAuthによるログインに対応しました。
  * 初回ログイン時のユーザー登録と、既存アカウントへのGoogle連携に対応しました。
  * ログイン後にアプリ専用アクセストークンを発行します。
  * APIのJWT認証と、認証コールバック用エンドポイントを追加しました。
  * ヘルスチェックを認証なしで利用できます。

* **セキュリティ**
  * PKCE、メール確認状態、トークンの署名・発行者・有効期限を検証します。
  * 認証エラーや入力エラーを適切なHTTPステータスで返します。

* **テスト**
  * Googleログイン、認証、エラー処理の統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->