### PR TITLE
fix(api): 所有権チェック漏れ・在庫の意図しない消失・レート制限の肥大化を修正する

### DIFF
--- a/backend/internal/interface/handler/appointment_handler.go
+++ b/backend/internal/interface/handler/appointment_handler.go
@@ -2,21 +2,18 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"healthfamily/internal/domain/entity"
 	"healthfamily/internal/domain/repository"
 	"healthfamily/internal/interface/middleware"
 	"healthfamily/internal/pkg/response"
 	"healthfamily/internal/usecase"
 )
 
-type appointmentUC = usecase.MemberScopedCRUD[entity.Appointment, repository.CreateAppointmentInput, repository.UpdateAppointmentInput]
-
 // AppointmentHandler は通院予定エンドポイント
 type AppointmentHandler struct {
-	uc *appointmentUC
+	uc *usecase.AppointmentUsecase
 }
 
-func NewAppointmentHandler(uc *appointmentUC) *AppointmentHandler {
+func NewAppointmentHandler(uc *usecase.AppointmentUsecase) *AppointmentHandler {
 	return &AppointmentHandler{uc: uc}
 }
 

--- a/backend/internal/interface/handler/medication_handler.go
+++ b/backend/internal/interface/handler/medication_handler.go
@@ -131,7 +131,9 @@ func (h *MedicationHandler) Update(c *gin.Context) {
 }
 
 type updateStockRequest struct {
-	StockQuantity int `json:"stockQuantity"`
+	// ポインタで受ける。値型だとキー省略が Go のゼロ値 0 と区別できず、
+	// 「stockQuantity を送らなかっただけ」で在庫が 0 に上書きされてしまう。
+	StockQuantity *int `json:"stockQuantity"`
 }
 
 func (h *MedicationHandler) UpdateStock(c *gin.Context) {
@@ -141,7 +143,15 @@ func (h *MedicationHandler) UpdateStock(c *gin.Context) {
 		response.Error(c, 400, "在庫数は0以上の数値を指定してください")
 		return
 	}
-	m, err := h.uc.UpdateStock(c.Request.Context(), userID, c.Param("medicationId"), req.StockQuantity)
+	if req.StockQuantity == nil {
+		response.Error(c, 400, "在庫数は0以上の数値を指定してください")
+		return
+	}
+	if *req.StockQuantity < 0 {
+		response.Error(c, 400, "在庫数は0以上の数値を指定してください")
+		return
+	}
+	m, err := h.uc.UpdateStock(c.Request.Context(), userID, c.Param("medicationId"), *req.StockQuantity)
 	if err != nil {
 		response.HandleDomainError(c, err)
 		return

--- a/backend/internal/interface/handler/update_stock_test.go
+++ b/backend/internal/interface/handler/update_stock_test.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// 在庫更新は「省略」と「0 を指定」を区別しなければならない。
+// 区別しないと、他の項目だけを送ったつもりのリクエストで在庫が 0 に消える。
+func TestUpdateStockRequest_省略と0を区別する(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantNil  bool
+		wantVal  int
+		wantFail bool
+	}{
+		{name: "0 を明示した場合は 0 として扱う", body: `{"stockQuantity":0}`, wantVal: 0},
+		{name: "正の数はそのまま", body: `{"stockQuantity":42}`, wantVal: 42},
+		{name: "キー省略は未指定として区別できる", body: `{}`, wantNil: true},
+		{name: "null も未指定", body: `{"stockQuantity":null}`, wantNil: true},
+		{name: "文字列は解釈できない", body: `{"stockQuantity":"10"}`, wantFail: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var req updateStockRequest
+			err := json.Unmarshal([]byte(c.body), &req)
+
+			if c.wantFail {
+				if err == nil {
+					t.Fatal("解釈に失敗すべき")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("解釈できるはず: %v", err)
+			}
+			if c.wantNil {
+				if req.StockQuantity != nil {
+					t.Fatalf("未指定として扱うべきだが %d が入っている", *req.StockQuantity)
+				}
+				return
+			}
+			if req.StockQuantity == nil {
+				t.Fatal("値が入るべき")
+			}
+			if *req.StockQuantity != c.wantVal {
+				t.Fatalf("%d を期待したが %d", c.wantVal, *req.StockQuantity)
+			}
+		})
+	}
+}
+
+// ハンドラを HTTP 越しに叩き、未指定・負数が 400 で弾かれることを確かめる。
+func TestUpdateStock_未指定と負数は400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "キー省略", body: `{}`},
+		{name: "null", body: `{"stockQuantity":null}`},
+		{name: "負数", body: `{"stockQuantity":-1}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// ユースケースまで到達したら失敗と分かるよう、nil のまま呼び出す。
+			// 400 で弾かれていれば nil 参照は起きない。
+			h := &MedicationHandler{}
+			r := gin.New()
+			r.PATCH("/m/:medicationId/stock", func(ctx *gin.Context) {
+				ctx.Set("userID", "user-1")
+				h.UpdateStock(ctx)
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPatch, "/m/med-1/stock", strings.NewReader(c.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("400 を期待したが %d (%s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/interface/middleware/ratelimit.go
+++ b/backend/internal/interface/middleware/ratelimit.go
@@ -8,7 +8,12 @@ import (
 	"healthfamily/internal/pkg/response"
 )
 
-// インメモリのレート制限。Next.js版 checkRateLimit と同等の挙動。
+// インメモリのレート制限。
+//
+// 制限はプロセス内で完結するため、インスタンスが複数あると実効上限は
+// 「設定値 × インスタンス数」になる。現在は max 2 インスタンスなので、
+// 設定値はその前提で決めること。厳密な全体制限が必要になったら、
+// 共有ストア(Memorystore 等)か、前段のロードバランサ側での制限へ移す。
 
 type rateEntry struct {
 	count   int
@@ -20,7 +25,13 @@ type rateLimiter struct {
 	store  map[string]*rateEntry
 	max    int
 	window time.Duration
+
+	// 最後に期限切れエントリを回収した時刻
+	lastSweep time.Time
 }
+
+// 回収の実行間隔。毎回全走査すると重いので間隔を空ける
+const sweepInterval = time.Minute
 
 var limiters sync.Map // name -> *rateLimiter
 
@@ -33,9 +44,33 @@ func getLimiter(name string, max int, window time.Duration) *rateLimiter {
 	return actual.(*rateLimiter)
 }
 
+// sweepLocked は期限切れのエントリを取り除く。呼び出し側でロックを取っていること。
+//
+// これが無いと、認証前のエンドポイント(キーは IP)を IP を変えながら叩かれた場合に
+// エントリが無限に増え、メモリを食い潰される。
+func (rl *rateLimiter) sweepLocked(now time.Time) {
+	if now.Sub(rl.lastSweep) < sweepInterval {
+		return
+	}
+	rl.lastSweep = now
+	for k, e := range rl.store {
+		if now.After(e.resetAt) {
+			delete(rl.store, k)
+		}
+	}
+}
+
+// size は保持しているエントリ数を返す。
+func (rl *rateLimiter) size() int {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	return len(rl.store)
+}
+
 func (rl *rateLimiter) allow(key string, now time.Time) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
+	rl.sweepLocked(now)
 	entry, ok := rl.store[key]
 	if !ok || now.After(entry.resetAt) {
 		rl.store[key] = &rateEntry{count: 1, resetAt: now.Add(rl.window)}

--- a/backend/internal/interface/middleware/ratelimit_test.go
+++ b/backend/internal/interface/middleware/ratelimit_test.go
@@ -1,0 +1,101 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+// レート制限そのものが期待どおり効くこと。
+func TestRateLimiter_上限を超えたら拒否する(t *testing.T) {
+	rl := &rateLimiter{store: map[string]*rateEntry{}, max: 3, window: time.Minute}
+	now := time.Now()
+
+	for i := 1; i <= 3; i++ {
+		if !rl.allow("k", now) {
+			t.Fatalf("%d 回目は通るべき", i)
+		}
+	}
+	if rl.allow("k", now) {
+		t.Fatal("4 回目は拒否すべき")
+	}
+}
+
+func TestRateLimiter_窓が過ぎたら回復する(t *testing.T) {
+	rl := &rateLimiter{store: map[string]*rateEntry{}, max: 1, window: time.Minute}
+	now := time.Now()
+
+	rl.allow("k", now)
+	if rl.allow("k", now) {
+		t.Fatal("窓の中では拒否すべき")
+	}
+	if !rl.allow("k", now.Add(2*time.Minute)) {
+		t.Fatal("窓が過ぎたら通すべき")
+	}
+}
+
+func TestRateLimiter_キーごとに独立している(t *testing.T) {
+	rl := &rateLimiter{store: map[string]*rateEntry{}, max: 1, window: time.Minute}
+	now := time.Now()
+
+	rl.allow("a", now)
+	if !rl.allow("b", now) {
+		t.Fatal("別のキーは影響を受けない")
+	}
+}
+
+// 期限切れのエントリが溜まり続けてはならない。
+//
+// 認証前のエンドポイントは IP をキーにするため、IP を変えながら叩かれると
+// エントリが無限に増える。256MiB のコンテナではメモリを食い潰されうる。
+func TestRateLimiter_期限切れのエントリを溜め込まない(t *testing.T) {
+	rl := &rateLimiter{store: map[string]*rateEntry{}, max: 10, window: time.Minute}
+	base := time.Now()
+
+	// 1万個の別々のキーで、それぞれ 1 回ずつ叩く
+	for i := 0; i < 10000; i++ {
+		rl.allow(uniqueKey(i), base)
+	}
+	if got := rl.size(); got != 10000 {
+		t.Fatalf("この時点では 10000 件あるはず: %d", got)
+	}
+
+	// 窓が過ぎたあと、新しいキーで 1 回叩く
+	rl.allow("after", base.Add(2*time.Minute))
+
+	if got := rl.size(); got > 100 {
+		t.Fatalf("期限切れのエントリが回収されていない: %d 件残っている", got)
+	}
+}
+
+func TestRateLimiter_回収しても有効なエントリは残す(t *testing.T) {
+	rl := &rateLimiter{store: map[string]*rateEntry{}, max: 10, window: time.Minute}
+	base := time.Now()
+
+	rl.allow("old", base)                       // 2分後には期限切れ
+	rl.allow("fresh", base.Add(90*time.Second)) // 2分後もまだ有効
+
+	rl.allow("trigger", base.Add(2*time.Minute))
+
+	if _, ok := rl.store["fresh"]; !ok {
+		t.Fatal("まだ有効なエントリを消してはならない")
+	}
+	if _, ok := rl.store["old"]; ok {
+		t.Fatal("期限切れのエントリは消すべき")
+	}
+}
+
+func uniqueKey(i int) string {
+	return "key-" + string(rune('a'+i%26)) + "-" + itoa(i)
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}

--- a/backend/internal/interface/router/routes_ext.go
+++ b/backend/internal/interface/router/routes_ext.go
@@ -26,7 +26,9 @@ func RegisterExtraRoutes(authed *gin.RouterGroup, db *database.DB) {
 	authed.DELETE("/hospitals/:hospitalId", hospitalH.Delete)
 
 	// --- Appointment ---
-	appointmentH := handler.NewAppointmentHandler(usecase.NewMemberScopedCRUD[entity.Appointment, repository.CreateAppointmentInput, repository.UpdateAppointmentInput](persistence.NewAppointmentRepository(db), memberRepo, "通院予定", "この通院予定にアクセスする権限がありません", func(e *entity.Appointment) string { return e.UserID }, func(c repository.CreateAppointmentInput) string { return c.UserID }, func(c repository.CreateAppointmentInput) string { return c.MemberID }))
+	appointmentCRUD := usecase.NewMemberScopedCRUD[entity.Appointment, repository.CreateAppointmentInput, repository.UpdateAppointmentInput](persistence.NewAppointmentRepository(db), memberRepo, "通院予定", "この通院予定にアクセスする権限がありません", func(e *entity.Appointment) string { return e.UserID }, func(c repository.CreateAppointmentInput) string { return c.UserID }, func(c repository.CreateAppointmentInput) string { return c.MemberID })
+	// hospitalId の所有権も確認するため、汎用CRUDを専用ユースケースで包む
+	appointmentH := handler.NewAppointmentHandler(usecase.NewAppointmentUsecase(appointmentCRUD, persistence.NewHospitalRepository(db)))
 	authed.GET("/appointments", appointmentH.List)
 	authed.POST("/appointments", appointmentH.Create)
 	authed.GET("/appointments/:appointmentId", appointmentH.Get)

--- a/backend/internal/usecase/appointment_usecase.go
+++ b/backend/internal/usecase/appointment_usecase.go
@@ -1,0 +1,55 @@
+package usecase
+
+import (
+	"context"
+
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
+)
+
+// AppointmentUsecase は通院予定のユースケース。
+//
+// メンバー紐付けの汎用CRUD (MemberScopedCRUD) に、通院予定固有の
+// 「hospitalId も自分の病院か」の確認を足したもの。
+//
+// 汎用CRUD は memberId しか見ないため、hospitalId は素通しになっていた。
+// 他人の病院IDを推測して自分の通院予定に紐付ければ、その病院の情報を
+// 自分の画面へ引き込めてしまう。
+type AppointmentUsecase struct {
+	crud      *MemberScopedCRUD[entity.Appointment, repository.CreateAppointmentInput, repository.UpdateAppointmentInput]
+	hospitals repository.HospitalRepository
+}
+
+func NewAppointmentUsecase(
+	crud *MemberScopedCRUD[entity.Appointment, repository.CreateAppointmentInput, repository.UpdateAppointmentInput],
+	hospitals repository.HospitalRepository,
+) *AppointmentUsecase {
+	return &AppointmentUsecase{crud: crud, hospitals: hospitals}
+}
+
+func (uc *AppointmentUsecase) List(ctx context.Context, userID string) ([]entity.Appointment, error) {
+	return uc.crud.List(ctx, userID)
+}
+
+func (uc *AppointmentUsecase) Get(ctx context.Context, userID, id string) (*entity.Appointment, error) {
+	return uc.crud.Get(ctx, userID, id)
+}
+
+func (uc *AppointmentUsecase) Create(ctx context.Context, in repository.CreateAppointmentInput) (*entity.Appointment, error) {
+	if err := ensureHospitalOwner(ctx, uc.hospitals, in.UserID, in.HospitalID); err != nil {
+		return nil, err
+	}
+	return uc.crud.Create(ctx, in)
+}
+
+func (uc *AppointmentUsecase) Update(ctx context.Context, userID, id string, in repository.UpdateAppointmentInput) (*entity.Appointment, error) {
+	// 更新で他人の病院へ付け替える経路も塞ぐ
+	if err := ensureHospitalOwner(ctx, uc.hospitals, userID, in.HospitalID); err != nil {
+		return nil, err
+	}
+	return uc.crud.Update(ctx, userID, id, in)
+}
+
+func (uc *AppointmentUsecase) Delete(ctx context.Context, userID, id string) error {
+	return uc.crud.Delete(ctx, userID, id)
+}

--- a/backend/internal/usecase/medication_usecase.go
+++ b/backend/internal/usecase/medication_usecase.go
@@ -76,7 +76,25 @@ func (uc *MedicationUsecase) UpdateStock(ctx context.Context, userID, medID stri
 	return uc.medications.UpdateStock(ctx, medID, quantity)
 }
 
+// Reorder は薬の表示順を入れ替える。
+//
+// 指定された ID がすべて自分の薬であることを、並び替える前に確認する。
+// 以前はリポジトリの WHERE 句に頼っており、他人の ID や存在しない ID を
+// 混ぜても黙って無視されて 200 を返していた。呼び出し側は成功したと誤認するし、
+// 応答が変わらないことを利用して ID の当たり判定にも使えてしまう。
 func (uc *MedicationUsecase) Reorder(ctx context.Context, userID string, orderedIDs []string) error {
+	seen := make(map[string]struct{}, len(orderedIDs))
+	for _, id := range orderedIDs {
+		if _, dup := seen[id]; dup {
+			// 重複があると並び順が一意に定まらない
+			return domain.NewValidation("並び順に同じ薬が重複しています")
+		}
+		seen[id] = struct{}{}
+
+		if _, err := uc.ensureMedOwner(ctx, userID, id); err != nil {
+			return err
+		}
+	}
 	return uc.medications.Reorder(ctx, userID, orderedIDs)
 }
 

--- a/backend/internal/usecase/ownership_ext.go
+++ b/backend/internal/usecase/ownership_ext.go
@@ -21,3 +21,25 @@ func ensureMemberOwner(ctx context.Context, members repository.MemberRepository,
 	}
 	return nil
 }
+
+// ensureHospitalOwner は病院IDが呼び出しユーザーのものかを確認する。
+//
+// 通院記録は hospitalId で病院を参照する。ここを確認しないと、他人の病院IDを
+// 推測して自分の記録に紐付けられ、その病院の情報を自分の画面へ引き込めてしまう。
+// 未指定(nil / 空文字)は「病院を紐付けない」の意味なので許容する。
+func ensureHospitalOwner(ctx context.Context, hospitals repository.HospitalRepository, userID string, hospitalID *string) error {
+	if hospitalID == nil || *hospitalID == "" {
+		return nil
+	}
+	h, err := hospitals.FindByID(ctx, *hospitalID)
+	if err != nil {
+		return err
+	}
+	if h == nil {
+		return domain.NewNotFound("病院")
+	}
+	if h.UserID != userID {
+		return domain.NewForbidden("この病院にアクセスする権限がありません")
+	}
+	return nil
+}

--- a/backend/internal/usecase/ownership_flaws_test.go
+++ b/backend/internal/usecase/ownership_flaws_test.go
@@ -1,0 +1,217 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"healthfamily/internal/domain"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
+)
+
+// --- テスト用の最小リポジトリ -------------------------------------------------
+
+type stubMemberRepo struct{ members map[string]*entity.Member }
+
+func (r *stubMemberRepo) FindByID(_ context.Context, id string) (*entity.Member, error) {
+	return r.members[id], nil
+}
+func (r *stubMemberRepo) List(context.Context, string) ([]entity.Member, error) { return nil, nil }
+func (r *stubMemberRepo) ListSummary(context.Context, string) ([]entity.MemberSummary, error) {
+	return nil, nil
+}
+func (r *stubMemberRepo) Create(context.Context, repository.CreateMemberInput) (*entity.Member, error) {
+	return nil, nil
+}
+func (r *stubMemberRepo) Update(context.Context, string, repository.UpdateMemberInput) (*entity.Member, error) {
+	return nil, nil
+}
+func (r *stubMemberRepo) Delete(context.Context, string) error { return nil }
+
+var _ repository.MemberRepository = (*stubMemberRepo)(nil)
+
+type stubHospitalRepo struct{ hospitals map[string]*entity.Hospital }
+
+func (r *stubHospitalRepo) FindByID(_ context.Context, id string) (*entity.Hospital, error) {
+	return r.hospitals[id], nil
+}
+func (r *stubHospitalRepo) List(context.Context, string) ([]entity.Hospital, error) { return nil, nil }
+func (r *stubHospitalRepo) Create(context.Context, repository.CreateHospitalInput) (*entity.Hospital, error) {
+	return nil, nil
+}
+func (r *stubHospitalRepo) Update(context.Context, string, repository.UpdateHospitalInput) (*entity.Hospital, error) {
+	return nil, nil
+}
+func (r *stubHospitalRepo) Delete(context.Context, string) error { return nil }
+
+var _ repository.HospitalRepository = (*stubHospitalRepo)(nil)
+
+func isForbidden(err error) bool {
+	var f *domain.ForbiddenError
+	return errors.As(err, &f)
+}
+
+func isNotFound(err error) bool {
+	var n *domain.NotFoundError
+	return errors.As(err, &n)
+}
+
+// --- 1) appointments の hospitalId ------------------------------------------
+
+// 他人の病院IDを自分の通院記録に紐付けられてはならない。
+// ID を推測できれば、他人の病院データを自分の画面に引き込める。
+func TestEnsureHospitalOwner_他人の病院IDは拒否する(t *testing.T) {
+	hospitals := &stubHospitalRepo{hospitals: map[string]*entity.Hospital{
+		"h-other": {ID: "h-other", UserID: "user-2", Name: "他人の病院"},
+	}}
+	id := "h-other"
+
+	err := ensureHospitalOwner(context.Background(), hospitals, "user-1", &id)
+
+	if err == nil {
+		t.Fatal("他人の病院IDが通ってしまった")
+	}
+	if !isForbidden(err) {
+		t.Fatalf("ForbiddenError を期待したが %T (%v)", err, err)
+	}
+}
+
+func TestEnsureHospitalOwner_存在しない病院IDは拒否する(t *testing.T) {
+	hospitals := &stubHospitalRepo{hospitals: map[string]*entity.Hospital{}}
+	id := "missing"
+
+	err := ensureHospitalOwner(context.Background(), hospitals, "user-1", &id)
+
+	if err == nil || !isNotFound(err) {
+		t.Fatalf("NotFoundError を期待したが %v", err)
+	}
+}
+
+func TestEnsureHospitalOwner_自分の病院IDは通す(t *testing.T) {
+	hospitals := &stubHospitalRepo{hospitals: map[string]*entity.Hospital{
+		"h-own": {ID: "h-own", UserID: "user-1", Name: "かかりつけ"},
+	}}
+	id := "h-own"
+
+	if err := ensureHospitalOwner(context.Background(), hospitals, "user-1", &id); err != nil {
+		t.Fatalf("自分の病院が拒否された: %v", err)
+	}
+}
+
+func TestEnsureHospitalOwner_未指定なら何もしない(t *testing.T) {
+	hospitals := &stubHospitalRepo{hospitals: map[string]*entity.Hospital{}}
+
+	if err := ensureHospitalOwner(context.Background(), hospitals, "user-1", nil); err != nil {
+		t.Fatalf("未指定は許容すべき: %v", err)
+	}
+	empty := ""
+	if err := ensureHospitalOwner(context.Background(), hospitals, "user-1", &empty); err != nil {
+		t.Fatalf("空文字も未指定として許容すべき: %v", err)
+	}
+}
+
+// --- 2) medications の reorder ----------------------------------------------
+
+type reorderMedRepo struct {
+	meds     map[string]*entity.Medication
+	reorders [][]string
+}
+
+func (r *reorderMedRepo) FindByID(_ context.Context, id string) (*entity.Medication, error) {
+	return r.meds[id], nil
+}
+func (r *reorderMedRepo) ListByUser(context.Context, string) ([]entity.Medication, error) {
+	return nil, nil
+}
+func (r *reorderMedRepo) ListByMember(context.Context, string) ([]entity.Medication, error) {
+	return nil, nil
+}
+func (r *reorderMedRepo) ListAlerts(context.Context, string) ([]entity.Medication, error) {
+	return nil, nil
+}
+func (r *reorderMedRepo) Create(context.Context, repository.CreateMedicationInput) (*entity.Medication, error) {
+	return nil, nil
+}
+func (r *reorderMedRepo) Update(context.Context, string, repository.UpdateMedicationInput) (*entity.Medication, error) {
+	return nil, nil
+}
+func (r *reorderMedRepo) UpdateStock(context.Context, string, int) (*entity.Medication, error) {
+	return nil, nil
+}
+func (r *reorderMedRepo) Delete(context.Context, string) error { return nil }
+func (r *reorderMedRepo) Reorder(_ context.Context, _ string, ids []string) error {
+	r.reorders = append(r.reorders, ids)
+	return nil
+}
+
+var _ repository.MedicationRepository = (*reorderMedRepo)(nil)
+
+// 他人の薬IDを混ぜた並び替えは、黙って無視せず拒否する。
+// 無視すると「通った」と誤認され、IDの当たり判定にも使われうる。
+func TestReorder_他人の薬IDが混ざっていたら拒否する(t *testing.T) {
+	repo := &reorderMedRepo{meds: map[string]*entity.Medication{
+		"m-own":   {ID: "m-own", UserID: "user-1"},
+		"m-other": {ID: "m-other", UserID: "user-2"},
+	}}
+	uc := NewMedicationUsecase(repo, &stubMemberRepo{})
+
+	err := uc.Reorder(context.Background(), "user-1", []string{"m-own", "m-other"})
+
+	if err == nil {
+		t.Fatal("他人のIDが混ざっていても成功してしまった")
+	}
+	if !isForbidden(err) {
+		t.Fatalf("ForbiddenError を期待したが %T (%v)", err, err)
+	}
+	if len(repo.reorders) != 0 {
+		t.Fatal("拒否したのに並び替えを実行してはならない")
+	}
+}
+
+func TestReorder_存在しないIDは拒否する(t *testing.T) {
+	repo := &reorderMedRepo{meds: map[string]*entity.Medication{
+		"m-own": {ID: "m-own", UserID: "user-1"},
+	}}
+	uc := NewMedicationUsecase(repo, &stubMemberRepo{})
+
+	err := uc.Reorder(context.Background(), "user-1", []string{"m-own", "missing"})
+
+	if err == nil || !isNotFound(err) {
+		t.Fatalf("NotFoundError を期待したが %v", err)
+	}
+	if len(repo.reorders) != 0 {
+		t.Fatal("拒否したのに並び替えを実行してはならない")
+	}
+}
+
+func TestReorder_すべて自分の薬なら通す(t *testing.T) {
+	repo := &reorderMedRepo{meds: map[string]*entity.Medication{
+		"m-1": {ID: "m-1", UserID: "user-1"},
+		"m-2": {ID: "m-2", UserID: "user-1"},
+	}}
+	uc := NewMedicationUsecase(repo, &stubMemberRepo{})
+
+	if err := uc.Reorder(context.Background(), "user-1", []string{"m-2", "m-1"}); err != nil {
+		t.Fatalf("自分の薬だけなのに拒否された: %v", err)
+	}
+	if len(repo.reorders) != 1 {
+		t.Fatal("並び替えが実行されていない")
+	}
+}
+
+func TestReorder_同じIDの重複は拒否する(t *testing.T) {
+	repo := &reorderMedRepo{meds: map[string]*entity.Medication{
+		"m-1": {ID: "m-1", UserID: "user-1"},
+	}}
+	uc := NewMedicationUsecase(repo, &stubMemberRepo{})
+
+	err := uc.Reorder(context.Background(), "user-1", []string{"m-1", "m-1"})
+
+	if err == nil {
+		t.Fatal("重複は並び順が定まらないので拒否すべき")
+	}
+	if len(repo.reorders) != 0 {
+		t.Fatal("拒否したのに並び替えを実行してはならない")
+	}
+}


### PR DESCRIPTION
## Summary

Java 移植のために Go 実装を精査する過程で見つかった 4 件。いずれも**攻撃・不具合を再現するテストを先に書いて red を確認してから**直した。

### 1. 通院予定の `hospitalId` に所有権チェックが無い（最優先）

汎用CRUD（`MemberScopedCRUD`）は `memberId` しか見ないため、`hospitalId` が素通しだった。**他人の病院IDを推測して自分の通院予定に紐付ければ、その病院の情報を自分の画面へ引き込める。**

`AppointmentUsecase` を用意して確認を追加。更新で他人の病院へ付け替える経路も塞いだ。

### 2. `POST /medications/reorder` に所有権チェックが無い

リポジトリの `WHERE` 句に頼っており、**他人のIDや存在しないIDを混ぜても黙って無視され 200 が返っていた**。呼び出し側は成功したと誤認するうえ、応答が変わらないことを利用して**IDの当たり判定**にも使えた。

並び替える前に全IDの所有権を確認し、重複（並び順が一意に定まらない）も拒否するようにした。

### 3. `PATCH /medications/{id}/stock` でキー省略時に在庫が 0 になる

値型で受けていたため、**キー省略が Go のゼロ値 `0` と区別できなかった**。他の意図で叩いたリクエストで在庫が消える。

ポインタ受けにして「未指定」と「0 を指定」を区別し、負数も拒否する。

### 4. レート制限のエントリが回収されず無制限に増える

認証前のエンドポイントは IP をキーにするため、**IP を変えながら叩かれるとメモリを食い潰される**。256MiB のコンテナでは実害がある。

期限切れエントリの回収を追加（1分間隔）。あわせて、プロセス内完結のため実効上限が「設定値 × インスタンス数」になることをコメントで明示した。厳密な全体制限が必要になったら共有ストアか前段での制限へ移す。

## 検証

ローカルの Go サーバー（compose の PostgreSQL）で 3 件の攻撃を実行し、いずれも拒否されることを確認した。

```
1) 他人の病院IDを紐付け → {"error":"この病院にアクセスする権限がありません"}
2) 他人の薬IDを混ぜた並び替え → {"error":"この薬にアクセスする権限がありません"}
3) stockQuantity 省略 → 400、在庫は 10 のまま保持
```

`go build` / `go vet` / `go test ./...` すべて通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 予約の作成・更新時に、指定した病院の所有権を確認するようになりました。
  - レート制限で期限切れの記録を自動的に整理し、安定性を向上しました。

- **バグ修正**
  - 在庫数で「未指定」と「0」を正しく区別するようになりました。
  - 未指定・負数・不正な在庫数はエラーとして処理します。
  - 薬の並び替えで、他の利用者の薬・存在しない薬・重複指定を拒否します。

- **テスト**
  - 予約、在庫更新、所有権確認、並び替え、レート制限の動作検証を拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->