### PR TITLE
feat(backend-java): 薬のRESTエンドポイントを追加し、残数判定をサーバーへ移す

### DIFF
--- a/backend-java/src/main/java/app/healthfamily/medication/application/ListMedicationsUseCase.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/application/ListMedicationsUseCase.java
@@ -1,0 +1,70 @@
+package app.healthfamily.medication.application;
+
+import app.healthfamily.medication.domain.Medication;
+import app.healthfamily.medication.domain.MedicationRepository;
+import app.healthfamily.shared.AppZone;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 薬の一覧と残数アラートを返すユースケース。
+ *
+ * <p>残数が少ないかどうかの判定は、これまでフロントの
+ * MemberMedications.tsx の中で行われていた。判定に使う「今日」が
+ * 端末の時計とタイムゾーンに依存していたため、サーバー側へ引き上げる。
+ */
+@Service
+public class ListMedicationsUseCase {
+
+    private final MedicationRepository medications;
+    private final AppZone zone;
+
+    public ListMedicationsUseCase(MedicationRepository medications, AppZone zone) {
+        this.medications = medications;
+        this.zone = zone;
+    }
+
+    @Transactional(readOnly = true)
+    public List<View> listAll(String userId) {
+        LocalDate today = zone.today();
+        return medications.listByUser(userId).stream().map(m -> View.of(m, today)).toList();
+    }
+
+    /** 残数が少ないものだけを返す。 */
+    @Transactional(readOnly = true)
+    public List<View> listLowStock(String userId) {
+        return listAll(userId).stream().filter(View::lowStock).toList();
+    }
+
+    /**
+     * 一覧表示に必要なだけの読み取り用の形。
+     *
+     * <p>集約そのものを外へ出さない。JSON の都合でドメインが歪むのを避けるため。
+     */
+    public record View(
+            String id,
+            String memberId,
+            String name,
+            String category,
+            String status,
+            Integer stockQuantity,
+            Integer intervalHours,
+            String dosageAmount,
+            boolean lowStock) {
+
+        static View of(Medication m, LocalDate today) {
+            return new View(
+                    m.id(),
+                    m.memberId(),
+                    m.name(),
+                    m.category().code(),
+                    m.status().code(),
+                    m.stock().map(s -> s.value()).orElse(null),
+                    m.interval().map(i -> i.hours()).orElse(null),
+                    m.dosageAmount().orElse(null),
+                    m.isLowStock(today));
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/domain/MedicationRepository.java
@@ -1,5 +1,6 @@
 package app.healthfamily.medication.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -11,6 +12,9 @@ import java.util.Optional;
 public interface MedicationRepository {
 
     Optional<Medication> findById(String medicationId);
+
+    /** 所有ユーザーの薬をすべて返す。 */
+    List<Medication> listByUser(String userId);
 
     /** 集約の現在の状態を書き戻す。 */
     void save(Medication medication);

--- a/backend-java/src/main/java/app/healthfamily/medication/infrastructure/JdbcMedicationRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/infrastructure/JdbcMedicationRepository.java
@@ -31,6 +31,15 @@ public class JdbcMedicationRepository implements MedicationRepository {
              WHERE id = :id
             """;
 
+    private static final String SELECT_BY_USER =
+            """
+            SELECT id, "memberId", "userId", name, category, "dosageAmount",
+                   "stockQuantity", "stockAlertDate", "intervalHours", status
+              FROM "Medication"
+             WHERE "userId" = :userId
+             ORDER BY "displayOrder", "createdAt"
+            """;
+
     private static final String UPDATE_STOCK =
             """
             UPDATE "Medication"
@@ -51,6 +60,14 @@ public class JdbcMedicationRepository implements MedicationRepository {
                 .param("id", medicationId)
                 .query(JdbcMedicationRepository::toAggregate)
                 .optional();
+    }
+
+    @Override
+    public java.util.List<Medication> listByUser(String userId) {
+        return jdbc.sql(SELECT_BY_USER)
+                .param("userId", userId)
+                .query(JdbcMedicationRepository::toAggregate)
+                .list();
     }
 
     @Override

--- a/backend-java/src/main/java/app/healthfamily/medication/web/MedicationController.java
+++ b/backend-java/src/main/java/app/healthfamily/medication/web/MedicationController.java
@@ -1,0 +1,88 @@
+package app.healthfamily.medication.web;
+
+import app.healthfamily.medication.application.ListMedicationsUseCase;
+import app.healthfamily.medication.application.TakeMedicationUseCase;
+import app.healthfamily.medication.domain.MedicationRecord;
+import app.healthfamily.shared.web.ApiResponse;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 薬のエンドポイント。
+ *
+ * <p>ユーザーIDは検証済みトークンの sub から取る。リクエストボディで受け取ると
+ * 他人のIDを名乗れてしまうため、body にも path にも含めない。
+ */
+@RestController
+@RequestMapping("/api/medications")
+public class MedicationController {
+
+    private final TakeMedicationUseCase takeMedication;
+    private final ListMedicationsUseCase listMedications;
+
+    public MedicationController(
+            TakeMedicationUseCase takeMedication, ListMedicationsUseCase listMedications) {
+        this.takeMedication = takeMedication;
+        this.listMedications = listMedications;
+    }
+
+    @GetMapping
+    public ApiResponse<List<ListMedicationsUseCase.View>> list(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(listMedications.listAll(jwt.getSubject()));
+    }
+
+    /** 残数が少ない薬。判定はサーバー側で行う。 */
+    @GetMapping("/alerts")
+    public ApiResponse<List<ListMedicationsUseCase.View>> alerts(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(listMedications.listLowStock(jwt.getSubject()));
+    }
+
+    /**
+     * 1 回ぶん服用したことを記録する。
+     *
+     * <p>残数の減算・服用間隔の確認・記録の作成が 1 トランザクションで行われる。
+     * 集約が拒否した場合は 409 を返し、何も書き込まれない。
+     */
+    @PostMapping("/{medicationId}/take")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<RecordResponse> take(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String medicationId,
+            @RequestBody(required = false) TakeRequest request) {
+        var record =
+                takeMedication.execute(
+                        new TakeMedicationUseCase.Command(
+                                jwt.getSubject(),
+                                medicationId,
+                                request == null ? null : request.notes()));
+        return ApiResponse.ok(RecordResponse.of(record));
+    }
+
+    /** @param notes 任意のメモ。「頭痛のため」など */
+    public record TakeRequest(@Size(max = 500) String notes) {}
+
+    public record RecordResponse(
+            String id,
+            String medicationId,
+            String memberId,
+            Instant takenAt,
+            String dosageAmount,
+            String notes) {
+
+        static RecordResponse of(MedicationRecord r) {
+            return new RecordResponse(
+                    r.id(), r.medicationId(), r.memberId(), r.takenAt(), r.dosageAmount(), r.notes());
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/shared/AppZone.java
+++ b/backend-java/src/main/java/app/healthfamily/shared/AppZone.java
@@ -1,0 +1,35 @@
+package app.healthfamily.shared;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.springframework.stereotype.Component;
+
+/**
+ * アプリケーションの基準タイムゾーン。
+ *
+ * <p>「今日」の境界は利用者の生活時間で決まる。服薬アラートや通院リマインダーは
+ * 日付単位で判断するため、UTC のまま扱うと 9 時間ずれる。
+ *
+ * <p>フロントの computeIsLowStock は端末の時計とタイムゾーンに依存していた。
+ * サーバー側では基準を 1 箇所に固定する。
+ */
+@Component
+public class AppZone {
+
+    private static final ZoneId TOKYO = ZoneId.of("Asia/Tokyo");
+
+    private final Clock clock;
+
+    public AppZone(Clock clock) {
+        this.clock = clock;
+    }
+
+    public LocalDate today() {
+        return LocalDate.now(clock.withZone(TOKYO));
+    }
+
+    public ZoneId zoneId() {
+        return TOKYO;
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/medication/web/MedicationControllerIT.java
+++ b/backend-java/src/test/java/app/healthfamily/medication/web/MedicationControllerIT.java
@@ -1,0 +1,266 @@
+package app.healthfamily.medication.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.healthfamily.TestcontainersConfiguration;
+import app.healthfamily.auth.domain.AccessTokenIssuer;
+import app.healthfamily.auth.domain.User;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 薬エンドポイントを、実 DB と実トークンで通す。
+ *
+ * <p>認証はモックせず、{@link AccessTokenIssuer} が発行した本物のトークンを
+ * Authorization ヘッダに載せる。認可設定まで含めて検証したいため。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({TestcontainersConfiguration.class, MedicationControllerIT.FixedClockConfig.class})
+@DisplayName("薬エンドポイント（実DB）")
+class MedicationControllerIT {
+
+    /** 2026-08-16 12:00 UTC = JST では 8/16 の 21:00。「今日」は 8/16 になる */
+    private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired JdbcClient jdbc;
+    @Autowired AccessTokenIssuer tokens;
+
+    private String bearer;
+
+    @BeforeEach
+    void setUp() {
+        jdbc.sql("TRUNCATE \"MedicationRecord\", \"Medication\", \"Member\", \"User\" CASCADE")
+                .update();
+        jdbc.sql(
+                        """
+                        INSERT INTO "User" (id, email, password, "displayName", "updatedAt")
+                        VALUES ('user-1', 'owner@example.test', '', '所有者', now()),
+                               ('user-2', 'other@example.test', '', '別人',   now())
+                        """)
+                .update();
+        jdbc.sql(
+                        """
+                        INSERT INTO "Member" (id, "userId", name, "memberType", "updatedAt")
+                        VALUES ('member-1', 'user-1', '本人', 'human', now())
+                        """)
+                .update();
+
+        var user = User.reconstitute("user-1", "owner@example.test", "", "所有者", "cat", null, true);
+        bearer = "Bearer " + tokens.issue(user, NOW);
+    }
+
+    private void insertMedication(
+            String id,
+            String category,
+            String status,
+            Integer stock,
+            Integer intervalHours,
+            LocalDate alertDate) {
+        jdbc.sql(
+                        """
+                        INSERT INTO "Medication"
+                               (id, "memberId", "userId", name, category, status,
+                                "stockQuantity", "intervalHours", "stockAlertDate",
+                                "dosageAmount", "updatedAt")
+                        VALUES (:id, 'member-1', 'user-1', :name, :category, :status,
+                                :stock, :interval, :alertDate, '1錠', now())
+                        """)
+                .param("id", id)
+                .param("name", "薬-" + id)
+                .param("category", category)
+                .param("status", status)
+                .param("stock", stock)
+                .param("interval", intervalHours)
+                .param(
+                        "alertDate",
+                        alertDate == null
+                                ? null
+                                : OffsetDateTime.of(alertDate.atStartOfDay(), ZoneOffset.UTC))
+                .update();
+    }
+
+    private Integer stockOf(String id) {
+        return jdbc.sql("SELECT \"stockQuantity\" FROM \"Medication\" WHERE id = :id")
+                .param("id", id)
+                .query(Integer.class)
+                .optional()
+                .orElse(null);
+    }
+
+    // --- 服用の記録 ---------------------------------------------------------
+
+    @Test
+    @DisplayName("服用を記録すると 201 が返り、残数が減る")
+    void takeReturnsCreated() throws Exception {
+        insertMedication("med-1", "prn", "active", 10, 4, null);
+
+        mockMvc.perform(
+                        post("/api/medications/med-1/take")
+                                .header(HttpHeaders.AUTHORIZATION, bearer)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"notes\":\"頭痛のため\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.medicationId").value("med-1"))
+                .andExpect(jsonPath("$.data.notes").value("頭痛のため"))
+                .andExpect(jsonPath("$.data.dosageAmount").value("1錠"));
+
+        assertThat(stockOf("med-1")).isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("ボディ無しでも服用を記録できる")
+    void takeWithoutBody() throws Exception {
+        insertMedication("med-2", "regular", "active", 5, null, null);
+
+        mockMvc.perform(
+                        post("/api/medications/med-2/take")
+                                .header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isCreated());
+
+        assertThat(stockOf("med-2")).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("服用間隔が空いていなければ 409 を返し、何も書き込まれない")
+    void intervalViolationReturnsConflict() throws Exception {
+        insertMedication("med-3", "prn", "active", 10, 4, null);
+        jdbc.sql(
+                        """
+                        INSERT INTO "MedicationRecord"
+                               (id, "medicationId", "memberId", "userId", "takenAt")
+                        VALUES ('rec-1', 'med-3', 'member-1', 'user-1', :at)
+                        """)
+                .param("at", OffsetDateTime.ofInstant(NOW.minus(Duration.ofHours(1)), ZoneOffset.UTC))
+                .update();
+
+        mockMvc.perform(
+                        post("/api/medications/med-3/take")
+                                .header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error").value(
+                        org.hamcrest.Matchers.containsString("4 時間")));
+
+        assertThat(stockOf("med-3")).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("休薬中の薬は 409")
+    void pausedReturnsConflict() throws Exception {
+        insertMedication("med-4", "prn", "paused", 10, null, null);
+
+        mockMvc.perform(
+                        post("/api/medications/med-4/take")
+                                .header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("存在しない薬は 404")
+    void unknownReturnsNotFound() throws Exception {
+        mockMvc.perform(
+                        post("/api/medications/missing/take")
+                                .header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("トークン無しでは 401")
+    void withoutTokenIsUnauthorized() throws Exception {
+        insertMedication("med-5", "prn", "active", 10, null, null);
+
+        mockMvc.perform(post("/api/medications/med-5/take")).andExpect(status().isUnauthorized());
+
+        assertThat(stockOf("med-5")).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("他人のトークンでは 403 で、残数も変わらない")
+    void otherUsersTokenIsForbidden() throws Exception {
+        insertMedication("med-6", "prn", "active", 10, null, null);
+        var other = User.reconstitute("user-2", "other@example.test", "", null, "cat", null, true);
+
+        mockMvc.perform(
+                        post("/api/medications/med-6/take")
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.issue(other, NOW)))
+                .andExpect(status().isForbidden());
+
+        assertThat(stockOf("med-6")).isEqualTo(10);
+    }
+
+    // --- 一覧と残数アラート --------------------------------------------------
+
+    @Test
+    @DisplayName("一覧は自分の薬だけを返す")
+    void listReturnsOwnMedications() throws Exception {
+        insertMedication("med-7", "prn", "active", 10, null, null);
+        insertMedication("med-8", "regular", "active", 3, null, null);
+
+        mockMvc.perform(get("/api/medications").header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("残数アラートはサーバー側で判定される")
+    void alertsAreComputedOnServer() throws Exception {
+        // アラート日まで 10 日 / 残数 3 → 少ない
+        insertMedication("low", "regular", "active", 3, null, LocalDate.of(2026, 8, 26));
+        // アラート日まで 10 日 / 残数 30 → 足りている
+        insertMedication("enough", "regular", "active", 30, null, LocalDate.of(2026, 8, 26));
+        // アラート日が過ぎている → 対象外
+        insertMedication("past", "regular", "active", 1, null, LocalDate.of(2026, 8, 1));
+        // 残数を管理していない → 対象外
+        insertMedication("untracked", "regular", "active", null, null, LocalDate.of(2026, 8, 26));
+
+        mockMvc.perform(get("/api/medications/alerts").header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value("low"))
+                .andExpect(jsonPath("$.data[0].lowStock").value(true));
+    }
+
+    @Test
+    @DisplayName("一覧にも lowStock が付く")
+    void listIncludesLowStockFlag() throws Exception {
+        insertMedication("med-9", "regular", "active", 3, null, LocalDate.of(2026, 8, 26));
+
+        mockMvc.perform(get("/api/medications").header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].lowStock").value(true));
+    }
+}


### PR DESCRIPTION
## Summary

- **`POST /api/medications/{id}/take`** — 残数の減算・服用間隔の確認・記録の作成が 1 トランザクションで走る。集約が拒否したときは 409 を返し、**何も書き込まれない**
- **`GET /api/medications`** / **`GET /api/medications/alerts`** — 残数が少ないかの判定を**サーバー側**で行う
  - これまでフロントの `MemberMedications.tsx` の `computeIsLowStock` にあり、判定に使う「今日」が**端末の時計とタイムゾーンに依存**していた
- `AppZone` を追加し、「今日」の基準を `Asia/Tokyo` に固定
- ユーザーIDは**検証済みトークンの sub** から取る。body にも path にも含めないので、他人のIDを名乗れない

## 検証

統合テスト 10 件を追加。認証はモックせず、`AccessTokenIssuer` が発行した**本物のトークン**を Authorization ヘッダに載せて、認可設定まで含めて通している。

| ケース | 期待 |
|---|---|
| 服用の記録 | 201 / 残数 10 → 9 |
| 服用間隔が空いていない | **409 / 残数は 10 のまま** |
| 休薬中 | 409 |
| 存在しない薬 | 404 |
| トークン無し | **401 / 残数は変化なし** |
| 他人のトークン | **403 / 残数は変化なし** |
| 残数アラート | 4 件中「残り日数 > 残数」の 1 件だけが返る |

テスト **89件** すべて通過。フロントは Go 版に接続したままなので、本番の動作には影響しない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 登録済みの薬一覧を確認できるようになりました。
  - 残量が少ない薬をアラート一覧で確認できます。
  - 薬の服用記録を作成でき、メモも追加できます。
  - 服用間隔や休薬中などの条件を考慮して記録を管理します。
  - 残量アラートは日本時間の日付に基づいて判定されます。

- **テスト**
  - 認証、薬一覧、残量判定、服用記録、在庫変動などの動作を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->