### PR TITLE
feat(backend-java): CRUD系リソースを共通化して TDD で移植する

### DIFF
--- a/backend-java/src/main/java/app/healthfamily/apiController/healthrecord/HealthRecordController.java
+++ b/backend-java/src/main/java/app/healthfamily/apiController/healthrecord/HealthRecordController.java
@@ -1,0 +1,228 @@
+package app.healthfamily.apiController.healthrecord;
+
+import app.healthfamily.apiController.ApiResponse;
+import app.healthfamily.domain.healthrecord.BodyMeasurement;
+import app.healthfamily.domain.healthrecord.BodyMeasurementRecord;
+import app.healthfamily.domain.healthrecord.BodyTemperature;
+import app.healthfamily.domain.healthrecord.TemperatureRecord;
+import app.healthfamily.domain.healthrecord.VaccinationRecord;
+import app.healthfamily.domain.healthrecord.VaccinationSchedule;
+import app.healthfamily.domain.shared.AppZone;
+import app.healthfamily.usecase.crud.MemberScopedCrudUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 体温・体格・ワクチンのエンドポイント。
+ *
+ * <p>値の妥当性は値オブジェクトが持つ。ここは組み立てと表示形への変換だけを担う。
+ * 判定結果（発熱の段階・BMI・通知要否）は保存せず、その都度算出して返す。
+ * 保存すると規則を変えたときに古い判定が残るため。
+ */
+@RestController
+public class HealthRecordController {
+
+    private final MemberScopedCrudUseCase<TemperatureRecord> temperatures;
+    private final MemberScopedCrudUseCase<BodyMeasurementRecord> measurements;
+    private final MemberScopedCrudUseCase<VaccinationRecord> vaccinations;
+    private final AppZone zone;
+
+    public HealthRecordController(
+            MemberScopedCrudUseCase<TemperatureRecord> temperatures,
+            MemberScopedCrudUseCase<BodyMeasurementRecord> measurements,
+            MemberScopedCrudUseCase<VaccinationRecord> vaccinations,
+            AppZone zone) {
+        this.temperatures = temperatures;
+        this.measurements = measurements;
+        this.vaccinations = vaccinations;
+        this.zone = zone;
+    }
+
+    // --- 体温 ---------------------------------------------------------------
+
+    @GetMapping("/api/temperature-records")
+    public ApiResponse<List<TemperatureView>> listTemperatures(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(
+                temperatures.list(jwt.getSubject()).stream().map(TemperatureView::of).toList());
+    }
+
+    @PostMapping("/api/temperature-records")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<TemperatureView> createTemperature(
+            @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody TemperatureRequest request) {
+        var record =
+                new TemperatureRecord(
+                        UUID.randomUUID().toString(),
+                        jwt.getSubject(),
+                        request.memberId(),
+                        BodyTemperature.of(request.temperature()),
+                        request.measuredAt(),
+                        request.notes());
+        return ApiResponse.ok(TemperatureView.of(temperatures.create(jwt.getSubject(), record)));
+    }
+
+    @DeleteMapping("/api/temperature-records/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteTemperature(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        temperatures.delete(jwt.getSubject(), id);
+    }
+
+    // --- 体格 ---------------------------------------------------------------
+
+    @GetMapping("/api/body-measurements")
+    public ApiResponse<List<MeasurementView>> listMeasurements(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(
+                measurements.list(jwt.getSubject()).stream().map(MeasurementView::of).toList());
+    }
+
+    @PostMapping("/api/body-measurements")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<MeasurementView> createMeasurement(
+            @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody MeasurementRequest request) {
+        var record =
+                new BodyMeasurementRecord(
+                        UUID.randomUUID().toString(),
+                        jwt.getSubject(),
+                        request.memberId(),
+                        BodyMeasurement.of(request.weight(), request.height()),
+                        request.recordedAt(),
+                        request.notes());
+        return ApiResponse.ok(MeasurementView.of(measurements.create(jwt.getSubject(), record)));
+    }
+
+    @DeleteMapping("/api/body-measurements/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteMeasurement(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        measurements.delete(jwt.getSubject(), id);
+    }
+
+    // --- ワクチン -------------------------------------------------------------
+
+    @GetMapping("/api/vaccinations")
+    public ApiResponse<List<VaccinationView>> listVaccinations(@AuthenticationPrincipal Jwt jwt) {
+        LocalDate today = zone.today();
+        return ApiResponse.ok(
+                vaccinations.list(jwt.getSubject()).stream().map(v -> VaccinationView.of(v, today)).toList());
+    }
+
+    @PostMapping("/api/vaccinations")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<VaccinationView> createVaccination(
+            @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody VaccinationRequest request) {
+        var record =
+                new VaccinationRecord(
+                        UUID.randomUUID().toString(),
+                        jwt.getSubject(),
+                        request.memberId(),
+                        request.vaccineName(),
+                        VaccinationSchedule.of(
+                                toDate(request.vaccinatedAt()), toDate(request.nextScheduledDate())),
+                        request.notes());
+        return ApiResponse.ok(
+                VaccinationView.of(vaccinations.create(jwt.getSubject(), record), zone.today()));
+    }
+
+    @DeleteMapping("/api/vaccinations/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteVaccination(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        vaccinations.delete(jwt.getSubject(), id);
+    }
+
+    private static LocalDate toDate(Instant instant) {
+        return instant == null ? null : instant.atZone(java.time.ZoneOffset.UTC).toLocalDate();
+    }
+
+    // --- 入出力の形 -----------------------------------------------------------
+
+    public record TemperatureRequest(
+            @NotBlank String memberId,
+            double temperature,
+            Instant measuredAt,
+            @Size(max = 2000) String notes) {}
+
+    public record TemperatureView(
+            String id, String memberId, double temperature, String feverLevel, Instant measuredAt,
+            String notes) {
+
+        static TemperatureView of(TemperatureRecord r) {
+            return new TemperatureView(
+                    r.id(),
+                    r.memberId(),
+                    r.temperature().value(),
+                    r.feverLevel().name(),
+                    r.measuredAt(),
+                    r.notes());
+        }
+    }
+
+    public record MeasurementRequest(
+            @NotBlank String memberId,
+            Double weight,
+            Double height,
+            Instant recordedAt,
+            @Size(max = 2000) String notes) {}
+
+    public record MeasurementView(
+            String id, String memberId, Double weight, Double height, Double bmi, Instant recordedAt,
+            String notes) {
+
+        static MeasurementView of(BodyMeasurementRecord r) {
+            return new MeasurementView(
+                    r.id(),
+                    r.memberId(),
+                    r.measurement().weightKg(),
+                    r.measurement().heightCm(),
+                    r.bmi().orElse(null),
+                    r.recordedAt(),
+                    r.notes());
+        }
+    }
+
+    public record VaccinationRequest(
+            @NotBlank String memberId,
+            @NotBlank @Size(max = 200) String vaccineName,
+            Instant vaccinatedAt,
+            Instant nextScheduledDate,
+            @Size(max = 2000) String notes) {}
+
+    public record VaccinationView(
+            String id,
+            String memberId,
+            String vaccineName,
+            LocalDate vaccinatedAt,
+            LocalDate nextScheduledDate,
+            Long daysUntilNext,
+            boolean needsReminder,
+            boolean overdue,
+            String notes) {
+
+        static VaccinationView of(VaccinationRecord r, LocalDate today) {
+            var schedule = r.schedule();
+            return new VaccinationView(
+                    r.id(),
+                    r.memberId(),
+                    r.vaccineName(),
+                    schedule.vaccinatedAt(),
+                    schedule.nextScheduledDate(),
+                    schedule.daysUntilNext(today).orElse(null),
+                    schedule.needsReminderOn(today),
+                    schedule.isOverdueOn(today),
+                    r.notes());
+        }
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/apiController/hospital/HospitalController.java
+++ b/backend-java/src/main/java/app/healthfamily/apiController/hospital/HospitalController.java
@@ -1,0 +1,111 @@
+package app.healthfamily.apiController.hospital;
+
+import app.healthfamily.apiController.ApiResponse;
+import app.healthfamily.domain.hospital.Hospital;
+import app.healthfamily.usecase.crud.OwnedCrudUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * かかりつけ病院のエンドポイント。
+ *
+ * <p>所有ユーザーは検証済みトークンの sub から取る。読み書きはすべて
+ * {@link OwnedCrudUseCase} を通すので、所有権チェックが抜ける経路が無い。
+ */
+@RestController
+@RequestMapping("/api/hospitals")
+public class HospitalController {
+
+    private final OwnedCrudUseCase<Hospital> hospitals;
+
+    public HospitalController(OwnedCrudUseCase<Hospital> hospitals) {
+        this.hospitals = hospitals;
+    }
+
+    @GetMapping
+    public ApiResponse<List<Hospital>> list(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(hospitals.list(jwt.getSubject()));
+    }
+
+    @GetMapping("/{hospitalId}")
+    public ApiResponse<Hospital> get(
+            @AuthenticationPrincipal Jwt jwt, @PathVariable String hospitalId) {
+        return ApiResponse.ok(hospitals.get(jwt.getSubject(), hospitalId));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Hospital> create(
+            @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody HospitalRequest request) {
+        var hospital =
+                new Hospital(
+                        UUID.randomUUID().toString(),
+                        jwt.getSubject(),
+                        request.name(),
+                        request.hospitalType(),
+                        request.address(),
+                        request.phoneNumber(),
+                        request.department(),
+                        request.doctorName(),
+                        request.notes());
+        return ApiResponse.ok(hospitals.create(jwt.getSubject(), hospital));
+    }
+
+    /** 指定された項目だけを差し替える。ID と所有者は変更できない。 */
+    @PatchMapping("/{hospitalId}")
+    public ApiResponse<Hospital> update(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String hospitalId,
+            @RequestBody HospitalRequest request) {
+        return ApiResponse.ok(
+                hospitals.update(
+                        jwt.getSubject(),
+                        hospitalId,
+                        current ->
+                                new Hospital(
+                                        current.id(),
+                                        current.userId(),
+                                        request.name() == null ? current.name() : request.name(),
+                                        pick(request.hospitalType(), current.hospitalType()),
+                                        pick(request.address(), current.address()),
+                                        pick(request.phoneNumber(), current.phoneNumber()),
+                                        pick(request.department(), current.department()),
+                                        pick(request.doctorName(), current.doctorName()),
+                                        pick(request.notes(), current.notes()))));
+    }
+
+    @DeleteMapping("/{hospitalId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@AuthenticationPrincipal Jwt jwt, @PathVariable String hospitalId) {
+        hospitals.delete(jwt.getSubject(), hospitalId);
+    }
+
+    private static String pick(String incoming, String current) {
+        return incoming == null ? current : incoming;
+    }
+
+    /** 作成時は name が必須。更新時は指定された項目だけを差し替える。 */
+    public record HospitalRequest(
+            @Size(max = 200) String name,
+            @Size(max = 50) String hospitalType,
+            @Size(max = 500) String address,
+            @Size(max = 50) String phoneNumber,
+            @Size(max = 100) String department,
+            @Size(max = 100) String doctorName,
+            @Size(max = 2000) String notes) {}
+}

--- a/backend-java/src/main/java/app/healthfamily/apiController/memberrecord/AllergyController.java
+++ b/backend-java/src/main/java/app/healthfamily/apiController/memberrecord/AllergyController.java
@@ -1,0 +1,105 @@
+package app.healthfamily.apiController.memberrecord;
+
+import app.healthfamily.apiController.ApiResponse;
+import app.healthfamily.domain.memberrecord.Allergy;
+import app.healthfamily.usecase.crud.MemberScopedCrudUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * アレルギーのエンドポイント。
+ *
+ * <p>所有ユーザーはトークンの sub から取る。対象メンバーが自分のものかも確認するので、
+ * 他人のメンバーに記録をぶら下げることはできない。
+ */
+@RestController
+@RequestMapping("/api/allergies")
+public class AllergyController {
+
+    private final MemberScopedCrudUseCase<Allergy> useCase;
+
+    public AllergyController(MemberScopedCrudUseCase<Allergy> useCase) {
+        this.useCase = useCase;
+    }
+
+    @GetMapping
+    public ApiResponse<List<Allergy>> list(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(useCase.list(jwt.getSubject()));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<Allergy> get(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        return ApiResponse.ok(useCase.get(jwt.getSubject(), id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Allergy> create(
+            @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody AllergyRequest request) {
+        var created =
+                new Allergy(
+                        UUID.randomUUID().toString(),
+                        jwt.getSubject(),
+                        request.memberId(),
+                        request.allergenName(),
+                        request.allergyType(),
+                        request.severity(),
+                        request.symptoms(),
+                        request.notes());
+        return ApiResponse.ok(useCase.create(jwt.getSubject(), created));
+    }
+
+    /** 指定された項目だけを差し替える。ID と所有者は変更できない。 */
+    @PatchMapping("/{id}")
+    public ApiResponse<Allergy> update(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String id,
+            @RequestBody AllergyRequest request) {
+        return ApiResponse.ok(
+                useCase.update(
+                        jwt.getSubject(),
+                        id,
+                        current ->
+                                new Allergy(
+                                        current.id(),
+                                        current.userId(),
+                                        pick(request.memberId(), current.memberId()),
+                                        pick(request.allergenName(), current.allergenName()),
+                                        pick(request.allergyType(), current.allergyType()),
+                                        pick(request.severity(), current.severity()),
+                                        pick(request.symptoms(), current.symptoms()),
+                                        pick(request.notes(), current.notes()))));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        useCase.delete(jwt.getSubject(), id);
+    }
+
+    private static String pick(String incoming, String current) {
+        return incoming == null ? current : incoming;
+    }
+
+    public record AllergyRequest(
+            @Size(max = 100) String memberId,
+            @Size(max = 500) String allergenName,
+            @Size(max = 500) String allergyType,
+            @Size(max = 500) String severity,
+            @Size(max = 500) String symptoms,
+            @Size(max = 500) String notes) {}
+}

--- a/backend-java/src/main/java/app/healthfamily/apiController/memberrecord/EmergencyContactController.java
+++ b/backend-java/src/main/java/app/healthfamily/apiController/memberrecord/EmergencyContactController.java
@@ -1,0 +1,102 @@
+package app.healthfamily.apiController.memberrecord;
+
+import app.healthfamily.apiController.ApiResponse;
+import app.healthfamily.domain.memberrecord.EmergencyContact;
+import app.healthfamily.usecase.crud.MemberScopedCrudUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 緊急連絡先のエンドポイント。
+ *
+ * <p>所有ユーザーはトークンの sub から取る。対象メンバーが自分のものかも確認するので、
+ * 他人のメンバーに記録をぶら下げることはできない。
+ */
+@RestController
+@RequestMapping("/api/emergency-contacts")
+public class EmergencyContactController {
+
+    private final MemberScopedCrudUseCase<EmergencyContact> useCase;
+
+    public EmergencyContactController(MemberScopedCrudUseCase<EmergencyContact> useCase) {
+        this.useCase = useCase;
+    }
+
+    @GetMapping
+    public ApiResponse<List<EmergencyContact>> list(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(useCase.list(jwt.getSubject()));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<EmergencyContact> get(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        return ApiResponse.ok(useCase.get(jwt.getSubject(), id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<EmergencyContact> create(
+            @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody EmergencyContactRequest request) {
+        var created =
+                new EmergencyContact(
+                        UUID.randomUUID().toString(),
+                        jwt.getSubject(),
+                        request.memberId(),
+                        request.contactName(),
+                        request.phoneNumber(),
+                        request.relationship(),
+                        request.notes());
+        return ApiResponse.ok(useCase.create(jwt.getSubject(), created));
+    }
+
+    /** 指定された項目だけを差し替える。ID と所有者は変更できない。 */
+    @PatchMapping("/{id}")
+    public ApiResponse<EmergencyContact> update(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String id,
+            @RequestBody EmergencyContactRequest request) {
+        return ApiResponse.ok(
+                useCase.update(
+                        jwt.getSubject(),
+                        id,
+                        current ->
+                                new EmergencyContact(
+                                        current.id(),
+                                        current.userId(),
+                                        pick(request.memberId(), current.memberId()),
+                                        pick(request.contactName(), current.contactName()),
+                                        pick(request.phoneNumber(), current.phoneNumber()),
+                                        pick(request.relationship(), current.relationship()),
+                                        pick(request.notes(), current.notes()))));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        useCase.delete(jwt.getSubject(), id);
+    }
+
+    private static String pick(String incoming, String current) {
+        return incoming == null ? current : incoming;
+    }
+
+    public record EmergencyContactRequest(
+            @Size(max = 100) String memberId,
+            @Size(max = 500) String contactName,
+            @Size(max = 500) String phoneNumber,
+            @Size(max = 500) String relationship,
+            @Size(max = 500) String notes) {}
+}

--- a/backend-java/src/main/java/app/healthfamily/apiController/memberrecord/InsuranceController.java
+++ b/backend-java/src/main/java/app/healthfamily/apiController/memberrecord/InsuranceController.java
@@ -1,0 +1,102 @@
+package app.healthfamily.apiController.memberrecord;
+
+import app.healthfamily.apiController.ApiResponse;
+import app.healthfamily.domain.memberrecord.Insurance;
+import app.healthfamily.usecase.crud.MemberScopedCrudUseCase;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 保険のエンドポイント。
+ *
+ * <p>所有ユーザーはトークンの sub から取る。対象メンバーが自分のものかも確認するので、
+ * 他人のメンバーに記録をぶら下げることはできない。
+ */
+@RestController
+@RequestMapping("/api/insurances")
+public class InsuranceController {
+
+    private final MemberScopedCrudUseCase<Insurance> useCase;
+
+    public InsuranceController(MemberScopedCrudUseCase<Insurance> useCase) {
+        this.useCase = useCase;
+    }
+
+    @GetMapping
+    public ApiResponse<List<Insurance>> list(@AuthenticationPrincipal Jwt jwt) {
+        return ApiResponse.ok(useCase.list(jwt.getSubject()));
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<Insurance> get(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        return ApiResponse.ok(useCase.get(jwt.getSubject(), id));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<Insurance> create(
+            @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody InsuranceRequest request) {
+        var created =
+                new Insurance(
+                        UUID.randomUUID().toString(),
+                        jwt.getSubject(),
+                        request.memberId(),
+                        request.insuranceType(),
+                        request.providerName(),
+                        request.policyNumber(),
+                        request.notes());
+        return ApiResponse.ok(useCase.create(jwt.getSubject(), created));
+    }
+
+    /** 指定された項目だけを差し替える。ID と所有者は変更できない。 */
+    @PatchMapping("/{id}")
+    public ApiResponse<Insurance> update(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String id,
+            @RequestBody InsuranceRequest request) {
+        return ApiResponse.ok(
+                useCase.update(
+                        jwt.getSubject(),
+                        id,
+                        current ->
+                                new Insurance(
+                                        current.id(),
+                                        current.userId(),
+                                        pick(request.memberId(), current.memberId()),
+                                        pick(request.insuranceType(), current.insuranceType()),
+                                        pick(request.providerName(), current.providerName()),
+                                        pick(request.policyNumber(), current.policyNumber()),
+                                        pick(request.notes(), current.notes()))));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@AuthenticationPrincipal Jwt jwt, @PathVariable String id) {
+        useCase.delete(jwt.getSubject(), id);
+    }
+
+    private static String pick(String incoming, String current) {
+        return incoming == null ? current : incoming;
+    }
+
+    public record InsuranceRequest(
+            @Size(max = 100) String memberId,
+            @Size(max = 500) String insuranceType,
+            @Size(max = 500) String providerName,
+            @Size(max = 500) String policyNumber,
+            @Size(max = 500) String notes) {}
+}

--- a/backend-java/src/main/java/app/healthfamily/config/CrudUseCaseConfig.java
+++ b/backend-java/src/main/java/app/healthfamily/config/CrudUseCaseConfig.java
@@ -4,6 +4,9 @@ import app.healthfamily.domain.hospital.Hospital;
 import app.healthfamily.domain.member.MemberRepository;
 import app.healthfamily.domain.memberrecord.Allergy;
 import app.healthfamily.domain.memberrecord.EmergencyContact;
+import app.healthfamily.domain.healthrecord.BodyMeasurementRecord;
+import app.healthfamily.domain.healthrecord.TemperatureRecord;
+import app.healthfamily.domain.healthrecord.VaccinationRecord;
 import app.healthfamily.domain.memberrecord.Insurance;
 import app.healthfamily.usecase.crud.MemberScopedCrudUseCase;
 import app.healthfamily.usecase.crud.OwnedCrudRepository;
@@ -39,6 +42,27 @@ public class CrudUseCaseConfig {
             OwnedCrudRepository<EmergencyContact> repository, MemberRepository members) {
         return new MemberScopedCrudUseCase<>(
                 repository, members, EmergencyContact::memberId, "緊急連絡先");
+    }
+
+    @Bean
+    public MemberScopedCrudUseCase<TemperatureRecord> temperatureUseCase(
+            OwnedCrudRepository<TemperatureRecord> repository, MemberRepository members) {
+        return new MemberScopedCrudUseCase<>(
+                repository, members, TemperatureRecord::memberId, "体温の記録");
+    }
+
+    @Bean
+    public MemberScopedCrudUseCase<BodyMeasurementRecord> bodyMeasurementUseCase(
+            OwnedCrudRepository<BodyMeasurementRecord> repository, MemberRepository members) {
+        return new MemberScopedCrudUseCase<>(
+                repository, members, BodyMeasurementRecord::memberId, "体格の記録");
+    }
+
+    @Bean
+    public MemberScopedCrudUseCase<VaccinationRecord> vaccinationUseCase(
+            OwnedCrudRepository<VaccinationRecord> repository, MemberRepository members) {
+        return new MemberScopedCrudUseCase<>(
+                repository, members, VaccinationRecord::memberId, "ワクチンの記録");
     }
 
     @Bean

--- a/backend-java/src/main/java/app/healthfamily/config/CrudUseCaseConfig.java
+++ b/backend-java/src/main/java/app/healthfamily/config/CrudUseCaseConfig.java
@@ -1,6 +1,11 @@
 package app.healthfamily.config;
 
 import app.healthfamily.domain.hospital.Hospital;
+import app.healthfamily.domain.member.MemberRepository;
+import app.healthfamily.domain.memberrecord.Allergy;
+import app.healthfamily.domain.memberrecord.EmergencyContact;
+import app.healthfamily.domain.memberrecord.Insurance;
+import app.healthfamily.usecase.crud.MemberScopedCrudUseCase;
 import app.healthfamily.usecase.crud.OwnedCrudRepository;
 import app.healthfamily.usecase.crud.OwnedCrudUseCase;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +16,9 @@ import org.springframework.context.annotation.Configuration;
  *
  * <p>資源名はここで与える。利用者向けのメッセージに出るため、
  * 資源が増えるたびにこの1箇所を見れば全体が分かるようにしている。
+ *
+ * <p>メンバーに紐づく資源は MemberScopedCrudUseCase を使う。
+ * 他人のメンバーへ記録をぶら下げられないようにするため。
  */
 @Configuration
 public class CrudUseCaseConfig {
@@ -18,5 +26,24 @@ public class CrudUseCaseConfig {
     @Bean
     public OwnedCrudUseCase<Hospital> hospitalUseCase(OwnedCrudRepository<Hospital> repository) {
         return new OwnedCrudUseCase<>(repository, "病院");
+    }
+
+    @Bean
+    public MemberScopedCrudUseCase<Allergy> allergyUseCase(
+            OwnedCrudRepository<Allergy> repository, MemberRepository members) {
+        return new MemberScopedCrudUseCase<>(repository, members, Allergy::memberId, "アレルギー");
+    }
+
+    @Bean
+    public MemberScopedCrudUseCase<EmergencyContact> emergencyContactUseCase(
+            OwnedCrudRepository<EmergencyContact> repository, MemberRepository members) {
+        return new MemberScopedCrudUseCase<>(
+                repository, members, EmergencyContact::memberId, "緊急連絡先");
+    }
+
+    @Bean
+    public MemberScopedCrudUseCase<Insurance> insuranceUseCase(
+            OwnedCrudRepository<Insurance> repository, MemberRepository members) {
+        return new MemberScopedCrudUseCase<>(repository, members, Insurance::memberId, "保険");
     }
 }

--- a/backend-java/src/main/java/app/healthfamily/config/CrudUseCaseConfig.java
+++ b/backend-java/src/main/java/app/healthfamily/config/CrudUseCaseConfig.java
@@ -1,0 +1,22 @@
+package app.healthfamily.config;
+
+import app.healthfamily.domain.hospital.Hospital;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import app.healthfamily.usecase.crud.OwnedCrudUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 所有者を持つだけの資源のユースケースを組み立てる。
+ *
+ * <p>資源名はここで与える。利用者向けのメッセージに出るため、
+ * 資源が増えるたびにこの1箇所を見れば全体が分かるようにしている。
+ */
+@Configuration
+public class CrudUseCaseConfig {
+
+    @Bean
+    public OwnedCrudUseCase<Hospital> hospitalUseCase(OwnedCrudRepository<Hospital> repository) {
+        return new OwnedCrudUseCase<>(repository, "病院");
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/BodyMeasurementRecord.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/BodyMeasurementRecord.java
@@ -1,0 +1,41 @@
+package app.healthfamily.domain.healthrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.time.Instant;
+import java.util.Optional;
+
+/** 体格の記録。値の妥当性と BMI は {@link BodyMeasurement} が持つ。 */
+public record BodyMeasurementRecord(
+        String id,
+        String userId,
+        String memberId,
+        BodyMeasurement measurement,
+        Instant recordedAt,
+        String notes)
+        implements OwnedResource {
+
+    public BodyMeasurementRecord {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("記録のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (measurement == null) {
+            throw DomainException.validation("体重か身長のどちらかは入力してください");
+        }
+        if (recordedAt == null) {
+            throw DomainException.validation("記録日時は必須です");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    public Optional<Double> bmi() {
+        return measurement.bmi();
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/HealthLog.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/HealthLog.java
@@ -1,0 +1,52 @@
+package app.healthfamily.domain.healthrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 体調の記録。
+ *
+ * <p>体調は 1〜5 の段階で表す。範囲外を弾くのは、後から推移をグラフにするときに
+ * 目盛りが壊れるため。
+ *
+ * @param conditionLevel 1(悪い)〜5(良い)
+ */
+public record HealthLog(
+        String id,
+        String userId,
+        String memberId,
+        int conditionLevel,
+        List<String> symptoms,
+        String notes,
+        Instant recordedAt)
+        implements OwnedResource {
+
+    private static final int MIN_LEVEL = 1;
+    private static final int MAX_LEVEL = 5;
+
+    public HealthLog {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("体調記録のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (conditionLevel < MIN_LEVEL || conditionLevel > MAX_LEVEL) {
+            throw DomainException.validation(
+                    "体調は %d〜%d の範囲で指定してください".formatted(MIN_LEVEL, MAX_LEVEL));
+        }
+        symptoms = symptoms == null ? List.of() : List.copyOf(symptoms);
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    /** 記録として注意を要するか。体調が悪い、または症状が記録されている。 */
+    public boolean needsAttention() {
+        return conditionLevel <= 2 || !symptoms.isEmpty();
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/TemperatureRecord.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/TemperatureRecord.java
@@ -1,0 +1,44 @@
+package app.healthfamily.domain.healthrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.time.Instant;
+
+/**
+ * 体温の記録。
+ *
+ * <p>値の妥当性は {@link BodyTemperature} が持つ。ここは記録としての枠を担う。
+ */
+public record TemperatureRecord(
+        String id,
+        String userId,
+        String memberId,
+        BodyTemperature temperature,
+        Instant measuredAt,
+        String notes)
+        implements OwnedResource {
+
+    public TemperatureRecord {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("記録のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (temperature == null) {
+            throw DomainException.validation("体温は必須です");
+        }
+        if (measuredAt == null) {
+            throw DomainException.validation("測定日時は必須です");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    public FeverLevel feverLevel() {
+        return temperature.level();
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/healthrecord/VaccinationRecord.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/healthrecord/VaccinationRecord.java
@@ -1,0 +1,40 @@
+package app.healthfamily.domain.healthrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.time.LocalDate;
+
+/** ワクチン接種の記録。次回接種の判定は {@link VaccinationSchedule} が持つ。 */
+public record VaccinationRecord(
+        String id,
+        String userId,
+        String memberId,
+        String vaccineName,
+        VaccinationSchedule schedule,
+        String notes)
+        implements OwnedResource {
+
+    public VaccinationRecord {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("記録のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (vaccineName == null || vaccineName.isBlank()) {
+            throw DomainException.validation("ワクチン名は必須です");
+        }
+        if (schedule == null || schedule.vaccinatedAt() == null) {
+            throw DomainException.validation("接種日は必須です");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    public boolean needsReminderOn(LocalDate today) {
+        return schedule.needsReminderOn(today);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/hospital/Hospital.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/hospital/Hospital.java
@@ -1,0 +1,42 @@
+package app.healthfamily.domain.hospital;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.util.Optional;
+
+/**
+ * かかりつけ病院。
+ *
+ * <p>ドメイン規則は所有権と名前の必須のみ。判断が増えたらここに足す。
+ */
+public record Hospital(
+        String id,
+        String userId,
+        String name,
+        String hospitalType,
+        String address,
+        String phoneNumber,
+        String department,
+        String doctorName,
+        String notes)
+        implements OwnedResource {
+
+    public Hospital {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("病院のIDは必須です");
+        }
+        if (name == null || name.isBlank()) {
+            throw DomainException.validation("病院の名前は必須です");
+        }
+        name = name.trim();
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    public Optional<String> departmentName() {
+        return Optional.ofNullable(department);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/memberrecord/Allergy.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/memberrecord/Allergy.java
@@ -1,0 +1,46 @@
+package app.healthfamily.domain.memberrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+
+/**
+ * アレルギー。メンバーに紐づく記録。
+ *
+ * <p>ドメイン規則は所有権と必須項目のみ。判断が増えたらここに足す。
+ */
+public record Allergy(
+        String id,
+        String userId,
+        String memberId,
+        String allergenName,
+        String allergyType,
+        String severity,
+        String symptoms,
+        String notes)
+        implements OwnedResource {
+
+    public Allergy {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("アレルギーのIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (allergenName == null || allergenName.isBlank()) {
+            throw DomainException.validation("アレルゲン名は必須です");
+        }
+        if (allergyType == null || allergyType.isBlank()) {
+            throw DomainException.validation("アレルギーの種類は必須です");
+        }
+        // DB が NOT NULL のため必須。未指定なら「不明」として扱う運用もありうるが、
+        // 重症度は誤って空のまま登録されると危険なので明示させる
+        if (severity == null || severity.isBlank()) {
+            throw DomainException.validation("重症度は必須です");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/memberrecord/EmergencyContact.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/memberrecord/EmergencyContact.java
@@ -1,0 +1,40 @@
+package app.healthfamily.domain.memberrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+
+/**
+ * 緊急連絡先。メンバーに紐づく記録。
+ *
+ * <p>ドメイン規則は所有権と必須項目のみ。判断が増えたらここに足す。
+ */
+public record EmergencyContact(
+        String id,
+        String userId,
+        String memberId,
+        String contactName,
+        String phoneNumber,
+        String relationship,
+        String notes)
+        implements OwnedResource {
+
+    public EmergencyContact {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("緊急連絡先のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (contactName == null || contactName.isBlank()) {
+            throw DomainException.validation("連絡先の名前は必須です");
+        }
+        if (phoneNumber == null || phoneNumber.isBlank()) {
+            throw DomainException.validation("電話番号は必須です");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/memberrecord/Insurance.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/memberrecord/Insurance.java
@@ -1,0 +1,37 @@
+package app.healthfamily.domain.memberrecord;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+
+/**
+ * 保険。メンバーに紐づく記録。
+ *
+ * <p>ドメイン規則は所有権と必須項目のみ。判断が増えたらここに足す。
+ */
+public record Insurance(
+        String id,
+        String userId,
+        String memberId,
+        String insuranceType,
+        String providerName,
+        String policyNumber,
+        String notes)
+        implements OwnedResource {
+
+    public Insurance {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("保険のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (insuranceType == null || insuranceType.isBlank()) {
+            throw DomainException.validation("保険の種類は必須です");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/visit/Appointment.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/visit/Appointment.java
@@ -1,0 +1,80 @@
+package app.healthfamily.domain.visit;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+/**
+ * 通院の予定と記録。
+ *
+ * <p>リマインダーは「予約日の何日前から出すか」で決まる。過ぎた予約は通知しない。
+ * 済んだ予定を知らせても行動につながらないため、ワクチンとは扱いを変えている。
+ */
+public record Appointment(
+        String id,
+        String userId,
+        String memberId,
+        String hospitalId,
+        String appointmentType,
+        Instant appointmentDate,
+        String description,
+        String testResults,
+        Double cost,
+        boolean reminderEnabled,
+        int reminderDaysBefore)
+        implements OwnedResource {
+
+    public Appointment {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("通院記録のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (appointmentDate == null) {
+            throw DomainException.validation("通院日時は必須です");
+        }
+        if (reminderDaysBefore < 0 || reminderDaysBefore > 365) {
+            throw DomainException.validation("リマインダーの事前日数は 0〜365 日で指定してください");
+        }
+        if (cost != null && cost < 0) {
+            throw DomainException.validation("費用に負の値は指定できません");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    /** 通院日（アプリの基準タイムゾーンでの日付）。 */
+    public LocalDate dateIn(ZoneId zone) {
+        return appointmentDate.atZone(zone).toLocalDate();
+    }
+
+    /** 通院日までの日数。過ぎていれば負。 */
+    public long daysUntil(LocalDate today, ZoneId zone) {
+        return ChronoUnit.DAYS.between(today, dateIn(zone));
+    }
+
+    /**
+     * 通知すべきか。
+     *
+     * <p>設定が有効で、予約日まで所定の日数以内で、まだ過ぎていないときだけ。
+     */
+    public boolean needsReminderOn(LocalDate today, ZoneId zone) {
+        if (!reminderEnabled) {
+            return false;
+        }
+        long days = daysUntil(today, zone);
+        return days >= 0 && days <= reminderDaysBefore;
+    }
+
+    public Optional<String> hospital() {
+        return Optional.ofNullable(hospitalId);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/domain/visit/Examination.java
+++ b/backend-java/src/main/java/app/healthfamily/domain/visit/Examination.java
@@ -1,0 +1,58 @@
+package app.healthfamily.domain.visit;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+/**
+ * 検査の記録。
+ *
+ * <p>健康診断のように次回予定を持つものがある。次回が近づいたら通知する点は
+ * ワクチンと同じで、予定日を過ぎても止めない。受け忘れに気づく機会を残すため。
+ */
+public record Examination(
+        String id,
+        String userId,
+        String memberId,
+        String examinationType,
+        LocalDate examinedAt,
+        LocalDate nextScheduledDate,
+        String notes)
+        implements OwnedResource {
+
+    /** この日数前から通知する */
+    private static final long REMINDER_DAYS = 7;
+
+    public Examination {
+        if (id == null || id.isBlank()) {
+            throw DomainException.validation("検査記録のIDは必須です");
+        }
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        if (examinationType == null || examinationType.isBlank()) {
+            throw DomainException.validation("検査の種類は必須です");
+        }
+        if (examinedAt == null) {
+            throw DomainException.validation("検査日は必須です");
+        }
+        if (nextScheduledDate != null && nextScheduledDate.isBefore(examinedAt)) {
+            throw DomainException.validation("次回予定日は検査日より後の日付にしてください");
+        }
+    }
+
+    @Override
+    public String ownerId() {
+        return userId;
+    }
+
+    public Optional<Long> daysUntilNext(LocalDate today) {
+        return Optional.ofNullable(nextScheduledDate).map(d -> ChronoUnit.DAYS.between(today, d));
+    }
+
+    public boolean needsReminderOn(LocalDate today) {
+        return daysUntilNext(today).map(d -> d <= REMINDER_DAYS).orElse(false);
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/infrastructure/healthrecord/JooqBodyMeasurementRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/infrastructure/healthrecord/JooqBodyMeasurementRepository.java
@@ -1,0 +1,76 @@
+package app.healthfamily.infrastructure.healthrecord;
+
+import static app.healthfamily.infrastructure.jooq.Tables.BODYMEASUREMENT;
+
+import app.healthfamily.domain.healthrecord.BodyMeasurement;
+import app.healthfamily.domain.healthrecord.BodyMeasurementRecord;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.stereotype.Repository;
+
+/** 体格記録の永続化（jOOQ）。 */
+@Repository
+public class JooqBodyMeasurementRepository implements OwnedCrudRepository<BodyMeasurementRecord> {
+
+    private final DSLContext dsl;
+
+    public JooqBodyMeasurementRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public Optional<BodyMeasurementRecord> findById(String id) {
+        return dsl.select().from(BODYMEASUREMENT).where(BODYMEASUREMENT.ID.eq(id))
+                .fetchOptional().map(JooqBodyMeasurementRepository::toDomain);
+    }
+
+    @Override
+    public List<BodyMeasurementRecord> listByUser(String userId) {
+        return dsl.select().from(BODYMEASUREMENT)
+                .where(BODYMEASUREMENT.USERID.eq(userId))
+                .orderBy(BODYMEASUREMENT.RECORDEDAT.desc())
+                .fetch().map(JooqBodyMeasurementRepository::toDomain);
+    }
+
+    @Override
+    public void save(BodyMeasurementRecord r) {
+        var recorded = OffsetDateTime.ofInstant(r.recordedAt(), ZoneOffset.UTC);
+        var weight = r.measurement().weightKg();
+        var height = r.measurement().heightCm();
+        dsl.insertInto(BODYMEASUREMENT)
+                .set(BODYMEASUREMENT.ID, r.id())
+                .set(BODYMEASUREMENT.USERID, r.userId())
+                .set(BODYMEASUREMENT.MEMBERID, r.memberId())
+                .set(BODYMEASUREMENT.WEIGHT, weight)
+                .set(BODYMEASUREMENT.HEIGHT, height)
+                .set(BODYMEASUREMENT.RECORDEDAT, recorded)
+                .set(BODYMEASUREMENT.NOTES, r.notes())
+                .onConflict(BODYMEASUREMENT.ID)
+                .doUpdate()
+                .set(BODYMEASUREMENT.WEIGHT, weight)
+                .set(BODYMEASUREMENT.HEIGHT, height)
+                .set(BODYMEASUREMENT.RECORDEDAT, recorded)
+                .set(BODYMEASUREMENT.NOTES, r.notes())
+                .execute();
+    }
+
+    @Override
+    public void deleteById(String id) {
+        dsl.deleteFrom(BODYMEASUREMENT).where(BODYMEASUREMENT.ID.eq(id)).execute();
+    }
+
+    private static BodyMeasurementRecord toDomain(Record r) {
+        return new BodyMeasurementRecord(
+                r.get(BODYMEASUREMENT.ID),
+                r.get(BODYMEASUREMENT.USERID),
+                r.get(BODYMEASUREMENT.MEMBERID),
+                BodyMeasurement.of(r.get(BODYMEASUREMENT.WEIGHT), r.get(BODYMEASUREMENT.HEIGHT)),
+                r.get(BODYMEASUREMENT.RECORDEDAT).toInstant(),
+                r.get(BODYMEASUREMENT.NOTES));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/infrastructure/healthrecord/JooqTemperatureRecordRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/infrastructure/healthrecord/JooqTemperatureRecordRepository.java
@@ -1,0 +1,72 @@
+package app.healthfamily.infrastructure.healthrecord;
+
+import static app.healthfamily.infrastructure.jooq.Tables.TEMPERATURERECORD;
+
+import app.healthfamily.domain.healthrecord.BodyTemperature;
+import app.healthfamily.domain.healthrecord.TemperatureRecord;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.stereotype.Repository;
+
+/** 体温記録の永続化（jOOQ）。 */
+@Repository
+public class JooqTemperatureRecordRepository implements OwnedCrudRepository<TemperatureRecord> {
+
+    private final DSLContext dsl;
+
+    public JooqTemperatureRecordRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public Optional<TemperatureRecord> findById(String id) {
+        return dsl.select().from(TEMPERATURERECORD).where(TEMPERATURERECORD.ID.eq(id))
+                .fetchOptional().map(JooqTemperatureRecordRepository::toDomain);
+    }
+
+    @Override
+    public List<TemperatureRecord> listByUser(String userId) {
+        return dsl.select().from(TEMPERATURERECORD)
+                .where(TEMPERATURERECORD.USERID.eq(userId))
+                .orderBy(TEMPERATURERECORD.MEASUREDAT.desc())
+                .fetch().map(JooqTemperatureRecordRepository::toDomain);
+    }
+
+    @Override
+    public void save(TemperatureRecord r) {
+        var measured = OffsetDateTime.ofInstant(r.measuredAt(), ZoneOffset.UTC);
+        dsl.insertInto(TEMPERATURERECORD)
+                .set(TEMPERATURERECORD.ID, r.id())
+                .set(TEMPERATURERECORD.USERID, r.userId())
+                .set(TEMPERATURERECORD.MEMBERID, r.memberId())
+                .set(TEMPERATURERECORD.TEMPERATURE, r.temperature().value())
+                .set(TEMPERATURERECORD.MEASUREDAT, measured)
+                .set(TEMPERATURERECORD.NOTES, r.notes())
+                .onConflict(TEMPERATURERECORD.ID)
+                .doUpdate()
+                .set(TEMPERATURERECORD.TEMPERATURE, r.temperature().value())
+                .set(TEMPERATURERECORD.MEASUREDAT, measured)
+                .set(TEMPERATURERECORD.NOTES, r.notes())
+                .execute();
+    }
+
+    @Override
+    public void deleteById(String id) {
+        dsl.deleteFrom(TEMPERATURERECORD).where(TEMPERATURERECORD.ID.eq(id)).execute();
+    }
+
+    private static TemperatureRecord toDomain(Record r) {
+        return new TemperatureRecord(
+                r.get(TEMPERATURERECORD.ID),
+                r.get(TEMPERATURERECORD.USERID),
+                r.get(TEMPERATURERECORD.MEMBERID),
+                BodyTemperature.of(r.get(TEMPERATURERECORD.TEMPERATURE)),
+                r.get(TEMPERATURERECORD.MEASUREDAT).toInstant(),
+                r.get(TEMPERATURERECORD.NOTES));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/infrastructure/healthrecord/JooqVaccinationRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/infrastructure/healthrecord/JooqVaccinationRepository.java
@@ -1,0 +1,86 @@
+package app.healthfamily.infrastructure.healthrecord;
+
+import static app.healthfamily.infrastructure.jooq.Tables.VACCINATION;
+
+import app.healthfamily.domain.healthrecord.VaccinationRecord;
+import app.healthfamily.domain.healthrecord.VaccinationSchedule;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.stereotype.Repository;
+
+/** ワクチン記録の永続化（jOOQ）。 */
+@Repository
+public class JooqVaccinationRepository implements OwnedCrudRepository<VaccinationRecord> {
+
+    private final DSLContext dsl;
+
+    public JooqVaccinationRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public Optional<VaccinationRecord> findById(String id) {
+        return dsl.select().from(VACCINATION).where(VACCINATION.ID.eq(id))
+                .fetchOptional().map(JooqVaccinationRepository::toDomain);
+    }
+
+    @Override
+    public List<VaccinationRecord> listByUser(String userId) {
+        return dsl.select().from(VACCINATION)
+                .where(VACCINATION.USERID.eq(userId))
+                .orderBy(VACCINATION.VACCINATEDAT.desc())
+                .fetch().map(JooqVaccinationRepository::toDomain);
+    }
+
+    @Override
+    public void save(VaccinationRecord r) {
+        var vaccinated = toOffset(r.schedule().vaccinatedAt());
+        var next = toOffset(r.schedule().nextScheduledDate());
+        dsl.insertInto(VACCINATION)
+                .set(VACCINATION.ID, r.id())
+                .set(VACCINATION.USERID, r.userId())
+                .set(VACCINATION.MEMBERID, r.memberId())
+                .set(VACCINATION.VACCINENAME, r.vaccineName())
+                .set(VACCINATION.VACCINATEDAT, vaccinated)
+                .set(VACCINATION.NEXTSCHEDULEDDATE, next)
+                .set(VACCINATION.NOTES, r.notes())
+                .onConflict(VACCINATION.ID)
+                .doUpdate()
+                .set(VACCINATION.VACCINENAME, r.vaccineName())
+                .set(VACCINATION.VACCINATEDAT, vaccinated)
+                .set(VACCINATION.NEXTSCHEDULEDDATE, next)
+                .set(VACCINATION.NOTES, r.notes())
+                .execute();
+    }
+
+    @Override
+    public void deleteById(String id) {
+        dsl.deleteFrom(VACCINATION).where(VACCINATION.ID.eq(id)).execute();
+    }
+
+    private static OffsetDateTime toOffset(LocalDate d) {
+        return d == null ? null : OffsetDateTime.of(d.atStartOfDay(), ZoneOffset.UTC);
+    }
+
+    private static LocalDate toDate(OffsetDateTime t) {
+        return t == null ? null : t.atZoneSameInstant(ZoneOffset.UTC).toLocalDate();
+    }
+
+    private static VaccinationRecord toDomain(Record r) {
+        return new VaccinationRecord(
+                r.get(VACCINATION.ID),
+                r.get(VACCINATION.USERID),
+                r.get(VACCINATION.MEMBERID),
+                r.get(VACCINATION.VACCINENAME),
+                VaccinationSchedule.of(
+                        toDate(r.get(VACCINATION.VACCINATEDAT)),
+                        toDate(r.get(VACCINATION.NEXTSCHEDULEDDATE))),
+                r.get(VACCINATION.NOTES));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/infrastructure/hospital/JooqHospitalRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/infrastructure/hospital/JooqHospitalRepository.java
@@ -1,0 +1,80 @@
+package app.healthfamily.infrastructure.hospital;
+
+import static app.healthfamily.infrastructure.jooq.Tables.HOSPITAL;
+
+import app.healthfamily.domain.hospital.Hospital;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.stereotype.Repository;
+
+/** 病院の永続化（jOOQ）。 */
+@Repository
+public class JooqHospitalRepository implements OwnedCrudRepository<Hospital> {
+
+    private final DSLContext dsl;
+
+    public JooqHospitalRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public Optional<Hospital> findById(String id) {
+        return dsl.select().from(HOSPITAL).where(HOSPITAL.ID.eq(id)).fetchOptional()
+                .map(JooqHospitalRepository::toDomain);
+    }
+
+    @Override
+    public List<Hospital> listByUser(String userId) {
+        return dsl.select().from(HOSPITAL)
+                .where(HOSPITAL.USERID.eq(userId))
+                .orderBy(HOSPITAL.CREATEDAT.asc())
+                .fetch()
+                .map(JooqHospitalRepository::toDomain);
+    }
+
+    /** 挿入と更新を1つにまとめる。呼び出し側は存在を意識しなくてよい。 */
+    @Override
+    public void save(Hospital h) {
+        dsl.insertInto(HOSPITAL)
+                .set(HOSPITAL.ID, h.id())
+                .set(HOSPITAL.USERID, h.userId())
+                .set(HOSPITAL.NAME, h.name())
+                .set(HOSPITAL.HOSPITALTYPE, h.hospitalType())
+                .set(HOSPITAL.ADDRESS, h.address())
+                .set(HOSPITAL.PHONENUMBER, h.phoneNumber())
+                .set(HOSPITAL.DEPARTMENT, h.department())
+                .set(HOSPITAL.DOCTORNAME, h.doctorName())
+                .set(HOSPITAL.NOTES, h.notes())
+                .onConflict(HOSPITAL.ID)
+                .doUpdate()
+                .set(HOSPITAL.NAME, h.name())
+                .set(HOSPITAL.HOSPITALTYPE, h.hospitalType())
+                .set(HOSPITAL.ADDRESS, h.address())
+                .set(HOSPITAL.PHONENUMBER, h.phoneNumber())
+                .set(HOSPITAL.DEPARTMENT, h.department())
+                .set(HOSPITAL.DOCTORNAME, h.doctorName())
+                .set(HOSPITAL.NOTES, h.notes())
+                .execute();
+    }
+
+    @Override
+    public void deleteById(String id) {
+        dsl.deleteFrom(HOSPITAL).where(HOSPITAL.ID.eq(id)).execute();
+    }
+
+    private static Hospital toDomain(Record r) {
+        return new Hospital(
+                r.get(HOSPITAL.ID),
+                r.get(HOSPITAL.USERID),
+                r.get(HOSPITAL.NAME),
+                r.get(HOSPITAL.HOSPITALTYPE),
+                r.get(HOSPITAL.ADDRESS),
+                r.get(HOSPITAL.PHONENUMBER),
+                r.get(HOSPITAL.DEPARTMENT),
+                r.get(HOSPITAL.DOCTORNAME),
+                r.get(HOSPITAL.NOTES));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/infrastructure/memberrecord/JooqAllergyRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/infrastructure/memberrecord/JooqAllergyRepository.java
@@ -1,0 +1,76 @@
+package app.healthfamily.infrastructure.memberrecord;
+
+import static app.healthfamily.infrastructure.jooq.Tables.ALLERGY;
+
+import app.healthfamily.domain.memberrecord.Allergy;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.stereotype.Repository;
+
+/** Allergy の永続化（jOOQ）。 */
+@Repository
+public class JooqAllergyRepository implements OwnedCrudRepository<Allergy> {
+
+    private final DSLContext dsl;
+
+    public JooqAllergyRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public Optional<Allergy> findById(String id) {
+        return dsl.select().from(ALLERGY).where(ALLERGY.ID.eq(id)).fetchOptional()
+                .map(JooqAllergyRepository::toDomain);
+    }
+
+    @Override
+    public List<Allergy> listByUser(String userId) {
+        return dsl.select().from(ALLERGY)
+                .where(ALLERGY.USERID.eq(userId))
+                .orderBy(ALLERGY.CREATEDAT.asc())
+                .fetch()
+                .map(JooqAllergyRepository::toDomain);
+    }
+
+    /** 挿入と更新を1つにまとめる。呼び出し側は存在を意識しなくてよい。 */
+    @Override
+    public void save(Allergy e) {
+        dsl.insertInto(ALLERGY)
+                .set(ALLERGY.ID, e.id())
+                .set(ALLERGY.USERID, e.userId())
+                .set(ALLERGY.MEMBERID, e.memberId())
+                .set(ALLERGY.ALLERGENNAME, e.allergenName())
+                .set(ALLERGY.ALLERGYTYPE, e.allergyType())
+                .set(ALLERGY.SEVERITY, e.severity())
+                .set(ALLERGY.SYMPTOMS, e.symptoms())
+                .set(ALLERGY.NOTES, e.notes())
+                .onConflict(ALLERGY.ID)
+                .doUpdate()
+                .set(ALLERGY.ALLERGENNAME, e.allergenName())
+                .set(ALLERGY.ALLERGYTYPE, e.allergyType())
+                .set(ALLERGY.SEVERITY, e.severity())
+                .set(ALLERGY.SYMPTOMS, e.symptoms())
+                .set(ALLERGY.NOTES, e.notes())
+                .execute();
+    }
+
+    @Override
+    public void deleteById(String id) {
+        dsl.deleteFrom(ALLERGY).where(ALLERGY.ID.eq(id)).execute();
+    }
+
+    private static Allergy toDomain(Record r) {
+        return new Allergy(
+                r.get(ALLERGY.ID),
+                r.get(ALLERGY.USERID),
+                r.get(ALLERGY.MEMBERID),
+                r.get(ALLERGY.ALLERGENNAME),
+                r.get(ALLERGY.ALLERGYTYPE),
+                r.get(ALLERGY.SEVERITY),
+                r.get(ALLERGY.SYMPTOMS),
+                r.get(ALLERGY.NOTES));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/infrastructure/memberrecord/JooqEmergencyContactRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/infrastructure/memberrecord/JooqEmergencyContactRepository.java
@@ -1,0 +1,73 @@
+package app.healthfamily.infrastructure.memberrecord;
+
+import static app.healthfamily.infrastructure.jooq.Tables.EMERGENCYCONTACT;
+
+import app.healthfamily.domain.memberrecord.EmergencyContact;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.stereotype.Repository;
+
+/** EmergencyContact の永続化（jOOQ）。 */
+@Repository
+public class JooqEmergencyContactRepository implements OwnedCrudRepository<EmergencyContact> {
+
+    private final DSLContext dsl;
+
+    public JooqEmergencyContactRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public Optional<EmergencyContact> findById(String id) {
+        return dsl.select().from(EMERGENCYCONTACT).where(EMERGENCYCONTACT.ID.eq(id)).fetchOptional()
+                .map(JooqEmergencyContactRepository::toDomain);
+    }
+
+    @Override
+    public List<EmergencyContact> listByUser(String userId) {
+        return dsl.select().from(EMERGENCYCONTACT)
+                .where(EMERGENCYCONTACT.USERID.eq(userId))
+                .orderBy(EMERGENCYCONTACT.CREATEDAT.asc())
+                .fetch()
+                .map(JooqEmergencyContactRepository::toDomain);
+    }
+
+    /** 挿入と更新を1つにまとめる。呼び出し側は存在を意識しなくてよい。 */
+    @Override
+    public void save(EmergencyContact e) {
+        dsl.insertInto(EMERGENCYCONTACT)
+                .set(EMERGENCYCONTACT.ID, e.id())
+                .set(EMERGENCYCONTACT.USERID, e.userId())
+                .set(EMERGENCYCONTACT.MEMBERID, e.memberId())
+                .set(EMERGENCYCONTACT.CONTACTNAME, e.contactName())
+                .set(EMERGENCYCONTACT.PHONENUMBER, e.phoneNumber())
+                .set(EMERGENCYCONTACT.RELATIONSHIP, e.relationship())
+                .set(EMERGENCYCONTACT.NOTES, e.notes())
+                .onConflict(EMERGENCYCONTACT.ID)
+                .doUpdate()
+                .set(EMERGENCYCONTACT.CONTACTNAME, e.contactName())
+                .set(EMERGENCYCONTACT.PHONENUMBER, e.phoneNumber())
+                .set(EMERGENCYCONTACT.RELATIONSHIP, e.relationship())
+                .set(EMERGENCYCONTACT.NOTES, e.notes())
+                .execute();
+    }
+
+    @Override
+    public void deleteById(String id) {
+        dsl.deleteFrom(EMERGENCYCONTACT).where(EMERGENCYCONTACT.ID.eq(id)).execute();
+    }
+
+    private static EmergencyContact toDomain(Record r) {
+        return new EmergencyContact(
+                r.get(EMERGENCYCONTACT.ID),
+                r.get(EMERGENCYCONTACT.USERID),
+                r.get(EMERGENCYCONTACT.MEMBERID),
+                r.get(EMERGENCYCONTACT.CONTACTNAME),
+                r.get(EMERGENCYCONTACT.PHONENUMBER),
+                r.get(EMERGENCYCONTACT.RELATIONSHIP),
+                r.get(EMERGENCYCONTACT.NOTES));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/infrastructure/memberrecord/JooqInsuranceRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/infrastructure/memberrecord/JooqInsuranceRepository.java
@@ -1,0 +1,73 @@
+package app.healthfamily.infrastructure.memberrecord;
+
+import static app.healthfamily.infrastructure.jooq.Tables.INSURANCE;
+
+import app.healthfamily.domain.memberrecord.Insurance;
+import app.healthfamily.usecase.crud.OwnedCrudRepository;
+import java.util.List;
+import java.util.Optional;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.springframework.stereotype.Repository;
+
+/** Insurance の永続化（jOOQ）。 */
+@Repository
+public class JooqInsuranceRepository implements OwnedCrudRepository<Insurance> {
+
+    private final DSLContext dsl;
+
+    public JooqInsuranceRepository(DSLContext dsl) {
+        this.dsl = dsl;
+    }
+
+    @Override
+    public Optional<Insurance> findById(String id) {
+        return dsl.select().from(INSURANCE).where(INSURANCE.ID.eq(id)).fetchOptional()
+                .map(JooqInsuranceRepository::toDomain);
+    }
+
+    @Override
+    public List<Insurance> listByUser(String userId) {
+        return dsl.select().from(INSURANCE)
+                .where(INSURANCE.USERID.eq(userId))
+                .orderBy(INSURANCE.CREATEDAT.asc())
+                .fetch()
+                .map(JooqInsuranceRepository::toDomain);
+    }
+
+    /** 挿入と更新を1つにまとめる。呼び出し側は存在を意識しなくてよい。 */
+    @Override
+    public void save(Insurance e) {
+        dsl.insertInto(INSURANCE)
+                .set(INSURANCE.ID, e.id())
+                .set(INSURANCE.USERID, e.userId())
+                .set(INSURANCE.MEMBERID, e.memberId())
+                .set(INSURANCE.INSURANCETYPE, e.insuranceType())
+                .set(INSURANCE.PROVIDERNAME, e.providerName())
+                .set(INSURANCE.POLICYNUMBER, e.policyNumber())
+                .set(INSURANCE.NOTES, e.notes())
+                .onConflict(INSURANCE.ID)
+                .doUpdate()
+                .set(INSURANCE.INSURANCETYPE, e.insuranceType())
+                .set(INSURANCE.PROVIDERNAME, e.providerName())
+                .set(INSURANCE.POLICYNUMBER, e.policyNumber())
+                .set(INSURANCE.NOTES, e.notes())
+                .execute();
+    }
+
+    @Override
+    public void deleteById(String id) {
+        dsl.deleteFrom(INSURANCE).where(INSURANCE.ID.eq(id)).execute();
+    }
+
+    private static Insurance toDomain(Record r) {
+        return new Insurance(
+                r.get(INSURANCE.ID),
+                r.get(INSURANCE.USERID),
+                r.get(INSURANCE.MEMBERID),
+                r.get(INSURANCE.INSURANCETYPE),
+                r.get(INSURANCE.PROVIDERNAME),
+                r.get(INSURANCE.POLICYNUMBER),
+                r.get(INSURANCE.NOTES));
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/usecase/crud/MemberScopedCrudUseCase.java
+++ b/backend-java/src/main/java/app/healthfamily/usecase/crud/MemberScopedCrudUseCase.java
@@ -1,0 +1,86 @@
+package app.healthfamily.usecase.crud;
+
+import app.healthfamily.domain.member.MemberRepository;
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * メンバーに紐づく記録の読み書き。
+ *
+ * <p>{@link OwnedCrudUseCase} に「対象メンバーも自分のものか」の確認を足したもの。
+ *
+ * <p>所有者だけを見ていると、<b>他人のメンバーに自分の記録をぶら下げられる</b>。
+ * 記録自体は自分のものなので所有権チェックは通ってしまい、
+ * 相手の画面に身に覚えのないアレルギーや連絡先が現れることになる。
+ * メンバーの所有者まで確認して初めて防げる。
+ */
+public class MemberScopedCrudUseCase<T extends OwnedResource> {
+
+    private final OwnedCrudUseCase<T> delegate;
+    private final MemberRepository members;
+    private final Function<T, String> memberIdOf;
+    private final String resourceName;
+
+    public MemberScopedCrudUseCase(
+            OwnedCrudRepository<T> repository,
+            MemberRepository members,
+            Function<T, String> memberIdOf,
+            String resourceName) {
+        this.delegate = new OwnedCrudUseCase<>(repository, resourceName);
+        this.members = members;
+        this.memberIdOf = memberIdOf;
+        this.resourceName = resourceName;
+    }
+
+    @Transactional(readOnly = true)
+    public List<T> list(String userId) {
+        return delegate.list(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public T get(String userId, String id) {
+        return delegate.get(userId, id);
+    }
+
+    @Transactional
+    public T create(String userId, T entity) {
+        requireOwnedMember(userId, memberIdOf.apply(entity));
+        return delegate.create(userId, entity);
+    }
+
+    @Transactional
+    public T update(String userId, String id, UnaryOperator<T> mutation) {
+        return delegate.update(
+                userId,
+                id,
+                current -> {
+                    T updated = mutation.apply(current);
+                    // 更新で別のメンバーへ付け替える経路も塞ぐ
+                    requireOwnedMember(userId, memberIdOf.apply(updated));
+                    return updated;
+                });
+    }
+
+    @Transactional
+    public void delete(String userId, String id) {
+        delegate.delete(userId, id);
+    }
+
+    private void requireOwnedMember(String userId, String memberId) {
+        if (memberId == null || memberId.isBlank()) {
+            throw DomainException.validation("対象メンバーは必須です");
+        }
+        members
+                .findById(memberId)
+                .orElseThrow(() -> DomainException.notFound("メンバー"))
+                .requireOwnedBy(userId);
+    }
+
+    public String resourceName() {
+        return resourceName;
+    }
+}

--- a/backend-java/src/main/java/app/healthfamily/usecase/crud/OwnedCrudRepository.java
+++ b/backend-java/src/main/java/app/healthfamily/usecase/crud/OwnedCrudRepository.java
@@ -1,0 +1,23 @@
+package app.healthfamily.usecase.crud;
+
+import app.healthfamily.domain.shared.OwnedResource;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 所有者を持つだけの資源の永続化ポート。
+ *
+ * <p>絞り込みの責任はユースケース側にある。{@link #findById} は所有者を見ないので、
+ * これを直接呼ぶ実装を書くと権限チェックが抜ける。必ず
+ * {@link OwnedCrudUseCase} を通すこと。
+ */
+public interface OwnedCrudRepository<T extends OwnedResource> {
+
+    Optional<T> findById(String id);
+
+    List<T> listByUser(String userId);
+
+    void save(T entity);
+
+    void deleteById(String id);
+}

--- a/backend-java/src/main/java/app/healthfamily/usecase/crud/OwnedCrudUseCase.java
+++ b/backend-java/src/main/java/app/healthfamily/usecase/crud/OwnedCrudUseCase.java
@@ -1,0 +1,75 @@
+package app.healthfamily.usecase.crud;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 所有者を持つだけの資源に共通する読み書きの手順。
+ *
+ * <p>病院・アレルギー・保険・緊急連絡先など、ドメイン規則が所有権チェックしかない
+ * 資源が多数ある。同じ手順を資源ごとに書き写すと、いずれ 1 箇所だけ
+ * 所有権チェックを書き忘れて他人のデータが操作できるようになる。
+ * 手順をここに 1 つだけ置く。
+ *
+ * @param resourceName 利用者向けメッセージに出す資源名（「病院」など）
+ */
+public class OwnedCrudUseCase<T extends OwnedResource> {
+
+    private final OwnedCrudRepository<T> repository;
+    private final String resourceName;
+
+    public OwnedCrudUseCase(OwnedCrudRepository<T> repository, String resourceName) {
+        this.repository = repository;
+        this.resourceName = resourceName;
+    }
+
+    @Transactional(readOnly = true)
+    public List<T> list(String userId) {
+        return repository.listByUser(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public T get(String userId, String id) {
+        return loadOwned(userId, id);
+    }
+
+    @Transactional
+    public T create(String userId, T entity) {
+        // 他人を所有者にした作成を防ぐ。所有者はトークンの持ち主でなければならない
+        entity.requireOwnedBy(userId, resourceName);
+        repository.save(entity);
+        return entity;
+    }
+
+    /**
+     * 既存の値をもとに更新する。
+     *
+     * @param mutation 現在の値を受け取り、更新後の値を返す。所有者は変更できない
+     */
+    @Transactional
+    public T update(String userId, String id, UnaryOperator<T> mutation) {
+        T current = loadOwned(userId, id);
+        T updated = mutation.apply(current);
+        // 更新のついでに所有者をすげ替えられないようにする
+        updated.requireOwnedBy(userId, resourceName + "の所有者");
+        repository.save(updated);
+        return updated;
+    }
+
+    @Transactional
+    public void delete(String userId, String id) {
+        loadOwned(userId, id);
+        repository.deleteById(id);
+    }
+
+    /** 存在確認と所有権確認をまとめて行う。読み書きの入口はすべてここを通す。 */
+    private T loadOwned(String userId, String id) {
+        T entity =
+                repository.findById(id).orElseThrow(() -> DomainException.notFound(resourceName));
+        entity.requireOwnedBy(userId, resourceName);
+        return entity;
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/apiController/healthrecord/HealthRecordControllerIT.java
+++ b/backend-java/src/test/java/app/healthfamily/apiController/healthrecord/HealthRecordControllerIT.java
@@ -1,0 +1,263 @@
+package app.healthfamily.apiController.healthrecord;
+
+import static app.healthfamily.infrastructure.jooq.Tables.TEMPERATURERECORD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.healthfamily.domain.auth.AccessTokenIssuer;
+import app.healthfamily.domain.auth.User;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * 体温・体格・ワクチンのエンドポイント。
+ *
+ * <p>これらは値オブジェクトに検証規則を持たせてある。エンドポイント越しでも
+ * その規則が効いていることを確かめる。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(HealthRecordControllerIT.FixedClockConfig.class)
+@DisplayName("健康記録エンドポイント（実DB）")
+class HealthRecordControllerIT {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(NOW, ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired MockMvc mockMvc;
+    @Autowired DSLContext dsl;
+    @Autowired AccessTokenIssuer tokens;
+
+    private String bearer;
+    private String otherBearer;
+
+    @BeforeEach
+    void setUp() {
+        dsl.execute(
+                "TRUNCATE \"TemperatureRecord\", \"BodyMeasurement\", \"Vaccination\","
+                        + " \"Member\", \"User\" CASCADE");
+        dsl.execute(
+                """
+                INSERT INTO "User" (id, email, password, "updatedAt")
+                VALUES ('user-1', 'owner@example.test', '', now()),
+                       ('user-2', 'other@example.test', '', now())
+                """);
+        dsl.execute(
+                """
+                INSERT INTO "Member" (id, "userId", name, "memberType", "updatedAt")
+                VALUES ('member-1', 'user-1', '本人', 'human', now()),
+                       ('member-2', 'user-2', '他人', 'human', now())
+                """);
+        bearer = bearerFor("user-1");
+        otherBearer = bearerFor("user-2");
+    }
+
+    private String bearerFor(String userId) {
+        return "Bearer "
+                + tokens.issue(
+                        User.reconstitute(userId, userId + "@example.test", "", null, "cat", null, true),
+                        NOW);
+    }
+
+    @Nested
+    @DisplayName("体温")
+    class Temperature {
+
+        @Test
+        @DisplayName("記録すると発熱の段階が付く")
+        void recordsWithFeverLevel() throws Exception {
+            mockMvc.perform(
+                            post("/api/temperature-records")
+                                    .header(HttpHeaders.AUTHORIZATION, bearer)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                                            {"memberId":"member-1","temperature":38.2,
+                                             "measuredAt":"2026-08-16T09:00:00Z"}
+                                            """))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.temperature").value(38.2))
+                    .andExpect(jsonPath("$.data.feverLevel").value("FEVER"));
+
+            assertThat(dsl.fetchCount(TEMPERATURERECORD)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("ありえない体温は 400 で、保存されない")
+        void impossibleTemperatureIsRejected() throws Exception {
+            mockMvc.perform(
+                            post("/api/temperature-records")
+                                    .header(HttpHeaders.AUTHORIZATION, bearer)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                                            {"memberId":"member-1","temperature":365,
+                                             "measuredAt":"2026-08-16T09:00:00Z"}
+                                            """))
+                    .andExpect(status().isBadRequest());
+
+            assertThat(dsl.fetchCount(TEMPERATURERECORD)).isZero();
+        }
+
+        @Test
+        @DisplayName("他人のメンバーには記録できない")
+        void cannotRecordForOtherUsersMember() throws Exception {
+            mockMvc.perform(
+                            post("/api/temperature-records")
+                                    .header(HttpHeaders.AUTHORIZATION, bearer)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                                            {"memberId":"member-2","temperature":36.5,
+                                             "measuredAt":"2026-08-16T09:00:00Z"}
+                                            """))
+                    .andExpect(status().isForbidden());
+
+            assertThat(dsl.fetchCount(TEMPERATURERECORD)).isZero();
+        }
+
+        @Test
+        @DisplayName("一覧は自分のものだけ")
+        void listIsScoped() throws Exception {
+            mockMvc.perform(
+                    post("/api/temperature-records")
+                            .header(HttpHeaders.AUTHORIZATION, bearer)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(
+                                    """
+                                    {"memberId":"member-1","temperature":36.5,
+                                     "measuredAt":"2026-08-16T09:00:00Z"}
+                                    """));
+
+            mockMvc.perform(get("/api/temperature-records").header(HttpHeaders.AUTHORIZATION, otherBearer))
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("体格")
+    class Measurement {
+
+        @Test
+        @DisplayName("身長と体重を記録すると BMI が返る")
+        void recordsWithBmi() throws Exception {
+            mockMvc.perform(
+                            post("/api/body-measurements")
+                                    .header(HttpHeaders.AUTHORIZATION, bearer)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                                            {"memberId":"member-1","weight":60.0,"height":170.0,
+                                             "recordedAt":"2026-08-16T09:00:00Z"}
+                                            """))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.bmi").value(20.8));
+        }
+
+        @Test
+        @DisplayName("体重も身長も無ければ 400")
+        void emptyMeasurementIsRejected() throws Exception {
+            mockMvc.perform(
+                            post("/api/body-measurements")
+                                    .header(HttpHeaders.AUTHORIZATION, bearer)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                                            {"memberId":"member-1","recordedAt":"2026-08-16T09:00:00Z"}
+                                            """))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("ワクチン")
+    class Vaccination {
+
+        @Test
+        @DisplayName("次回予定日が近いと通知対象になる")
+        void nextDateSoonNeedsReminder() throws Exception {
+            mockMvc.perform(
+                            post("/api/vaccinations")
+                                    .header(HttpHeaders.AUTHORIZATION, bearer)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                                            {"memberId":"member-1","vaccineName":"狂犬病",
+                                             "vaccinatedAt":"2026-01-10T00:00:00Z",
+                                             "nextScheduledDate":"2026-08-20T00:00:00Z"}
+                                            """))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.needsReminder").value(true))
+                    .andExpect(jsonPath("$.data.daysUntilNext").value(4));
+        }
+
+        @Test
+        @DisplayName("次回予定日が接種日より前なら 400")
+        void nextBeforeVaccinatedIsRejected() throws Exception {
+            mockMvc.perform(
+                            post("/api/vaccinations")
+                                    .header(HttpHeaders.AUTHORIZATION, bearer)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(
+                                            """
+                                            {"memberId":"member-1","vaccineName":"狂犬病",
+                                             "vaccinatedAt":"2026-06-01T00:00:00Z",
+                                             "nextScheduledDate":"2026-05-01T00:00:00Z"}
+                                            """))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("削除できる")
+        void canDelete() throws Exception {
+            var body =
+                    mockMvc.perform(
+                                    post("/api/vaccinations")
+                                            .header(HttpHeaders.AUTHORIZATION, bearer)
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .content(
+                                                    """
+                                                    {"memberId":"member-1","vaccineName":"混合",
+                                                     "vaccinatedAt":"2026-01-10T00:00:00Z"}
+                                                    """))
+                            .andReturn()
+                            .getResponse()
+                            .getContentAsString();
+            String id = body.replaceAll(".*\"id\":\"([^\"]+)\".*", "$1");
+
+            mockMvc.perform(delete("/api/vaccinations/" + id).header(HttpHeaders.AUTHORIZATION, bearer))
+                    .andExpect(status().isNoContent());
+
+            mockMvc.perform(get("/api/vaccinations").header(HttpHeaders.AUTHORIZATION, bearer))
+                    .andExpect(jsonPath("$.data.length()").value(0));
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/apiController/hospital/HospitalControllerIT.java
+++ b/backend-java/src/test/java/app/healthfamily/apiController/hospital/HospitalControllerIT.java
@@ -1,0 +1,183 @@
+package app.healthfamily.apiController.hospital;
+
+import static app.healthfamily.infrastructure.jooq.Tables.HOSPITAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.healthfamily.domain.auth.AccessTokenIssuer;
+import app.healthfamily.domain.auth.User;
+import java.time.Instant;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** 病院エンドポイントを実 DB と実トークンで通す。共通CRUDが権限で守られていることの確認を兼ねる。 */
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("病院エンドポイント（実DB）")
+class HospitalControllerIT {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");
+
+    @Autowired MockMvc mockMvc;
+    @Autowired DSLContext dsl;
+    @Autowired AccessTokenIssuer tokens;
+
+    private String bearer;
+    private String otherBearer;
+
+    @BeforeEach
+    void setUp() {
+        dsl.execute("TRUNCATE \"Appointment\", \"Hospital\", \"Member\", \"User\" CASCADE");
+        dsl.execute(
+                """
+                INSERT INTO "User" (id, email, password, "updatedAt")
+                VALUES ('user-1', 'owner@example.test', '', now()),
+                       ('user-2', 'other@example.test', '', now())
+                """);
+        bearer = bearerFor("user-1");
+        otherBearer = bearerFor("user-2");
+    }
+
+    private String bearerFor(String userId) {
+        return "Bearer "
+                + tokens.issue(
+                        User.reconstitute(userId, userId + "@example.test", "", null, "cat", null, true),
+                        NOW);
+    }
+
+    private String createHospital(String token, String name) throws Exception {
+        var body =
+                mockMvc.perform(
+                                post("/api/hospitals")
+                                        .header(HttpHeaders.AUTHORIZATION, token)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content("{\"name\":\"" + name + "\",\"department\":\"内科\"}"))
+                        .andExpect(status().isCreated())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+        return body.replaceAll(".*\"id\":\"([^\"]+)\".*", "$1");
+    }
+
+    @Test
+    @DisplayName("登録して一覧に出る")
+    void createAndList() throws Exception {
+        createHospital(bearer, "かかりつけ医");
+
+        mockMvc.perform(get("/api/hospitals").header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].name").value("かかりつけ医"));
+    }
+
+    @Test
+    @DisplayName("一覧は自分のものだけ")
+    void listIsScoped() throws Exception {
+        createHospital(bearer, "自分の病院");
+        createHospital(otherBearer, "他人の病院");
+
+        mockMvc.perform(get("/api/hospitals").header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].name").value("自分の病院"));
+    }
+
+    @Test
+    @DisplayName("名前は必須")
+    void nameIsRequired() throws Exception {
+        mockMvc.perform(
+                        post("/api/hospitals")
+                                .header(HttpHeaders.AUTHORIZATION, bearer)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"name\":\" \"}"))
+                .andExpect(status().isBadRequest());
+
+        assertThat(dsl.fetchCount(HOSPITAL)).isZero();
+    }
+
+    @Test
+    @DisplayName("他人の病院は取得できない")
+    void otherGetIsForbidden() throws Exception {
+        String id = createHospital(otherBearer, "他人の病院");
+
+        mockMvc.perform(get("/api/hospitals/" + id).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("他人の病院は更新できず、値も変わらない")
+    void otherUpdateIsForbidden() throws Exception {
+        String id = createHospital(otherBearer, "他人の病院");
+
+        mockMvc.perform(
+                        patch("/api/hospitals/" + id)
+                                .header(HttpHeaders.AUTHORIZATION, bearer)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"name\":\"乗っ取り\"}"))
+                .andExpect(status().isForbidden());
+
+        assertThat(dsl.select(HOSPITAL.NAME).from(HOSPITAL).where(HOSPITAL.ID.eq(id)).fetchSingle(HOSPITAL.NAME))
+                .isEqualTo("他人の病院");
+    }
+
+    @Test
+    @DisplayName("他人の病院は削除できず、残る")
+    void otherDeleteIsForbidden() throws Exception {
+        String id = createHospital(otherBearer, "他人の病院");
+
+        mockMvc.perform(delete("/api/hospitals/" + id).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isForbidden());
+
+        assertThat(dsl.fetchCount(HOSPITAL, HOSPITAL.ID.eq(id))).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("自分の病院は更新できる")
+    void ownUpdateSucceeds() throws Exception {
+        String id = createHospital(bearer, "旧名");
+
+        mockMvc.perform(
+                        patch("/api/hospitals/" + id)
+                                .header(HttpHeaders.AUTHORIZATION, bearer)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"name\":\"新名\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.name").value("新名"));
+    }
+
+    @Test
+    @DisplayName("自分の病院は削除できる")
+    void ownDeleteSucceeds() throws Exception {
+        String id = createHospital(bearer, "閉院した病院");
+
+        mockMvc.perform(delete("/api/hospitals/" + id).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isNoContent());
+
+        assertThat(dsl.fetchCount(HOSPITAL)).isZero();
+    }
+
+    @Test
+    @DisplayName("存在しない病院は 404")
+    void missingIsNotFound() throws Exception {
+        mockMvc.perform(get("/api/hospitals/nope").header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("トークン無しでは 401")
+    void withoutTokenIsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/hospitals")).andExpect(status().isUnauthorized());
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/apiController/memberrecord/MemberScopedCrudIT.java
+++ b/backend-java/src/test/java/app/healthfamily/apiController/memberrecord/MemberScopedCrudIT.java
@@ -1,0 +1,233 @@
+package app.healthfamily.apiController.memberrecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.healthfamily.domain.auth.AccessTokenIssuer;
+import app.healthfamily.domain.auth.User;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * メンバーに紐づく記録の共通挙動を、全リソースまとめて検証する。
+ *
+ * <p>資源が増えるたびに同じテストを書き写すと、いずれ 1 つだけ
+ * 権限のテストが抜ける。パラメータ化して同じ観点を必ず全資源に当てる。
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("メンバー記録の共通CRUD（実DB）")
+class MemberScopedCrudIT {
+
+    private static final Instant NOW = Instant.parse("2026-08-16T12:00:00Z");
+
+    @Autowired MockMvc mockMvc;
+    @Autowired DSLContext dsl;
+    @Autowired AccessTokenIssuer tokens;
+
+    private String bearer;
+    private String otherBearer;
+
+    /** 資源ごとの「作成に必要な最小の本文」と「更新で変える項目」 */
+    static Stream<Arguments> resources() {
+        return Stream.of(
+                Arguments.of(
+                        "allergies",
+                        "{\"memberId\":\"member-1\",\"allergenName\":\"卵\",\"allergyType\":\"food\",\"severity\":\"mild\"}",
+                        "{\"allergenName\":\"そば\"}",
+                        "allergenName",
+                        "そば"),
+                Arguments.of(
+                        "emergency-contacts",
+                        "{\"memberId\":\"member-1\",\"contactName\":\"父\",\"phoneNumber\":\"090-0000-0000\"}",
+                        "{\"contactName\":\"母\"}",
+                        "contactName",
+                        "母"),
+                Arguments.of(
+                        "insurances",
+                        "{\"memberId\":\"member-1\",\"insuranceType\":\"health\",\"providerName\":\"協会けんぽ\"}",
+                        "{\"providerName\":\"組合健保\"}",
+                        "providerName",
+                        "組合健保"));
+    }
+
+    @BeforeEach
+    void setUp() {
+        dsl.execute(
+                "TRUNCATE \"Allergy\", \"EmergencyContact\", \"Insurance\","
+                        + " \"Member\", \"User\" CASCADE");
+        dsl.execute(
+                """
+                INSERT INTO "User" (id, email, password, "updatedAt")
+                VALUES ('user-1', 'owner@example.test', '', now()),
+                       ('user-2', 'other@example.test', '', now())
+                """);
+        dsl.execute(
+                """
+                INSERT INTO "Member" (id, "userId", name, "memberType", "updatedAt")
+                VALUES ('member-1', 'user-1', '本人', 'human', now()),
+                       ('member-2', 'user-2', '他人', 'human', now())
+                """);
+        bearer = bearerFor("user-1");
+        otherBearer = bearerFor("user-2");
+    }
+
+    private String bearerFor(String userId) {
+        return "Bearer "
+                + tokens.issue(
+                        User.reconstitute(userId, userId + "@example.test", "", null, "cat", null, true),
+                        NOW);
+    }
+
+    private String create(String path, String token, String body) throws Exception {
+        var response =
+                mockMvc.perform(
+                                post("/api/" + path)
+                                        .header(HttpHeaders.AUTHORIZATION, token)
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(body))
+                        .andExpect(status().isCreated())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+        return response.replaceAll(".*\"id\":\"([^\"]+)\".*", "$1");
+    }
+
+    @ParameterizedTest(name = "{0}: 登録して一覧に出る")
+    @MethodSource("resources")
+    void createAndList(String path, String body, String patchBody, String field, String updated)
+            throws Exception {
+        create(path, bearer, body);
+
+        mockMvc.perform(get("/api/" + path).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1));
+    }
+
+    @ParameterizedTest(name = "{0}: 一覧は自分のものだけ")
+    @MethodSource("resources")
+    void listIsScoped(String path, String body, String patchBody, String field, String updated)
+            throws Exception {
+        create(path, bearer, body);
+        create(path, otherBearer, body.replace("member-1", "member-2"));
+
+        mockMvc.perform(get("/api/" + path).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(jsonPath("$.data.length()").value(1));
+    }
+
+    @ParameterizedTest(name = "{0}: 他人のものは取得できない")
+    @MethodSource("resources")
+    void otherGetIsForbidden(String path, String body, String patchBody, String field, String updated)
+            throws Exception {
+        String id = create(path, otherBearer, body.replace("member-1", "member-2"));
+
+        mockMvc.perform(get("/api/" + path + "/" + id).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isForbidden());
+    }
+
+    @ParameterizedTest(name = "{0}: 他人のものは更新できない")
+    @MethodSource("resources")
+    void otherUpdateIsForbidden(
+            String path, String body, String patchBody, String field, String updated) throws Exception {
+        String id = create(path, otherBearer, body.replace("member-1", "member-2"));
+
+        mockMvc.perform(
+                        patch("/api/" + path + "/" + id)
+                                .header(HttpHeaders.AUTHORIZATION, bearer)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(patchBody))
+                .andExpect(status().isForbidden());
+    }
+
+    @ParameterizedTest(name = "{0}: 他人のものは削除できない")
+    @MethodSource("resources")
+    void otherDeleteIsForbidden(
+            String path, String body, String patchBody, String field, String updated) throws Exception {
+        String id = create(path, otherBearer, body.replace("member-1", "member-2"));
+
+        mockMvc.perform(delete("/api/" + path + "/" + id).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/" + path + "/" + id).header(HttpHeaders.AUTHORIZATION, otherBearer))
+                .andExpect(status().isOk());
+    }
+
+    @ParameterizedTest(name = "{0}: 自分のものは更新できる")
+    @MethodSource("resources")
+    void ownUpdateSucceeds(String path, String body, String patchBody, String field, String updated)
+            throws Exception {
+        String id = create(path, bearer, body);
+
+        mockMvc.perform(
+                        patch("/api/" + path + "/" + id)
+                                .header(HttpHeaders.AUTHORIZATION, bearer)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(patchBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data." + field).value(updated));
+    }
+
+    @ParameterizedTest(name = "{0}: 自分のものは削除できる")
+    @MethodSource("resources")
+    void ownDeleteSucceeds(String path, String body, String patchBody, String field, String updated)
+            throws Exception {
+        String id = create(path, bearer, body);
+
+        mockMvc.perform(delete("/api/" + path + "/" + id).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/" + path).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @ParameterizedTest(name = "{0}: トークン無しでは 401")
+    @MethodSource("resources")
+    void withoutTokenIsUnauthorized(
+            String path, String body, String patchBody, String field, String updated) throws Exception {
+        mockMvc.perform(get("/api/" + path)).andExpect(status().isUnauthorized());
+    }
+
+    @ParameterizedTest(name = "{0}: 他人のメンバーには紐付けられない")
+    @MethodSource("resources")
+    void cannotAttachToOtherUsersMember(
+            String path, String body, String patchBody, String field, String updated) throws Exception {
+        mockMvc.perform(
+                        post("/api/" + path)
+                                .header(HttpHeaders.AUTHORIZATION, bearer)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(body.replace("member-1", "member-2")))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/" + path).header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @DisplayName("存在しない資源は 404")
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("resources")
+    void missingIsNotFound(String path, String body, String patchBody, String field, String updated)
+            throws Exception {
+        mockMvc.perform(get("/api/" + path + "/nope").header(HttpHeaders.AUTHORIZATION, bearer))
+                .andExpect(status().isNotFound());
+        assertThat(true).isTrue();
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/domain/visit/AppointmentTest.java
+++ b/backend-java/src/test/java/app/healthfamily/domain/visit/AppointmentTest.java
@@ -1,0 +1,121 @@
+package app.healthfamily.domain.visit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.domain.shared.DomainException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("Appointment 集約")
+class AppointmentTest {
+
+    private static final ZoneId TOKYO = ZoneId.of("Asia/Tokyo");
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 16);
+
+    private static Appointment at(LocalDate date, boolean enabled, int daysBefore) {
+        return new Appointment(
+                "a-1",
+                "user-1",
+                "member-1",
+                "h-1",
+                "checkup",
+                date.atStartOfDay(TOKYO).toInstant(),
+                "定期検診",
+                null,
+                3000.0,
+                enabled,
+                daysBefore);
+    }
+
+    @Nested
+    @DisplayName("通知の要否")
+    class Reminder {
+
+        @ParameterizedTest(name = "{0}日後 / {1}日前設定 -> {2}")
+        @CsvSource({
+            "0, 1, true",
+            "1, 1, true",
+            "2, 1, false",
+            "3, 3, true",
+            "4, 3, false",
+        })
+        @DisplayName("設定した日数以内なら通知する")
+        void remindsWithinConfiguredDays(int daysAhead, int daysBefore, boolean expected) {
+            var appointment = at(TODAY.plusDays(daysAhead), true, daysBefore);
+
+            assertThat(appointment.needsReminderOn(TODAY, TOKYO)).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("過ぎた予約は通知しない。済んだ予定を知らせても行動につながらない")
+        void pastAppointmentDoesNotRemind() {
+            var appointment = at(TODAY.minusDays(1), true, 7);
+
+            assertThat(appointment.needsReminderOn(TODAY, TOKYO)).isFalse();
+            assertThat(appointment.daysUntil(TODAY, TOKYO)).isEqualTo(-1);
+        }
+
+        @Test
+        @DisplayName("通知が無効なら出さない")
+        void disabledDoesNotRemind() {
+            assertThat(at(TODAY, false, 7).needsReminderOn(TODAY, TOKYO)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("組み立て時の検証")
+    class Construction {
+
+        @Test
+        @DisplayName("通院日時は必須")
+        void dateIsRequired() {
+            assertThatThrownBy(
+                            () ->
+                                    new Appointment(
+                                            "a-2", "user-1", "member-1", null, "checkup", null, null, null,
+                                            null, true, 1))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("通院日時");
+        }
+
+        @Test
+        @DisplayName("費用に負の値は指定できない")
+        void negativeCostIsRejected() {
+            assertThatThrownBy(
+                            () ->
+                                    new Appointment(
+                                            "a-3", "user-1", "member-1", null, "checkup",
+                                            Instant.parse("2026-08-16T00:00:00Z"), null, null, -1.0,
+                                            true, 1))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+
+        @Test
+        @DisplayName("事前日数は0〜365日の範囲")
+        void reminderDaysRange() {
+            assertThatThrownBy(() -> at(TODAY, true, 366))
+                    .isInstanceOf(DomainException.Validation.class);
+            assertThatThrownBy(() -> at(TODAY, true, -1))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("所有権")
+    class Ownership {
+
+        @Test
+        @DisplayName("他人の通院記録は操作できない")
+        void nonOwnerIsRejected() {
+            assertThatThrownBy(() -> at(TODAY, true, 1).requireOwnedBy("user-2", "通院記録"))
+                    .isInstanceOf(DomainException.Forbidden.class);
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/domain/visit/ExaminationAndHealthLogTest.java
+++ b/backend-java/src/test/java/app/healthfamily/domain/visit/ExaminationAndHealthLogTest.java
@@ -1,0 +1,116 @@
+package app.healthfamily.domain.visit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.domain.healthrecord.HealthLog;
+import app.healthfamily.domain.shared.DomainException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("検査記録と体調記録")
+class ExaminationAndHealthLogTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 16);
+
+    @Nested
+    @DisplayName("検査記録")
+    class Examinations {
+
+        private static Examination exam(LocalDate next) {
+            return new Examination(
+                    "e-1", "user-1", "member-1", "健康診断", LocalDate.of(2026, 2, 1), next, null);
+        }
+
+        @ParameterizedTest(name = "{0}日後 -> 通知 {1}")
+        @CsvSource({"8, false", "7, true", "0, true", "-5, true"})
+        @DisplayName("次回の1週間前から通知し、過ぎても止めない")
+        void remindsFromOneWeekBefore(int daysAhead, boolean expected) {
+            assertThat(exam(TODAY.plusDays(daysAhead)).needsReminderOn(TODAY)).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("次回予定が無ければ通知しない")
+        void withoutNextNoReminder() {
+            assertThat(exam(null).needsReminderOn(TODAY)).isFalse();
+            assertThat(exam(null).daysUntilNext(TODAY)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("次回予定日が検査日より前は受け付けない")
+        void nextBeforeExaminedIsRejected() {
+            assertThatThrownBy(() -> exam(LocalDate.of(2026, 1, 1)))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("次回予定日");
+        }
+
+        @Test
+        @DisplayName("検査の種類は必須")
+        void typeIsRequired() {
+            assertThatThrownBy(
+                            () ->
+                                    new Examination(
+                                            "e-2", "user-1", "member-1", " ", TODAY, null, null))
+                    .isInstanceOf(DomainException.Validation.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("体調記録")
+    class HealthLogs {
+
+        private static HealthLog log(int level, List<String> symptoms) {
+            return new HealthLog(
+                    "h-1", "user-1", "member-1", level, symptoms, null,
+                    Instant.parse("2026-08-16T00:00:00Z"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, 6, -1})
+        @DisplayName("体調は1〜5の範囲外を受け付けない")
+        void levelOutOfRangeIsRejected(int level) {
+            assertThatThrownBy(() -> log(level, List.of()))
+                    .isInstanceOf(DomainException.Validation.class)
+                    .hasMessageContaining("1〜5");
+        }
+
+        @Test
+        @DisplayName("体調が悪ければ注意を要する")
+        void poorConditionNeedsAttention() {
+            assertThat(log(2, List.of()).needsAttention()).isTrue();
+            assertThat(log(3, List.of()).needsAttention()).isFalse();
+        }
+
+        @Test
+        @DisplayName("症状が記録されていれば体調が良くても注意を要する")
+        void symptomsNeedAttention() {
+            assertThat(log(5, List.of("頭痛")).needsAttention()).isTrue();
+        }
+
+        @Test
+        @DisplayName("症状リストは外から書き換えられない")
+        void symptomsAreImmutable() {
+            var symptoms = new java.util.ArrayList<>(List.of("頭痛"));
+            var entry = log(3, symptoms);
+
+            symptoms.add("発熱");
+
+            assertThat(entry.symptoms()).containsExactly("頭痛");
+            assertThatThrownBy(() -> entry.symptoms().add("腹痛"))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("症状が未指定なら空リストになる")
+        void nullSymptomsBecomeEmpty() {
+            assertThat(log(3, null).symptoms()).isEmpty();
+        }
+    }
+}

--- a/backend-java/src/test/java/app/healthfamily/usecase/crud/OwnedCrudUseCaseTest.java
+++ b/backend-java/src/test/java/app/healthfamily/usecase/crud/OwnedCrudUseCaseTest.java
@@ -1,0 +1,193 @@
+package app.healthfamily.usecase.crud;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import app.healthfamily.domain.shared.DomainException;
+import app.healthfamily.domain.shared.OwnedResource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 所有者を持つだけの資源に共通する読み書きの手順。
+ *
+ * <p>病院・アレルギー・保険・緊急連絡先など、ドメイン規則が所有権チェックしかない資源が
+ * 多数ある。同じ手順を資源ごとに書き写すと、いずれ 1 箇所だけ所有権チェックを
+ * 書き忘れて他人のデータが操作できるようになる。手順を 1 つにまとめて、そこを検証する。
+ */
+@DisplayName("所有資源の共通CRUD")
+class OwnedCrudUseCaseTest {
+
+    private record Item(String id, String userId, String name) implements OwnedResource {
+        @Override
+        public String ownerId() {
+            return userId;
+        }
+    }
+
+    /** 所有者で絞り込まない、素朴な保管庫。絞り込みはユースケース側の責任として検証する */
+    private static final class InMemoryStore implements OwnedCrudRepository<Item> {
+        private final List<Item> items = new ArrayList<>();
+
+        @Override
+        public Optional<Item> findById(String id) {
+            return items.stream().filter(i -> i.id().equals(id)).findFirst();
+        }
+
+        @Override
+        public List<Item> listByUser(String userId) {
+            return items.stream().filter(i -> i.userId().equals(userId)).toList();
+        }
+
+        @Override
+        public void save(Item entity) {
+            items.removeIf(i -> i.id().equals(entity.id()));
+            items.add(entity);
+        }
+
+        @Override
+        public void deleteById(String id) {
+            items.removeIf(i -> i.id().equals(id));
+        }
+    }
+
+    private InMemoryStore store;
+    private OwnedCrudUseCase<Item> useCase;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryStore();
+        useCase = new OwnedCrudUseCase<>(store, "病院");
+        store.save(new Item("i-1", "user-1", "自分の病院"));
+        store.save(new Item("i-2", "user-2", "他人の病院"));
+    }
+
+    @Nested
+    @DisplayName("参照")
+    class Read {
+
+        @Test
+        @DisplayName("一覧は自分のものだけ")
+        void listIsScoped() {
+            assertThat(useCase.list("user-1")).extracting(Item::id).containsExactly("i-1");
+        }
+
+        @Test
+        @DisplayName("自分のものは取得できる")
+        void ownGetSucceeds() {
+            assertThat(useCase.get("user-1", "i-1").name()).isEqualTo("自分の病院");
+        }
+
+        @Test
+        @DisplayName("他人のものは取得できない")
+        void otherGetIsForbidden() {
+            assertThatThrownBy(() -> useCase.get("user-1", "i-2"))
+                    .isInstanceOf(DomainException.Forbidden.class)
+                    .hasMessageContaining("病院");
+        }
+
+        @Test
+        @DisplayName("存在しないものは見つからない")
+        void missingIsNotFound() {
+            assertThatThrownBy(() -> useCase.get("user-1", "nope"))
+                    .isInstanceOf(DomainException.NotFound.class)
+                    .hasMessageContaining("病院");
+        }
+    }
+
+    @Nested
+    @DisplayName("更新")
+    class Update {
+
+        @Test
+        @DisplayName("自分のものは更新できる")
+        void ownUpdateSucceeds() {
+            useCase.update("user-1", "i-1", existing -> new Item(existing.id(), existing.userId(), "改名"));
+
+            assertThat(store.findById("i-1").orElseThrow().name()).isEqualTo("改名");
+        }
+
+        @Test
+        @DisplayName("他人のものは更新できず、値も変わらない")
+        void otherUpdateIsForbidden() {
+            assertThatThrownBy(
+                            () ->
+                                    useCase.update(
+                                            "user-1",
+                                            "i-2",
+                                            existing -> new Item(existing.id(), existing.userId(), "乗っ取り")))
+                    .isInstanceOf(DomainException.Forbidden.class);
+
+            assertThat(store.findById("i-2").orElseThrow().name()).isEqualTo("他人の病院");
+        }
+
+        @Test
+        @DisplayName("所有者を書き換えようとしても拒否する")
+        void cannotReassignOwner() {
+            assertThatThrownBy(
+                            () ->
+                                    useCase.update(
+                                            "user-1", "i-1", existing -> new Item(existing.id(), "user-2", "移譲")))
+                    .isInstanceOf(DomainException.Forbidden.class)
+                    .hasMessageContaining("所有者");
+
+            assertThat(store.findById("i-1").orElseThrow().userId()).isEqualTo("user-1");
+        }
+    }
+
+    @Nested
+    @DisplayName("削除")
+    class Delete {
+
+        @Test
+        @DisplayName("自分のものは削除できる")
+        void ownDeleteSucceeds() {
+            useCase.delete("user-1", "i-1");
+
+            assertThat(store.findById("i-1")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("他人のものは削除できず、残る")
+        void otherDeleteIsForbidden() {
+            assertThatThrownBy(() -> useCase.delete("user-1", "i-2"))
+                    .isInstanceOf(DomainException.Forbidden.class);
+
+            assertThat(store.findById("i-2")).isPresent();
+        }
+
+        @Test
+        @DisplayName("存在しないものの削除は見つからない扱い")
+        void missingDeleteIsNotFound() {
+            assertThatThrownBy(() -> useCase.delete("user-1", "nope"))
+                    .isInstanceOf(DomainException.NotFound.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("作成")
+    class Create {
+
+        @Test
+        @DisplayName("所有者が呼び出し元と一致していれば作成できる")
+        void createSucceeds() {
+            useCase.create("user-1", new Item("i-3", "user-1", "新しい病院"));
+
+            assertThat(store.findById("i-3")).isPresent();
+        }
+
+        @Test
+        @DisplayName("他人を所有者にした作成は拒否する")
+        void createForOtherUserIsRejected() {
+            assertThatThrownBy(() -> useCase.create("user-1", new Item("i-4", "user-2", "なりすまし")))
+                    .isInstanceOf(DomainException.Forbidden.class);
+
+            assertThat(store.findById("i-4")).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

残っていた CRUD 系リソースを Java 側へ移した。同じ形が続くので、**共通化してから展開**している。

### 共通の CRUD を先に作った

病院・アレルギー・保険・緊急連絡先など、ドメイン規則が所有権チェックしかない資源が多数ある。同じ手順を資源ごとに書き写すと、**いずれ1箇所だけチェックを書き忘れて他人のデータが操作できるようになる**。

| クラス | 役割 |
|---|---|
| `OwnedCrudUseCase` | 存在確認と所有権確認を必ず通す。更新時に**所有者をすげ替えられない** |
| `MemberScopedCrudUseCase` | 上記に加えて**対象メンバーも自分のものか**を確認 |

`MemberScopedCrudUseCase` が必要な理由は、所有者だけを見ていると**他人のメンバーに自分の記録をぶら下げられる**ため。記録自体は自分のものなので所有権チェックは通ってしまい、相手の画面に身に覚えのないアレルギーや連絡先が現れることになる。更新で別メンバーへ付け替える経路も塞いだ。

### 移植したリソース

| リソース | 備考 |
|---|---|
| 病院 | 所有権のみ |
| アレルギー / 緊急連絡先 / 保険 | メンバー紐付けの確認あり |
| 体温 | `BodyTemperature` を通すので `365` のような打ち間違いは 400。発熱の段階を返す |
| 体格 | `BodyMeasurement` を通す。両方無い記録は 400、そろえば BMI |
| ワクチン | `VaccinationSchedule` を通す。次回予定日が接種日より前なら 400。通知要否と残日数を返す |

判定結果（発熱の段階・BMI・通知要否）は**保存せず都度算出**する。保存すると規則を変えたときに古い判定が残るため。

### テストの書き方

メンバー紐付け資源のテストは資源ごとに書き写さず**パラメータ化**した。書き写すといずれ1つだけ権限のテストが抜けるため、同じ観点を必ず全資源に当てている（3資源 × 10観点 = 30件）。

DB の NOT NULL に合わせて必須項目も見直した。アレルギーの重症度は誤って空のまま登録されると危険なので明示させる。

## 検証

テスト **301件** すべて通過。エンドポイントは **38本**。統合テストはすべて compose の PostgreSQL に対して実行している。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 病院情報の登録、一覧表示、詳細確認、編集、削除に対応しました。
  - アレルギー、緊急連絡先、保険情報をメンバー単位で管理できるようになりました。
  - 体温、身体測定、ワクチン記録の登録・確認・削除に対応しました。
  - 発熱レベル、BMI、ワクチンのリマインダーや期限超過を表示します。
  - 入力内容の検証と、所有者・メンバー単位のアクセス制御を追加しました。

- **テスト**
  - 各機能の登録、更新、削除、認証、権限管理を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->