### PR TITLE
feat(backend-java): 通知設定のドメインを TDD で追加する

### DIFF
--- a/backend-java/src/main/java/app/healthfamily/domain/notification/NotificationKind.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/notification/NotificationKind.java
@@ -1,0 +1,18 @@
+package app.healthfamily.domain.notification;
+
+/**
+ * 通知の種類。
+ *
+ * <p>種類ごとに可否を持つのは、利用者が「飲み忘れだけは知らせてほしいが、
+ * 予約の通知はいらない」といった選び方をするため。
+ */
+public enum NotificationKind {
+    /** 服薬時刻のリマインダー */
+    MEDICATION_REMINDER,
+    /** 飲み忘れの検知 */
+    MISSED_MEDICATION,
+    /** 通院予定のリマインダー */
+    APPOINTMENT_REMINDER,
+    /** 薬の残数が少ないことの通知 */
+    LOW_STOCK
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/notification/NotificationSetting.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/notification/NotificationSetting.java
@@ -1,0 +1,167 @@
+package app.healthfamily.domain.notification;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * 通知設定の集約ルート。
+ *
+ * <p>「その種類を通知してよいか」と「メールで送ってよいか」は別の判断。
+ * 種類が有効でもメール通知が切られていれば送らない。利用者が明示的に
+ * 切った経路へ送ってしまうのは、通知の信頼を損なう。
+ *
+ * <p>既定値は DB のデフォルトと揃えてある。設定行が無い利用者にも
+ * 同じ既定で通知したいため。
+ */
+public class NotificationSetting implements OwnedResource {
+
+    private static final int MAX_REMINDER_MINUTES = 24 * 60;
+    private static final int MAX_APPOINTMENT_DAYS = 365;
+
+    private final String id;
+    private final String userId;
+    private final Map<NotificationKind, Boolean> enabledByKind;
+    private final boolean emailNotificationEnabled;
+    private final int reminderMinutesBefore;
+    private final int appointmentReminderDaysBefore;
+
+    private NotificationSetting(Builder b) {
+        if (b.userId == null || b.userId.isBlank()) {
+            throw DomainException.validation("所有ユーザーは必須です");
+        }
+        if (b.reminderMinutesBefore < 0 || b.reminderMinutesBefore > MAX_REMINDER_MINUTES) {
+            throw DomainException.validation(
+                    "服薬リマインダーの事前分数は 0〜%d 分で指定してください".formatted(MAX_REMINDER_MINUTES));
+        }
+        if (b.appointmentReminderDaysBefore < 0
+                || b.appointmentReminderDaysBefore > MAX_APPOINTMENT_DAYS) {
+            throw DomainException.validation(
+                    "通院リマインダーの事前日数は 0〜%d 日で指定してください".formatted(MAX_APPOINTMENT_DAYS));
+        }
+        this.id = b.id;
+        this.userId = b.userId;
+        this.emailNotificationEnabled = b.emailNotificationEnabled;
+        this.reminderMinutesBefore = b.reminderMinutesBefore;
+        this.appointmentReminderDaysBefore = b.appointmentReminderDaysBefore;
+
+        var map = new EnumMap<NotificationKind, Boolean>(NotificationKind.class);
+        map.put(NotificationKind.MEDICATION_REMINDER, b.medicationReminderEnabled);
+        map.put(NotificationKind.MISSED_MEDICATION, b.missedMedicationEnabled);
+        map.put(NotificationKind.APPOINTMENT_REMINDER, b.appointmentReminderEnabled);
+        map.put(NotificationKind.LOW_STOCK, b.lowStockAlertEnabled);
+        this.enabledByKind = map;
+    }
+
+    // --- 振る舞い ---------------------------------------------------------
+
+    /** その種類の通知を出してよいか。 */
+    public boolean allows(NotificationKind kind) {
+        return Boolean.TRUE.equals(enabledByKind.get(kind));
+    }
+
+    /**
+     * その種類をメールで送ってよいか。
+     *
+     * <p>種類とメール経路の両方が有効なときだけ true。
+     */
+    public boolean allowsEmail(NotificationKind kind) {
+        return allows(kind) && emailNotificationEnabled;
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    // --- 参照 -------------------------------------------------------------
+
+    public String id() {
+        return id;
+    }
+
+    public String userId() {
+        return userId;
+    }
+
+    public boolean emailNotificationEnabled() {
+        return emailNotificationEnabled;
+    }
+
+    public int reminderMinutesBefore() {
+        return reminderMinutesBefore;
+    }
+
+    public int appointmentReminderDaysBefore() {
+        return appointmentReminderDaysBefore;
+    }
+
+    // --- 組み立て ---------------------------------------------------------
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** 既定値は DB のデフォルトと揃えている。 */
+    public static final class Builder {
+        private String id;
+        private String userId;
+        private boolean medicationReminderEnabled = true;
+        private boolean missedMedicationEnabled = true;
+        private boolean appointmentReminderEnabled = true;
+        private boolean lowStockAlertEnabled = true;
+        private boolean emailNotificationEnabled = true;
+        private int reminderMinutesBefore = 5;
+        private int appointmentReminderDaysBefore = 1;
+
+        public Builder id(String v) {
+            this.id = v;
+            return this;
+        }
+
+        public Builder userId(String v) {
+            this.userId = v;
+            return this;
+        }
+
+        public Builder medicationReminderEnabled(boolean v) {
+            this.medicationReminderEnabled = v;
+            return this;
+        }
+
+        public Builder missedMedicationEnabled(boolean v) {
+            this.missedMedicationEnabled = v;
+            return this;
+        }
+
+        public Builder appointmentReminderEnabled(boolean v) {
+            this.appointmentReminderEnabled = v;
+            return this;
+        }
+
+        public Builder lowStockAlertEnabled(boolean v) {
+            this.lowStockAlertEnabled = v;
+            return this;
+        }
+
+        public Builder emailNotificationEnabled(boolean v) {
+            this.emailNotificationEnabled = v;
+            return this;
+        }
+
+        public Builder reminderMinutesBefore(int v) {
+            this.reminderMinutesBefore = v;
+            return this;
+        }
+
+        public Builder appointmentReminderDaysBefore(int v) {
+            this.appointmentReminderDaysBefore = v;
+            return this;
+        }
+
+        public NotificationSetting build() {
+            return new NotificationSetting(this);
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/domain/notification/NotificationSettingTest.java
+++ b/backend-java/src/test/java/app/healthfamily/domain/notification/NotificationSettingTest.java
@@ -1,0 +1,123 @@
+package app.healthfamily.domain.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.domain.shared.DomainException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("通知設定")
+class NotificationSettingTest {
+
+    private static NotificationSetting.Builder base() {
+        return NotificationSetting.builder().id("n-1").userId("user-1");
+    }
+
+    @Nested
+    @DisplayName("既定値")
+    class Defaults {
+
+        @Test
+        @DisplayName("何も指定しなければ、すべての通知が有効")
+        void allEnabledByDefault() {
+            var setting = base().build();
+
+            assertThat(setting.allows(NotificationKind.MEDICATION_REMINDER)).isTrue();
+            assertThat(setting.allows(NotificationKind.MISSED_MEDICATION)).isTrue();
+            assertThat(setting.allows(NotificationKind.APPOINTMENT_REMINDER)).isTrue();
+            assertThat(setting.allows(NotificationKind.LOW_STOCK)).isTrue();
+        }
+
+        @Test
+        @DisplayName("既定のリマインダーは服薬5分前・通院1日前")
+        void defaultLeadTimes() {
+            var setting = base().build();
+
+            assertThat(setting.reminderMinutesBefore()).isEqualTo(5);
+            assertThat(setting.appointmentReminderDaysBefore()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("種類ごとの可否")
+    class PerKind {
+
+        @Test
+        @DisplayName("無効にした種類だけが止まる")
+        void disablingOneKindDoesNotAffectOthers() {
+            var setting = base().missedMedicationEnabled(false).build();
+
+            assertThat(setting.allows(NotificationKind.MISSED_MEDICATION)).isFalse();
+            assertThat(setting.allows(NotificationKind.MEDICATION_REMINDER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("メール通知を切ると、種類が有効でもメールは送らない")
+        void emailOffBlocksEmailDelivery() {
+            var setting = base().emailNotificationEnabled(false).build();
+
+            assertThat(setting.allows(NotificationKind.MEDICATION_REMINDER)).isTrue();
+            assertThat(setting.allowsEmail(NotificationKind.MEDICATION_REMINDER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("種類が無効ならメールも送らない")
+        void disabledKindBlocksEmailToo() {
+            var setting = base().lowStockAlertEnabled(false).build();
+
+            assertThat(setting.allowsEmail(NotificationKind.LOW_STOCK)).isFalse();
+        }
+
+        @Test
+        @DisplayName("両方有効なときだけメールを送る")
+        void emailRequiresBothEnabled() {
+            var setting = base().build();
+
+            assertThat(setting.allowsEmail(NotificationKind.LOW_STOCK)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("入力の検証")
+    class Validation {
+
+        @ParameterizedTest
+        @ValueSource(ints = {-1, 1441})
+        @DisplayName("服薬リマインダーの事前分数は0〜1440分の範囲")
+        void reminderMinutesRange(int minutes) {
+            assertThatThrownBy(() -> base().reminderMinutesBefore(minutes).build())
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {-1, 366})
+        @DisplayName("通院リマインダーの事前日数は0〜365日の範囲")
+        void appointmentDaysRange(int days) {
+            assertThatThrownBy(() -> base().appointmentReminderDaysBefore(days).build())
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+
+        @Test
+        @DisplayName("所有ユーザーは必須")
+        void ownerIsRequired() {
+            assertThatThrownBy(() -> NotificationSetting.builder().id("n-2").build())
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("所有権")
+    class Ownership {
+
+        @Test
+        @DisplayName("他人の通知設定は参照できない")
+        void nonOwnerIsRejected() {
+            assertThatThrownBy(() -> base().build().requireOwnedBy("user-2", "通知設定"))
+                    .isInstanceOf(DomainException.Forbidden.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **「その種類を通知してよいか」と「メールで送ってよいか」を別の判断にした。** 種類が有効でもメール通知が切られていれば送らない。利用者が明示的に切った経路へ送るのは通知の信頼を損なうため
- 通知の種類（服薬リマインダー / 飲み忘れ / 通院 / 残数）ごとに可否を持つ。「飲み忘れだけは知らせてほしいが予約通知はいらない」という選び方に対応する
- 事前分数と事前日数に上限を設けた（24時間 / 365日）
- 既定値は DB のデフォルトと揃えた。設定行が無い利用者にも同じ既定で通知するため

テスト **252件** すべて通過。