### PR TITLE
fix(auth): 認証コードを検証せずトークンを発行する不具合を修正する

### DIFF
--- a/backend/internal/interface/handler/auth_handler.go
+++ b/backend/internal/interface/handler/auth_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"crypto/subtle"
 	"github.com/gin-gonic/gin"
 	"healthfamily/internal/pkg/response"
 	"healthfamily/internal/usecase"
@@ -25,7 +26,9 @@ type testLoginRequest struct {
 
 // TestLogin はE2E用のログインバイパス。X-E2E-Secret が一致した場合のみ JWT を返す。
 func (h *AuthHandler) TestLogin(c *gin.Context) {
-	if h.testLoginSecret == "" || c.GetHeader("X-E2E-Secret") != h.testLoginSecret {
+	// シークレットの比較は定数時間で行う。応答時間の差から1文字ずつ絞り込まれうる。
+	if h.testLoginSecret == "" ||
+		subtle.ConstantTimeCompare([]byte(c.GetHeader("X-E2E-Secret")), []byte(h.testLoginSecret)) != 1 {
 		response.Error(c, 403, "テストログインは無効です")
 		return
 	}

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"crypto/subtle"
 	"strings"
 	"time"
 
@@ -78,16 +79,18 @@ func (uc *AuthUsecase) Verify(ctx context.Context, email, code string) (string, 
 	if err != nil {
 		return "", nil, err
 	}
-	if u == nil {
-		return "", nil, domain.NewValidation("認証コードが正しくありません")
-	}
-	if u.EmailVerified {
-		token, err := uc.tokens.Generate(u.ID, u.Email, uc.now())
-		return token, u, err
-	}
-	if u.VerificationCode == nil || u.VerificationExpiry == nil ||
-		*u.VerificationCode != code || uc.now().After(*u.VerificationExpiry) {
-		return "", nil, domain.NewValidation("認証コードが正しくないか、有効期限が切れています")
+	// 存在しないユーザーと、コードが合わないユーザーは同じ結果にする（列挙防止）。
+	// ここで分岐すると「そのメールアドレスは登録済みか」が漏れる。
+	const invalidCode = "認証コードが正しくないか、有効期限が切れています"
+
+	// 認証済みかどうかに関わらず、必ずコードを検証する。
+	// 以前はここで EmailVerified を見て検証を飛ばしていたため、
+	// メールアドレスを知っているだけで任意のアカウントのトークンを発行できた。
+	if u == nil ||
+		u.VerificationCode == nil || u.VerificationExpiry == nil ||
+		subtle.ConstantTimeCompare([]byte(*u.VerificationCode), []byte(code)) != 1 ||
+		uc.now().After(*u.VerificationExpiry) {
+		return "", nil, domain.NewValidation(invalidCode)
 	}
 
 	u.EmailVerified = true
@@ -243,8 +246,11 @@ func (uc *AuthUsecase) ResetPassword(ctx context.Context, email, code, newPasswo
 	if err != nil {
 		return err
 	}
+	// コードの比較は定数時間で行う。通常の文字列比較は先頭一致の長さで
+	// 応答時間が変わるため、6桁のコードを1桁ずつ絞り込まれうる。
 	if u == nil || u.ResetCode == nil || u.ResetCodeExpiry == nil ||
-		*u.ResetCode != code || uc.now().After(*u.ResetCodeExpiry) {
+		subtle.ConstantTimeCompare([]byte(*u.ResetCode), []byte(code)) != 1 ||
+		uc.now().After(*u.ResetCodeExpiry) {
 		return domain.NewValidation("再設定コードが正しくないか、有効期限が切れています")
 	}
 	hashed, err := auth.HashPassword(newPassword)

--- a/backend/internal/usecase/auth_verify_test.go
+++ b/backend/internal/usecase/auth_verify_test.go
@@ -1,0 +1,158 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"healthfamily/internal/domain"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
+	"healthfamily/internal/pkg/auth"
+)
+
+// verifyUserRepo は Verify のテストに必要な最小のリポジトリ実装。
+type verifyUserRepo struct {
+	user    *entity.User
+	updated *entity.User
+}
+
+func (r *verifyUserRepo) FindByEmail(_ context.Context, email string) (*entity.User, error) {
+	if r.user != nil && r.user.Email == email {
+		return r.user, nil
+	}
+	return nil, nil
+}
+func (r *verifyUserRepo) FindByID(context.Context, string) (*entity.User, error) { return nil, nil }
+func (r *verifyUserRepo) FindByGoogleID(context.Context, string) (*entity.User, error) {
+	return nil, nil
+}
+func (r *verifyUserRepo) Create(context.Context, *entity.User) error { return nil }
+func (r *verifyUserRepo) Update(_ context.Context, u *entity.User) error {
+	r.updated = u
+	return nil
+}
+
+var _ repository.UserRepository = (*verifyUserRepo)(nil)
+
+func newVerifyUsecase(u *entity.User) (*AuthUsecase, *verifyUserRepo) {
+	repo := &verifyUserRepo{user: u}
+	uc := NewAuthUsecase(repo, auth.NewTokenManager("test-secret-0123456789abcdef", time.Hour), nil, nil)
+	return uc, repo
+}
+
+func verifiedUser() *entity.User {
+	return &entity.User{
+		ID:            "victim",
+		Email:         "victim@example.test",
+		Password:      "hashed",
+		EmailVerified: true,
+	}
+}
+
+// メールアドレスさえ知っていれば任意のコードでログインできてはならない。
+// 認証済みユーザーに対してコード検証を飛ばすと、アカウント乗っ取りになる。
+func TestVerify_認証済みユーザーへの不正なコードを拒否する(t *testing.T) {
+	uc, _ := newVerifyUsecase(verifiedUser())
+
+	token, user, err := uc.Verify(context.Background(), "victim@example.test", "000000")
+
+	if err == nil {
+		t.Fatalf("でたらめなコードが通ってしまった: token=%q user=%v", token, user)
+	}
+	var validation *domain.ValidationError
+	if !asValidation(err, &validation) {
+		t.Fatalf("ValidationError を期待したが %T (%v)", err, err)
+	}
+	if token != "" {
+		t.Fatalf("トークンを発行してはならない: %q", token)
+	}
+}
+
+// 認証済みかどうかを問わず、存在しないユーザーは同じ結果にする（列挙防止）。
+func TestVerify_存在しないユーザーは同じメッセージで拒否する(t *testing.T) {
+	uc, _ := newVerifyUsecase(verifiedUser())
+
+	_, _, errUnknown := uc.Verify(context.Background(), "nobody@example.test", "000000")
+	_, _, errVerified := uc.Verify(context.Background(), "victim@example.test", "000000")
+
+	if errUnknown == nil || errVerified == nil {
+		t.Fatal("どちらも拒否されるべき")
+	}
+	if errUnknown.Error() != errVerified.Error() {
+		t.Fatalf("メッセージが異なると存在有無が漏れる: %q vs %q", errUnknown.Error(), errVerified.Error())
+	}
+}
+
+// 正しいコードなら、未認証ユーザーは認証済みになってログインできる。
+func TestVerify_正しいコードで認証が完了する(t *testing.T) {
+	code := "123456"
+	expiry := time.Now().Add(10 * time.Minute)
+	u := &entity.User{
+		ID:                 "u-1",
+		Email:              "user@example.test",
+		EmailVerified:      false,
+		VerificationCode:   &code,
+		VerificationExpiry: &expiry,
+	}
+	uc, repo := newVerifyUsecase(u)
+
+	token, user, err := uc.Verify(context.Background(), "user@example.test", code)
+
+	if err != nil {
+		t.Fatalf("正しいコードが拒否された: %v", err)
+	}
+	if token == "" || user == nil {
+		t.Fatal("トークンとユーザーが返るべき")
+	}
+	if repo.updated == nil || !repo.updated.EmailVerified {
+		t.Fatal("emailVerified を true にして保存すべき")
+	}
+	if repo.updated.VerificationCode != nil || repo.updated.VerificationExpiry != nil {
+		t.Fatal("使い終わったコードは消すべき")
+	}
+}
+
+// 一度使ったコードは再利用できない。
+func TestVerify_使用済みのコードは再利用できない(t *testing.T) {
+	code := "123456"
+	expiry := time.Now().Add(10 * time.Minute)
+	u := &entity.User{
+		ID:                 "u-2",
+		Email:              "user2@example.test",
+		EmailVerified:      false,
+		VerificationCode:   &code,
+		VerificationExpiry: &expiry,
+	}
+	uc, _ := newVerifyUsecase(u)
+
+	if _, _, err := uc.Verify(context.Background(), "user2@example.test", code); err != nil {
+		t.Fatalf("1回目は成功すべき: %v", err)
+	}
+	if _, _, err := uc.Verify(context.Background(), "user2@example.test", code); err == nil {
+		t.Fatal("2回目は拒否すべき")
+	}
+}
+
+// 期限切れのコードは通らない。
+func TestVerify_期限切れのコードを拒否する(t *testing.T) {
+	code := "123456"
+	expiry := time.Now().Add(-1 * time.Minute)
+	u := &entity.User{
+		ID:                 "u-3",
+		Email:              "user3@example.test",
+		EmailVerified:      false,
+		VerificationCode:   &code,
+		VerificationExpiry: &expiry,
+	}
+	uc, _ := newVerifyUsecase(u)
+
+	if _, _, err := uc.Verify(context.Background(), "user3@example.test", code); err == nil {
+		t.Fatal("期限切れは拒否すべき")
+	}
+}
+
+func asValidation(err error, target **domain.ValidationError) bool {
+	return errors.As(err, target)
+}


### PR DESCRIPTION
## 概要

`POST /api/auth/verify` が、対象ユーザーが認証済み（`emailVerified = true`）の場合に**認証コードを一切検証せず JWT を発行**していた。

**メールアドレスさえ知っていれば、任意のコードでそのアカウントに完全ログインできる状態だった。**

- 既存利用者は全員 `emailVerified = true` のため、**全アカウントが対象**
- このエンドポイントは公開（認証不要）で、必要なのはメールアドレスのみ
- 発行されるトークンは有効期限 7 日

該当箇所は、コード検証より前にある早期 return。

```go
if u.EmailVerified {
    token, err := uc.tokens.Generate(u.ID, u.Email, uc.now())
    return token, u, err   // ← code を一切見ていない
}
```

## 修正内容

- **認証済みかどうかに関わらず、必ずコードを検証する**
- 存在しないユーザーとコード不一致を**同じメッセージ**にした（ユーザー列挙の防止）
- コード比較を**定数時間比較**に変更。通常の文字列比較は先頭一致の長さで応答時間が変わるため、6桁のコードを1桁ずつ絞り込まれうる
  - `Verify` / `ResetPassword` / `test-login` のシークレット比較すべて

## 検証

**修正前**、ローカルの Go サーバー（compose の PostgreSQL 使用）で攻撃が成立することを再現した。本番には一切触れていない。

```
POST /api/auth/verify {"email":"victim@example.test","code":"000000"}
→ 200 { token: "eyJ..." }
→ そのトークンで GET /api/users/me が成功
```

**修正後**、同じ攻撃が拒否され、存在しないメールとの応答も一致することを確認した。

```
→ 400 {"error":"認証コードが正しくないか、有効期限が切れています"}
（存在しないメールでも完全に同じ応答）
```

攻撃を再現するテストを先に書いて red を確認してから修正している。正常系（正しいコードでの認証・使用済みコードの拒否・期限切れの拒否）も追加した。

`go build` / `go vet` / `go test ./...` すべて通過。

## 補足

この不具合は、Java 移植のために Go 実装の契約を精査する過程で見つかった。同じ精査で他にも複数の問題が見つかっており、`backend-java/docs/go-api-contract.md` に記録している（`reorder` の所有権チェック漏れ、在庫更新でのキー省略時のゼロ上書き、`appointments` の `hospitalId` 所有権未確認など）。それらは本 PR とは分けて対応する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **セキュリティ改善**
  - 認証シークレットやパスワード再設定コードの比較を強化し、解析耐性を高めました。
  - 認証コード検証時に、ユーザーの状態にかかわらずコードの有効性と期限を確認するよう改善しました。
  - 存在しないユーザーや無効・期限切れコードは、統一された検証エラーとして扱います。

- **テスト**
  - 正常な認証、無効・使用済み・期限切れコードなど、認証コード検証の主要なケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->