### PR TITLE
feat(backend-java): 医療費控除・予算・所有権・健康記録のドメインを TDD で追加する

### DIFF
--- a/backend-java/src/main/java/app/healthfamily/domain/expense/Budget.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/expense/Budget.java
@@ -1,0 +1,132 @@
+package app.healthfamily.domain.expense;
+
+import app.healthfamily.domain.shared.DomainException;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 医療費の予算とアラートの集約ルート。
+ *
+ * <p>「超過しているか」と「通知してよいか」は別の判断。超過していても同じ月に
+ * 通知済みなら黙る。毎回通知すると利用者が通知そのものを無視するようになるため。
+ */
+public class Budget {
+
+    private static final DateTimeFormatter MONTH = DateTimeFormatter.ofPattern("yyyy-MM");
+
+    private final String id;
+    private final String userId;
+    private final int monthlyAmount;
+    private final boolean alertEnabled;
+    private final String lastAlertedMonth;
+    private final Map<String, Integer> categoryBudgets;
+
+    private Budget(
+            String id,
+            String userId,
+            int monthlyAmount,
+            boolean alertEnabled,
+            String lastAlertedMonth,
+            Map<String, Integer> categoryBudgets) {
+        if (userId == null || userId.isBlank()) {
+            throw DomainException.validation("所有ユーザーは必須です");
+        }
+        if (monthlyAmount < 0) {
+            throw DomainException.validation("月予算に負の値は指定できません");
+        }
+        Map<String, Integer> categories = categoryBudgets == null ? Map.of() : Map.copyOf(categoryBudgets);
+        categories.forEach(
+                (category, amount) -> {
+                    if (amount == null || amount < 0) {
+                        throw DomainException.validation(
+                                "カテゴリ予算に負の値は指定できません: " + category);
+                    }
+                });
+        this.id = id;
+        this.userId = userId;
+        this.monthlyAmount = monthlyAmount;
+        this.alertEnabled = alertEnabled;
+        this.lastAlertedMonth = lastAlertedMonth;
+        this.categoryBudgets = categories;
+    }
+
+    public static Budget reconstitute(
+            String id,
+            String userId,
+            int monthlyAmount,
+            boolean alertEnabled,
+            String lastAlertedMonth,
+            Map<String, Integer> categoryBudgets) {
+        return new Budget(id, userId, monthlyAmount, alertEnabled, lastAlertedMonth, categoryBudgets);
+    }
+
+    // --- 振る舞い ---------------------------------------------------------
+
+    /**
+     * その月の支出を予算と突き合わせる。
+     *
+     * @param month 対象月
+     * @param monthTotal その月の支出合計
+     * @param categoryTotals カテゴリ別の支出合計
+     */
+    public Status evaluate(YearMonth month, int monthTotal, Map<String, Integer> categoryTotals) {
+        boolean overBudget = monthlyAmount > 0 && monthTotal > monthlyAmount;
+
+        List<String> overCategories =
+                categoryBudgets.entrySet().stream()
+                        .filter(e -> e.getValue() > 0)
+                        .filter(e -> categoryTotals.getOrDefault(e.getKey(), 0) > e.getValue())
+                        .map(Map.Entry::getKey)
+                        .sorted()
+                        .toList();
+
+        boolean exceeded = overBudget || !overCategories.isEmpty();
+        boolean alreadyAlerted = month.format(MONTH).equals(lastAlertedMonth);
+        boolean shouldNotify = exceeded && alertEnabled && !alreadyAlerted;
+
+        return new Status(overBudget, overCategories, monthTotal, monthlyAmount, shouldNotify);
+    }
+
+    // --- 参照 -------------------------------------------------------------
+
+    public String id() {
+        return id;
+    }
+
+    public String userId() {
+        return userId;
+    }
+
+    public int monthlyAmount() {
+        return monthlyAmount;
+    }
+
+    public boolean alertEnabled() {
+        return alertEnabled;
+    }
+
+    public Optional<String> lastAlertedMonth() {
+        return Optional.ofNullable(lastAlertedMonth);
+    }
+
+    public Map<String, Integer> categoryBudgets() {
+        return categoryBudgets;
+    }
+
+    /**
+     * 突き合わせの結果。
+     *
+     * @param overBudget 月予算を超えているか
+     * @param overCategories 予算を超えているカテゴリ
+     * @param shouldNotify 通知してよいか。超過していても同じ月に通知済みなら false
+     */
+    public record Status(
+            boolean overBudget,
+            List<String> overCategories,
+            int monthTotal,
+            int monthlyAmount,
+            boolean shouldNotify) {}
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/expense/DeductionScheme.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/expense/DeductionScheme.java
@@ -1,0 +1,26 @@
+package app.healthfamily.domain.expense;
+
+/**
+ * 医療費控除の制度。
+ *
+ * <p>通常の医療費控除とセルフメディケーション税制は<b>併用できない</b>ため、
+ * どちらか一方を選ぶことになる。
+ */
+public enum DeductionScheme {
+    /** 控除を受けられる見込みが無い */
+    NONE("none"),
+    /** 通常の医療費控除 */
+    REGULAR("regular"),
+    /** セルフメディケーション税制 */
+    SELF_MEDICATION("selfmed");
+
+    private final String code;
+
+    DeductionScheme(String code) {
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/expense/MedicalDeduction.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/expense/MedicalDeduction.java
@@ -1,0 +1,51 @@
+package app.healthfamily.domain.expense;
+
+import app.healthfamily.domain.shared.DomainException;
+
+/**
+ * 医療費控除の試算結果。
+ *
+ * <p>2 つの制度は併用できないので、両方の控除額を出したうえで有利なほうを示す。
+ *
+ * <p>あくまで概算であり、申告額を保証するものではない。通常の医療費控除の足切りは
+ * 本来「10万円か所得の5%の低いほう」だが、所得を扱っていないため 10万円で固定している。
+ *
+ * @param regularDeduction 通常の医療費控除の対象額
+ * @param selfMedicationDeduction セルフメディケーション税制の対象額
+ * @param recommended 有利なほうの制度
+ */
+public record MedicalDeduction(
+        int regularDeduction, int selfMedicationDeduction, DeductionScheme recommended) {
+
+    /** 通常の医療費控除の足切り */
+    private static final int REGULAR_THRESHOLD = 100_000;
+
+    /** セルフメディケーション税制の足切り */
+    private static final int SELF_MEDICATION_FLOOR = 12_000;
+
+    /** セルフメディケーション税制の上限 */
+    private static final int SELF_MEDICATION_CAP = 88_000;
+
+    /**
+     * @param deductibleTotal 控除対象として記録された医療費の合計
+     * @param pharmacyTotal 薬局(OTC)での購入額。セルフメディケーション税制の概算に使う
+     */
+    public static MedicalDeduction simulate(int deductibleTotal, int pharmacyTotal) {
+        if (deductibleTotal < 0 || pharmacyTotal < 0) {
+            throw DomainException.validation("金額に負の値は指定できません");
+        }
+        int regular = Math.max(0, deductibleTotal - REGULAR_THRESHOLD);
+        int selfMedication =
+                Math.min(SELF_MEDICATION_CAP, Math.max(0, pharmacyTotal - SELF_MEDICATION_FLOOR));
+
+        DeductionScheme recommended;
+        if (regular == 0 && selfMedication == 0) {
+            recommended = DeductionScheme.NONE;
+        } else if (regular >= selfMedication) {
+            recommended = DeductionScheme.REGULAR;
+        } else {
+            recommended = DeductionScheme.SELF_MEDICATION;
+        }
+        return new MedicalDeduction(regular, selfMedication, recommended);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/BodyMeasurement.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/BodyMeasurement.java
@@ -1,0 +1,51 @@
+package app.healthfamily.domain.healthrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import java.util.Optional;
+
+/**
+ * 体重と身長の記録。
+ *
+ * <p>どちらか一方だけの記録もありうる（体重だけ毎日測る等）が、両方無い記録は意味がない。
+ *
+ * @param weightKg 体重(kg)。未測定なら null
+ * @param heightCm 身長(cm)。未測定なら null
+ */
+public record BodyMeasurement(Double weightKg, Double heightCm) {
+
+    private static final double MAX_WEIGHT_KG = 1000.0;
+    private static final double MAX_HEIGHT_CM = 300.0;
+
+    public BodyMeasurement {
+        if (weightKg == null && heightCm == null) {
+            throw DomainException.validation("体重か身長のどちらかは入力してください");
+        }
+        if (weightKg != null && (weightKg <= 0 || weightKg > MAX_WEIGHT_KG)) {
+            throw DomainException.validation("体重の値が正しくありません");
+        }
+        if (heightCm != null && (heightCm <= 0 || heightCm > MAX_HEIGHT_CM)) {
+            throw DomainException.validation("身長の値が正しくありません");
+        }
+    }
+
+    public static BodyMeasurement of(Double weightKg, Double heightCm) {
+        return new BodyMeasurement(weightKg, heightCm);
+    }
+
+    /** BMI。両方そろっているときだけ算出する。小数第1位に丸める。 */
+    public Optional<Double> bmi() {
+        if (weightKg == null || heightCm == null) {
+            return Optional.empty();
+        }
+        double meters = heightCm / 100.0;
+        return Optional.of(Math.round(weightKg / (meters * meters) * 10.0) / 10.0);
+    }
+
+    public Optional<Double> weight() {
+        return Optional.ofNullable(weightKg);
+    }
+
+    public Optional<Double> height() {
+        return Optional.ofNullable(heightCm);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/BodyTemperature.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/BodyTemperature.java
@@ -1,0 +1,44 @@
+package app.healthfamily.domain.healthrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+
+/**
+ * 体温。
+ *
+ * <p>人体としてありえない値をコンストラクタで弾く。入力ミス（36.5 のつもりで 365）が
+ * そのまま記録され、後から見返したときにグラフが壊れるのを防ぐ。
+ */
+public record BodyTemperature(double value) {
+
+    /** 生存しうる下限。これを下回る記録は入力ミスとみなす */
+    private static final double MIN = 30.0;
+
+    /** 生存しうる上限 */
+    private static final double MAX = 45.0;
+
+    public BodyTemperature {
+        if (Double.isNaN(value) || value < MIN || value > MAX) {
+            throw DomainException.validation(
+                    "体温は %.1f〜%.1f 度の範囲で入力してください".formatted(MIN, MAX));
+        }
+        // 測定器の精度以上の桁は持たない
+        value = Math.round(value * 10.0) / 10.0;
+    }
+
+    public static BodyTemperature of(double value) {
+        return new BodyTemperature(value);
+    }
+
+    public FeverLevel level() {
+        if (value >= 38.0) {
+            return FeverLevel.FEVER;
+        }
+        if (value >= 37.5) {
+            return FeverLevel.SLIGHT_FEVER;
+        }
+        if (value >= 36.0) {
+            return FeverLevel.NORMAL;
+        }
+        return FeverLevel.LOW;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/FeverLevel.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/FeverLevel.java
@@ -1,0 +1,18 @@
+package app.healthfamily.domain.healthrecord;
+
+/**
+ * 発熱の段階。
+ *
+ * <p>診断ではなく、記録を見返すときの目印として使う。
+ * 受診の要否を判断するものではない。
+ */
+public enum FeverLevel {
+    /** 36.0 度未満 */
+    LOW,
+    /** 36.0 度以上 37.5 度未満 */
+    NORMAL,
+    /** 37.5 度以上 38.0 度未満 */
+    SLIGHT_FEVER,
+    /** 38.0 度以上 */
+    FEVER
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/VaccinationSchedule.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/VaccinationSchedule.java
@@ -1,0 +1,49 @@
+package app.healthfamily.domain.healthrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+/**
+ * ワクチンの接種日と次回予定。
+ *
+ * <p>次回接種のリマインダーは 1 週間前から出す。予定日を過ぎても止めない。
+ * 打ち忘れたまま通知が消えると、気づく機会がなくなるため。
+ *
+ * @param vaccinatedAt 接種日
+ * @param nextScheduledDate 次回予定日。未設定なら null
+ */
+public record VaccinationSchedule(LocalDate vaccinatedAt, LocalDate nextScheduledDate) {
+
+    /** この日数前から通知する */
+    private static final long REMINDER_DAYS = 7;
+
+    public VaccinationSchedule {
+        if (vaccinatedAt != null
+                && nextScheduledDate != null
+                && nextScheduledDate.isBefore(vaccinatedAt)) {
+            throw DomainException.validation("次回接種日は接種日より後の日付にしてください");
+        }
+    }
+
+    public static VaccinationSchedule of(LocalDate vaccinatedAt, LocalDate nextScheduledDate) {
+        return new VaccinationSchedule(vaccinatedAt, nextScheduledDate);
+    }
+
+    /** 次回予定日までの日数。過ぎていれば負になる。 */
+    public Optional<Long> daysUntilNext(LocalDate today) {
+        return Optional.ofNullable(nextScheduledDate)
+                .map(next -> ChronoUnit.DAYS.between(today, next));
+    }
+
+    /** 通知すべきか。1週間前から、過ぎたあとも出し続ける。 */
+    public boolean needsReminderOn(LocalDate today) {
+        return daysUntilNext(today).map(days -> days <= REMINDER_DAYS).orElse(false);
+    }
+
+    /** 予定日を過ぎているか。 */
+    public boolean isOverdueOn(LocalDate today) {
+        return daysUntilNext(today).map(days -> days < 0).orElse(false);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/medication/Medication.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/medication/Medication.java
@@ -1,6 +1,7 @@
 package app.healthfamily.domain.medication;
 
 import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -15,7 +16,7 @@ import java.util.Optional;
  *
  * <p>状態を変えられるのはこのクラスのメソッド経由だけで、setter は公開しない。
  */
-public class Medication {
+public class Medication implements OwnedResource {
 
     private final String id;
     private final String userId;
@@ -133,16 +134,15 @@ public class Medication {
         return stock.isBelow(daysUntilAlert);
     }
 
-    /** 指定ユーザーの所有物か。 */
-    public boolean ownedBy(String candidateUserId) {
-        return userId.equals(candidateUserId);
+    /** 所有者でなければ例外を投げる。 */
+    @Override
+    public String ownerId() {
+        return userId;
     }
 
-    /** 所有者でなければ例外を投げる。 */
+    /** 資源名を固定した呼び出し口。既存の呼び出しをそのまま使えるようにしている。 */
     public void requireOwnedBy(String candidateUserId) {
-        if (!ownedBy(candidateUserId)) {
-            throw DomainException.forbidden("この薬にアクセスする権限がありません");
-        }
+        requireOwnedBy(candidateUserId, "薬");
     }
 
     // --- 参照 -------------------------------------------------------------

--- a/backend-java/src/main/java/app/healthfamily/domain/member/Member.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/member/Member.java
@@ -1,6 +1,7 @@
 package app.healthfamily.domain.member;
 
 import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.Optional;
@@ -15,7 +16,7 @@ import java.util.Optional;
  * 組み立て時に必ず検証する。DB は両方 nullable な text なので、
  * 型で防げない分をここで潰す。
  */
-public class Member {
+public class Member implements OwnedResource {
 
     private final String id;
     private final String userId;
@@ -67,10 +68,14 @@ public class Member {
         return userId.equals(candidateUserId);
     }
 
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    /** 資源名を固定した呼び出し口。既存の呼び出しをそのまま使えるようにしている。 */
     public void requireOwnedBy(String candidateUserId) {
-        if (!ownedBy(candidateUserId)) {
-            throw DomainException.forbidden("このメンバーにアクセスする権限がありません");
-        }
+        requireOwnedBy(candidateUserId, "メンバー");
     }
 
     // --- 参照 -------------------------------------------------------------

--- a/backend-java/src/main/java/app/healthfamily/domain/prescription/Prescription.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/prescription/Prescription.java
@@ -1,6 +1,7 @@
 package app.healthfamily.domain.prescription;
 
 import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,7 +17,7 @@ import java.util.Optional;
  *
  * <p>明細の入れ替えも調剤も、必ずこのクラスのメソッド経由で行う。
  */
-public class Prescription {
+public class Prescription implements OwnedResource {
 
     /** 一度の調剤で作れる薬の上限。誤操作で大量生成されるのを防ぐ */
     private static final int MAX_ITEMS = 50;
@@ -122,10 +123,14 @@ public class Prescription {
         return expiresAt != null && now.isAfter(expiresAt);
     }
 
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    /** 資源名を固定した呼び出し口。既存の呼び出しをそのまま使えるようにしている。 */
     public void requireOwnedBy(String candidateUserId) {
-        if (!userId.equals(candidateUserId)) {
-            throw DomainException.forbidden("この処方箋にアクセスする権限がありません");
-        }
+        requireOwnedBy(candidateUserId, "処方箋");
     }
 
     // --- 参照 -------------------------------------------------------------

--- a/backend-java/src/main/java/app/healthfamily/domain/schedule/Schedule.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/schedule/Schedule.java
@@ -1,6 +1,7 @@
 package app.healthfamily.domain.schedule;
 
 import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
 import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -27,7 +28,7 @@ import java.util.Set;
  *   <li>頓服（決まった予定日を持たない）</li>
  * </ul>
  */
-public class Schedule {
+public class Schedule implements OwnedResource {
 
     /** 頓服を表す間隔の値。DB に -1 で入っている */
     public static final int AS_NEEDED = -1;
@@ -143,10 +144,14 @@ public class Schedule {
         return LocalDateTime.of(date, scheduledTime);
     }
 
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    /** 資源名を固定した呼び出し口。既存の呼び出しをそのまま使えるようにしている。 */
     public void requireOwnedBy(String candidateUserId) {
-        if (!userId.equals(candidateUserId)) {
-            throw DomainException.forbidden("このスケジュールにアクセスする権限がありません");
-        }
+        requireOwnedBy(candidateUserId, "スケジュール");
     }
 
     // --- 参照 -------------------------------------------------------------

--- a/backend-java/src/main/java/app/healthfamily/domain/shared/OwnedResource.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/shared/OwnedResource.java
@@ -1,0 +1,40 @@
+package app.healthfamily.domain.shared;
+
+/**
+ * ユーザーに属する資源。
+ *
+ * <p>アレルギー・通院・病院・検査・保険など、所有者を持つだけの資源が多数ある。
+ * それぞれに同じ判定を書き写すと、いずれ 1 箇所だけ書き忘れて他人のデータが
+ * 見えるようになる。判定はここに 1 つだけ置く。
+ */
+public interface OwnedResource {
+
+    /** この資源の所有者。 */
+    String ownerId();
+
+    /**
+     * 所有者かどうか。
+     *
+     * <p>所有者が未設定の資源、および問い合わせ側のIDが空の場合は所有していないと扱う。
+     * 「不明なら拒否」に倒すことで、null の取り違えが権限の抜け穴にならないようにしている。
+     */
+    default boolean ownedBy(String candidateUserId) {
+        String owner = ownerId();
+        return owner != null
+                && !owner.isBlank()
+                && candidateUserId != null
+                && !candidateUserId.isBlank()
+                && owner.equals(candidateUserId);
+    }
+
+    /**
+     * 所有者でなければ拒否する。
+     *
+     * @param resourceName 利用者向けメッセージに出す資源名（「アレルギー」など）
+     */
+    default void requireOwnedBy(String candidateUserId, String resourceName) {
+        if (!ownedBy(candidateUserId)) {
+            throw DomainException.forbidden("この%sにアクセスする権限がありません".formatted(resourceName));
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/domain/expense/BudgetTest.java
+++ b/backend-java/src/test/java/app/healthfamily/domain/expense/BudgetTest.java
@@ -1,0 +1,146 @@
+package app.healthfamily.domain.expense;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.domain.shared.DomainException;
+import java.time.YearMonth;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Budget 集約")
+class BudgetTest {
+
+    private static final YearMonth AUGUST = YearMonth.of(2026, 8);
+
+    private static Budget budget(int monthly, boolean alertEnabled, String lastAlerted) {
+        return Budget.reconstitute(
+                "b-1", "user-1", monthly, alertEnabled, lastAlerted, Map.of("pharmacy", 5_000));
+    }
+
+    @Nested
+    @DisplayName("超過の判定")
+    class OverBudget {
+
+        @Test
+        @DisplayName("月予算を超えたら超過")
+        void exceedsMonthlyAmount() {
+            var status = budget(30_000, true, null).evaluate(AUGUST, 30_001, Map.of());
+
+            assertThat(status.overBudget()).isTrue();
+        }
+
+        @Test
+        @DisplayName("ちょうど同額は超過ではない")
+        void exactAmountIsNotOver() {
+            var status = budget(30_000, true, null).evaluate(AUGUST, 30_000, Map.of());
+
+            assertThat(status.overBudget()).isFalse();
+        }
+
+        @Test
+        @DisplayName("月予算が0なら判定しない")
+        void zeroBudgetNeverOver() {
+            var status = budget(0, true, null).evaluate(AUGUST, 100_000, Map.of());
+
+            assertThat(status.overBudget()).isFalse();
+        }
+
+        @Test
+        @DisplayName("カテゴリ別の超過も拾う")
+        void detectsOverCategories() {
+            var status =
+                    budget(100_000, true, null)
+                            .evaluate(AUGUST, 10_000, Map.of("pharmacy", 5_001, "hospital", 1_000));
+
+            assertThat(status.overCategories()).containsExactly("pharmacy");
+        }
+
+        @Test
+        @DisplayName("カテゴリ予算ちょうどは超過ではない")
+        void categoryExactIsNotOver() {
+            var status = budget(100_000, true, null).evaluate(AUGUST, 0, Map.of("pharmacy", 5_000));
+
+            assertThat(status.overCategories()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("通知の可否")
+    class Alerting {
+
+        @Test
+        @DisplayName("超過していて未通知なら通知する")
+        void notifiesWhenOverAndNotYetAlerted() {
+            var status = budget(10_000, true, null).evaluate(AUGUST, 20_000, Map.of());
+
+            assertThat(status.shouldNotify()).isTrue();
+        }
+
+        @Test
+        @DisplayName("同じ月に通知済みなら重複して通知しない")
+        void doesNotNotifyTwiceInSameMonth() {
+            var status = budget(10_000, true, "2026-08").evaluate(AUGUST, 20_000, Map.of());
+
+            assertThat(status.shouldNotify()).isFalse();
+        }
+
+        @Test
+        @DisplayName("先月通知済みでも今月は通知する")
+        void notifiesAgainInNewMonth() {
+            var status = budget(10_000, true, "2026-07").evaluate(AUGUST, 20_000, Map.of());
+
+            assertThat(status.shouldNotify()).isTrue();
+        }
+
+        @Test
+        @DisplayName("通知が無効なら通知しない")
+        void doesNotNotifyWhenDisabled() {
+            var status = budget(10_000, false, null).evaluate(AUGUST, 20_000, Map.of());
+
+            assertThat(status.shouldNotify()).isFalse();
+        }
+
+        @Test
+        @DisplayName("超過していなければ通知しない")
+        void doesNotNotifyWhenWithinBudget() {
+            var status = budget(100_000, true, null).evaluate(AUGUST, 20_000, Map.of());
+
+            assertThat(status.shouldNotify()).isFalse();
+        }
+
+        @Test
+        @DisplayName("カテゴリだけ超過でも通知する")
+        void notifiesOnCategoryOverrun() {
+            var status =
+                    budget(1_000_000, true, null).evaluate(AUGUST, 10_000, Map.of("pharmacy", 9_999));
+
+            assertThat(status.overBudget()).isFalse();
+            assertThat(status.shouldNotify()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("組み立て時の検証")
+    class Construction {
+
+        @Test
+        @DisplayName("月予算に負の値は指定できない")
+        void negativeMonthlyIsRejected() {
+            assertThatThrownBy(() -> budget(-1, true, null))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+
+        @Test
+        @DisplayName("カテゴリ予算に負の値は指定できない")
+        void negativeCategoryIsRejected() {
+            assertThatThrownBy(
+                            () ->
+                                    Budget.reconstitute(
+                                            "b-2", "user-1", 1000, true, null, Map.of("pharmacy", -1)))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/domain/expense/MedicalDeductionTest.java
+++ b/backend-java/src/test/java/app/healthfamily/domain/expense/MedicalDeductionTest.java
@@ -1,0 +1,125 @@
+package app.healthfamily.domain.expense;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.domain.shared.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * 医療費控除の試算。
+ *
+ * <p>金額の境界を間違えると利用者の申告額を誤らせるので、閾値の前後を明示的に固定する。
+ */
+@DisplayName("医療費控除の試算")
+class MedicalDeductionTest {
+
+    @Nested
+    @DisplayName("通常の医療費控除")
+    class Regular {
+
+        @ParameterizedTest(name = "対象額 {0}円 -> 控除 {1}円")
+        @CsvSource({
+            "0, 0",
+            "99999, 0",
+            "100000, 0",
+            "100001, 1",
+            "250000, 150000",
+        })
+        @DisplayName("10万円を超えた分だけが控除対象になる")
+        void deductsAboveThreshold(int deductibleTotal, int expected) {
+            var result = MedicalDeduction.simulate(deductibleTotal, 0);
+
+            assertThat(result.regularDeduction()).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("セルフメディケーション税制")
+    class SelfMedication {
+
+        @ParameterizedTest(name = "薬局購入 {0}円 -> 控除 {1}円")
+        @CsvSource({
+            "0, 0",
+            "12000, 0",
+            "12001, 1",
+            "50000, 38000",
+            "100000, 88000",
+            "1000000, 88000",
+        })
+        @DisplayName("1万2千円を超えた分が対象で、8万8千円が上限")
+        void deductsBetweenFloorAndCap(int pharmacyTotal, int expected) {
+            var result = MedicalDeduction.simulate(0, pharmacyTotal);
+
+            assertThat(result.selfMedicationDeduction()).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("どちらを使うべきかの判定")
+    class Recommendation {
+
+        @Test
+        @DisplayName("どちらも0なら勧めない")
+        void bothZeroRecommendsNone() {
+            assertThat(MedicalDeduction.simulate(50_000, 5_000).recommended())
+                    .isEqualTo(DeductionScheme.NONE);
+        }
+
+        @Test
+        @DisplayName("通常のほうが大きければ通常を勧める")
+        void regularWins() {
+            var result = MedicalDeduction.simulate(300_000, 50_000);
+
+            assertThat(result.regularDeduction()).isEqualTo(200_000);
+            assertThat(result.selfMedicationDeduction()).isEqualTo(38_000);
+            assertThat(result.recommended()).isEqualTo(DeductionScheme.REGULAR);
+        }
+
+        @Test
+        @DisplayName("セルフメディケーションのほうが大きければそちらを勧める")
+        void selfMedicationWins() {
+            var result = MedicalDeduction.simulate(110_000, 100_000);
+
+            assertThat(result.regularDeduction()).isEqualTo(10_000);
+            assertThat(result.selfMedicationDeduction()).isEqualTo(88_000);
+            assertThat(result.recommended()).isEqualTo(DeductionScheme.SELF_MEDICATION);
+        }
+
+        @Test
+        @DisplayName("同額なら通常を勧める")
+        void tieGoesToRegular() {
+            // 通常: 138000-100000 = 38000 / セルフメディケーション: 50000-12000 = 38000
+            var result = MedicalDeduction.simulate(138_000, 50_000);
+
+            assertThat(result.regularDeduction()).isEqualTo(result.selfMedicationDeduction());
+            assertThat(result.recommended()).isEqualTo(DeductionScheme.REGULAR);
+        }
+
+        @Test
+        @DisplayName("両制度は併用できないので、勧めるのは常に片方だけ")
+        void schemesAreExclusive() {
+            var result = MedicalDeduction.simulate(300_000, 100_000);
+
+            assertThat(result.recommended()).isIn(DeductionScheme.REGULAR, DeductionScheme.SELF_MEDICATION);
+        }
+    }
+
+    @Nested
+    @DisplayName("入力の検証")
+    class Validation {
+
+        @Test
+        @DisplayName("負の金額は受け付けない")
+        void negativeAmountIsRejected() {
+            assertThatThrownBy(() -> MedicalDeduction.simulate(-1, 0))
+                    .isInstanceOf(DomainException.Validation.class);
+            assertThatThrownBy(() -> MedicalDeduction.simulate(0, -1))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/domain/healthrecord/HealthRecordTest.java
+++ b/backend-java/src/test/java/app/healthfamily/domain/healthrecord/HealthRecordTest.java
@@ -1,0 +1,161 @@
+package app.healthfamily.domain.healthrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.domain.shared.DomainException;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("健康記録のドメイン")
+class HealthRecordTest {
+
+    @Nested
+    @DisplayName("体温")
+    class Temperature {
+
+        @ParameterizedTest
+        @ValueSource(doubles = {29.9, 45.1, 0.0, -1.0})
+        @DisplayName("人体としてありえない値は受け付けない")
+        void impossibleValuesAreRejected(double value) {
+            assertThatThrownBy(() -> BodyTemperature.of(value))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("体温");
+        }
+
+        @ParameterizedTest
+        @ValueSource(doubles = {30.0, 36.5, 45.0})
+        @DisplayName("ありうる範囲は受け付ける")
+        void plausibleValuesAreAccepted(double value) {
+            assertThatCode(() -> BodyTemperature.of(value)).doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest(name = "{0}度 -> {1}")
+        @CsvSource({
+            "35.9, LOW",
+            "36.0, NORMAL",
+            "37.4, NORMAL",
+            "37.5, SLIGHT_FEVER",
+            "37.9, SLIGHT_FEVER",
+            "38.0, FEVER",
+            "39.0, FEVER",
+        })
+        @DisplayName("発熱の段階を判定する")
+        void classifiesFever(double value, FeverLevel expected) {
+            assertThat(BodyTemperature.of(value).level()).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("小数第1位に丸める。測定器の精度以上の桁は持たない")
+        void roundsToOneDecimal() {
+            assertThat(BodyTemperature.of(36.55).value()).isEqualTo(36.6);
+            assertThat(BodyTemperature.of(36.44).value()).isEqualTo(36.4);
+        }
+    }
+
+    @Nested
+    @DisplayName("体格")
+    class Measurement {
+
+        @Test
+        @DisplayName("身長と体重から BMI を求める")
+        void computesBmi() {
+            var measurement = BodyMeasurement.of(60.0, 170.0);
+
+            assertThat(measurement.bmi()).contains(20.8);
+        }
+
+        @Test
+        @DisplayName("身長が無ければ BMI は出せない")
+        void withoutHeightNoBmi() {
+            assertThat(BodyMeasurement.of(60.0, null).bmi()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("体重が無ければ BMI は出せない")
+        void withoutWeightNoBmi() {
+            assertThat(BodyMeasurement.of(null, 170.0).bmi()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("体重も身長も無い記録は作れない")
+        void emptyMeasurementIsRejected() {
+            assertThatThrownBy(() -> BodyMeasurement.of(null, null))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("体重か身長");
+        }
+
+        @ParameterizedTest
+        @ValueSource(doubles = {0.0, -1.0, 1001.0})
+        @DisplayName("ありえない体重は受け付けない")
+        void impossibleWeightIsRejected(double weight) {
+            assertThatThrownBy(() -> BodyMeasurement.of(weight, 170.0))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(doubles = {0.0, -1.0, 301.0})
+        @DisplayName("ありえない身長は受け付けない")
+        void impossibleHeightIsRejected(double height) {
+            assertThatThrownBy(() -> BodyMeasurement.of(60.0, height))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("ワクチンの次回接種")
+    class Vaccination {
+
+        private static final LocalDate TODAY = LocalDate.of(2026, 8, 16);
+
+        @Test
+        @DisplayName("次回予定日が未設定なら通知しない")
+        void withoutNextDateNoReminder() {
+            var v = VaccinationSchedule.of(LocalDate.of(2026, 1, 1), null);
+
+            assertThat(v.needsReminderOn(TODAY)).isFalse();
+            assertThat(v.daysUntilNext(TODAY)).isEmpty();
+        }
+
+        @ParameterizedTest(name = "{0}日後 -> 通知 {1}")
+        @CsvSource({
+            "8, false",
+            "7, true",
+            "1, true",
+            "0, true",
+        })
+        @DisplayName("次回接種の1週間前から通知する")
+        void remindsOneWeekBefore(int daysAhead, boolean expected) {
+            var v = VaccinationSchedule.of(LocalDate.of(2026, 1, 1), TODAY.plusDays(daysAhead));
+
+            assertThat(v.needsReminderOn(TODAY)).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("予定日を過ぎていても通知し続ける")
+        void overdueStillReminds() {
+            var v = VaccinationSchedule.of(LocalDate.of(2026, 1, 1), TODAY.minusDays(3));
+
+            assertThat(v.needsReminderOn(TODAY)).isTrue();
+            assertThat(v.isOverdueOn(TODAY)).isTrue();
+            assertThat(v.daysUntilNext(TODAY)).contains(-3L);
+        }
+
+        @Test
+        @DisplayName("次回予定日が接種日より前は受け付けない")
+        void nextBeforeVaccinatedIsRejected() {
+            assertThatThrownBy(
+                            () ->
+                                    VaccinationSchedule.of(
+                                            LocalDate.of(2026, 6, 1), LocalDate.of(2026, 5, 1)))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("次回接種日");
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/domain/shared/OwnedResourceTest.java
+++ b/backend-java/src/test/java/app/healthfamily/domain/shared/OwnedResourceTest.java
@@ -1,0 +1,66 @@
+package app.healthfamily.domain.shared;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 所有権チェックの共通化。
+ *
+ * <p>アレルギー・通院・病院・検査など、ユーザーに属するだけの資源が多数ある。
+ * それぞれに同じ判定を書き写すと、いずれ 1 箇所だけ書き忘れて他人のデータが
+ * 見えるようになる。判定を 1 つにまとめて、そこだけを検証する。
+ */
+@DisplayName("所有資源の共通判定")
+class OwnedResourceTest {
+
+    /** 所有者だけを持つ最小の実装 */
+    private record Sample(String userId) implements OwnedResource {
+        @Override
+        public String ownerId() {
+            return userId;
+        }
+    }
+
+    @Test
+    @DisplayName("所有者なら通る")
+    void ownerPasses() {
+        assertThatCode(() -> new Sample("user-1").requireOwnedBy("user-1", "アレルギー"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("所有者でなければ拒否し、資源名をメッセージに含める")
+    void nonOwnerIsRejected() {
+        assertThatThrownBy(() -> new Sample("user-1").requireOwnedBy("user-2", "アレルギー"))
+                .isInstanceOf(DomainException.Forbidden.class)
+                .hasMessageContaining("アレルギー")
+                .hasMessageContaining("権限がありません");
+    }
+
+    @Test
+    @DisplayName("所有者が未設定なら誰のものでもないとして拒否する")
+    void nullOwnerIsRejected() {
+        assertThatThrownBy(() -> new Sample(null).requireOwnedBy("user-1", "通院"))
+                .isInstanceOf(DomainException.Forbidden.class);
+    }
+
+    @Test
+    @DisplayName("問い合わせ側のIDが空でも通してはいけない")
+    void blankCandidateIsRejected() {
+        assertThatThrownBy(() -> new Sample("user-1").requireOwnedBy(null, "病院"))
+                .isInstanceOf(DomainException.Forbidden.class);
+        assertThatThrownBy(() -> new Sample("user-1").requireOwnedBy(" ", "病院"))
+                .isInstanceOf(DomainException.Forbidden.class);
+    }
+
+    @Test
+    @DisplayName("判定だけを取り出せる")
+    void canQueryWithoutThrowing() {
+        assertThat(new Sample("user-1").ownedBy("user-1")).isTrue();
+        assertThat(new Sample("user-1").ownedBy("user-2")).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

「間違えると実害が出る」領域を、テスト先行で固めた。

### 医療費控除の試算

通常の医療費控除とセルフメディケーション税制を試算し、有利なほうを示す。**両制度は併用できない**ため片方だけを勧める（通常は10万円超過分、セルフメディケーションは1万2千円超〜8万8千円上限、同額なら通常）。

閾値の前後（`99999` / `100000` / `100001` など）をパラメータ化テストで固定した。**金額の境界を間違えると利用者の申告額を誤らせる**ため。

### 予算アラート

**「超過しているか」と「通知してよいか」を別の判断として分けた。** 超過していても同じ月に通知済みなら黙る。毎回通知すると利用者が通知そのものを無視するようになるため。

### 所有権チェックの共通化

所有者を持つだけの資源が多数あり、判定を書き写すと**いずれ1箇所だけ書き忘れて他人のデータが見えるようになる**。`OwnedResource` に1つだけ置き、`Medication` / `Member` / `Prescription` / `Schedule` に適用した。

**「不明なら拒否」に倒している。** 所有者が未設定、または問い合わせ側の ID が空なら所有していないと扱う。null の取り違えが権限の抜け穴にならないようにするため。

### 健康記録

| 値オブジェクト | 押さえたルール |
|---|---|
| `BodyTemperature` | 30〜45度の範囲外を拒否。`36.5` のつもりで `365` と打ち間違えた記録が残るとグラフが壊れるため。小数第1位に丸め、発熱の段階を判定 |
| `BodyMeasurement` | 体重か身長の一方だけは許すが両方無い記録は拒否。両方そろったときだけ BMI |
| `VaccinationSchedule` | 次回接種の1週間前から通知し、**予定日を過ぎても止めない**。打ち忘れたまま通知が消えると気づく機会がなくなるため |

## 検証

テスト **240件** すべて通過。統合テストは compose の PostgreSQL に対して実行している。