### PR TITLE
feat(frontend): Google ログインを認可コードグラント + PKCE に変更する

### DIFF
--- a/backend-java/docs/cutover-diff-verification.md
+++ b/backend-java/docs/cutover-diff-verification.md
@@ -1,0 +1,712 @@
+# Go / Java 応答差分の検証設計
+
+切り替え前のゲートとして使う。両実装を同じ DB・同じ入力で走らせ、応答を突き合わせる。
+
+両バックエンドを実際に起動して挙動を確認したうえで設計しました。以下、実測に基づく設計です。
+
+---
+
+# Go / Java 応答差分検証ハーネス 設計
+
+## 0. 前提として実測で確認した事実
+
+設計の土台になるので先に列挙します（すべてこの環境で実行して確認済み）。
+
+| 確認項目 | 結果 |
+|---|---|
+| Go 版が compose の PostgreSQL (`localhost:55432`) で起動するか | **起動する**。`MIGRATIONS_DIR` を渡しても `CREATE TABLE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` なので schema.sql 焼き込み済み DB に対して no-op |
+| Go のルート総数 | **106**（`GET /health` と `POST /api/auth/test-login` を含む。test-login は `E2E_TEST_LOGIN_SECRET` 設定時のみ登録されるので、本番相当だと 105） |
+| Java 版のビルド | `./mvnw package -DskipTests` で jar 生成可。**ただし jOOQ codegen が compose の DB を読むので、DB が起動していないとビルド自体が失敗する** |
+| Java 版の起動 | `java -jar target/healthfamily-api-0.0.1-SNAPSHOT.jar` で起動。`spring-boot:run` はプラグイン依存の解決が別途必要なので CI では jar 推奨 |
+| **Go が発行したトークンを Java が受理するか** | **する**。`JWT_SECRET` を揃えた状態で Go の `/api/auth/test-login` が返したトークンで Java の `/api/members` が 200 を返した |
+| Java 実装済みコントローラ | auth / member / medication / prescription の **4 つのみ**（106 中 十数エンドポイント程度）。残りは未移植 |
+
+さらに、**ハーネスを作る前から見えている差分**が既にあります（後述の §9）。これは「作れば必ず検出できるものが実在する」という意味で、設計の妥当性の裏付けになります。
+
+---
+
+## 1. 全体構成
+
+**2 モード構成**にします。副作用の扱いを分けるのが要点です。
+
+### モード R: read-parity（共有 DB・GET のみ）
+1 つの DB に現実的なデータを流し込み、**両実装に同じ GET を投げて即座に比較**する。副作用がないので順序も状態も問題にならない。安く速く、最初に通すべきゲート。
+
+### モード W: write-parity（DB 分離・ロックステップ）
+`healthfamily_go` / `healthfamily_java` の**2 つの DB に分離**し、同じスキーマ・同じシードから開始。各ステップを両方へ送り、応答を即比較。書き込み系はこちら。
+
+```
+                      ┌─────────────┐
+   scenario step ────►│  Go :18080  │──► healthfamily_go
+        │             └─────────────┘
+        │             ┌─────────────┐
+        └────────────►│ Java :18081 │──► healthfamily_java
+                      └─────────────┘
+                            │
+                    正規化 → 突き合わせ → 差分レポート
+```
+
+**「DB をリセットして実装ごとに 2 回再生する」方式は採りません。** 理由は、Go が発行した UUID と Java が発行した UUID は必ず違うので、後続ステップで `{{memberId}}` を参照するときに結局実装ごとに別の値を保持する必要があり、それなら最初から DB を分けてロックステップで進めたほうが単純だからです。加えて、ロックステップだと**差分が出た瞬間にどのステップで壊れたかが確定する**（再生方式だと全部走らせてから突き合わせるので、最初の差分以降のカスケードを人間が読み解くことになる）。
+
+---
+
+## 2. 認証をどうするか
+
+### 結論: ハーネスが自前で HS256 トークンを署名する
+
+両実装のログイン API に依存させてはいけません。理由:
+
+- Go 版のログイン導線は `POST /api/auth/login`（email/password）と `POST /api/auth/google`（ID トークン直渡し）
+- Java 版は `POST /api/auth/google/callback`（**認可コードグラント + PKCE**）のみ
+- つまり**ログイン導線そのものが別物**で、ここを比較の土台にすると土台ごと崩れる
+
+`POST /api/auth/test-login`（`E2E_TEST_LOGIN_SECRET`）は Go にしかないので、これも使えません。
+
+そこで、ハーネス内で直接署名します。`backend` モジュール内に置けば `github.com/golang-jwt/jwt/v5` がそのまま使えます。
+
+```go
+// parity/internal/token.go
+func Mint(secret []byte, userID, email string, now time.Time) string {
+	claims := jwt.MapClaims{
+		"sub":   userID, // Java の JwtAuthenticationConverter が principal に使う
+		"uid":   userID, // Go の auth.Claims が使う
+		"email": email,
+		"iat":   now.Unix(),
+		"exp":   now.Add(1 * time.Hour).Unix(),
+	}
+	s, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(secret)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+```
+
+**必須の注意点**: `JWT_SECRET` は **32 バイト以上**にすること。Java 側は `HmacAccessTokenIssuer` が明示的に拒否し、`NimbusJwtDecoder.withSecretKey` も HS256 で 256bit 未満の鍵を受け付けません。Go 側には長さ制約がないので、短い鍵にすると「Go だけ起動して Java が落ちる」という分かりにくい失敗になります。検証では `parity-secret-0123456789abcdefghij`（34 バイト）を使いました。
+
+### 認証系エンドポイント自体の比較
+
+`/api/auth/*` は「対応表」で個別に扱い、自動掃引の対象外にします。片方にしかないものが大半なので、機械比較しても意味のあるシグナルが出ません。代わりに**明示的な対応表を人間が書き、その表自体をレビュー対象にする**のが正直な扱い方です。
+
+```go
+// parity/authmap.go
+var AuthEndpointMap = []AuthPair{
+	{Go: "POST /api/auth/login",           Java: "", Note: "Java は Google のみ。移行時に導線ごと変える判断が必要"},
+	{Go: "POST /api/auth/google",          Java: "POST /api/auth/google/callback",
+	 Note: "Go=IDトークン直受け / Java=認可コード+PKCE。プロトコルが違うのでレスポンス比較のみ手動で行う"},
+	{Go: "POST /api/auth/signup",          Java: "", Note: "未移植"},
+	// ...
+}
+```
+
+---
+
+## 3. 揺らぐ値の正規化
+
+### 基本方針: パース済み JSON で比較する（バイト比較は不可能）
+
+実測で確認したとおり、キー順が根本的に違います。
+
+```
+Go:   {"data":{...},"success":true}          ← gin.H は map → encoding/json が辞書順にソート
+Java: {"success":true,"data":{...}}          ← record の宣言順
+```
+
+### 正規化ポリシー: 「値はクラス化、形式は保持」の 2 層
+
+単純に ID や日時を伏せ字にすると、**本物のバグまで一緒に伏せてしまいます**。そこで値と形式を分離します。
+
+#### 3-1. ID: 出現順プレースホルダ（構造は保つ）
+
+UUID / cuid 形状の文字列を、**そのシナリオ実行内での初出順**に `<id:1>`, `<id:2>` … へ置き換える。同じ ID が 2 回出てくれば 2 回とも `<id:1>` になるので、**参照関係が壊れていれば検出できる**。単なる伏せ字より格段に強い。
+
+```go
+func (n *Norm) id(s string) string {
+	if p, ok := n.ids[s]; ok {
+		return p
+	}
+	n.next++
+	p := fmt.Sprintf("<id:%d>", n.next)
+	n.ids[s] = p
+	return p
+}
+```
+
+**シードで投入する固定 ID は UUID 形状にしない**（`u_owner`, `m_mother` のようにする）。そうすれば正規化器が触らず、レポート上でそのまま読めます。これは地味ですが効きます。
+
+#### 3-2. 日時: 形式クラス + 値クラス
+
+これが一番厄介で、一番重要です。実測値:
+
+```
+Go   POST /api/members → "birthDate":"1960-04-01T09:00:00+09:00"
+                         "createdAt":"2026-08-16T14:51:34.261073+09:00"
+Java POST /api/members → "birthDate":"1960-04-01"
+```
+
+`birthDate` は**形式が違うだけでなくフロントの解釈が変わる本物の破壊的差分**です。伏せてはいけません。一方 `createdAt` のマイクロ秒は当然ずれるので、そこは無視したい。
+
+そこで `<形式クラス|値クラス>` の形に落とします。
+
+| 入力 | 正規化結果 |
+|---|---|
+| `2026-08-16T14:51:34.261073+09:00`（実行時刻の窓内） | `<ts:dt+offset.us\|now>` |
+| `2026-08-16T05:51:34.261073Z`（同上） | `<ts:dt+Z.us\|now>` |
+| `1960-04-01T09:00:00+09:00` | `<ts:dt+offset.s\|1960-04-01>` |
+| `1960-04-01` | `<ts:date\|1960-04-01>` |
+
+- **値部分**: 実行開始〜終了の時刻ウィンドウ内なら `now`。それ以外は日付まで丸めた実値を残す。
+- **形式部分**: 常に保持。
+
+結果として、`birthDate` は「値は同じだが形式が違う」と報告され、`createdAt` は形式が同じなら一致する。欲しい挙動そのものです。
+
+オフセット表記 (`+09:00`) と Z 表記を同一視したい場合のために `PARITY_TIME_FORMAT=lenient` を用意し、既定は `strict` にします。既定を厳しくしておくのが安全側です。
+
+#### 3-3. 数値
+
+Go の `encoding/json` は全部 `float64`、Java は `Integer` / `BigDecimal`。`1` と `1.0` を同一視するため、整数値の float は整数文字列へ寄せます。
+
+#### 3-4. null と「キーの欠落」は正規化しない
+
+これも本物の差分です。Go の `response.Success(c, nil)` は `"data":null` を出しますが、Java の `ApiResponse` は `@JsonInclude(NON_NULL)` なので `data` キーごと消えます。実際 `PUT /api/prescriptions/{id}/items` は Go が処方箋オブジェクトを返し、Java は `ApiResponse.ok(null)` で `{"success":true}` を返します。フロントが `data` を読んでいれば壊れる。**必ず差分として報告させること。**
+
+#### 3-5. 配列順序
+
+既定は**順序込みで比較**。順序が仕様として未定義の一覧だけ、ステップ単位でソートキーを明示します。既定を「順序無視」にすると、`displayOrder` を持つ薬一覧のような**順序が仕様である**エンドポイントの回帰を見逃します。
+
+#### 3-6. フィールド単位の上書き
+
+```go
+Norm: map[string]Policy{
+	"$.data[*].age":       PolicyIgnore,        // 実行日で変わる派生値
+	"$.data[*].createdAt": PolicyTimeLenient,
+	"$.data":              PolicySortBy("id"),
+}
+```
+
+---
+
+## 4. 副作用のある操作の扱い
+
+### 4-1. DB 分離 + ステップごとの変数バインディングを実装別に持つ
+
+これが副作用問題の核です。
+
+```go
+vars := map[Impl]map[string]string{ImplGo: {}, ImplJava: {}}
+// POST /api/members の応答から
+//   vars[ImplGo]["memberId"]   = "500cfbce-..."   (Go が採番)
+//   vars[ImplJava]["memberId"] = "9bec5bd7-..."   (Java が採番)
+// 次のステップ GET /api/members/{{memberId}} は実装ごとに別 URL になる
+```
+
+こうすると ID 差分が後続ステップを汚しません。
+
+### 4-2. シナリオ間はリセット、シナリオ内は順序依存を明示
+
+- **シナリオ間**: 毎回 TRUNCATE + 共通シード再投入 → シナリオは互いに独立。実行順に依存しない。
+- **シナリオ内**: `Steps` は順序ありの配列。順序依存は型で表現されているので、暗黙にならない。
+
+リセット SQL（テーブル名はハードコードせず動的取得。テーブル追加時に更新漏れが起きないように）:
+
+```sql
+SET lock_timeout = '5s';   -- 接続が滞留していたら黙って固まらせず即失敗させる
+DO $$
+DECLARE stmt text;
+BEGIN
+  SELECT 'TRUNCATE ' || string_agg(format('%I.%I', schemaname, tablename), ', ')
+         || ' RESTART IDENTITY CASCADE'
+    INTO stmt
+    FROM pg_tables WHERE schemaname = 'public';
+  IF stmt IS NOT NULL THEN EXECUTE stmt; END IF;
+END $$;
+```
+
+TRUNCATE は ACCESS EXCLUSIVE ロックを取りますが、両サーバのコネクションはアイドル（トランザクション外）なのでブロックしません。ロックステップ実行なのでリセット中に飛んでいるリクエストもありません。
+
+### 4-3. DB 状態も比較する
+
+**応答が一致しても書き込みが違うことがあります。** 例えば Java の `MemberUseCase.View` には `updatedAt` が無いので、`updatedAt` を更新し忘れていても応答比較では絶対に検出できません。
+
+シナリオ末尾で両 DB をダンプして突き合わせます。
+
+```sql
+SELECT jsonb_agg(to_jsonb(t) ORDER BY t.id) FROM "Member" t;
+```
+
+正規化は応答と同じパイプラインを通します（UUID → `<id:N>`、timestamptz → 時刻クラス）。これで「応答は同じだが DB が違う」を捕まえられます。
+
+### 4-4. 差分が出たらシナリオを打ち切る
+
+ステータスコードが違う、あるいは片方だけエラーになった時点で、以降のステップの比較結果は意味を持ちません。`Fatal` 判定で打ち切り、レポートには「ここで打ち切り」と明記します。差分の洪水を防ぎます。
+
+---
+
+## 5. レート制限（これを踏まないと必ずハマる）
+
+Go 側:
+- 認証済み API 全体: `RateLimit("api", 120, time.Minute, PerUser)` → **1 ユーザー 120 req/min**
+- 認証系: signup 10/min, login 20/min, resend/forgot/reset 5/min（**IP 単位**）
+
+Java 側: **レート制限なし**。
+
+106 エンドポイント × 数ステップ = 300〜500 リクエストなので、**全掃引すると Go だけ 429 を返し、大量の偽差分が出ます**。
+
+### 対策（3 つ併用）
+
+**(a) Go に env 上書きを足す（推奨・小さい変更）**
+
+`/Users/takuma.kawano/HealthFamily/backend/internal/config/config.go`:
+```go
+RateLimitMax: getEnvInt("RATE_LIMIT_MAX", 120),
+```
+`router.Setup` に渡して `middleware.RateLimit("api", cfg.RateLimitMax, ...)` にする。パリティ実行時は `RATE_LIMIT_MAX=100000`。
+
+**(b) シナリオごとに別ユーザーを使う**
+
+`api` リミッタは per-user なので、シナリオごとに `u_s001_owner` のようなユーザーを切れば実質リセットされます。ただし**認証系の IP 単位リミッタには効きません**（ハーネスは常に 127.0.0.1）。(a) と併用が必要。
+
+**(c) レート制限そのものを差分項目として扱う**
+
+Java に制限が無いのは隠すべきことではなく**報告すべき差分**です。専用シナリオを 1 本置き、既定設定の Go に 130 連射して 429 が返ること、Java が 200 を返し続けることを差分として出させます。切替判断の材料になります。
+
+---
+
+## 6. 起動方法（実測済みコマンド）
+
+### 共通の前提: TZ を両方 `Asia/Tokyo` に固定する
+
+**これは必須です。** 実測で Go は timestamptz を**プロセスのローカル TZ** でレンダリングしました（`2026-08-16T14:51:34.261073+09:00`）。`TZ=UTC` で起動すると `Z` 表記になり、それだけで全タイムスタンプが差分になります。Java 側は `AppZone` が `Asia/Tokyo` 固定、`ClockConfig` は `Clock.systemUTC()`。アプリのドメイン基準に合わせて**両方 `Asia/Tokyo`** にします。
+
+なお **Go には Clock 注入がありません**（`time.Now()` 直呼び）。固定時刻にはできないので、時刻は「凍結」ではなく「実行ウィンドウによる正規化」で吸収します（§3-2）。Java の `ClockConfig` もパリティ実行では差し替えず、素の `systemUTC` のままにします。両方を実時計で走らせるのが、比較としては最も素直です。
+
+### DB の準備
+
+```bash
+cd /Users/takuma.kawano/HealthFamily/backend-java
+docker compose up -d
+# healthy 待ち
+until docker compose exec -T postgres pg_isready -U healthfamily -d healthfamily >/dev/null 2>&1; do sleep 1; done
+```
+
+Go のマイグレーションは**テンプレート DB に対して 1 回だけ**当て、そのあとクローンします。こうすれば 2 つの DB のスキーマが確実に一致します。
+
+```bash
+# 1) テンプレート(healthfamily)に Go のマイグレーションを適用（no-op のはずだが念のため）
+#    → Go サーバを MIGRATIONS_DIR 付きで一度起動して落とす、でよい
+
+# 2) クローン
+PSQL="docker compose exec -T postgres psql -U healthfamily -d postgres"
+$PSQL -c 'DROP DATABASE IF EXISTS healthfamily_go;'
+$PSQL -c 'DROP DATABASE IF EXISTS healthfamily_java;'
+$PSQL -c 'CREATE DATABASE healthfamily_go   TEMPLATE healthfamily;'
+$PSQL -c 'CREATE DATABASE healthfamily_java TEMPLATE healthfamily;'
+```
+
+### Go 版
+
+```bash
+cd /Users/takuma.kawano/HealthFamily/backend
+go build -o /tmp/hf-parity-go ./cmd/server     # go run より速い。毎回コンパイルしない
+
+TZ=Asia/Tokyo \
+GIN_MODE=release \
+PORT=18080 \
+DATABASE_URL="postgres://healthfamily:healthfamily@localhost:55432/healthfamily_go?sslmode=disable" \
+JWT_SECRET="$PARITY_JWT_SECRET" \
+RATE_LIMIT_MAX=100000 \
+ALLOWED_ORIGINS=http://localhost:5173 \
+/tmp/hf-parity-go &
+# MIGRATIONS_DIR は「渡さない」。クローン元で適用済みで、両DBを同一に保つため
+# E2E_TEST_LOGIN_SECRET も「渡さない」。本番相当のルート集合にするため
+```
+
+ヘルスチェック: `curl -sf http://localhost:18080/health` → `{"status":"ok"}`
+
+### Java 版
+
+```bash
+cd /Users/takuma.kawano/HealthFamily/backend-java
+export JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home  # 環境依存
+./mvnw -q package -DskipTests            # ← compose の DB が上がっていないと jOOQ codegen で失敗する
+
+TZ=Asia/Tokyo \
+SERVER_PORT=18081 \
+DATABASE_JDBC_URL="jdbc:postgresql://localhost:55432/healthfamily_java" \
+DATABASE_USER=healthfamily \
+DATABASE_PASSWORD=healthfamily \
+JWT_SECRET="$PARITY_JWT_SECRET" \
+GOOGLE_CLIENT_ID=dummy.apps.googleusercontent.com \
+GOOGLE_CLIENT_SECRET=dummy \
+"$JAVA_HOME/bin/java" -Duser.timezone=Asia/Tokyo \
+  -jar target/healthfamily-api-0.0.1-SNAPSHOT.jar &
+```
+
+ヘルスチェック: `curl -sf http://localhost:18081/actuator/health` → `{"status":"UP",...}`
+
+**注意**: この環境では `java` が PATH に無く（Homebrew の `openjdk@25` が未リンク）、`JAVA_HOME` の明示が必要でした。`run.sh` の冒頭で `JAVA_HOME` 未設定なら `/usr/libexec/java_home -v 25` → Homebrew パスの順にフォールバックさせるとよいです。
+
+---
+
+## 7. 実行手段の選択
+
+### 結論: **Go のテスト（`//go:build parity` タグ付き）+ 起動オーケストレーションのシェル 1 本**
+
+比較検討:
+
+| 手段 | 評価 |
+|---|---|
+| シェル + curl + jq | ID の出現順マッピング、時刻の形式クラス化、再帰的 JSON 正規化を jq で書くのは急速に地獄になる。保守不能。**不採用** |
+| **Go テスト** | **採用**。`engine.Routes()` でルート表を直接取れる／正規化ロジックを型付きで書ける／`t.Run` でエンドポイント単位の結果が出る／既存の `go test` と同じ道具 |
+| Java テスト | Java 側は 4 コントローラしか無く、比較の主語は「Go の 106 本」。ルート表も Go 側にある。逆立ち |
+| 別言語のスクリプト | 3 つ目の言語とツールチェーンを持ち込むコストに見合わない |
+
+**重要な制約**: ハーネスは **`backend` の Go モジュール内**に置く必要があります。ルート表を取るには `healthfamily/internal/interface/router` を import しますが、Go の `internal` パッケージは同一モジュールからしか import できないためです。
+
+置き場所: `/Users/takuma.kawano/HealthFamily/backend/parity/`
+
+`//go:build parity` タグで通常の `go test ./...` から除外し、`go test -tags parity ./parity/...` でのみ走るようにします（外部プロセス 2 つと DB が要るため）。
+
+リポジトリルートに置きたい場合は、代わりに `/Users/takuma.kawano/HealthFamily/backend/cmd/routedump/main.go`（30 行程度、ルートを JSON で標準出力）を足して、別モジュールのハーネスがそれを読む構成にできます。ただし可動部が増えるので、最初は同一モジュール案を推奨します。
+
+### ルート表の自動生成（網羅性の担保）
+
+`router_smoke_test.go` が既に nil 依存でエンジンを組み立てているので、同じ手が使えます。
+
+```go
+// parity/catalog/catalog.go
+func Routes() []string {
+	tm := auth.NewTokenManager("x", time.Hour)
+	h := &router.Handlers{ /* router_smoke_test.go と同じ nil 組み立て */ }
+	engine := router.Setup(h, tm, &database.DB{}, []string{"http://localhost:5173"})
+
+	out := make([]string, 0, 128)
+	for _, r := range engine.Routes() {
+		out = append(out, r.Method+" "+r.Path)
+	}
+	sort.Strings(out)
+	return out
+}
+```
+
+**これがこの設計の肝です。** エンドポイント一覧を手書きの YAML で持つと、Go に新ルートが増えたときに黙って検証対象から漏れます。ルータから引くことで、**新しいルートは必ずカタログに現れ、シナリオ未定義なら網羅ゲートで落ちる**。
+
+---
+
+## 8. ファイル構成
+
+```
+/Users/takuma.kawano/HealthFamily/backend/parity/
+├── README.md                    使い方・差分が出たときの読み方
+├── run.sh                       オーケストレーション（これ 1 本で全部走る）
+├── doc.go                       //go:build parity  パッケージ説明
+│
+├── catalog/
+│   └── catalog.go               gin engine.Routes() からルート表を生成
+│
+├── internal/
+│   ├── client.go                HTTP クライアント（両実装へ同一リクエスト）
+│   ├── token.go                 HS256 自前署名
+│   ├── normalize.go             正規化パイプライン（ID / 時刻 / 数値 / ポリシー上書き）
+│   ├── diff.go                  正規化済み JSON の再帰差分
+│   ├── db.go                    TRUNCATE / シード投入 / テーブルダンプ
+│   ├── runner.go                シナリオ再生エンジン（ロックステップ）
+│   └── report.go                Markdown + JSON レポート出力
+│
+├── scenarios/
+│   ├── scenario.go              Scenario / Step / Policy の型定義
+│   ├── seed.sql                 全シナリオ共通の決定的シード
+│   ├── members.go               メンバー系シナリオ
+│   ├── medications.go
+│   ├── schedules.go
+│   ├── records.go
+│   ├── expenses.go
+│   ├── budget.go
+│   ├── prescriptions.go
+│   ├── crud_generic.go          MemberScopedCRUD 系 8 リソースを表駆動でまとめて生成
+│   ├── errors.go                401 / 404 / 400 / 405 / 429 の異常系
+│   └── all.go                   All() で全シナリオを返す
+│
+├── pending.go                   未移植ルートの明示リスト（切替ゲートの本体）
+├── authmap.go                   認証エンドポイントの手動対応表
+├── coverage_test.go             網羅ゲート
+├── parity_test.go               エントリポイント
+└── report/                      出力先（.gitignore）
+    ├── report.md
+    └── raw/{go,java}/<scenario>/<step>.json
+```
+
+### 型定義
+
+```go
+// parity/scenarios/scenario.go
+type Scenario struct {
+	Name  string
+	Mode  Mode   // ModeRead / ModeWrite
+	Seed  string // 追加シード SQL（任意）
+	Steps []Step
+}
+
+type Step struct {
+	Name    string
+	Route   string            // "POST /api/members" — カタログ上のルート。網羅判定に使う
+	Method  string
+	Path    string            // "/api/members/{{memberId}}"
+	Query   map[string]string
+	Body    string            // "{{var}}" 展開可
+	As      string            // "owner" / "other" / "" (無認証)
+	Capture map[string]string // "memberId" -> "$.data.id"
+	Norm    map[string]Policy // JSONPath -> 正規化ポリシー上書き
+	Fatal   bool              // 差分が出たらシナリオ打ち切り（既定 true）
+}
+```
+
+### 汎用 CRUD の表駆動生成
+
+`routes_ext.go` の `MemberScopedCRUD` は 8 リソース（appointment / health-log / vaccination / examination / insurance / allergy / body-measurement / emergency-contact）で**完全に同形**です。106 本を手書きせずに済みます。
+
+```go
+// parity/scenarios/crud_generic.go
+var memberScoped = []crudSpec{
+	{Base: "/api/appointments",     Create: `{"memberId":"{{memberId}}","hospitalName":"○○内科","scheduledAt":"2026-09-01T10:00:00+09:00"}`,
+	                                Update: `{"notes":"変更"}`},
+	{Base: "/api/health-logs",      Create: `{"memberId":"{{memberId}}","recordedAt":"2026-08-16","condition":"good"}`,
+	                                Update: `{"condition":"bad"}`},
+	// ... 8 リソース
+}
+
+func crudScenarios() []Scenario {
+	out := make([]Scenario, 0, len(memberScoped))
+	for _, s := range memberScoped {
+		out = append(out, Scenario{
+			Name: "crud" + s.Base, Mode: ModeWrite,
+			Steps: []Step{
+				{Name: "作成",   Route: "POST " + s.Base,             Method: "POST",   Path: s.Base, Body: s.Create, As: "owner",
+				 Capture: map[string]string{"id": "$.data.id"}},
+				{Name: "一覧",   Route: "GET " + s.Base,              Method: "GET",    Path: s.Base, As: "owner"},
+				{Name: "取得",   Route: "GET " + s.Base + "/:id",     Method: "GET",    Path: s.Base + "/{{id}}", As: "owner"},
+				{Name: "他人",   Route: "GET " + s.Base + "/:id",     Method: "GET",    Path: s.Base + "/{{id}}", As: "other"},
+				{Name: "更新",   Route: "PATCH " + s.Base + "/:id",   Method: "PATCH",  Path: s.Base + "/{{id}}", Body: s.Update, As: "owner"},
+				{Name: "削除",   Route: "DELETE " + s.Base + "/:id",  Method: "DELETE", Path: s.Base + "/{{id}}", As: "owner"},
+				{Name: "削除後", Route: "GET " + s.Base + "/:id",     Method: "GET",    Path: s.Base + "/{{id}}", As: "owner"},
+				{Name: "無認証", Route: "GET " + s.Base,              Method: "GET",    Path: s.Base, As: ""},
+			},
+		})
+	}
+	return out
+}
+```
+
+これで 8 リソース × 8 ステップ = 64 ステップが 20 行程度で書けます。残りは個別に書く。
+
+### 網羅ゲート（切替前ゲートの本体）
+
+```go
+// parity/coverage_test.go
+//go:build parity
+
+func TestCatalogCoverage(t *testing.T) {
+	covered := map[string]bool{}
+	for _, sc := range scenarios.All() {
+		for _, st := range sc.Steps {
+			covered[st.Route] = true
+		}
+	}
+
+	for _, route := range catalog.Routes() {
+		if route == "GET /health" || strings.HasPrefix(route, "POST /api/auth/") {
+			continue // 認証系は authmap.go の手動対応表で扱う
+		}
+		if covered[route] {
+			continue
+		}
+		if reason, ok := Pending[route]; ok {
+			t.Logf("未移植 (シナリオ免除): %s — %s", route, reason)
+			continue
+		}
+		t.Errorf("ルート %s がどのシナリオからも叩かれていない。scenarios/ に追加するか pending.go に登録すること", route)
+	}
+
+	// 切替直前チェック: 未移植が残っていたら落とす
+	if os.Getenv("PARITY_CUTOVER") == "1" && len(Pending) > 0 {
+		t.Errorf("切替不可: 未移植ルートが %d 件残っている", len(Pending))
+	}
+}
+```
+
+`pending.go` は Java 移植が進むにつれて縮み、**空になったときが切替可能なとき**。これが「ゲート」の具体的な形です。
+
+```go
+// parity/pending.go
+var Pending = map[string]string{
+	"GET /api/users/me":            "未移植: UserProfileController が無い",
+	"PATCH /api/users/me":          "未移植",
+	"GET /api/expenses":            "未移植: 支出系コントローラ一式",
+	"PATCH /api/members/:memberId": "未移植: MemberController に更新が無い",
+	// ...
+}
+```
+
+**重要**: Java は未実装ルートに対して **404 ではなく 500** を返します（実測済み。`DomainExceptionHandler` の `@ExceptionHandler(Exception.class)` が `NoResourceFoundException` を飲み込む）。したがって**未移植は自動判別できず、明示リストが必須**です。
+
+### オーケストレーション
+
+```bash
+#!/usr/bin/env bash
+# /Users/takuma.kawano/HealthFamily/backend/parity/run.sh
+set -euo pipefail
+
+ROOT=/Users/takuma.kawano/HealthFamily
+export PARITY_JWT_SECRET="${PARITY_JWT_SECRET:-parity-secret-0123456789abcdefghij}"  # 32バイト以上必須
+: "${JAVA_HOME:=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home}"; export JAVA_HOME
+
+GO_PID=""; JAVA_PID=""
+cleanup() { [ -n "$GO_PID" ] && kill "$GO_PID" 2>/dev/null || true
+            [ -n "$JAVA_PID" ] && kill "$JAVA_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "== 1. DB 起動 =="
+cd "$ROOT/backend-java" && docker compose up -d
+until docker compose exec -T postgres pg_isready -U healthfamily -d healthfamily >/dev/null 2>&1; do sleep 1; done
+
+echo "== 2. DB クローン =="
+PSQL=(docker compose exec -T postgres psql -U healthfamily -d postgres -v ON_ERROR_STOP=1)
+"${PSQL[@]}" -c 'DROP DATABASE IF EXISTS healthfamily_go;'
+"${PSQL[@]}" -c 'DROP DATABASE IF EXISTS healthfamily_java;'
+"${PSQL[@]}" -c 'CREATE DATABASE healthfamily_go   TEMPLATE healthfamily;'
+"${PSQL[@]}" -c 'CREATE DATABASE healthfamily_java TEMPLATE healthfamily;'
+
+echo "== 3. ビルド (Java は DB 起動後でないと jOOQ codegen が失敗する) =="
+cd "$ROOT/backend"      && go build -o /tmp/hf-parity-go ./cmd/server
+cd "$ROOT/backend-java" && ./mvnw -q package -DskipTests
+
+echo "== 4. 起動 =="
+TZ=Asia/Tokyo GIN_MODE=release PORT=18080 RATE_LIMIT_MAX=100000 \
+  DATABASE_URL="postgres://healthfamily:healthfamily@localhost:55432/healthfamily_go?sslmode=disable" \
+  JWT_SECRET="$PARITY_JWT_SECRET" \
+  /tmp/hf-parity-go > /tmp/parity-go.log 2>&1 & GO_PID=$!
+
+TZ=Asia/Tokyo SERVER_PORT=18081 \
+  DATABASE_JDBC_URL="jdbc:postgresql://localhost:55432/healthfamily_java" \
+  DATABASE_USER=healthfamily DATABASE_PASSWORD=healthfamily \
+  JWT_SECRET="$PARITY_JWT_SECRET" \
+  GOOGLE_CLIENT_ID=dummy.apps.googleusercontent.com GOOGLE_CLIENT_SECRET=dummy \
+  "$JAVA_HOME/bin/java" -Duser.timezone=Asia/Tokyo \
+  -jar "$ROOT/backend-java/target/healthfamily-api-0.0.1-SNAPSHOT.jar" > /tmp/parity-java.log 2>&1 & JAVA_PID=$!
+
+for i in $(seq 60); do curl -sf http://localhost:18080/health >/dev/null 2>&1 && break; sleep 1; done
+for i in $(seq 60); do curl -sf http://localhost:18081/actuator/health >/dev/null 2>&1 && break; sleep 1; done
+
+echo "== 5. 差分検証 =="
+cd "$ROOT/backend"
+PARITY_GO_URL=http://localhost:18080 \
+PARITY_JAVA_URL=http://localhost:18081 \
+PARITY_DB_HOST=localhost PARITY_DB_PORT=55432 \
+go test -tags parity ./parity/... -v -count=1 "$@"
+```
+
+---
+
+## 9. ハーネスを作れば即座に出る差分（実測で既に確認済み）
+
+作る前から検出可能と分かっているもの。**最初のレポートに必ず載ります**ので、既知として整理しておくと立ち上げが速くなります。
+
+| # | エンドポイント | Go | Java | 種別 |
+|---|---|---|---|---|
+| 1 | `GET/POST /api/members` | `userId` / `createdAt` / `updatedAt` を返す | **返さない** | フィールド欠落 |
+| 2 | `GET/POST /api/members` | `age` なし | **`age` を返す** | フィールド追加 |
+| 3 | `GET/POST /api/members` | `birthDate: "1960-04-01T09:00:00+09:00"` | `birthDate: "1960-04-01"` | 型・形式差 |
+| 4 | 全認証必須ルート（401 時） | `{"success":false,"error":"認証エラー"}` | **本文空** + `WWW-Authenticate` ヘッダ | エラー契約差 |
+| 5 | 存在しないパス | 404 + **プレーンテキスト** `404 page not found` | **500** + `{"success":false,"error":"サーバーエラーが発生しました"}` | ステータス差 |
+| 6 | 未実装メソッド（例 `DELETE /api/members/:id`） | 404 JSON | **500** | ステータス差 |
+| 7 | ヘルスチェック | `GET /health` | `GET /actuator/health`（`/health` は 401） | パス差 |
+| 8 | `PUT /api/prescriptions/:id/items` | 処方箋オブジェクトを返す | `{"success":true}`（`data` キーごと無い） | 応答本体差 |
+| 9 | `POST /api/prescriptions/:id/dispense` | 作成された薬の配列 | `{createdCount, medicationIds}` | 応答本体差 |
+| 10 | レート制限 | 120/min per user, 認証系は IP 単位 | **無し** | 挙動欠落 |
+
+### 先に潰しておくべきもの
+
+**#5 / #6（Java の 500）は最優先で直すべきです。** これを直さないと、「未実装だから 500」と「実装したが壊れて 500」が区別できず、ハーネスのシグナルが常に濁ります。`DomainExceptionHandler` に以下を足すだけです。
+
+```java
+@ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
+public ResponseEntity<ApiResponse<Void>> notFoundRoute() {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure("見つかりません"));
+}
+
+@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+public ResponseEntity<ApiResponse<Void>> methodNotAllowed() {
+    return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(ApiResponse.failure("許可されていないメソッドです"));
+}
+```
+
+（`@ExceptionHandler(Exception.class)` の catch-all がこれらを飲んでいるのが原因です。ついでに、これは移行と無関係に本番でも「404 が 500 になる」バグなので、Java 切替時にそのまま持ち込まれます。）
+
+**#4** は `AuthenticationEntryPoint` をカスタムして Go と同じ JSON を返させる必要があります。フロントが 401 の本文を読んでいるなら破壊的です。
+
+---
+
+## 10. CI への載せ方
+
+```yaml
+# .github/workflows/parity.yml
+name: backend parity
+on:
+  pull_request:
+    paths: ['backend/**', 'backend-java/**']
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.26' }
+      - uses: actions/setup-java@v4
+        with: { distribution: temurin, java-version: '25', cache: maven }
+      - run: ./backend/parity/run.sh
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: parity-report
+          path: backend/parity/report/
+```
+
+`docker compose` は GitHub Actions の ubuntu ランナーに同梱されているので、compose.yaml をそのまま使えます。
+
+**運用の段取り:**
+1. 導入直後は既知差分（§9）を `known_diffs.go` に登録して**グリーンから始める**。赤いまま放置されるゲートは誰も見なくなります。
+2. Java にエンドポイントを移植 → `pending.go` から 1 行消す → ハーネスが差分を出す → 直す → `known_diffs.go` からも消す。
+3. `pending.go` と `known_diffs.go` の両方が空になった時点で `PARITY_CUTOVER=1` が通る。**それが切替の定義。**
+
+---
+
+## 11. 実装の推奨順序
+
+1. `run.sh` + 両サーバ起動 + ヘルスチェックまで（**§0 で実証済みなので確実に動く**）
+2. `catalog/` — ルート表 106 件を吐かせる
+3. `pending.go` — Java 未実装を全部書き出す（現状 90 件超になるはず）
+4. `internal/token.go` + `internal/client.go` + 最小の diff — **`GET /api/members` 1 本だけ**通す。ここで §9 の #1〜#3 が出れば土台が正しいことの証明になる
+5. `internal/normalize.go` — ID と時刻の正規化
+6. `internal/db.go` — リセット・シード・ダンプ
+7. `scenarios/crud_generic.go` — 表駆動で 8 リソース一気に
+8. 個別シナリオを埋める
+9. `coverage_test.go` でゲート化
+10. CI へ
+
+ステップ 4 まで（半日程度）で「差分が実際に見える」状態になり、以降の投資判断ができます。
+
+---
+
+## 参照ファイル
+
+- Go ルータ: `/Users/takuma.kawano/HealthFamily/backend/internal/interface/router/router.go`, `/Users/takuma.kawano/HealthFamily/backend/internal/interface/router/routes_ext.go`
+- Go ルート列挙の下敷き: `/Users/takuma.kawano/HealthFamily/backend/internal/interface/router/router_smoke_test.go`
+- Go レート制限（要 env 化）: `/Users/takuma.kawano/HealthFamily/backend/internal/interface/middleware/ratelimit.go`
+- Go 設定（`RateLimitMax` 追加先）: `/Users/takuma.kawano/HealthFamily/backend/internal/config/config.go`
+- Go 応答契約: `/Users/takuma.kawano/HealthFamily/backend/internal/pkg/response/response.go`
+- Java 応答契約: `/Users/takuma.kawano/HealthFamily/backend-java/src/main/java/app/healthfamily/apiController/ApiResponse.java`
+- Java 例外→HTTP（**404/405 ハンドラ追加が必要**）: `/Users/takuma.kawano/HealthFamily/backend-java/src/main/java/app/healthfamily/apiController/DomainExceptionHandler.java`
+- Java 認可設定（401 本文のカスタマイズ先）: `/Users/takuma.kawano/HealthFamily/backend-java/src/main/java/app/healthfamily/config/SecurityConfig.java`
+- JWT: `/Users/takuma.kawano/HealthFamily/backend/internal/pkg/auth/jwt.go` / `/Users/takuma.kawano/HealthFamily/backend-java/src/main/java/app/healthfamily/infrastructure/auth/HmacAccessTokenIssuer.java`
+- 既存 IT のシード手法（`TRUNCATE` + 直 INSERT）が参考になる: `/Users/takuma.kawano/HealthFamily/backend-java/src/test/java/app/healthfamily/apiController/member/MemberControllerIT.java`

--- a/backend-java/docs/go-api-contract.md
+++ b/backend-java/docs/go-api-contract.md
@@ -1,0 +1,1067 @@
+# Go 版 API 契約（Java 移植の元仕様）
+
+Go 実装から抽出した契約。Java 側へ移すときの元にする。
+推測ではなく、handler / usecase / repository / SQL から確認した内容のみを載せている。
+
+## appointment-hospital (Hospital / Appointment)
+
+### 移植時の注意
+
+【全体構造】ルート登録は router.go ではなく routes_ext.go:20-34（router.go:118 の RegisterExtraRoutes 経由）。認証必須グループ `api.Group("")` に middleware.Auth(JWT) + middleware.RateLimit("api", 120, 1分, PerUser) が適用され、10 本すべて認証必須。エラー→HTTP は pkg/response/response.go の HandleDomainError で NotFound→404 / Conflict→409 / Validation→400 / Forbidden→403 / それ以外→500「サーバーエラーが発生しました」。Appointment/Hospital のコードパス上 ConflictError と ValidationError は一度も生成されないので、実質 409 と（ドメイン由来の）400 は発生しない。
+
+【Java 側に移すべきドメイン規則（単なる CRUD と区別）】
+1. Appointment 作成時のメンバー所有権チェック（ensureMemberOwner）。userId は必ず JWT から。
+2. Appointment 作成時の既定値: reminderEnabled=true, reminderDaysBefore=1。Go は DB DEFAULT に頼らずアプリ層（AppointmentRepository.Create）で明示設定しているので、Java でも明示設定が安全。
+3. 所有者不一致は 404 ではなく 403 を返す（存在は漏れる仕様）。日本語メッセージ文字列も契約の一部: 「病院が見つかりません」「この病院にアクセスする権限がありません」「通院予定が見つかりません」「この通院予定にアクセスする権限がありません」「メンバーが見つかりません」「このメンバーにアクセスする権限がありません」。
+4. 一覧のソート順（Hospital: createdAt DESC / Appointment: appointmentDate DESC）。
+5. PATCH は「送られたキーのみ更新」。memberId・userId・createdAt は不変。
+6. DELETE の戻りは 200 + data:{ok:true}（204 ではない）。フロントが data.ok を見ている可能性あり。
+これ以外（Hospital の CRUD 本体、Appointment の Get/List/Delete）は所有権チェック付きの素の CRUD で、ドメインロジックは無い。HospitalUsecase.Create に至っては検証ゼロでリポジトリに素通し。
+
+【Go 側の不具合・危うい実装（移植時に直すか、意図的に踏襲するか判断が必要）】
+A. hospitalId の所有権チェック漏れ（重大）: POST/PATCH /api/appointments の hospitalId は存在確認も所有権確認も一切していない（appointment_handler.go:70,105 → crud.go の MemberScopedCRUD は memberId しか見ない）。他人の Hospital の id を推測・入手できれば自分の Appointment に他人の病院を紐付けられる（クロステナントの参照生成）。FK は "Hospital"("id") 全体を参照するだけで userId を含まない。Java 側では hospitalId 指定時に「その病院が同一 userId 所有か」を検証すべき。
+B. A の副作用として、他人の Appointment が自分の Hospital を参照していると、自分の DELETE /api/hospitals/{id} が FK 違反で 500 になる（自分では原因を解消できない DoS 的状態）。
+C. Hospital 削除時の FK 挙動: migrations/0001_init.sql:118 の `"hospitalId" TEXT REFERENCES "Hospital"("id")` は ON DELETE 未指定＝NO ACTION。参照中の病院を削除すると PostgreSQL の FK 違反がそのまま default 分岐に落ちて 500「サーバーエラーが発生しました」になる。本来は 409（Conflict）を返すか、hospitalId を SET NULL するのが正しい。Java 側では明示的にハンドリングすること。
+D. 存在しない hospitalId を POST /api/appointments に渡すと FK 違反で 500。本来 400/404 相当。
+E. PATCH /api/appointments の appointmentDate パース失敗が黙殺される（appointment_handler.go:107、parseDate が nil を返すと「更新しない」と区別できない）。"あああ" を送っても 200 が返り日付は変わらない。POST は同じ入力で 400。Java では PATCH でも 400 にすべき。
+F. nullable フィールドを NULL に戻せない: Update 系はすべて `if in.X != nil` 判定で、JSON の明示 null とキー省略を区別していない（hospital_repository.go:85-106, appointment_repository.go:98-122）。一度入れた notes/cost/hospitalId をクリアする API 経路が存在しない。Java で JsonNullable などを使う場合は挙動が変わる点に注意。
+G. Hospital の name バリデーション非対称: POST は `binding:"required,max=200"` だが PATCH の Name には binding タグが無い（hospital_handler.go:41 vs 75）。PATCH 経由なら 200 文字超も空文字も通る。DB 側にも長さ制約は無い（TEXT NOT NULL のみ）。
+H. トランザクション不在 + プール分離: database/db.go で pgxpool（読み）と GORM（書き）の別プールを張り、GORM は `SkipDefaultTransaction: true`。Create/Update は「GORM で書き込み → 別プールの sqlc で FindByID 再読込」という 2 接続にまたがる非トランザクショナルな read-after-write。並行削除等で FindByID が nil を返すと、Create が data:null のまま 201、Update が data:null のまま 200 を返す（nil チェックが無い: appointment_repository.go:94, hospital_repository.go:81）。Java では単一トランザクション内で完結させるべき。
+I. FindByID の SQL に userId 条件が無く（queries/hospital.sql, appointment.sql の GetHospital/GetAppointment は WHERE "id" = $1 のみ）、Update/Delete の WHERE も id のみ。防御が usecase 層の 1 行比較だけに依存しており、リポジトリを直接呼ぶ経路を足すと即座に横断アクセスになる。Java では WHERE 句に userId を含める（またはリポジトリメソッド自体を userId 必須にする）ことを推奨。
+J. bind エラーのメッセージが固定文言で実際の原因を表さない。例えば POST /api/appointments で cost に文字列を渡しても「メンバーIDと予定日時は必須です」が返る（appointment_handler.go:59）。
+K. タイムゾーン: parseDate（handler/helpers.go）はオフセット無し形式 "2006-01-02T15:04:05" と "2006-01-02" を time.Parse でパースするため UTC 扱いになる。JST 前提のクライアントが "2026-08-20" を送ると UTC 00:00＝JST 09:00 として保存される。列型は TIMESTAMPTZ。
+L. 数値の範囲検証が皆無: cost の負値、reminderDaysBefore の負値・極端な値がそのまま保存される。DB 制約も無い（cost DOUBLE PRECISION、reminderDaysBefore INTEGER NOT NULL DEFAULT 1）。
+M. レート制限はプロセス内 map で、キー（"api:"+userID）が期限切れ後も削除されない（middleware/ratelimit.go の store から evict する処理が無い）。マルチインスタンスでは共有されない。
+N. Appointment には対応するテストが無い（usecase/crud_test.go・router/router_smoke_test.go のいずれにも appointment/hospital の記述なし）。移植時の回帰比較に使える既存テストは無い。
+
+【DB 列との対応（migrations/0001_init.sql:88-129）】
+Hospital: id TEXT PK / userId TEXT NOT NULL REFERENCES User(id) ON DELETE CASCADE / name TEXT NOT NULL / hospitalType, address, phoneNumber, department, doctorName, notes は TEXT NULL / createdAt TIMESTAMPTZ NOT NULL DEFAULT now()。INDEX: Hospital_userId_idx。
+Appointment: id TEXT PK / userId TEXT NOT NULL REFERENCES User(id) ON DELETE CASCADE / memberId TEXT NOT NULL REFERENCES Member(id) ON DELETE CASCADE / hospitalId TEXT NULL REFERENCES Hospital(id)（ON DELETE 指定なし）/ appointmentType TEXT NULL / appointmentDate TIMESTAMPTZ NOT NULL / description, testResults TEXT NULL / cost DOUBLE PRECISION NULL / reminderEnabled BOOLEAN NOT NULL DEFAULT TRUE / reminderDaysBefore INTEGER NOT NULL DEFAULT 1 / createdAt TIMESTAMPTZ NOT NULL DEFAULT now()。INDEX: Appointment_userId_idx, Appointment_memberId_idx。テーブル名・列名はダブルクオート付きのキャメルケース（Prisma 由来）なので、JPA では @Table(name="\"Appointment\"") 相当のクオート指定が必須。NOT NULL の影響として reminderEnabled / reminderDaysBefore は Java 側でも primitive（非 null）で扱ってよいが、appointmentDate も非 null なので PATCH で明示的に null 化できない点は現行仕様と一致している。
+
+【関連ファイル（絶対パス）】
+/Users/takuma.kawano/HealthFamily/backend/internal/interface/router/routes_ext.go
+/Users/takuma.kawano/HealthFamily/backend/internal/interface/router/router.go
+/Users/takuma.kawano/HealthFamily/backend/internal/interface/handler/hospital_handler.go
+/Users/takuma.kawano/HealthFamily/backend/internal/interface/handler/appointment_handler.go
+/Users/takuma.kawano/HealthFamily/backend/internal/interface/handler/helpers.go
+/Users/takuma.kawano/HealthFamily/backend/internal/usecase/hospital_usecase.go
+/Users/takuma.kawano/HealthFamily/backend/internal/usecase/crud.go
+/Users/takuma.kawano/HealthFamily/backend/internal/usecase/ownership_ext.go
+/Users/takuma.kawano/HealthFamily/backend/internal/domain/entity/entities_ext.go
+/Users/takuma.kawano/HealthFamily/backend/internal/domain/repository/repository_ext.go
+/Users/takuma.kawano/HealthFamily/backend/internal/domain/errors.go
+/Users/takuma.kawano/HealthFamily/backend/internal/pkg/response/response.go
+/Users/takuma.kawano/HealthFamily/backend/internal/infrastructure/persistence/hospital_repository.go
+/Users/takuma.kawano/HealthFamily/backend/internal/infrastructure/persistence/appointment_repository.go
+/Users/takuma.kawano/HealthFamily/backend/internal/infrastructure/persistence/gorm_models.go
+/Users/takuma.kawano/HealthFamily/backend/internal/infrastructure/sqlc/queries/hospital.sql
+/Users/takuma.kawano/HealthFamily/backend/internal/infrastructure/sqlc/queries/appointment.sql
+/Users/takuma.kawano/HealthFamily/backend/internal/infrastructure/database/db.go
+/Users/takuma.kawano/HealthFamily/backend/internal/interface/middleware/auth.go
+/Users/takuma.kawano/HealthFamily/backend/internal/interface/middleware/ratelimit.go
+/Users/takuma.kawano/HealthFamily/backend/migrations/0001_init.sql
+
+### GET /api/hospitals
+
+**レスポンス**: data: Hospital[]（0件でも null ではなく空配列 []）。Hospital = { id: string(UUID v4), userId: string, name: string, hospitalType: string|null, address: string|null, phoneNumber: string|null, department: string|null, doctorName: string|null, notes: string|null, createdAt: string(RFC3339 timestamptz) }。並び順は createdAt DESC（sqlc ListHospitals: SELECT ... FROM "Hospital" WHERE "userId"=$1 ORDER BY "createdAt" DESC）
+
+**ステータス**: 200 成功 / 401 認証エラー（Bearer 欠落・JWT 検証失敗、body: {success:false,error:"認証エラー"}）/ 429 レート制限（authed 全体に user 単位 120req/分, error:"リクエストが多すぎます。しばらくしてから再試行してください。"）/ 500 "サーバーエラーが発生しました"
+
+**所有権**: SQL の WHERE "userId" = <JWTのuserID> のみでスコープ。アプリ層の追加チェックなし
+
+**ドメイン規則**: 単純な一覧取得。副作用なし。ソートは createdAt 降順（作成日時のみ、name ソートなし）
+
+### POST /api/hospitals
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `name` | string | ○ | binding:"required,max=200"（空文字不可・200文字以内。go-playground/validator の max はルーン数）。違反時は 400 "病院名は必須です" 固定文言 |
+| `hospitalType` | string|null | — | 検証なし。任意の自由文字列（enum 制約は DB にもコードにも無い） |
+| `address` | string|null | — | 検証なし |
+| `phoneNumber` | string|null | — | 検証なし（電話番号形式チェックは無い） |
+| `department` | string|null | — | 検証なし |
+| `doctorName` | string|null | — | 検証なし |
+| `notes` | string|null | — | 検証なし |
+
+**レスポンス**: data: Hospital（GET /api/hospitals と同一形状の単一オブジェクト）。INSERT 後に FindByID で再読込した値を返すため createdAt は DB の now() 実値
+
+**ステータス**: 201 Created（response.Created）/ 400 "病院名は必須です"（ShouldBindJSON 失敗すべてがこの固定文言。型不一致・JSON 壊れも同じ）/ 401 / 429 / 500
+
+**所有権**: userId は JWT の userID を強制設定（リクエストボディから userId は受け取らない）。他の所有権チェックは無し（Hospital は member 紐付けを持たない user スコープ資源）
+
+**ドメイン規則**: id はアプリ側で UUID v4 生成（auth.NewID / google/uuid）。createdAt は DB DEFAULT now()。usecase.HospitalUsecase.Create は検証を一切行わず repository.Create をそのまま呼ぶ純 CRUD。実質ドメイン規則は「name 必須・200文字以内」のみ
+
+### GET /api/hospitals/{hospitalId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `hospitalId` | string (path param) | ○ | 形式検証なし（UUID 検証もしていない。存在しなければ 404） |
+
+**レスポンス**: data: Hospital（単一オブジェクト）
+
+**ステータス**: 200 / 404 "病院が見つかりません"（domain.NewNotFound("病院")）/ 403 "この病院にアクセスする権限がありません"（domain.NewForbidden）/ 401 / 429 / 500
+
+**所有権**: HospitalUsecase.ensureOwner: FindByID(id) → nil なら 404、h.UserID != JWT userID なら 403。SQL 側は WHERE "id"=$1 のみで userId 絞り込みをしない（usecase 層の比較だけが防御）
+
+**ドメイン規則**: 参照のみ。副作用なし
+
+### PATCH /api/hospitals/{hospitalId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `hospitalId` | string (path param) | ○ | 形式検証なし |
+| `name` | string|null | — | binding タグ無し。POST にある max=200 が PATCH には無い（200文字超も通る）。空文字 "" を渡すと NOT NULL は満たすが name が空になる |
+| `hospitalType` | string|null | — | 検証なし |
+| `address` | string|null | — | 検証なし |
+| `phoneNumber` | string|null | — | 検証なし |
+| `department` | string|null | — | 検証なし |
+| `doctorName` | string|null | — | 検証なし |
+| `notes` | string|null | — | 検証なし |
+
+**レスポンス**: data: Hospital（UPDATE 後に FindByID で再読込した最新値）
+
+**ステータス**: 200 / 400 "入力内容が正しくありません"（ShouldBindJSON 失敗時のみ）/ 404 "病院が見つかりません" / 403 "この病院にアクセスする権限がありません" / 401 / 429 / 500
+
+**所有権**: ensureOwner を先に実行 → 404/403。通過後に repository.Update(id, in)（Update 側は id のみで userId を条件に入れない）
+
+**ドメイン規則**: 部分更新セマンティクス: ポインタが nil でないフィールドのみ map に積んで GORM Updates。JSON で null を送っても省略と区別できず「無変更」になる（＝NULL に戻す手段が無い）。全フィールド nil の場合は UPDATE 文を発行せず現在値をそのまま返す（200）。userId / createdAt は更新対象外
+
+### DELETE /api/hospitals/{hospitalId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `hospitalId` | string (path param) | ○ | 形式検証なし |
+
+**レスポンス**: data: { ok: true }（gin.H{"ok": true}）。削除したエンティティは返さない
+
+**ステータス**: 200（204 ではない）/ 404 "病院が見つかりません" / 403 "この病院にアクセスする権限がありません" / 401 / 429 / 500（Appointment から参照されている病院を削除すると FK 違反で 500。notes 参照）
+
+**所有権**: ensureOwner 実行後に repository.Delete(id)（DELETE FROM "Hospital" WHERE "id" = ?、userId 条件なし）
+
+**ドメイン規則**: 物理削除（論理削除フラグ無し・GORM ソフトデリート列も無し）。Appointment.hospitalId の FK は ON DELETE 未指定＝NO ACTION なので、参照中の病院は削除できない（カスケードも SET NULL もしない）
+
+### GET /api/appointments
+
+**レスポンス**: data: Appointment[]（0件でも空配列 []）。Appointment = { id: string(UUID v4), userId: string, memberId: string, hospitalId: string|null, appointmentType: string|null, appointmentDate: string(RFC3339), description: string|null, testResults: string|null, cost: number|null (double), reminderEnabled: boolean, reminderDaysBefore: number (int, non-null), createdAt: string(RFC3339) }。並び順は appointmentDate DESC（ListAppointments: WHERE "userId"=$1 ORDER BY "appointmentDate" DESC）
+
+**ステータス**: 200 / 401 / 429 / 500
+
+**所有権**: SQL の WHERE "userId" = <JWTのuserID> のみ。memberId によるフィルタ・クエリパラメータは存在しない（member 別取得エンドポイントは無い）
+
+**ドメイン規則**: 未来/過去の絞り込み、ページング、リマインダ判定などは一切なし。Hospital の JOIN も無く hospitalId は ID 文字列のみ返す（病院名は別途 /api/hospitals から解決する必要あり）
+
+### POST /api/appointments
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required"。失敗時 400 "メンバーIDと予定日時は必須です" |
+| `appointmentDate` | string | ○ | binding:"required"。handler.parseDate で RFC3339 / "2006-01-02T15:04:05" / "2006-01-02" の順に time.Parse。どれにも一致しなければ 400 "予定日時の形式が正しくありません"。オフセット無しの2形式は UTC として解釈される |
+| `hospitalId` | string|null | — | 存在確認・所有権確認とも無し。DB の FK 制約のみ（notes 参照） |
+| `appointmentType` | string|null | — | 検証なし（enum 制約なし） |
+| `description` | string|null | — | 検証なし |
+| `testResults` | string|null | — | 検証なし |
+| `cost` | number|null (float64) | — | 検証なし（負値・巨大値も通る） |
+| `reminderEnabled` | boolean|null | — | 検証なし。未指定(nil)なら true を適用 |
+| `reminderDaysBefore` | number|null (int) | — | 検証なし（負値も可）。未指定(nil)なら 1 を適用 |
+
+**レスポンス**: data: Appointment（GET と同一形状の単一オブジェクト）。INSERT 後 FindByID で再読込した値
+
+**ステータス**: 201 Created / 400 "メンバーIDと予定日時は必須です"（bind 失敗）または "予定日時の形式が正しくありません"（日付パース失敗）/ 404 "メンバーが見つかりません" / 403 "このメンバーにアクセスする権限がありません" / 401 / 429 / 500（存在しない hospitalId 指定時の FK 違反もここに落ちる）
+
+**所有権**: MemberScopedCRUD.Create → ensureMemberOwner(members, in.UserID, in.MemberID): MemberRepository.FindByID(memberId) が nil なら 404「メンバーが見つかりません」、m.UserID != JWT userID なら 403「このメンバーにアクセスする権限がありません」。userId はボディからではなく JWT から設定。hospitalId の所有権は検証しない
+
+**ドメイン規則**: 既定値をアプリ層で再現: reminderEnabled 未指定→true、reminderDaysBefore 未指定→1（AppointmentRepository.Create 内。DB DEFAULT TRUE / 1 とも一致）。id は UUID v4 をアプリ生成。createdAt は DB DEFAULT now()。日時重複チェック・過去日拒否・メンバー×日時のユニーク制約は無い。リマインダの実送信処理は存在せずフラグ保存のみ（副作用なし）
+
+### GET /api/appointments/{appointmentId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `appointmentId` | string (path param) | ○ | 形式検証なし |
+
+**レスポンス**: data: Appointment（単一オブジェクト）
+
+**ステータス**: 200 / 404 "通院予定が見つかりません" / 403 "この通院予定にアクセスする権限がありません" / 401 / 429 / 500
+
+**所有権**: MemberScopedCRUD.ensureOwner: FindByID(id)（SQL は WHERE "id"=$1 のみ）→ nil なら 404、entity.UserID != JWT userID なら 403。メンバー所有権の再確認はしない（作成時のみ）
+
+**ドメイン規則**: 参照のみ。副作用なし
+
+### PATCH /api/appointments/{appointmentId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `appointmentId` | string (path param) | ○ | 形式検証なし |
+| `hospitalId` | string|null | — | 存在確認・所有権確認なし |
+| `appointmentType` | string|null | — | 検証なし |
+| `appointmentDate` | string|null | — | parseDate で同3形式を試行。パース失敗すると nil になり 400 ではなく「無変更」として黙って無視される（POST と非対称） |
+| `description` | string|null | — | 検証なし |
+| `testResults` | string|null | — | 検証なし |
+| `cost` | number|null (float64) | — | 検証なし |
+| `reminderEnabled` | boolean|null | — | 検証なし |
+| `reminderDaysBefore` | number|null (int) | — | 検証なし |
+
+**レスポンス**: data: Appointment（UPDATE 後に FindByID で再読込した最新値）
+
+**ステータス**: 200 / 400 "入力内容が正しくありません"（bind 失敗時のみ）/ 404 "通院予定が見つかりません" / 403 "この通院予定にアクセスする権限がありません" / 401 / 429 / 500
+
+**所有権**: ensureOwner で 404/403 判定後に repository.Update(id, in)（WHERE "id" = ? のみ、userId 条件なし）
+
+**ドメイン規則**: 部分更新。nil でないフィールドのみ更新（JSON null＝省略扱いで NULL 化不可）。memberId は UpdateAppointmentInput に存在せず変更不可（作成後は不変）。userId / createdAt も更新対象外。更新フィールドが1つも無ければ UPDATE を発行せず現在値を返す
+
+### DELETE /api/appointments/{appointmentId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `appointmentId` | string (path param) | ○ | 形式検証なし |
+
+**レスポンス**: data: { ok: true }
+
+**ステータス**: 200（204 ではない）/ 404 "通院予定が見つかりません" / 403 "この通院予定にアクセスする権限がありません" / 401 / 429 / 500
+
+**所有権**: ensureOwner 実行後に repository.Delete(id)（DELETE FROM "Appointment" WHERE "id" = ?、userId 条件なし）
+
+**ドメイン規則**: 物理削除。子テーブル無し。Appointment を消しても Hospital / Member は変わらない
+
+## healthlog-temperature-body
+
+### 移植時の注意
+
+【確認に使ったファイル】
+- ルート登録: /Users/takuma.kawano/HealthFamily/backend/internal/interface/router/router.go (L67-119), routes_ext.go (L37-42 HealthLog, L77-82 BodyMeasurement, L85-91 TemperatureRecord)
+- handler: internal/interface/handler/health_log_handler.go, body_measurement_handler.go, temperature_record_handler.go, helpers.go (parseDate)
+- usecase: internal/usecase/crud.go (MemberScopedCRUD), temperature_record_usecase.go, ownership_ext.go (ensureMemberOwner)
+- repository: internal/infrastructure/persistence/{health_log,body_measurement,temperature_record}_repository.go, gorm_models.go (L157-167, L213-223, L272-283)
+- SQL: internal/infrastructure/sqlc/queries/{health_log,body_measurement,temperature_record}.sql
+- DDL: migrations/0001_init.sql (L102-112, L186-210), 0008_add_missing_column_defaults.sql (HealthLog.symptoms DEFAULT '{}')
+- 共通: internal/pkg/response/response.go, internal/domain/errors.go, internal/interface/middleware/{auth,ratelimit}.go, internal/infrastructure/database/db.go
+
+【共通の契約】
+- レスポンス: 成功 {success:true, data:...}、エラー {success:false, error:"日本語メッセージ"}。エラー時に data キーは出ない。
+- ドメイン例外 → HTTP: NotFoundError→404 / ConflictError→409 / ValidationError→400 / ForbiddenError→403 / それ以外→500 "サーバーエラーが発生しました"。この3リソースは Conflict / Validation ドメイン例外を一度も生成していない（400 は全て handler の bind/parse 段階）。
+- 認証: Authorization: Bearer <JWT>。middleware.Auth が claims.UserID を context に格納。userId は必ず JWT 由来でリクエスト body からは受け取らない。
+- レート制限: 全認証エンドポイントに RateLimit("api", 120, 1分, PerUser)。超過で 429。
+- HealthLog は createdAt 列が存在しない（Body/Temperature にはある）。Java の Entity で createdAt を足すと契約が変わるので注意。
+- List 系は必ず配列を返す（make([]T, 0, n)）。null にならない。Java 側も空配列を返すこと。
+- 3リソースとも同じ DB 制約: userId/memberId は TEXT NOT NULL + User/Member への FK ON DELETE CASCADE。メンバー削除で記録も消える。
+
+【移植で Java 側に必ず移すべきドメイン規則（これだけ）】
+1. Create 時: memberId が呼び出しユーザー所有のメンバーであること（未存在→404「メンバーが見つかりません」、他人所有→403「このメンバーにアクセスする権限がありません」）
+2. Get/Update/Delete 時: レコードの userId == 認証ユーザー（未存在→404「<リソース名>が見つかりません」、他人→403「この<リソース名>にアクセスする権限がありません」）
+3. GET /temperature-records/member/:memberId 時: メンバーの所有権のみ確認
+4. HealthLog.symptoms の nil → [] 正規化（TEXT[] NOT NULL 制約対応）
+5. recordedAt / measuredAt の日付パース許容形式 3種（RFC3339, yyyy-MM-dd'T'HH:mm:ss, yyyy-MM-dd）
+それ以外は完全に素の CRUD。計算・状態遷移・通知・他リソースへの波及は一切ない。
+
+【Go 側の不具合・危うい実装（Java 移植時に直すべき／意図的に踏襲するか判断が要る）】
+(A) 【重要】PATCH で NULL にクリアできない: notes / weight / height / conditionLevel はすべてポインタで `if in.X != nil` 判定のため、JSON の null は「未指定」と区別されず無視される。フロント側 frontend/src/pages/health-logs/model/health-logs.ts の UpdateBodyMeasurementInput は `weight?: number|null; height?: number|null; notes?: string|null` と「null でクリアする」型定義になっており、フロントの意図とバックエンドの実装が食い違っている。Java では JsonNullable / Optional<Optional<T>> 等で三値（未指定／null／値）を区別すべき。
+
+(B) 【重要】不正な日付文字列が黙って捨てられる: PATCH の recordedAt / measuredAt は parseDate が nil を返しても 400 にならず「未指定」扱いで無視され、200 が返る。ユーザーには更新成功に見えるのに更新されていない。さらに POST /health-logs は Create でも nil チェックが無く、不正な日付文字列を送ると黙って DB の now() が入る（POST /temperature-records と POST /body-measurements は Create 時に 400 を返すので、3リソースで挙動が非対称）。
+
+(C) 【重要】値域検証がサーバ側に一切ない:
+  - conditionLevel: 0 / -1 / 999999 がそのまま保存される（実測で 200 を確認。フロントは 1..5 前提で CONDITION_LABELS[level] を引くので undefined になる）
+  - temperature: 0 / -100 / 1000 も保存可能（実測確認）
+  - weight / height: 負値可、両方 null のレコードも作成可能
+  - symptoms: フロントは 18 種の enum を想定するがサーバは任意文字列を許す
+  DB 側にも CHECK 制約が無い。Java 移植時に Bean Validation で入れるべきだが、既存データに範囲外の値が入っている可能性があるので読み出し側を壊さないこと。
+
+(D) ListTemperatureRecordsByMember の SQL に userId 条件が無い: `WHERE "memberId" = $1` のみ。現状は usecase の ensureMemberOwner が防いでいるので漏洩しないが、多重防御が無い。将来メンバー共有機能を入れたりデータ不整合（同一 member に別 userId のレコード）が起きると他人のデータを返す。Java では `WHERE memberId = ? AND userId = ?` にすべき。同様に Get/Update/Delete の SQL もすべて `WHERE id = ?` のみで userId 条件が無く、アプリ層の比較だけが境界になっている。
+
+(E) TOCTOU / トランザクション欠如: ensureMemberOwner（SELECT）→ INSERT、ensureOwner（SELECT）→ UPDATE/DELETE がいずれも別クエリ・別トランザクション。しかも database.DB は「読み = pgxpool(sqlc)」「書き = GORM(database/sql)」の別プール構成で、gorm.Config に SkipDefaultTransaction: true が設定されており単発書き込みにトランザクションが張られない。所有権チェックと書き込みが原子的でない。Java では @Transactional + `UPDATE ... WHERE id = ? AND userId = ?` の更新件数チェックにするのが安全。
+
+(F) 書き込み直後の読み直しがクロスプール: Create/Update は GORM で書いた直後に sqlc(別プール・別コネクション)の FindByID で読み直す。同一 primary への読みなので実害は出にくいが、リードレプリカやコネクションプーラを挟むと read-your-write が壊れる。
+
+(G) 書き込み直後の FindByID が nil でもエラーにならない: Create は `return r.FindByID(ctx, m.ID)` をそのまま返すため、読み直しで見つからないと (nil, nil) になり handler が 201 + `data: null` を返す。Update/Delete 直前に他セッションが削除した場合も PATCH が 200 + `data: null` を返す。Java では 404 か 500 を返すべき。
+
+(H) 情報漏洩（軽微）: 存在しない ID は 404、存在するが他人の ID は 403 と返り分けるため、ID の存在有無が判別できる。ID は UUID v4 なので実害は小さいが、Java 側で 404 に統一する選択肢はある。
+
+(I) エンドポイントの非対称性: `/member/:memberId` 形式の一覧は temperature-records にしか無い。health-logs / body-measurements にメンバー別一覧が必要ならフロントが全件取得してクライアント側で絞っている（frontend/src/pages/health-logs/model/health-logs.ts）。移植時にどちらへ揃えるか要判断。
+
+(J) 400 のエラーメッセージが実態と合わない: POST /health-logs はどんなバインド失敗でも "メンバーIDと体調レベルは必須です" を返すため、型不一致（例: conditionLevel に文字列）や空 body でも同じメッセージになりデバッグしにくい。
+
+(K) レート制限がプロセス内メモリ（sync.Map）: Cloud Run の複数インスタンス構成ではインスタンスごとにカウントされ、実効上限が インスタンス数 × 120/分 になる。エントリの期限切れ削除も無くメモリが単調増加する。
+
+(L) List 系にページング・件数上限が無い: WHERE userId のみで全件返す。体温記録は日次で増えるので長期利用でレスポンスが肥大する。
+
+### GET /api/health-logs
+
+**レスポンス**: data: HealthLog[] (配列。0件でも null ではなく [])。HealthLog = { id: string(UUIDv4), userId: string, memberId: string, conditionLevel: number(int32), symptoms: string[](NOT NULL、空なら []), notes: string|null, recordedAt: string(RFC3339 timestamptz) }。※HealthLog だけ createdAt 列が存在せずレスポンスにも無い
+
+**ステータス**: 200 成功 / 401 Authorization: Bearer 無し・JWT 検証失敗 (error="認証エラー") / 429 レート制限超過 (error="リクエストが多すぎます。しばらくしてから再試行してください。") / 500 DB エラー (error="サーバーエラーが発生しました")
+
+**所有権**: WHERE userId = JWT の userID。usecase 層では追加チェック無し（SQL の userId 条件のみが所有権境界）
+
+**ドメイン規則**: SQL: SELECT id, memberId, userId, conditionLevel, symptoms, notes, recordedAt FROM "HealthLog" WHERE "userId" = $1 ORDER BY "recordedAt" DESC。ページング・フィルタ・memberId 絞り込みは一切無し。単なる CRUD の List
+
+### POST /api/health-logs
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required" — 未指定/null/空文字はすべて 400。値域検証なし。存在チェックは usecase の ensureMemberOwner が実施 |
+| `conditionLevel` | *int (integer) | ○ | binding:"required" — キー欠落 or null なら 400。ポインタなので 0 や -1 は通る（実測確認済み）。範囲検証は Go 側に一切なし（フロントは 1..5 を想定） |
+| `symptoms` | string[] | — | 検証なし。省略/null → Go では nil → repository が []string{} に正規化（symptoms 列は TEXT[] NOT NULL DEFAULT '{}'）。[] を送ると非 nil の空配列。要素の enum 検証はサーバ側に無い（フロントは headache/fever/... 18種を想定） |
+| `notes` | *string | — | 検証なし。長さ制限なし（DB は TEXT） |
+| `recordedAt` | *string | — | handler の parseDate で RFC3339 → "2006-01-02T15:04:05" → "2006-01-02" の順に試行。いずれも失敗すると nil を返し、エラーにならず「未指定」と同じ扱いになる。未指定/パース失敗時は DB の DEFAULT now()（GORM の default:now() タグでカラム省略） |
+
+**レスポンス**: data: HealthLog（Create 後に FindByID で読み直した値。{ id, userId, memberId, conditionLevel, symptoms, notes, recordedAt }）
+
+**ステータス**: 201 成功 / 400 バインド失敗 (error="メンバーIDと体調レベルは必須です"。空 body・memberId 空文字・conditionLevel 欠落/null・型不一致すべてこの1メッセージ) / 403 メンバーが他人の所有 (error="このメンバーにアクセスする権限がありません") / 404 memberId が存在しない (error="メンバーが見つかりません") / 401 / 429 / 500
+
+**所有権**: usecase.MemberScopedCRUD.Create → ensureMemberOwner: MemberRepository.FindByID(memberId) を引き、nil なら NotFound("メンバー")、member.UserID != JWT userID なら Forbidden。通過後に INSERT（所有権確認と INSERT は同一トランザクションではない）
+
+**ドメイン規則**: ドメイン規則は「memberId が呼び出しユーザーの所有メンバーであること」のみ。id はサーバ側で UUID v4 生成 (auth.NewID)。userId は JWT から強制設定（body からは受け取らない）。symptoms の nil → [] 正規化は NOT NULL 制約対応。conditionLevel/notes/recordedAt に業務検証・計算・副作用なし
+
+### GET /api/health-logs/:logId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `logId` | string (path param) | ○ | 形式検証なし。DB の id 列は TEXT なので UUID 以外でも 404 になるだけ |
+
+**レスポンス**: data: HealthLog（単体オブジェクト）
+
+**ステータス**: 200 / 404 該当なし (error="体調ログが見つかりません") / 403 他人のログ (error="この体調ログにアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: usecase.MemberScopedCRUD.ensureOwner: FindByID(id) が nil → NotFound、entity.UserID != JWT userID → Forbidden。存在するが他人のものだと 403 が返るため「その ID が存在すること」が漏れる
+
+**ドメイン規則**: SELECT ... FROM "HealthLog" WHERE "id" = $1（userId 条件なしで取得 → アプリ層で所有者比較）。単なる CRUD の Get
+
+### PATCH /api/health-logs/:logId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `logId` | string (path param) | ○ | なし |
+| `conditionLevel` | *int | — | binding タグなし。省略/null なら未更新。値域検証なし（0・負値・巨大値も通る） |
+| `symptoms` | string[] | — | 省略 or null → nil → 未更新。[] → 空配列で上書き（クリア可能）。要素の enum 検証なし |
+| `notes` | *string | — | 省略 or null → 未更新。"" を送れば空文字で上書き。NULL に戻す手段が無い |
+| `recordedAt` | *string | — | parseDate。パース失敗しても 400 にならず「未指定」と同じ扱いで黙って無視される |
+
+**レスポンス**: data: HealthLog（更新後に FindByID で読み直した値）。更新対象フィールドが1つも無い場合は UPDATE を発行せず現在値をそのまま返す
+
+**ステータス**: 200 / 400 body が JSON でない・空 body (error="入力内容が正しくありません") / 404 (error="体調ログが見つかりません") / 403 (error="この体調ログにアクセスする権限がありません") / 401 / 429 / 500。※空オブジェクト {} は 400 ではなく 200
+
+**所有権**: ensureOwner で所有者確認 → その後 UPDATE。UPDATE 側の WHERE は id のみ（userId 条件なし）。確認と更新が別クエリ・別トランザクション
+
+**ドメイン規則**: 部分更新（nil でないフィールドのみ map に積んで GORM Updates）。UPDATE "HealthLog" SET <指定列> WHERE "id" = ?。memberId・userId は更新不可（Update input に存在しない）。検証・計算・副作用なし
+
+### DELETE /api/health-logs/:logId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `logId` | string (path param) | ○ | なし |
+
+**レスポンス**: data: { ok: true }（固定オブジェクト。削除されたエンティティは返さない）
+
+**ステータス**: 200 / 404 (error="体調ログが見つかりません") / 403 (error="この体調ログにアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: ensureOwner 通過後に DELETE。DELETE の WHERE は id のみ
+
+**ドメイン規則**: 物理削除（DELETE FROM "HealthLog" WHERE "id" = ?）。論理削除カラム無し。カスケード対象の子テーブル無し
+
+### GET /api/temperature-records
+
+**レスポンス**: data: TemperatureRecord[]（0件でも []）。TemperatureRecord = { id: string(UUIDv4), userId: string, memberId: string, temperature: number(double), measuredAt: string(RFC3339), notes: string|null, createdAt: string(RFC3339) }
+
+**ステータス**: 200 / 401 / 429 / 500
+
+**所有権**: WHERE userId = JWT userID
+
+**ドメイン規則**: SELECT ... FROM "TemperatureRecord" WHERE "userId" = $1 ORDER BY "measuredAt" DESC。ページング無し
+
+### GET /api/temperature-records/member/:memberId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string (path param) | ○ | なし |
+
+**レスポンス**: data: TemperatureRecord[]（0件でも []）
+
+**ステータス**: 200 / 404 memberId が存在しない (error="メンバーが見つかりません") / 403 他人のメンバー (error="このメンバーにアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: usecase.ListByMember → ensureMemberOwner(memberId) でメンバーの所有者のみ確認。レコード自身の userId は照合しない（SQL も memberId のみ）
+
+**ドメイン規則**: SELECT ... FROM "TemperatureRecord" WHERE "memberId" = $1 ORDER BY "measuredAt" DESC。※SQL 側に userId 条件が無い。この形の member 別一覧は temperature-records のみ存在し、health-logs / body-measurements には対応エンドポイントが無い（非対称）。インデックス TemperatureRecord_memberId_measuredAt_idx あり
+
+### POST /api/temperature-records
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required" — 未指定/空文字は 400 |
+| `temperature` | *float64 | ○ | binding:"required" — キー欠落/null は 400。ポインタなので 0 や -100、1000 も通る（実測確認済み）。上下限検証は Go 側に無く、DB の CHECK 制約も無い |
+| `measuredAt` | string | ○ | binding:"required"（空文字は 400）。さらに parseDate が nil を返すと 400 "測定日時の形式が正しくありません"。許容形式は RFC3339 / "2006-01-02T15:04:05" / "2006-01-02"。タイムゾーン無し形式は UTC 扱いで parse される |
+| `notes` | *string | — | 検証なし |
+
+**レスポンス**: data: TemperatureRecord（Create 後に FindByID した値）
+
+**ステータス**: 201 / 400 バインド失敗 (error="メンバーID・体温・測定日時は必須です") / 400 日付形式不正 (error="測定日時の形式が正しくありません") / 403 (error="このメンバーにアクセスする権限がありません") / 404 (error="メンバーが見つかりません") / 401 / 429 / 500
+
+**所有権**: TemperatureRecordUsecase.Create → ensureMemberOwner(in.UserID, in.MemberID)。member が nil → 404、member.UserID != userID → 403。通過後に INSERT（別トランザクション）
+
+**ドメイン規則**: ドメイン規則は memberId の所有権確認のみ。id は UUID v4 をサーバ生成。userId は JWT から。temperature 列は DOUBLE PRECISION NOT NULL、measuredAt は TIMESTAMPTZ NOT NULL（DEFAULT 無し・GORM の default タグも無いので必ず値が入る）、createdAt は DEFAULT now()。発熱判定・アラート等の計算や副作用は一切なし
+
+### GET /api/temperature-records/:recordId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `recordId` | string (path param) | ○ | なし |
+
+**レスポンス**: data: TemperatureRecord（単体）
+
+**ステータス**: 200 / 404 (error="体温記録が見つかりません") / 403 (error="この体温記録にアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: TemperatureRecordUsecase.ensureOwner: t == nil → NotFound("体温記録")、t.UserID != userID → Forbidden
+
+**ドメイン規則**: SELECT ... WHERE "id" = $1（userId 条件なし）。単なる CRUD の Get。Gin のルーティング上 /temperature-records/member/:memberId が静的セグメント優先で先にマッチするため、recordId に "member" は到達しない（router_smoke_test で登録時 panic しないことを検証済み）
+
+### PATCH /api/temperature-records/:recordId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `recordId` | string (path param) | ○ | なし |
+| `temperature` | *float64 | — | 省略/null なら未更新。値域検証なし。0 を送れば 0 で上書きされる（map 更新なので GORM のゼロ値スキップは効かない） |
+| `measuredAt` | *string | — | parseDate。省略/null/パース失敗すべて「未更新」になる（Create と違い形式エラーで 400 にならない） |
+| `notes` | *string | — | 省略/null なら未更新。NULL に戻す手段が無い |
+
+**レスポンス**: data: TemperatureRecord（更新後に FindByID した値）。更新フィールドが 0 個なら UPDATE を発行せず現在値を返す
+
+**ステータス**: 200 / 400 JSON パース失敗・空 body (error="入力内容が正しくありません") / 404 (error="体温記録が見つかりません") / 403 (error="この体温記録にアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: ensureOwner 通過後に UPDATE ... WHERE "id" = ?（userId 条件なし）
+
+**ドメイン規則**: 部分更新のみ。memberId・userId は変更不可。検証・計算・副作用なし
+
+### DELETE /api/temperature-records/:recordId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `recordId` | string (path param) | ○ | なし |
+
+**レスポンス**: data: { ok: true }
+
+**ステータス**: 200 / 404 (error="体温記録が見つかりません") / 403 (error="この体温記録にアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: ensureOwner 通過後に DELETE（WHERE は id のみ）
+
+**ドメイン規則**: 物理削除。DELETE FROM "TemperatureRecord" WHERE "id" = ?
+
+### GET /api/body-measurements
+
+**レスポンス**: data: BodyMeasurement[]（0件でも []）。BodyMeasurement = { id: string(UUIDv4), userId: string, memberId: string, weight: number|null(double), height: number|null(double), recordedAt: string(RFC3339), notes: string|null, createdAt: string(RFC3339) }
+
+**ステータス**: 200 / 401 / 429 / 500
+
+**所有権**: WHERE userId = JWT userID
+
+**ドメイン規則**: SELECT ... FROM "BodyMeasurement" WHERE "userId" = $1 ORDER BY "recordedAt" DESC。ページング無し。BMI 等の算出はサーバ側でしていない（フロント側の責務）
+
+### POST /api/body-measurements
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required" — 未指定/空文字は 400 |
+| `weight` | *float64 | — | 検証なし。null 可（DB も NULL 許容）。負値・非現実値も通る。weight と height が両方 null のレコードも作成できてしまう（「少なくとも一方必須」の検証は無い） |
+| `height` | *float64 | — | 検証なし。null 可。負値も通る |
+| `recordedAt` | string | ○ | binding:"required"（空文字は 400）。さらに parseDate が nil を返すと 400 "記録日時の形式が正しくありません"。許容形式は RFC3339 / "2006-01-02T15:04:05" / "2006-01-02" |
+| `notes` | *string | — | 検証なし |
+
+**レスポンス**: data: BodyMeasurement（Create 後に FindByID した値）
+
+**ステータス**: 201 / 400 バインド失敗 (error="メンバーIDと記録日時は必須です") / 400 日付形式不正 (error="記録日時の形式が正しくありません") / 403 (error="このメンバーにアクセスする権限がありません") / 404 (error="メンバーが見つかりません") / 401 / 429 / 500
+
+**所有権**: MemberScopedCRUD.Create → ensureMemberOwner。member が nil → 404、他人所有 → 403。通過後に INSERT（別トランザクション）
+
+**ドメイン規則**: ドメイン規則は memberId の所有権確認のみ。id は UUID v4 をサーバ生成、userId は JWT から。recordedAt は TIMESTAMPTZ NOT NULL（DEFAULT 無し）、createdAt は DEFAULT now()。BMI 計算・前回差分などの計算や副作用は一切なし
+
+### GET /api/body-measurements/:measurementId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `measurementId` | string (path param) | ○ | なし |
+
+**レスポンス**: data: BodyMeasurement（単体）
+
+**ステータス**: 200 / 404 (error="身体測定記録が見つかりません") / 403 (error="この身体測定記録にアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: MemberScopedCRUD.ensureOwner: nil → NotFound("身体測定記録")、UserID 不一致 → Forbidden
+
+**ドメイン規則**: SELECT ... WHERE "id" = $1（userId 条件なし）。単なる CRUD の Get
+
+### PATCH /api/body-measurements/:measurementId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `measurementId` | string (path param) | ○ | なし |
+| `weight` | *float64 | — | 省略/null なら未更新。null 送信で NULL クリアはできない（フロントは weight?: number|null を送る設計なので意図と食い違う） |
+| `height` | *float64 | — | 省略/null なら未更新。NULL クリア不可 |
+| `recordedAt` | *string | — | parseDate。省略/null/パース失敗すべて未更新（Create と違い形式エラーで 400 にならない） |
+| `notes` | *string | — | 省略/null なら未更新。NULL クリア不可 |
+
+**レスポンス**: data: BodyMeasurement（更新後に FindByID した値）。更新フィールドが 0 個なら UPDATE を発行せず現在値を返す
+
+**ステータス**: 200 / 400 JSON パース失敗・空 body (error="入力内容が正しくありません") / 404 (error="身体測定記録が見つかりません") / 403 (error="この身体測定記録にアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: ensureOwner 通過後に UPDATE ... WHERE "id" = ?（userId 条件なし）
+
+**ドメイン規則**: 部分更新のみ。memberId・userId は変更不可。検証・計算・副作用なし
+
+### DELETE /api/body-measurements/:measurementId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `measurementId` | string (path param) | ○ | なし |
+
+**レスポンス**: data: { ok: true }
+
+**ステータス**: 200 / 404 (error="身体測定記録が見つかりません") / 403 (error="この身体測定記録にアクセスする権限がありません") / 401 / 429 / 500
+
+**所有権**: ensureOwner 通過後に DELETE（WHERE は id のみ）
+
+**ドメイン規則**: 物理削除。DELETE FROM "BodyMeasurement" WHERE "id" = ?
+
+## medication-record
+
+### 移植時の注意
+
+【共通契約】
+- レスポンスは常に {success:true, data:…} / {success:false, error:"…"}。成功は response.Success=200、作成は response.Created=201。エラーは pkg/response/response.go の HandleDomainError で NotFoundError→404 / ConflictError→409 / ValidationError→400 / ForbiddenError→403 / それ以外→500「サーバーエラーが発生しました」。medication-record 系で 409 を返す経路は存在しない。
+- 認証は middleware.Auth（Authorization: Bearer <JWT>）。ヘッダ欠落・不正はすべて 401「認証エラー」。userId は必ず JWT クレームから取得し、ボディの userId は一切受け付けない。
+- レート制限は authed グループ全体で middleware.RateLimit("api", 120, 1分, PerUser)。超過は 429「リクエストが多すぎます。しばらくしてから再試行してください。」。実装はプロセス内メモリの sync.Map なので水平スケール時は無効（Java 移植時は分散キャッシュ等の検討が必要）。
+- ルート優先順位: /api/medications/alerts（GET）と /api/medications/reorder（POST）は /api/medications/{medicationId} より先に一致する必要がある。Spring では @GetMapping("/medications/alerts") が {medicationId} より優先されるが、Ant パターン順序に依存する構成では明示が必要。
+
+【Java に移すべきドメイン規則（単なる CRUD ではない部分）】
+1. 所有権判定が 2 系統ある: (a) Medication/MedicationRecord は自身の userId と JWT userId を直接比較、(b) member 配下エンドポイントは Member.userId を確認したうえで memberId で引く。(b) は SQL に userId 条件が無いため、Member を所有していれば userId の異なる行も返る。
+2. POST /api/records の memberId はクライアント値を捨てて Medication.memberId から導出する。
+3. POST /api/medications の category 空文字 → "regular" 補完。
+4. GET /api/medications/alerts の在庫僅少判定（isActive=TRUE かつ「残数 <= 5」または「stockAlertDate <= now()+7日」、ソートは stockQuantity ASC NULLS LAST, createdAt ASC）。
+5. reorder の displayOrder = 配列インデックス、かつ userId スコープ付き UPDATE。
+6. 一覧のソート順（薬: displayOrder ASC, createdAt ASC / 記録: takenAt DESC）は UI が依存しているため維持必須。
+7. GET /api/records の動的フィルタ（memberId / takenAt >= from / takenAt < to（排他） / days は from を上書き / limit）。
+8. 更新時 updatedAt は常に now()、作成時 displayOrder=0・isActive=true・status='active'・takenAt=now() は DB 既定値。
+
+【Go 側の不具合・危うい実装（移植時に是正判断が必要）】
+A. PATCH /medications/{id}/stock に検証が皆無。struct が `StockQuantity int`（非ポインタ・binding タグ無し）のため、(1) stockQuantity を省略すると 0 として在庫が消える、(2) 負数がそのまま保存される。にもかかわらずエラーメッセージは「在庫数は0以上の数値を指定してください」で、実際には一度も検証していない。
+B. POST /medications/reorder に usecase レベルの所有権チェックが無い。防御は repository の `WHERE "id" = ? AND "userId" = ?` だけで、他人の薬 ID や存在しない ID を渡してもエラーにならず 200 {ok:true} を返す（サイレント失敗）。orderedIds の件数上限も無く、1 件ずつ UPDATE をループするため巨大配列で長時間トランザクションになる。空配列 [] は binding:"required" を通過して no-op。
+C. parseDate（handler/helpers.go）が解釈不能な日付文字列に対して 400 を返さず nil を返すため、「不正な日付」と「未指定」が区別できない。stockAlertDate に "abc" を送ると黙って無視され、GET /records?from=不正 もフィルタ無しの全件取得になる。さらに time.Parse をロケーション指定なしで呼ぶため "2026-01-01" は UTC 0 時扱いになり、JST 前提の日付境界と 9 時間ずれる。
+D. GET /api/records はデフォルト limit が無く、パラメータ無しだと当該ユーザーの全服薬履歴を返す（フロントの履歴画面が実際にパラメータ無しで叩いている）。limit の上限ガードも無い。また from と days を同時指定すると days が from を上書きする（後勝ち）仕様が明文化されていない。
+E. isActive と status が二重管理で同期処理が無い。PATCH で status='paused' にしても isActive は true のままなので、/medications/alerts（isActive=TRUE 条件）や /members/summary の activeMedicationCount には「休薬中」の薬が含まれ続ける。一方 schedule_repository.go:154 の今日の予定クエリだけが `m."status" NOT IN ('paused','discontinued')` で除外しており、リソース間で判定基準が食い違っている。Java 側では status を単一の真実にするか、両者の整合を明示的に保つべき。
+F. category / status に列挙値検証が無く任意文字列を保存できる（想定値は migration 0007 のコメントにある active/paused/discontinued のみ）。name の max=200 も POST だけで、PATCH には binding タグが無いため長さ無制限で更新できる。
+G. bind 失敗時のエラーメッセージが原因を問わず固定文字列（例: name が 201 文字でも「薬の名前とメンバーIDは必須です」）。Java 側で Bean Validation に置き換えるとメッセージが変わるためフロントの文言依存に注意。
+H. 所有権チェックと書き込みが別トランザクション（ensureMedOwner → UPDATE/DELETE）で TOCTOU がある。さらに Update/UpdateStock は UPDATE 後に FindByID し直すため、その間に行が消えると `{"success":true,"data":null}` を 200 で返す（クライアントが null を想定していない可能性）。
+I. DELETE /medications/{id} は物理削除で、FK の ON DELETE CASCADE により Schedule と MedicationRecord（服薬履歴）まで連鎖削除される。アプリコードに連鎖の記述が無いため、Java + JPA へ移す際に DB 制約に依存し続けるのか明示的に削除するのかを決めないと、履歴が消えない／二重に消えるといった差異が出る。
+J. POST /records の scheduleId が無検証。MedicationRecord."scheduleId" は TEXT で FK も無いため、他人の scheduleId や存在しない ID をそのまま保存できる（参照整合性の穴）。
+K. "Medication"."userId" は NOT NULL だが FK 制約が無い（"memberId" のみ Member への FK）。MedicationRecord."userId" は User への FK + CASCADE があるのと非対称で、ユーザー削除時に Medication 行が孤児として残る。
+L. intervalHours 列はレスポンスに含まれるが、書き込む API が 1 つも存在しない（Create/Update の入力にも無い）ため常に null。移植時に落とすか API を用意するかの判断が必要。
+M. 服薬記録の作成が在庫 stockQuantity を減らさない（記録と在庫が連動していない）。逆に記録削除でも在庫は戻らない。仕様なのか漏れなのか要確認。
+N. prescription の Dispense（POST /prescriptions/{id}/dispense、担当外だが Medication を作成する経路）は MedicationRepository.Create をループで呼ぶだけでトランザクションが無く、途中で失敗すると薬が部分的に作成されたまま 500 になる。Medication を作る経路が medication-record 以外にもある点は移植時に見落としやすい。
+
+### GET /api/medications
+
+**レスポンス**: data = Medication[] （空でも null にならず [] を返す）。Medication = { id: string, memberId: string, userId: string, name: string, category: string, dosageAmount: string|null, frequency: string|null, stockQuantity: number|null, stockAlertDate: string(ISO8601 timestamptz)|null, intervalHours: number|null, instructions: string|null, displayOrder: number, isActive: boolean, status: string, createdAt: string, updatedAt: string }
+
+**ステータス**: 200 成功 / 401 "認証エラー"(Bearer 無し・JWT不正) / 429 "リクエストが多すぎます。しばらくしてから再試行してください。" / 500 "サーバーエラーが発生しました"
+
+**所有権**: usecase では所有権チェック無し。SQL の WHERE "userId" = $1 のみで自分の薬に限定 (sqlc ListMedicationsByUser)。
+
+**ドメイン規則**: 並び順は ORDER BY "displayOrder" ASC, "createdAt" ASC 固定。件数上限・ページングは無し（全件返却）。isActive / status による絞り込みはサーバ側では一切行わない（休薬・中止も含めて全件返す）。
+
+### GET /api/medications/alerts
+
+**レスポンス**: data = Medication[]（GET /api/medications と同一の Medication 形状）
+
+**ステータス**: 200 成功 / 401 / 429 / 500
+
+**所有権**: SQL の WHERE "userId"=$1 のみ。usecase 側チェック無し (MedicationUsecase.ListAlerts は素通し)。
+
+**ドメイン規則**: 在庫アラート判定は生SQL (aggregate_queries.go ListAlerts): WHERE "userId"=$1 AND "isActive" = TRUE AND ( ("stockQuantity" IS NOT NULL AND "stockQuantity" <= 5) OR ("stockAlertDate" IS NOT NULL AND "stockAlertDate" <= now() + interval '7 days') )。閾値 5 は定数 lowStockThreshold、期間は 7 日固定。stockAlertDate は過去日も条件を満たす（下限なし）。並び順は ORDER BY "stockQuantity" ASC NULLS LAST, "createdAt" ASC。status（paused/discontinued）は判定に使われず isActive のみで絞る。
+
+### GET /api/medications/{medicationId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `medicationId` | string (path param) | ○ | バリデーション無し。存在しなければ 404 |
+
+**レスポンス**: data = Medication（単体オブジェクト）
+
+**ステータス**: 200 成功 / 401 / 403 "この薬にアクセスする権限がありません" / 404 "薬が見つかりません" / 429 / 500
+
+**所有権**: MedicationUsecase.ensureMedOwner: id で FindByID → nil なら NotFound("薬") → m.UserID != userID なら Forbidden。memberId 経由ではなく Medication.userId 直接比較。
+
+**ドメイン規則**: 取得のみ。副作用なし。
+
+### POST /api/medications
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required"。空文字・キー欠落は 400。存在/所有権は usecase で確認 |
+| `name` | string | ○ | binding:"required,max=200"。201文字以上は 400（ただしメッセージは「薬の名前とメンバーIDは必須です」固定） |
+| `category` | string | — | バリデーション無し。空文字/未指定なら usecase で "regular" を代入。列挙値チェックは無し |
+| `dosageAmount` | string|null | — | 検証なし。長さ制限なし |
+| `frequency` | string|null | — | 検証なし |
+| `stockQuantity` | number|null | — | 検証なし。負数もそのまま保存される |
+| `stockAlertDate` | string|null | — | parseDate で RFC3339 / "2006-01-02T15:04:05" / "2006-01-02" の順に time.Parse。どれにも合致しなければエラーにせず nil（＝未指定扱い）。ロケーション指定なしのため日付のみ文字列は UTC 0時として解釈 |
+| `instructions` | string|null | — | 検証なし |
+
+**レスポンス**: data = Medication（作成後に FindByID で再取得した完全な行。displayOrder=0, isActive=true, status="active", createdAt/updatedAt=now() が DB 既定値で入る）
+
+**ステータス**: 201 作成 / 400 "薬の名前とメンバーIDは必須です"（JSONパース不能・binding違反すべて同一メッセージ） / 401 / 403 "このメンバーにアクセスする権限がありません" / 404 "メンバーが見つかりません" / 429 / 500
+
+**所有権**: ensureMemberOwner(members, in.UserID, in.MemberID): Member を FindByID → nil なら NotFound("メンバー") → member.UserID != 認証ユーザー なら Forbidden。userId はリクエストボディからではなく JWT から取得して保存。
+
+**ドメイン規則**: category 空 → "regular" 補完のみがドメイン規則。displayOrder / isActive / status / intervalHours はリクエストで指定不可、DB 既定値 (0 / TRUE / 'active' / NULL) に委ねる（GORM の default タグでゼロ値を INSERT から除外）。ID は auth.NewID() でアプリ側採番（DB 側 default なし、TEXT PRIMARY KEY）。
+
+### PATCH /api/medications/{medicationId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `medicationId` | string (path param) | ○ | 存在しなければ 404 |
+| `name` | string|null | — | binding タグ無し。create と違い max=200 が効かない（PATCH なら 200 文字超も保存可能）。null/未指定なら未更新 |
+| `category` | string|null | — | 検証なし。任意文字列を保存可能 |
+| `dosageAmount` | string|null | — | 検証なし |
+| `frequency` | string|null | — | 検証なし |
+| `stockQuantity` | number|null | — | 検証なし。負数可 |
+| `stockAlertDate` | string|null | — | parseDate。解釈不能な文字列は nil になり「未指定」と区別されず無視される |
+| `instructions` | string|null | — | 検証なし |
+| `isActive` | boolean|null | — | 検証なし |
+| `status` | string|null | — | 検証なし。'active'/'paused'/'discontinued' は migration 0007 のコメント上の想定値にすぎず、コード上の enum チェックは存在しない |
+
+**レスポンス**: data = Medication（更新後に FindByID で再取得）。同時削除等で行が消えていた場合は data: null で 200 が返る
+
+**ステータス**: 200 成功 / 400 "入力内容が正しくありません"（JSON パース失敗時のみ。ボディ空の場合も EOF で 400、{} は成功） / 401 / 403 "この薬にアクセスする権限がありません" / 404 "薬が見つかりません" / 429 / 500
+
+**所有権**: ensureMedOwner（Medication.userId == JWT userId）。所有権確認と UPDATE は別トランザクション（TOCTOU）。
+
+**ドメイン規則**: nil でないフィールドのみ UPDATE する部分更新。updatedAt は更新項目の有無に関わらず常に now() を設定（{} を送っただけでも updatedAt が進む）。memberId / userId / displayOrder / intervalHours は更新不可。isActive と status を同期させるロジックは無い（status=paused にしても isActive は true のまま）。
+
+### PATCH /api/medications/{medicationId}/stock
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `medicationId` | string (path param) | ○ | 存在しなければ 404 |
+| `stockQuantity` | number (int, 非ポインタ) | — | binding タグ無し。キー省略・null は Go のゼロ値 0 として扱われ在庫が 0 に上書きされる。負数チェックも無い（エラーメッセージは「在庫数は0以上の数値を指定してください」だが実際には未検証） |
+
+**レスポンス**: data = Medication（更新後の完全な行。行が消えていれば data: null）
+
+**ステータス**: 200 成功 / 400 "在庫数は0以上の数値を指定してください"（JSON 不正・型不一致のときのみ） / 401 / 403 "この薬にアクセスする権限がありません" / 404 "薬が見つかりません" / 429 / 500
+
+**所有権**: ensureMedOwner（Medication.userId == JWT userId）。
+
+**ドメイン規則**: 絶対値の上書き（増減ではない）。UPDATE "Medication" SET "stockQuantity"=?, "updatedAt"=now() WHERE "id"=?。在庫アラートの再計算・通知等の副作用は無し。
+
+### POST /api/medications/reorder
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `orderedIds` | string[] | ○ | binding:"required"。ただし slice の required は nil 判定のみのため、キー欠落/null は 400、空配列 [] は通過して no-op。要素数の上限・重複チェック・存在チェックは無し |
+
+**レスポンス**: data = { ok: true }（並び替え後の Medication は返さない）
+
+**ステータス**: 200 成功 / 400 "並び順の指定が正しくありません" / 401 / 429 / 500。403 / 404 は返らない
+
+**所有権**: usecase には所有権チェックが無い。リポジトリの UPDATE ... WHERE "id" = ? AND "userId" = ? のみで防御しているため、他人の ID や存在しない ID を混ぜてもエラーにならず黙って無視され 200 { ok: true } が返る。
+
+**ドメイン規則**: 配列のインデックス i を displayOrder に設定（0 始まり）。GORM の Transaction 内で 1 件ずつ UPDATE をループ（N クエリ）。updatedAt も同時に now()。指定されなかった薬の displayOrder は据え置きのため、部分配列を送ると displayOrder が重複しうる（一覧は displayOrder ASC, createdAt ASC で解決）。
+
+### DELETE /api/medications/{medicationId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `medicationId` | string (path param) | ○ | 存在しなければ 404 |
+
+**レスポンス**: data = { ok: true }
+
+**ステータス**: 200 成功 / 401 / 403 "この薬にアクセスする権限がありません" / 404 "薬が見つかりません" / 429 / 500
+
+**所有権**: ensureMedOwner（Medication.userId == JWT userId）。
+
+**ドメイン規則**: 物理削除（DELETE FROM "Medication" WHERE "id"=?）。論理削除・status 変更ではない。DB の FK により "Schedule"."medicationId" と "MedicationRecord"."medicationId" が ON DELETE CASCADE で連鎖削除され、服薬履歴も消える（アプリ側に明示的な連鎖処理コードは無い＝Java 移植時は JPA/DB どちらで担保するか要決定）。
+
+### GET /api/members/{memberId}/medications
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string (path param) | ○ | 存在しなければ 404 |
+
+**レスポンス**: data = Medication[]
+
+**ステータス**: 200 成功 / 401 / 403 "このメンバーにアクセスする権限がありません" / 404 "メンバーが見つかりません" / 429 / 500
+
+**所有権**: ensureMemberOwner でメンバーの所有者を確認した後、SQL は WHERE "memberId" = $1 のみ（userId 条件なし）。したがって memberId が一致すれば userId が異なる行も返る。
+
+**ドメイン規則**: ORDER BY "displayOrder" ASC, "createdAt" ASC。フィルタ・ページングなし。
+
+### GET /api/records
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string (query) | — | 空文字/未指定なら絞り込みなし。指定時のみ所有権チェックが走る |
+| `from` | string (query) | — | parseDate（RFC3339 / 2006-01-02T15:04:05 / 2006-01-02）。解釈不能なら 400 ではなく黙って無視。条件は "takenAt" >= from |
+| `to` | string (query) | — | parseDate。条件は "takenAt" < to（上限は排他的）。解釈不能なら無視 |
+| `days` | string (query, 整数) | — | strconv.Atoi が成功し d > 0 のときのみ有効。From = time.Now().AddDate(0,0,-d) を代入するため from パラメータを上書きする。非数値・0・負数は無視 |
+| `limit` | string (query, 整数) | — | Atoi 成功かつ l > 0 のときのみ LIMIT に反映。上限値のガードは無く、未指定なら無制限 |
+
+**レスポンス**: data = MedicationRecord[]（空でも []）。MedicationRecord = { id: string, memberId: string, medicationId: string, userId: string, scheduleId: string|null, takenAt: string(ISO8601), notes: string|null, dosageAmount: string|null }
+
+**ステータス**: 200 成功 / 401 / 403 "このメンバーにアクセスする権限がありません"（memberId 指定時のみ） / 404 "メンバーが見つかりません"（memberId 指定時のみ） / 429 / 500
+
+**所有権**: ベースは常に WHERE "userId"=$1（JWT のユーザー）。memberId クエリが空でないときだけ ensureMemberOwner を追加実行。
+
+**ドメイン規則**: 動的 SQL 組み立て（aggregate_queries.go ListByUserFiltered）。条件は userId AND [memberId] AND [takenAt >= from] AND [takenAt < to]、ORDER BY "takenAt" DESC、LIMIT は limit>0 のときだけ付与。パラメータ無しだと全期間・全件返却。
+
+### GET /api/members/{memberId}/records
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string (path param) | ○ | 存在しなければ 404 |
+
+**レスポンス**: data = MedicationRecord[]
+
+**ステータス**: 200 成功 / 401 / 403 "このメンバーにアクセスする権限がありません" / 404 "メンバーが見つかりません" / 429 / 500
+
+**所有権**: ensureMemberOwner のみ。SQL は WHERE "memberId" = $1 だけで userId 条件が無いため、memberId 一致なら userId が異なる行も返る（GET /api/records?memberId=… と結果が食い違いうる）。
+
+**ドメイン規則**: ORDER BY "takenAt" DESC。期間・件数フィルタは無し（全件）。
+
+### POST /api/records
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | — | 受け取るが usecase で med.MemberID に上書きされ完全に無視される（クライアント値は使わない） |
+| `medicationId` | string | ○ | binding:"required"。欠落・空文字は 400 |
+| `scheduleId` | string|null | — | 検証なし。Schedule の存在確認も所有権確認も無く、DB 側にも FK が無い（"scheduleId" TEXT のみ）ので任意文字列が保存される |
+| `notes` | string|null | — | 検証なし。長さ制限なし |
+| `dosageAmount` | string|null | — | 検証なし。薬側の dosageAmount を自動コピーする処理は無い |
+| `takenAt` | string|null | — | parseDate。未指定/解釈不能なら nil → DB 既定値 now() が入る。未来日時のチェック無し。ロケーション指定なしのため日付のみ文字列は UTC 0時 |
+
+**レスポンス**: data = MedicationRecord（作成後に FindByID で再取得した完全な行。memberId はサーバが薬から導出した値）
+
+**ステータス**: 201 作成 / 400 "薬の指定は必須です" / 401 / 403 "この薬にアクセスする権限がありません" / 404 "薬が見つかりません" / 429 / 500
+
+**所有権**: RecordUsecase.Create: medicationId で Medication を FindByID → nil なら NotFound("薬") → med.UserID != 認証ユーザー なら Forbidden。Member 側の所有権は薬経由で担保。userId は JWT、memberId は med.MemberID をサーバ側で設定。
+
+**ドメイン規則**: memberId のサーバ側導出（in.MemberID = med.MemberID）が唯一のドメイン計算。在庫（stockQuantity）の自動減算は行わない。同一薬・同一時刻の重複記録の防止や、scheduleId 単位の一意制約も無い。ID は auth.NewID() でアプリ採番。
+
+### DELETE /api/records/{recordId}
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `recordId` | string (path param) | ○ | 存在しなければ 404 |
+
+**レスポンス**: data = { ok: true }
+
+**ステータス**: 200 成功 / 401 / 403 "この記録にアクセスする権限がありません" / 404 "記録が見つかりません" / 429 / 500
+
+**所有権**: MedicationRecord.userId == JWT userId を FindByID 後に比較。memberId 経由の判定はしない。
+
+**ドメイン規則**: 物理削除。在庫の戻し（stockQuantity の復元）等の副作用は無し。
+
+## misc-crud (allergies / insurances / emergency-contacts / notification-settings / dashboard-preferences)
+
+### 移植時の注意
+
+【共通の契約】
+- ルート登録: /api/allergies, /api/insurances, /api/emergency-contacts, /api/notification-settings は internal/interface/router/routes_ext.go（それぞれ 68-74行, 60-66行, 93-99行, 111-114行）。/api/dashboard-preferences のみ router.go:113-114 に直接登録。すべて `authed` グループ配下で middleware.Auth(JWT) + middleware.RateLimit("api", 120, 1分, PerUser) が適用される。
+- レスポンス形式は response.go の通り { success: true, data } / { success: false, error }。Success=200, Created=201。HandleDomainError: NotFoundError→404, ConflictError→409, ValidationError→400, ForbiddenError→403, それ以外→500 "サーバーエラーが発生しました"。この 5 リソースの usecase は ConflictError/ValidationError を一切生成しないので、実際に出るのは 400(バインド失敗のみ)/401/403/404/429/500。
+- 401 の本文は必ず { success:false, error:"認証エラー" }。429 は { success:false, error:"リクエストが多すぎます。しばらくしてから再試行してください。" }（in-memory・インスタンスローカル。Java 移植時は分散対応を検討）。
+- allergies/insurances/emergency-contacts の 3 つは usecase/crud.go の汎用 `MemberScopedCRUD[E,C,U]` を型パラメータだけ変えて共有しているだけで、リソース固有のドメインロジックは **一切ない**（差分は notFoundName と forbiddenMsg の文言のみ）。Java 側でも共通抽象クラス/ジェネリックサービスに寄せられる。
+- テーブル・カラム名は Prisma 時代の camelCase でクォート必須（"Allergy"."allergenName" 等）。JPA では @Table(name="\"Allergy\"") / @Column(name="\"allergenName\"") 相当が必要。
+- Allergy/Insurance/EmergencyContact の userId・memberId は User/Member への FK ON DELETE CASCADE 付き（migrations/0001_init.sql:158-223）。メンバー削除で自動的に消える。
+
+【Java 側にドメイン規則として移すべきもの（単なる CRUD ではない部分）】
+1. 作成時のメンバー所有権チェック（usecase/ownership_ext.go）: member が無ければ 404「メンバーが見つかりません」、他人のものなら 403「このメンバーにアクセスする権限がありません」。userId は必ず JWT から入れ、リクエストボディの userId は受け付けない。
+2. 取得/更新/削除時の行所有権チェック（crud.go ensureOwner）: 404 判定→403 判定の順序と文言をそのまま維持する必要がある。
+3. NotificationSetting / DashboardPreference の「行が無ければ保存せず既定値を返す」挙動（Get は副作用なし）。
+4. NotificationSetting Upsert の INSERT 経路 = 未指定を true/5/1 で補完、UPDATE 経路 = 指定項目のみ更新、という非対称な合成規則。
+5. DashboardPreference の defaultMemberId 空文字→null 正規化と、hiddenCards/cardOrder の null→[] 正規化。
+
+【Go 側の不具合・危うい実装（移植時に直すか、意図的に踏襲するか判断が必要）】
+A. **DashboardPreference.defaultMemberId に所有権チェックも存在チェックも FK もない**（usecase/dashboard_preference_usecase.go:32-37 は MemberRepository を持たない / migrations/0004_budget_personalization.sql の DDL に FK なし）。他人の memberId や存在しない ID をそのまま保存できる。Member 削除後もダングリング参照が残る。Java 側では ensureMemberOwner 相当を入れるべき。
+B. **PUT /dashboard-preferences が破壊的**。省略したキーは [] に正規化されて ON CONFLICT DO UPDATE で EXCLUDED 上書きされるため、defaultMemberId だけ送ると hiddenCards と cardOrder が消える。現行フロント(frontend/src/pages/home/ui/DashboardSettings.tsx)は 3 フィールドを常に全部送るので顕在化していないだけ。
+C. **PATCH でヌル化ができない**。全リソースの Update 入力がポインタで「nil = 未指定」なので、JSON で null を送っても notes / symptoms / relationship / providerName / policyNumber / diagnosedAt を NULL に戻せない。逆に空文字 "" は「値」として通るので、NOT NULL 列である allergenName / contactName / phoneNumber / insuranceType を空文字に更新できてしまう（Create には binding:"required" があるのに Update には無い、という非対称）。
+D. **不正な日付が黙って無視される**（handler/helpers.go parseDate）。diagnosedAt に "2026-13-45" のようなパース不能文字列を送っても 400 にならず、Create では NULL、Update では「未指定扱い」でスキップされる。Java の LocalDate/OffsetDateTime パースだと例外→400 になるので、意図的に合わせないと挙動が変わる。
+E. **所有権チェックと UPDATE/DELETE が TOCTOU かつ非トランザクション**。ensureOwner で SELECT した後、UPDATE/DELETE の WHERE は `"id" = ?` のみで userId を含まない（allergy_repository.go:106,114 ほか同型）。Java 側では WHERE に userId を含めて 1 文で済ませるのが安全。
+F. **Create/Update の read-after-write が非トランザクションかつ別ドライバ**（書き込み GORM / 読み戻し pgx+sqlc）。FindByID が pgx.ErrNoRows を返すと repository は (nil, nil) を返し、ハンドラは 201 or 200 で `"data": null` を返す（エラーにならない）。Java では INSERT/UPDATE の返り値をそのまま使うべき。
+G. NotificationSetting の分数・日数に範囲検証が無い（負値・0・巨大値が保存できる）。int32 を超える値は DB エラーで 500 になる。
+H. GET /notification-settings の未作成時レスポンスに id: ""、createdAt/updatedAt: "0001-01-01T00:00:00Z" という Go のゼロ値が漏れる。Java で LocalDateTime のゼロ値を再現するのは不自然なので、フロント(frontend/src/pages/settings-notifications/ui/NotificationSettingsPage.tsx は enabled 系フィールドしか使っていない)を確認のうえ null にするなど契約変更を検討する余地がある。
+I. DELETE は 200 + { ok: true } を返す（204 でもエンティティでもない）。作成は 201、通知設定/ダッシュボード設定の PUT は新規作成でも 200。この不揃いをそのまま維持すること。
+J. allergyType / severity / insuranceType など enum らしきフィールドがすべて自由文字列で、長さ制限も無い（DB は TEXT）。Insurance.policyNumber（保険証番号）も平文保存・平文返却。
+K. 一覧 API に memberId 等の絞り込みクエリが無く、ユーザーの全件を返す（フロントが取得後にクライアント側でフィルタしている: frontend/src/pages/member-detail/ui/MemberDetail.tsx, member-report/ui/MemberReport.tsx）。ページングも無い。
+
+### GET /api/allergies
+
+**レスポンス**: data: Allergy[] （必ず配列。0件でも null ではなく []）。Allergy = { id: string, userId: string, memberId: string, allergenName: string, allergyType: string, severity: string, symptoms: string|null, diagnosedAt: string(RFC3339)|null, notes: string|null, createdAt: string(RFC3339) }
+
+**ステータス**: 200 成功 / 401 "認証エラー"(Bearer 無し・JWT不正) / 429 "リクエストが多すぎます。しばらくしてから再試行してください。" / 500 "サーバーエラーが発生しました"
+
+**所有権**: SQL 側で WHERE "userId" = $1。認証ユーザー所有の行のみ。memberId でのサーバー側フィルタは無い（フロントが取得後にクライアント側で絞り込んでいる）
+
+**ドメイン規則**: sqlc ListAllergies: SELECT ... FROM "Allergy" WHERE "userId"=$1 ORDER BY "createdAt" DESC。計算・副作用なし
+
+### POST /api/allergies
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required" — キー欠落も空文字も 400。所有権チェックあり |
+| `allergenName` | string | ○ | binding:"required" — 空文字不可。長さ・文字種の検証なし(DB は TEXT) |
+| `allergyType` | string | ○ | binding:"required" — 自由文字列。enum 検証なし |
+| `severity` | string | ○ | binding:"required" — 自由文字列。enum 検証なし |
+| `symptoms` | string|null | — | 検証なし |
+| `diagnosedAt` | string|null | — | parseDate() で RFC3339 / "2006-01-02T15:04:05" / "2006-01-02" の順に試行。どれにも一致しない不正文字列・空文字は **エラーにならず nil** になり NULL 保存される |
+| `notes` | string|null | — | 検証なし |
+
+**レスポンス**: data: Allergy（上記と同一形状）。作成後に FindByID で再取得した値を返す。まれに data: null になり得る（notes 参照）
+
+**ステータス**: 201 作成成功 / 400 バインド失敗時 固定文言 "メンバーID・アレルゲン名・種別・重症度は必須です"（フィールド別メッセージではない） / 401 / 403 "このメンバーにアクセスする権限がありません" / 404 "メンバーが見つかりません" / 429 / 500
+
+**所有権**: usecase.ensureMemberOwner: members.FindByID(memberId) → nil なら 404「メンバーが見つかりません」、m.UserID != 認証userID なら 403「このメンバーにアクセスする権限がありません」。userId はボディではなく JWT から設定される（クライアント指定不可）
+
+**ドメイン規則**: id は auth.NewID() でサーバー生成。createdAt は DB DEFAULT now()。メンバー所有チェックと INSERT は同一トランザクションではない（FK 制約が最後の砦）。GORM で INSERT → pgx(sqlc) で SELECT し直す read-after-write
+
+### GET /api/allergies/:allergyId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `allergyId` | string (path param) | ○ | 形式検証なし |
+
+**レスポンス**: data: Allergy
+
+**ステータス**: 200 / 401 / 403 "このアレルギー情報にアクセスする権限がありません" / 404 "アレルギーが見つかりません" / 429 / 500
+
+**所有権**: MemberScopedCRUD.ensureOwner: FindByID(id) が nil → 404、entity.UserID != 認証userID → 403。404 判定が先で 403 が後（存在の有無は他人にも漏れる設計ではない＝存在すれば 403 を返すため ID 存在は推測可能）
+
+**ドメイン規則**: 単純取得。sqlc GetAllergy は WHERE "id"=$1 のみ（userId 条件なし）でアプリ層が所有権を判定している
+
+### PATCH /api/allergies/:allergyId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `allergyId` | string (path param) | ○ | — |
+| `allergenName` | string|null | — | 未指定(nil)なら更新しない。空文字 "" を送ると空文字で上書きされる（必須検証は Update には無い） |
+| `allergyType` | string|null | — | 同上 |
+| `severity` | string|null | — | 同上 |
+| `symptoms` | string|null | — | null を送っても NULL に戻せない（nil = 未指定扱い） |
+| `diagnosedAt` | string|null | — | parseDate。不正文字列・空文字は nil になり **黙って無視**（400 にならない）。NULL に戻す手段がない |
+| `notes` | string|null | — | null で NULL に戻せない |
+
+**レスポンス**: data: Allergy（更新後に再取得した値）
+
+**ステータス**: 200 / 400 "入力内容が正しくありません"（JSON 不正・ボディ空(EOF)含む） / 401 / 403 / 404 / 429 / 500
+
+**所有権**: ensureOwner で 404/403 判定した後、UPDATE の WHERE は "id" のみ（userId を含まない）。memberId は変更不可（Update 入力に存在しない）
+
+**ドメイン規則**: 部分更新: 非 nil のフィールドだけ map に詰めて GORM Updates。全フィールド nil（{} 送信）なら DB 更新を行わず現在値を 200 で返す。updatedAt 列は Allergy には存在しない
+
+### DELETE /api/allergies/:allergyId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `allergyId` | string (path param) | ○ | — |
+
+**レスポンス**: data: { ok: true }（削除したエンティティは返さない）
+
+**ステータス**: 200（204 ではない） / 401 / 403 / 404 / 429 / 500
+
+**所有権**: ensureOwner で 404/403 判定後に DELETE。DELETE の WHERE も "id" のみ
+
+**ドメイン規則**: 物理削除。カスケード先なし
+
+### GET /api/insurances
+
+**レスポンス**: data: Insurance[]（0件でも []）。Insurance = { id, userId, memberId, insuranceType: string, providerName: string|null, policyNumber: string|null, notes: string|null, createdAt: string(RFC3339) }
+
+**ステータス**: 200 / 401 / 429 / 500
+
+**所有権**: WHERE "userId" = 認証userID
+
+**ドメイン規則**: ORDER BY "createdAt" DESC。policyNumber（保険証番号）を平文でそのまま返す点に注意
+
+### POST /api/insurances
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required"（空文字不可） |
+| `insuranceType` | string | ○ | binding:"required"。enum 検証なし・自由文字列 |
+| `providerName` | string|null | — | 検証なし |
+| `policyNumber` | string|null | — | 検証なし（マスキング・暗号化もなし） |
+| `notes` | string|null | — | 検証なし |
+
+**レスポンス**: data: Insurance
+
+**ステータス**: 201 / 400 "メンバーIDと保険種別は必須です" / 401 / 403 "このメンバーにアクセスする権限がありません" / 404 "メンバーが見つかりません" / 429 / 500
+
+**所有権**: ensureMemberOwner（memberId が認証ユーザー所有か）。userId は JWT 由来
+
+**ドメイン規則**: id サーバー生成、createdAt は DB DEFAULT now()。計算・副作用なし
+
+### GET /api/insurances/:insuranceId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `insuranceId` | string (path param) | ○ | — |
+
+**レスポンス**: data: Insurance
+
+**ステータス**: 200 / 401 / 403 "この保険にアクセスする権限がありません" / 404 "保険が見つかりません" / 429 / 500
+
+**所有権**: ensureOwner（entity.userId == 認証userID）
+
+**ドメイン規則**: 単純取得
+
+### PATCH /api/insurances/:insuranceId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `insuranceId` | string (path param) | ○ | — |
+| `insuranceType` | string|null | — | 未指定なら不変。空文字で上書き可能（必須検証なし） |
+| `providerName` | string|null | — | null で NULL に戻せない |
+| `policyNumber` | string|null | — | null で NULL に戻せない |
+| `notes` | string|null | — | null で NULL に戻せない |
+
+**レスポンス**: data: Insurance（更新後）
+
+**ステータス**: 200 / 400 "入力内容が正しくありません" / 401 / 403 / 404 / 429 / 500
+
+**所有権**: ensureOwner 後に WHERE "id" のみで UPDATE
+
+**ドメイン規則**: 部分更新。{} なら DB 更新せず現在値を返す
+
+### DELETE /api/insurances/:insuranceId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `insuranceId` | string (path param) | ○ | — |
+
+**レスポンス**: data: { ok: true }
+
+**ステータス**: 200 / 401 / 403 / 404 / 429 / 500
+
+**所有権**: ensureOwner 後に WHERE "id" のみで DELETE
+
+**ドメイン規則**: 物理削除
+
+### GET /api/emergency-contacts
+
+**レスポンス**: data: EmergencyContact[]（0件でも []）。EmergencyContact = { id, userId, memberId, contactName: string, phoneNumber: string, relationship: string|null, notes: string|null, createdAt: string(RFC3339) }
+
+**ステータス**: 200 / 401 / 429 / 500
+
+**所有権**: WHERE "userId" = 認証userID
+
+**ドメイン規則**: ORDER BY "createdAt" DESC
+
+### POST /api/emergency-contacts
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `memberId` | string | ○ | binding:"required" |
+| `contactName` | string | ○ | binding:"required"（空文字不可） |
+| `phoneNumber` | string | ○ | binding:"required" のみ。**電話番号の書式検証は一切なし**（DB も TEXT NOT NULL） |
+| `relationship` | string|null | — | 検証なし |
+| `notes` | string|null | — | 検証なし |
+
+**レスポンス**: data: EmergencyContact
+
+**ステータス**: 201 / 400 "メンバーID・連絡先名・電話番号は必須です" / 401 / 403 "このメンバーにアクセスする権限がありません" / 404 "メンバーが見つかりません" / 429 / 500
+
+**所有権**: ensureMemberOwner。userId は JWT 由来
+
+**ドメイン規則**: id サーバー生成、createdAt は DB DEFAULT now()
+
+### GET /api/emergency-contacts/:contactId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `contactId` | string (path param) | ○ | — |
+
+**レスポンス**: data: EmergencyContact
+
+**ステータス**: 200 / 401 / 403 "この緊急連絡先にアクセスする権限がありません" / 404 "緊急連絡先が見つかりません" / 429 / 500
+
+**所有権**: ensureOwner
+
+**ドメイン規則**: 単純取得
+
+### PATCH /api/emergency-contacts/:contactId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `contactId` | string (path param) | ○ | — |
+| `contactName` | string|null | — | 未指定なら不変。空文字で上書き可能（NOT NULL 列だが空文字は通る） |
+| `phoneNumber` | string|null | — | 同上。書式検証なし |
+| `relationship` | string|null | — | null で NULL に戻せない |
+| `notes` | string|null | — | null で NULL に戻せない |
+
+**レスポンス**: data: EmergencyContact（更新後）
+
+**ステータス**: 200 / 400 "入力内容が正しくありません" / 401 / 403 / 404 / 429 / 500
+
+**所有権**: ensureOwner 後に WHERE "id" のみで UPDATE
+
+**ドメイン規則**: 部分更新。{} なら DB 更新せず現在値を返す
+
+### DELETE /api/emergency-contacts/:contactId
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `contactId` | string (path param) | ○ | — |
+
+**レスポンス**: data: { ok: true }
+
+**ステータス**: 200 / 401 / 403 / 404 / 429 / 500
+
+**所有権**: ensureOwner 後に WHERE "id" のみで DELETE
+
+**ドメイン規則**: 物理削除
+
+### GET /api/notification-settings
+
+**レスポンス**: data: NotificationSetting = { id: string, userId: string, medicationReminderEnabled: bool, missedMedicationEnabled: bool, appointmentReminderEnabled: bool, lowStockAlertEnabled: bool, defaultReminderMinutesBefore: int, defaultAppointmentReminderDaysBefore: int, emailNotificationEnabled: bool, createdAt: string(RFC3339), updatedAt: string(RFC3339) }。行が未作成の場合は **DB に保存せず** 既定値オブジェクトを返す: 4つの bool = true, defaultReminderMinutesBefore = 5, defaultAppointmentReminderDaysBefore = 1, emailNotificationEnabled = true, id = ""（空文字）, createdAt/updatedAt = "0001-01-01T00:00:00Z"（Go の time.Time ゼロ値）
+
+**ステータス**: 200（未作成でも 404 ではなく 200 + 既定値） / 401 / 429 / 500
+
+**所有権**: userId は JWT 由来。SELECT ... WHERE "userId" = $1。ユーザー単位の単一行（DB 側 UNIQUE 制約あり）
+
+**ドメイン規則**: NotificationSettingUsecase.Get: repo が nil を返したら遅延生成せずデフォルト entity を組み立てて返す（副作用なし）
+
+### PUT /api/notification-settings
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `medicationReminderEnabled` | bool|null | — | nil = 未指定 |
+| `missedMedicationEnabled` | bool|null | — | nil = 未指定 |
+| `appointmentReminderEnabled` | bool|null | — | nil = 未指定 |
+| `lowStockAlertEnabled` | bool|null | — | nil = 未指定 |
+| `defaultReminderMinutesBefore` | int|null | — | **範囲検証なし**。負値・巨大値もそのまま保存（DB は INTEGER NOT NULL なので int32 超過は 500） |
+| `defaultAppointmentReminderDaysBefore` | int|null | — | **範囲検証なし**（負値可） |
+| `emailNotificationEnabled` | bool|null | — | nil = 未指定 |
+
+**レスポンス**: data: NotificationSetting（Upsert 後に再取得した実 DB 行。id/createdAt/updatedAt は実値）
+
+**ステータス**: 200（201 ではない。新規作成時も 200） / 400 "入力内容が正しくありません"（JSON 不正・ボディ空） / 401 / 429 / 500
+
+**所有権**: userId は必ず JWT 由来。ON CONFLICT ("userId") で自ユーザー行のみを更新するため他人の行に触れる経路はない
+
+**ドメイン規則**: INSERT ... ON CONFLICT("userId") DO UPDATE。**INSERT 経路と UPDATE 経路で未指定フィールドの扱いが違う**: 行が無い場合は未指定を既定値(true / 5 / 1)で埋めて INSERT、既存行がある場合は指定されたフィールドのみ更新し未指定は既存値を維持。updatedAt は毎回 now() で更新。id は行が無いときだけ auth.NewID() が採用される
+
+### GET /api/dashboard-preferences
+
+**レスポンス**: data: DashboardPreference = { userId: string, hiddenCards: string[], cardOrder: string[], defaultMemberId: string|null } のみ。**id / createdAt / updatedAt は含まない**（NotificationSetting と形が違う）。行が未作成なら保存せず { userId, hiddenCards: [], cardOrder: [], defaultMemberId: null } を返す
+
+**ステータス**: 200（未作成でも 200 + 既定値） / 401 / 429 / 500
+
+**所有権**: userId は JWT 由来。SELECT ... WHERE "userId" = $1。ユーザー単位の単一行（DB 側 UNIQUE 制約あり）
+
+**ドメイン規則**: DashboardPreferenceUsecase.Get: nil のとき空配列の既定値を返す（副作用なし）
+
+### PUT /api/dashboard-preferences
+
+| 項目 | 型 | 必須 | 検証 |
+|---|---|---|---|
+| `hiddenCards` | string[]|null | — | 要素の中身の検証なし（カードキーの enum 検証なし）。省略/null は [] に正規化され、既存値を **[] で上書きする** |
+| `cardOrder` | string[]|null | — | 同上。重複・欠落・未知キーの検証なし。省略/null は [] で上書き |
+| `defaultMemberId` | string|null | — | 空文字 "" は nil に正規化される。**メンバーの存在確認も所有権確認もしていない** |
+
+**レスポンス**: data: DashboardPreference（Upsert 後に再取得した値。id/createdAt/updatedAt は含まない）
+
+**ステータス**: 200（新規作成時も 200） / 400 "入力内容が正しくありません" / 401 / 429 / 500
+
+**所有権**: userId は JWT 由来で ON CONFLICT("userId") のため行自体は自ユーザーに限定される。ただし **defaultMemberId の所有権チェックは無い**（DashboardPreferenceUsecase は MemberRepository を持っていない: cmd/server/main.go:70 で prefs リポジトリのみ注入）。DB 側にも FK 制約が無い（migrations/0004: "defaultMemberId" TEXT のみ）
+
+**ドメイン規則**: INSERT ... ON CONFLICT("userId") DO UPDATE SET hiddenCards/cardOrder/defaultMemberId を EXCLUDED（今回の値）で全上書き + updatedAt = now()。完全置換セマンティクス（部分更新ではない）

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,21 +23,33 @@
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.61.0",
         "@react-router/dev": "^7.1.0",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "@vitest/coverage-v8": "^4.1.10",
         "autoprefixer": "^10.4.20",
         "eslint": "^10.8.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.11.0",
+        "jsdom": "^30.0.1",
         "postcss": "^8.4.47",
         "serve": "^14.2.6",
         "tailwindcss": "^3.4.15",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.67.0",
         "vite": "^6.0.0",
-        "vite-tsconfig-paths": "^5.1.0"
+        "vite-tsconfig-paths": "^5.1.0",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -50,6 +62,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -467,6 +532,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -513,6 +588,169 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1122,6 +1360,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1786,6 +2042,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
@@ -1811,6 +2074,117 @@
       "peerDependencies": {
         "react": "^18 || ^19"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2132,6 +2506,164 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zeit/schemas": {
       "version": "2.36.0",
       "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
@@ -2309,6 +2841,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -2377,6 +2948,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2542,6 +3123,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "5.0.1",
@@ -2799,6 +3390,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2818,6 +3430,58 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/date-fns": {
       "version": "4.4.0",
@@ -2846,6 +3510,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -2879,6 +3550,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2892,6 +3573,14 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2913,6 +3602,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -3224,6 +3926,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3269,6 +3981,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -3555,6 +4277,26 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3589,6 +4331,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ini": {
@@ -3705,6 +4457,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3753,6 +4512,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3769,6 +4567,95 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.0.2",
@@ -3903,6 +4790,62 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -3975,6 +4918,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4128,6 +5081,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-headers": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
@@ -4224,6 +5191,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4569,6 +5549,47 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4647,6 +5668,14 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -4701,6 +5730,20 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -4866,6 +5909,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4966,6 +6022,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4982,6 +6045,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -5025,6 +6102,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -5085,6 +6175,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -5223,6 +6320,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5271,6 +6385,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5282,6 +6426,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -5394,6 +6551,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -5643,6 +6810,136 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wasm-feature-detect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
@@ -5654,6 +6951,16 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -5679,6 +6986,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -5724,6 +7048,23 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "e2e": "playwright test",
     "e2e:install": "playwright install --with-deps chromium",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@react-router/node": "^7.18.0",
@@ -31,19 +33,24 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.0",
     "@react-router/dev": "^7.1.0",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "autoprefixer": "^10.4.20",
     "eslint": "^10.8.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.11.0",
+    "jsdom": "^30.0.1",
     "postcss": "^8.4.47",
     "serve": "^14.2.6",
     "tailwindcss": "^3.4.15",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.67.0",
     "vite": "^6.0.0",
-    "vite-tsconfig-paths": "^5.1.0"
+    "vite-tsconfig-paths": "^5.1.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -1,4 +1,5 @@
 // features/auth の Public API。
 // 認証状態の参照と認可ガードは必ずここを通す。内部実装を直接触らせない。
 export { AuthProvider, useAuth, useRequireAuth } from "./model/auth";
-export { GoogleLoginButton } from "./ui/GoogleLoginButton";
+export { GoogleLoginButton, GOOGLE_CALLBACK_PATH } from "./ui/GoogleLoginButton";
+export { buildAuthorizationRequest, consumeAuthorizationState } from "./model/googleOauth";

--- a/frontend/src/features/auth/model/googleOauth.test.ts
+++ b/frontend/src/features/auth/model/googleOauth.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildAuthorizationRequest,
+  consumeAuthorizationState,
+  GOOGLE_AUTHORIZE_ENDPOINT,
+} from "./googleOauth";
+
+/**
+ * 認可リクエストの組み立てと、コールバックでの検証。
+ *
+ * ここが甘いと、認可コードグラントにしても CSRF や合言葉の使い回しで突破される。
+ * 「1度きり」「state 一致」を明示的に固定する。
+ */
+describe("Google 認可リクエスト", () => {
+  const CLIENT_ID = "test-client.apps.googleusercontent.com";
+  // location をスタブすると jsdom のストレージが壊れるので、実オリジンから組み立てる
+  const REDIRECT_URI = `${location.origin}/auth/callback`;
+
+  // Node 25 のネイティブ localStorage が jsdom のものを覆うため、
+  // 「localStorage に書かない」ことは呼び出しの有無で検証する
+  const localSetItem = vi.fn();
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    localSetItem.mockClear();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: { setItem: localSetItem, getItem: vi.fn(), removeItem: vi.fn(), length: 0 },
+    });
+  });
+
+  describe("認可 URL の組み立て", () => {
+    it("認可コードグラントとして必要なパラメータが揃う", async () => {
+      const { url } = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+      const params = new URL(url).searchParams;
+
+      expect(url.startsWith(GOOGLE_AUTHORIZE_ENDPOINT)).toBe(true);
+      expect(params.get("response_type")).toBe("code");
+      expect(params.get("client_id")).toBe(CLIENT_ID);
+      expect(params.get("redirect_uri")).toBe(REDIRECT_URI);
+      expect(params.get("scope")).toBe("openid email profile");
+    });
+
+    it("PKCE は常に S256。plain は使わない", async () => {
+      const { url } = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+      const params = new URL(url).searchParams;
+
+      expect(params.get("code_challenge_method")).toBe("S256");
+      expect(params.get("code_challenge")).toMatch(/^[A-Za-z0-9\-_]{43}$/);
+    });
+
+    it("state と nonce が付く", async () => {
+      const { url } = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+      const params = new URL(url).searchParams;
+
+      expect(params.get("state")).toBeTruthy();
+      expect(params.get("nonce")).toBeTruthy();
+      expect(params.get("state")).not.toBe(params.get("nonce"));
+    });
+
+    it("code_verifier は URL に出さない。ハッシュだけを預ける", async () => {
+      const { url } = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+
+      expect(url).not.toContain("code_verifier");
+    });
+
+    it("呼ぶたびに state と合言葉が変わる", async () => {
+      const a = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+      const b = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+
+      expect(new URL(a.url).searchParams.get("state")).not.toBe(
+        new URL(b.url).searchParams.get("state"),
+      );
+    });
+
+    it("合言葉は sessionStorage に置く。localStorage には残さない", async () => {
+      await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+
+      expect(window.sessionStorage.length).toBeGreaterThan(0);
+      expect(localSetItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("コールバックでの検証", () => {
+    it("state が一致すれば合言葉を取り出せる", async () => {
+      const { state } = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+
+      const consumed = consumeAuthorizationState(state);
+
+      expect(consumed.codeVerifier).toMatch(/^[A-Za-z0-9\-._~]{128}$/);
+      expect(consumed.redirectUri).toBe(REDIRECT_URI);
+    });
+
+    it("state が違えば拒否する。CSRF を通さない", async () => {
+      await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+
+      expect(() => consumeAuthorizationState("attacker-state")).toThrow(/state/);
+    });
+
+    it("一度使った合言葉は再利用できない", async () => {
+      const { state } = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+
+      consumeAuthorizationState(state);
+
+      expect(() => consumeAuthorizationState(state)).toThrow();
+    });
+
+    it("取り出したあと sessionStorage に痕跡が残らない", async () => {
+      const { state } = await buildAuthorizationRequest(CLIENT_ID, REDIRECT_URI);
+
+      consumeAuthorizationState(state);
+
+      expect(window.sessionStorage.length).toBe(0);
+    });
+
+    it("開始していない状態でのコールバックは拒否する", () => {
+      expect(() => consumeAuthorizationState("whatever")).toThrow();
+    });
+  });
+
+  describe("リダイレクト先の検証", () => {
+    it("同一オリジンでない redirect_uri は組み立てない", async () => {
+      await expect(
+        buildAuthorizationRequest(CLIENT_ID, "https://evil.example/steal"),
+      ).rejects.toThrow(/リダイレクト/);
+    });
+  });
+});

--- a/frontend/src/features/auth/model/googleOauth.ts
+++ b/frontend/src/features/auth/model/googleOauth.ts
@@ -1,0 +1,106 @@
+import { createCodeChallenge, createRandomString } from "@/shared/lib/pkce";
+
+/**
+ * Google の認可コードグラント（+ PKCE）の開始とコールバック検証。
+ *
+ * <p>従来の Google Identity Services は ID トークンをブラウザへ直接渡す方式で、
+ * 実質インプリシットに近い。ここでは認可コードだけを受け取り、
+ * トークン交換はバックエンドがサーバー間通信で行う。
+ */
+
+export const GOOGLE_AUTHORIZE_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+
+/** 合言葉の置き場。タブを閉じれば消えるよう sessionStorage を使う */
+const STORAGE_KEY = "hf_oauth_pending";
+
+/** code_verifier は仕様上の最大長を使う。短くする理由が無い */
+const VERIFIER_LENGTH = 128;
+
+interface PendingAuthorization {
+  state: string;
+  nonce: string;
+  codeVerifier: string;
+  redirectUri: string;
+}
+
+export interface AuthorizationRequest {
+  url: string;
+  state: string;
+}
+
+/**
+ * 認可リクエストを組み立て、合言葉を保存する。
+ *
+ * @param redirectUri 認可サーバーからの戻り先。自分のオリジンでなければ拒否する
+ */
+export async function buildAuthorizationRequest(
+  clientId: string,
+  redirectUri: string,
+): Promise<AuthorizationRequest> {
+  requireSameOrigin(redirectUri);
+
+  const codeVerifier = createRandomString(VERIFIER_LENGTH);
+  const state = createRandomString(43);
+  const nonce = createRandomString(43);
+  const codeChallenge = await createCodeChallenge(codeVerifier);
+
+  const pending: PendingAuthorization = { state, nonce, codeVerifier, redirectUri };
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: "openid email profile",
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state,
+    nonce,
+    // 毎回アカウント選択を出す。共有端末で前回の利用者のまま入るのを防ぐ
+    prompt: "select_account",
+  });
+
+  return { url: `${GOOGLE_AUTHORIZE_ENDPOINT}?${params.toString()}`, state };
+}
+
+/**
+ * コールバックで受け取った state を検証し、合言葉を取り出す。
+ *
+ * <p>取り出したら即座に消す。認可コードは 1 度しか使えないので、
+ * 合言葉を残しておく理由が無いうえ、残すと再送で悪用される余地ができる。
+ *
+ * @throws state が一致しない、または開始記録が無い場合
+ */
+export function consumeAuthorizationState(state: string): PendingAuthorization {
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    throw new Error("ログインの開始記録が見つかりません。もう一度お試しください");
+  }
+  // 検証の成否にかかわらず消す。失敗した合言葉を再利用させない
+  sessionStorage.removeItem(STORAGE_KEY);
+
+  let pending: PendingAuthorization;
+  try {
+    pending = JSON.parse(raw) as PendingAuthorization;
+  } catch {
+    throw new Error("ログインの開始記録が壊れています。もう一度お試しください");
+  }
+
+  if (!pending.state || pending.state !== state) {
+    throw new Error("state が一致しません。ログインをやり直してください");
+  }
+  return pending;
+}
+
+/** 認可サーバーからの戻り先が自分のオリジンであることを確かめる。 */
+function requireSameOrigin(redirectUri: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUri);
+  } catch {
+    throw new Error("リダイレクト先が正しくありません");
+  }
+  if (parsed.origin !== location.origin) {
+    throw new Error("リダイレクト先が自分のオリジンと一致しません");
+  }
+}

--- a/frontend/src/features/auth/ui/GoogleLoginButton.tsx
+++ b/frontend/src/features/auth/ui/GoogleLoginButton.tsx
@@ -1,99 +1,72 @@
-import { useEffect, useRef } from "react";
-import { useNavigate } from "react-router";
-import { api, ApiError } from "@/shared/api";
-import { useAuth } from "../model/auth";
-import type { User } from "@/shared/api";
+import { useState } from "react";
+import { buildAuthorizationRequest } from "../model/googleOauth";
 
-const GSI_SRC = "https://accounts.google.com/gsi/client";
-
-interface GoogleCredentialResponse {
-  credential: string;
-}
-
-interface GoogleAccountsId {
-  initialize: (config: {
-    client_id: string;
-    callback: (response: GoogleCredentialResponse) => void;
-  }) => void;
-  renderButton: (parent: HTMLElement, options: Record<string, unknown>) => void;
-}
-
-declare global {
-  interface Window {
-    google?: { accounts?: { id?: GoogleAccountsId } };
-  }
-}
+/** 認可サーバーからの戻り先。Google Cloud Console にも同じ値の登録が必要 */
+export const GOOGLE_CALLBACK_PATH = "/auth/callback";
 
 /**
- * Google Identity Services の公式ボタン。
- * 取得した ID トークンをバックエンドで検証し、自前 JWT に交換してログインする。
- * VITE_GOOGLE_CLIENT_ID 未設定時は何も表示しない。
+ * Google ログインの開始ボタン。
+ *
+ * <p>認可コードグラント + PKCE でリダイレクトする。ブラウザが受け取るのは認可コードだけで、
+ * ID トークンも client_secret も JavaScript からは触れない。
+ * 従来の Google Identity Services は ID トークンをブラウザへ直接渡す方式だった。
+ *
+ * <p>VITE_GOOGLE_CLIENT_ID 未設定時は何も表示しない。
  */
 export function GoogleLoginButton({ onError }: { onError?: (message: string) => void }) {
   const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined;
-  const { loginWithToken } = useAuth();
-  const navigate = useNavigate();
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!clientId || !containerRef.current) return;
-
-    const container = containerRef.current;
-    const init = () => {
-      const gsi = window.google?.accounts?.id;
-      if (!gsi || !container.isConnected) return;
-      gsi.initialize({
-        client_id: clientId,
-        callback: async ({ credential }) => {
-          try {
-            const data = await api.post<{ token: string; user: User }>(
-              "/auth/google",
-              { credential },
-              false,
-            );
-            loginWithToken(data.token, data.user);
-            navigate("/", { replace: true });
-          } catch (err) {
-            onError?.(err instanceof ApiError ? err.message : "Googleログインに失敗しました");
-          }
-        },
-      });
-      gsi.renderButton(container, {
-        theme: "outline",
-        size: "large",
-        text: "continue_with",
-        width: 300,
-        locale: "ja",
-      });
-    };
-
-    if (window.google?.accounts?.id) {
-      init();
-      return;
-    }
-    const existing = document.querySelector<HTMLScriptElement>(`script[src="${GSI_SRC}"]`);
-    if (existing) {
-      existing.addEventListener("load", init, { once: true });
-      return;
-    }
-    const script = document.createElement("script");
-    script.src = GSI_SRC;
-    script.async = true;
-    script.onload = init;
-    document.head.appendChild(script);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [clientId]);
+  const [starting, setStarting] = useState(false);
 
   if (!clientId) return null;
 
+  const start = async () => {
+    setStarting(true);
+    try {
+      const { url } = await buildAuthorizationRequest(
+        clientId,
+        `${location.origin}${GOOGLE_CALLBACK_PATH}`,
+      );
+      // replace にして、戻るボタンで認可前の状態に戻らないようにする
+      location.replace(url);
+    } catch (err) {
+      setStarting(false);
+      onError?.(err instanceof Error ? err.message : "Googleログインを開始できませんでした");
+    }
+  };
+
   return (
-    <div className="mt-5">
-      <div className="mb-4 flex items-center gap-3 text-xs text-ink-400">
-        <span className="h-px flex-1 bg-primary-100" aria-hidden />
-        または
-        <span className="h-px flex-1 bg-primary-100" aria-hidden />
-      </div>
-      <div ref={containerRef} className="flex justify-center" />
-    </div>
+    <button
+      type="button"
+      onClick={start}
+      disabled={starting}
+      className="flex w-full items-center justify-center gap-3 rounded-xl border border-ink-400/20 bg-white px-4 py-3 text-sm font-medium text-ink-700 transition hover:bg-ink-400/5 disabled:opacity-60"
+    >
+      <GoogleMark />
+      {starting ? "Googleへ移動しています..." : "Googleでログイン"}
+    </button>
+  );
+}
+
+/** Google のブランドマーク */
+function GoogleMark() {
+  return (
+    <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden>
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1Z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.65l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0 0 12 23Z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.11a6.6 6.6 0 0 1 0-4.22V7.05H2.18a11 11 0 0 0 0 9.9l3.66-2.84Z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 4.75c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 1.46 14.97.5 12 .5A11 11 0 0 0 2.18 7.05l3.66 2.84c.87-2.6 3.3-4.14 6.16-4.14Z"
+      />
+    </svg>
   );
 }

--- a/frontend/src/pages/auth-callback/index.ts
+++ b/frontend/src/pages/auth-callback/index.ts
@@ -1,0 +1,3 @@
+// auth-callback 画面の Public API。
+// ルート定義 (app 層) からのみ参照される。
+export { default } from "./ui/AuthCallback";

--- a/frontend/src/pages/auth-callback/ui/AuthCallback.tsx
+++ b/frontend/src/pages/auth-callback/ui/AuthCallback.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import { api, ApiError } from "@/shared/api";
+import type { User } from "@/shared/api";
+import { consumeAuthorizationState, useAuth } from "@/features/auth";
+
+/**
+ * Google からの戻り先。
+ *
+ * <p>受け取るのは認可コードだけ。state を検証してから、コードと合言葉を
+ * バックエンドへ渡す。トークン交換はサーバー間通信で行われるので、
+ * ID トークンはブラウザに一切渡らない。
+ */
+export default function AuthCallback() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const { loginWithToken } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  // 認可コードは1度しか使えない。開発時の二重実行で無駄に消費しないようにする
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    const run = async () => {
+      const denied = params.get("error");
+      if (denied) {
+        // 利用者が同意しなかった場合。認可サーバーの生の文言は出さない
+        setError("Googleログインがキャンセルされました");
+        return;
+      }
+
+      const code = params.get("code");
+      const state = params.get("state");
+      if (!code || !state) {
+        setError("Googleからの応答が不正です");
+        return;
+      }
+
+      try {
+        const pending = consumeAuthorizationState(state);
+        const data = await api.post<{ token: string; user: User }>(
+          "/auth/google/callback",
+          { code, codeVerifier: pending.codeVerifier, redirectUri: pending.redirectUri },
+          false,
+        );
+        loginWithToken(data.token, data.user);
+        navigate("/", { replace: true });
+      } catch (err) {
+        setError(
+          err instanceof ApiError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : "Googleログインに失敗しました",
+        );
+      }
+    };
+    void run();
+  }, [params, loginWithToken, navigate]);
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
+        <p className="text-sm text-red-600">{error}</p>
+        <button
+          type="button"
+          onClick={() => navigate("/login", { replace: true })}
+          className="rounded-xl bg-primary px-5 py-2.5 text-sm font-medium text-white"
+        >
+          ログイン画面へ戻る
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center text-ink-500">
+      ログインしています...
+    </div>
+  );
+}

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -10,6 +10,9 @@ export default [
   route("forgot-password", "pages/forgot-password/index.ts"),
   route("reset-password", "pages/reset-password/index.ts"),
 
+  // Google 認可サーバーからの戻り先。Cloud Console にも同じパスの登録が必要
+  route("auth/callback", "pages/auth-callback/index.ts"),
+
   // 医師共有用の印刷最適化レポート（サイドバー等を出さない独立ページ）
   // 認証済みレイアウトの外にあるため、画面側で個別に useRequireAuth を呼んでいる
   route("members/:memberId/report", "pages/member-report/index.ts"),

--- a/frontend/src/shared/lib/pkce.test.ts
+++ b/frontend/src/shared/lib/pkce.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { createCodeChallenge, createRandomString } from "./pkce";
+
+/**
+ * PKCE の合言葉まわり。
+ *
+ * 認可コードを盗まれても、合言葉の本体を知らない攻撃者はトークンを取得できない。
+ * ここが弱いと認可コードグラントにした意味が無くなるので、性質を明示的に固定する。
+ */
+describe("PKCE", () => {
+  describe("ランダム文字列", () => {
+    it("指定した長さで生成される", () => {
+      expect(createRandomString(43)).toHaveLength(43);
+      expect(createRandomString(128)).toHaveLength(128);
+    });
+
+    it("RFC 7636 が許す文字だけを使う", () => {
+      const value = createRandomString(128);
+
+      expect(value).toMatch(/^[A-Za-z0-9\-._~]+$/);
+    });
+
+    it("呼ぶたびに異なる値になる", () => {
+      const values = new Set(Array.from({ length: 50 }, () => createRandomString(43)));
+
+      expect(values.size).toBe(50);
+    });
+
+    it("43文字未満は作れない。短い合言葉は総当たりされうる", () => {
+      expect(() => createRandomString(42)).toThrow();
+    });
+
+    it("128文字を超える長さは作れない", () => {
+      expect(() => createRandomString(129)).toThrow();
+    });
+  });
+
+  describe("code_challenge", () => {
+    it("RFC 7636 の例と一致する", async () => {
+      // RFC 7636 Appendix B の検証ベクタ
+      const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+
+      expect(await createCodeChallenge(verifier)).toBe(
+        "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      );
+    });
+
+    it("Base64URL なので + / = を含まない", async () => {
+      const challenge = await createCodeChallenge(createRandomString(128));
+
+      expect(challenge).toMatch(/^[A-Za-z0-9\-_]+$/);
+    });
+
+    it("同じ合言葉からは同じ値になる", async () => {
+      const verifier = createRandomString(64);
+
+      expect(await createCodeChallenge(verifier)).toBe(await createCodeChallenge(verifier));
+    });
+
+    it("合言葉が1文字違えば結果は変わる", async () => {
+      const a = await createCodeChallenge("a".repeat(43));
+      const b = await createCodeChallenge("a".repeat(42) + "b");
+
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/frontend/src/shared/lib/pkce.ts
+++ b/frontend/src/shared/lib/pkce.ts
@@ -1,0 +1,53 @@
+/**
+ * PKCE（Proof Key for Code Exchange, RFC 7636）の合言葉まわり。
+ *
+ * SPA は公開クライアントで client_secret を安全に持てない。認可コードだけを盗まれても
+ * トークンを取得されないよう、毎回ランダムな合言葉を作り、そのハッシュを先に
+ * 認可サーバーへ預けておく。
+ */
+
+/** RFC 7636 が code_verifier に許す文字 */
+const UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+
+const MIN_LENGTH = 43;
+const MAX_LENGTH = 128;
+
+/**
+ * 暗号論的に安全なランダム文字列を作る。
+ *
+ * <p>Math.random は使わない。予測可能な合言葉は PKCE の意味を無くす。
+ */
+export function createRandomString(length: number): string {
+  if (length < MIN_LENGTH || length > MAX_LENGTH) {
+    throw new Error(`長さは ${MIN_LENGTH}〜${MAX_LENGTH} の範囲で指定してください`);
+  }
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+
+  // 剰余を取るとわずかに偏るが、UNRESERVED は 66 文字で 256 に対する偏りは
+  // 合言葉の総当たり耐性に影響しない程度に小さい。
+  let result = "";
+  for (const byte of bytes) {
+    result += UNRESERVED[byte % UNRESERVED.length];
+  }
+  return result;
+}
+
+/**
+ * code_challenge を作る。方式は常に S256。
+ *
+ * <p>plain（ハッシュ化しない）は仕様上選べるが、盗まれた時点で意味がなくなるので使わない。
+ */
+export async function createCodeChallenge(codeVerifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(codeVerifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+/** Base64URL（+ / = を含まない形）へ変換する。 */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// ユニットテストは Vite のビルド設定とは切り離す。
+// React Router のプラグインを噛ませると型生成が必要になり、テストが重くなるため。
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    // オリジンを与えないと localStorage が生えず、同一オリジン判定も検証できない
+    environmentOptions: { jsdom: { url: "https://app.example" } },
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary

従来の Google Identity Services は **ID トークンをブラウザへ直接渡す**方式で、実質インプリシットに近い。認可コードグラント + PKCE へ移した。

### セキュリティ上の判断

| 項目 | 判断 |
|---|---|
| `code_verifier` | `crypto.getRandomValues` で 128 文字。`Math.random` は予測可能で PKCE の意味を無くす |
| `code_challenge` | **常に S256**。plain は盗まれた時点で無意味 |
| 保存先 | **sessionStorage のみ**。localStorage に書かないことをテストで固定 |
| `state` | 不一致は拒否。**検証の成否にかかわらず即座に消す**（再送での悪用を防ぐ） |
| `redirect_uri` | 自分のオリジンでなければ**組み立て自体を拒否** |
| `nonce` | 付与 |
| `prompt` | `select_account`。共有端末で前の利用者のまま入るのを防ぐ |

`PKCE` は **RFC 7636 の検証ベクタとの一致**も確認している。

### テスト基盤

フロントにユニットテストが無かったので **vitest を導入**し、TDD で進めた。フロントのテスト **21件**。

途中 Node 25 のネイティブ `localStorage` が jsdom のものを覆う問題に当たったため、「localStorage に書かない」ことは**呼び出しの有無**で検証している。

## 移植の元仕様も残した

`backend-java/docs/` に 2 つ追加。

- **go-api-contract.md** — Go 実装から抽出した 58 エンドポイントの契約。推測ではなく handler / usecase / repository / SQL から確認した内容のみ
- **cutover-diff-verification.md** — Go と Java の応答差分を突き合わせる設計（read-parity / write-parity の 2 モード、揺らぐ値の正規化、レート制限の回避、起動手順）

## 切り替えはまだ行わない

エンドポイントを数え直したところ **Go 106本に対し Java 38本**で、**88本が未実装**だった。この状態で `VITE_API_URL` を切り替えるとログインすらできなくなる。

本 PR のコールバック画面は Java 版の `/api/auth/google/callback` を呼ぶが、**ルート追加のみで既存の導線は変えていない**ため、本番の動作には影響しない。

### 切り替え前に必要な外部作業

私では実行できないものが 2 つある。

1. **Google Cloud Console で承認済みリダイレクト URI を登録**（OAuth クライアント設定に対応する gcloud コマンドが存在しない）
   - `https://health-family-five.vercel.app/auth/callback`
   - `http://localhost:5173/auth/callback`
2. **`GOOGLE_CLIENT_SECRET` を Secret Manager に登録**（バックエンドのトークン交換に必要。GSI 方式では不要だった）