### PR TITLE
fix(e2e): 「ホーム」リンクの曖昧なロケータを解消する

### DIFF
--- a/frontend/e2e/authed.spec.ts
+++ b/frontend/e2e/authed.spec.ts
@@ -41,8 +41,12 @@ test.describe("認証付きフロー", () => {
   test("ログイン済みならホーム(ダッシュボード)が表示される", async ({ page }) => {
     await page.goto("/");
     await expect(page).toHaveURL(/\/$/);
-    // _authed レイアウトのナビ（サイドバー）が出る
-    await expect(page.getByRole("link", { name: "ホーム" })).toBeVisible();
+    // 認証済みレイアウトのナビが出る。
+    // 「ホーム」リンクは PC のサイドバーとスマホの下部タブの両方に存在するため、
+    // どちらを見ているかを明示しないと strict mode 違反になる。
+    await expect(
+      page.getByRole("complementary").getByRole("link", { name: "ホーム" }),
+    ).toBeVisible();
     await expect(page.getByRole("button", { name: "ログアウト" })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

- サイドバーと下部タブの両方に「ホーム」リンクがあり、`getByRole` の **strict mode 違反**で認証付きフローのテストが落ちていた
- どちらを検証しているのかをロケータで明示（`getByRole("complementary")` でサイドバーに限定）

E2E ワークフローは **2026-08-15 から main で失敗し続けていた**。PR をブロックしない設定（`push: [main]` と手動実行のみ）のため気づかれにくくなっていた。

これで **11 件すべて成功**する。認証前フローのリダイレクト検証を含むテストなので、緑に戻しておく価値が高い。