### PR TITLE
feat(auth): Googleログインを認可コードグラント + PKCE に対応させる

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -59,8 +59,17 @@ func main() {
 	budgetRepo := persistence.NewBudgetRepository(db)
 	dashboardPrefRepo := persistence.NewDashboardPreferenceRepository(db)
 
+	authUsecase := usecase.NewAuthUsecase(userRepo, tm, mail, google)
+	// client_secret がある時だけ認可コードグラントを有効にする。
+	// 中途半端に有効化すると、失敗の理由が分かりにくい形で表に出る
+	if cfg.GoogleClientID != "" && cfg.GoogleClientSecret != "" {
+		authUsecase.WithGoogleExchanger(
+			googleauth.NewExchanger(cfg.GoogleClientID, cfg.GoogleClientSecret, googleauth.TokenEndpoint, nil),
+		)
+	}
+
 	handlers := &router.Handlers{
-		Auth:       handler.NewAuthHandler(usecase.NewAuthUsecase(userRepo, tm, mail, google), cfg.E2ETestLoginSecret),
+		Auth:       handler.NewAuthHandler(authUsecase, cfg.E2ETestLoginSecret),
 		Member:     handler.NewMemberHandler(usecase.NewMemberUsecase(memberRepo)),
 		Medication: handler.NewMedicationHandler(usecase.NewMedicationUsecase(medRepo, memberRepo)),
 		Schedule:   handler.NewScheduleHandler(usecase.NewScheduleUsecase(schedRepo, medRepo)),

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -17,6 +17,9 @@ type Config struct {
 	AppBaseURL     string
 	// Google OIDC ログイン用 OAuth クライアントID。空なら Google ログイン無効。
 	GoogleClientID string
+	// 認可コードグラント用のクライアントシークレット。
+	// 空なら /google/callback は無効。ID トークン方式 (/google) だけが残る。
+	GoogleClientSecret string
 	// E2Eテスト用ログインバイパスの共有シークレット。空なら無効(本番)。
 	E2ETestLoginSecret string
 }
@@ -31,6 +34,7 @@ func Load() (*Config, error) {
 		MailFrom:           getEnv("MAIL_FROM", "HealthFamily <onboarding@resend.dev>"),
 		AppBaseURL:         getEnv("APP_BASE_URL", "http://localhost:5173"),
 		GoogleClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+		GoogleClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		E2ETestLoginSecret: os.Getenv("E2E_TEST_LOGIN_SECRET"),
 	}
 

--- a/backend/internal/interface/handler/auth_handler.go
+++ b/backend/internal/interface/handler/auth_handler.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"crypto/subtle"
 	"github.com/gin-gonic/gin"
+
+	"healthfamily/internal/pkg/googleauth"
 	"healthfamily/internal/pkg/response"
 	"healthfamily/internal/usecase"
 )
@@ -57,6 +59,34 @@ func (h *AuthHandler) GoogleLogin(c *gin.Context) {
 		return
 	}
 	token, user, err := h.uc.LoginWithGoogle(c.Request.Context(), req.Credential)
+	if err != nil {
+		response.HandleDomainError(c, err)
+		return
+	}
+	response.Success(c, gin.H{"token": token, "user": user})
+}
+
+type googleCallbackRequest struct {
+	Code         string `json:"code" binding:"required"`
+	CodeVerifier string `json:"codeVerifier" binding:"required"`
+	RedirectURI  string `json:"redirectUri" binding:"required"`
+}
+
+// GoogleCallback は認可コードグラント (PKCE) でログインする。
+//
+// ブラウザが持つのは一度きりの認可コードだけで、ID トークンもリフレッシュトークンも
+// 渡らない。トークンへの交換は client_secret を持つこのサーバーだけが行える。
+func (h *AuthHandler) GoogleCallback(c *gin.Context) {
+	var req googleCallbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.Error(c, 400, "認証情報が正しくありません")
+		return
+	}
+	token, user, err := h.uc.LoginWithGoogleCode(c.Request.Context(), googleauth.CodeGrant{
+		Code:         req.Code,
+		CodeVerifier: req.CodeVerifier,
+		RedirectURI:  req.RedirectURI,
+	})
 	if err != nil {
 		response.HandleDomainError(c, err)
 		return

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -54,6 +54,7 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 		authGroup.POST("/verify", ipLimit("verify", 20), h.Auth.Verify)
 		authGroup.POST("/login", ipLimit("login", 20), h.Auth.Login)
 		authGroup.POST("/google", ipLimit("google", 20), h.Auth.GoogleLogin)
+		authGroup.POST("/google/callback", ipLimit("google-callback", 20), h.Auth.GoogleCallback)
 		authGroup.POST("/resend-code", ipLimit("resend", 5), h.Auth.ResendCode)
 		authGroup.POST("/forgot-password", ipLimit("forgot", 5), h.Auth.ForgotPassword)
 		authGroup.POST("/reset-password", ipLimit("reset", 5), h.Auth.ResetPassword)

--- a/backend/internal/pkg/googleauth/exchange.go
+++ b/backend/internal/pkg/googleauth/exchange.go
@@ -1,0 +1,123 @@
+package googleauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// TokenEndpoint は Google の本番トークンエンドポイント
+const TokenEndpoint = "https://oauth2.googleapis.com/token"
+
+// codeVerifier の長さ。RFC 7636 が定める範囲
+const (
+	minVerifierLength = 43
+	maxVerifierLength = 128
+)
+
+// CodeGrant はブラウザから受け取る認可コードグラント一式。
+//
+// ブラウザが持つのはここにある 3 つだけで、ID トークンもリフレッシュトークンも渡らない。
+// 交換に必要な client_secret はサーバーしか知らないため、
+// 認可コードが漏れても第三者はトークンにできない。
+type CodeGrant struct {
+	Code         string
+	CodeVerifier string
+	RedirectURI  string
+}
+
+// Validate は Google へ投げる前に形式を確かめる。
+//
+// code_verifier の長さを見るのは、短い合言葉を許すと PKCE が
+// 総当たり可能になり、認可コード横取りを防げなくなるため。
+func (g CodeGrant) Validate() error {
+	if strings.TrimSpace(g.Code) == "" {
+		return errors.New("認可コードが指定されていません")
+	}
+	if strings.TrimSpace(g.RedirectURI) == "" {
+		return errors.New("リダイレクトURIが指定されていません")
+	}
+	n := len(g.CodeVerifier)
+	if n < minVerifierLength || n > maxVerifierLength {
+		return fmt.Errorf("code_verifier は %d〜%d 文字である必要があります", minVerifierLength, maxVerifierLength)
+	}
+	return nil
+}
+
+// Exchanger は認可コードを ID トークンに交換する抽象 (テストで差し替え可能にする)
+type Exchanger interface {
+	Exchange(ctx context.Context, grant CodeGrant) (string, error)
+}
+
+type exchanger struct {
+	clientID     string
+	clientSecret string
+	endpoint     string
+	client       *http.Client
+}
+
+// NewExchanger は Google のトークンエンドポイントと通信する Exchanger を返す。
+func NewExchanger(clientID, clientSecret, endpoint string, client *http.Client) Exchanger {
+	if endpoint == "" {
+		endpoint = TokenEndpoint
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &exchanger{clientID: clientID, clientSecret: clientSecret, endpoint: endpoint, client: client}
+}
+
+func (e *exchanger) Exchange(ctx context.Context, grant CodeGrant) (string, error) {
+	if err := grant.Validate(); err != nil {
+		return "", err
+	}
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {grant.Code},
+		"code_verifier": {grant.CodeVerifier},
+		"redirect_uri":  {grant.RedirectURI},
+		"client_id":     {e.clientID},
+		"client_secret": {e.clientSecret},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := e.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("exchange authorization code: %w", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	// 応答は素直に読み切る。上限を設けるのは、壊れた相手に無限に付き合わないため
+	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("read token response: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		// Google の応答本文はそのまま返さない。利用者に見せる情報ではないうえ、
+		// ここを素通しすると内部の設定が応答に混ざりうる
+		return "", fmt.Errorf("google token endpoint returned %d", res.StatusCode)
+	}
+
+	var payload struct {
+		IDToken string `json:"id_token"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+	if payload.IDToken == "" {
+		return "", errors.New("google token response has no id_token")
+	}
+	return payload.IDToken, nil
+}

--- a/backend/internal/pkg/googleauth/exchange_test.go
+++ b/backend/internal/pkg/googleauth/exchange_test.go
@@ -1,0 +1,129 @@
+package googleauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// 認可コードグラントの肝は「交換をサーバー間で行い、ID トークンをブラウザに渡さない」こと。
+// ブラウザが受け取るのは一度きりの認可コードだけで、それ単体では
+// client_secret と code_verifier が無ければトークンにならない。
+func TestExchangerSendsTheRightRequest(t *testing.T) {
+	var got url.Values
+	var contentType string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("フォームを読めない: %v", err)
+		}
+		got = r.PostForm
+		contentType = r.Header.Get("Content-Type")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id_token": "the-id-token"})
+	}))
+	defer server.Close()
+
+	ex := NewExchanger("client-id", "client-secret", server.URL, http.DefaultClient)
+	idToken, err := ex.Exchange(context.Background(), CodeGrant{
+		Code:         "the-code",
+		CodeVerifier: strings.Repeat("v", 43),
+		RedirectURI:  "https://app.example.com/auth/callback",
+	})
+	if err != nil {
+		t.Fatalf("交換に失敗: %v", err)
+	}
+
+	if idToken != "the-id-token" {
+		t.Errorf("id_token = %q, want %q", idToken, "the-id-token")
+	}
+	if !strings.HasPrefix(contentType, "application/x-www-form-urlencoded") {
+		t.Errorf("Content-Type = %q", contentType)
+	}
+
+	// PKCE の合言葉を送らないと、盗まれた認可コードだけで交換が通ってしまう
+	for key, want := range map[string]string{
+		"grant_type":    "authorization_code",
+		"code":          "the-code",
+		"code_verifier": strings.Repeat("v", 43),
+		"redirect_uri":  "https://app.example.com/auth/callback",
+		"client_id":     "client-id",
+		"client_secret": "client-secret",
+	} {
+		if got.Get(key) != want {
+			t.Errorf("%s = %q, want %q", key, got.Get(key), want)
+		}
+	}
+}
+
+func TestExchangerRejectsGoogleErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer server.Close()
+
+	ex := NewExchanger("client-id", "client-secret", server.URL, http.DefaultClient)
+	_, err := ex.Exchange(context.Background(), CodeGrant{
+		Code:         "used-already",
+		CodeVerifier: strings.Repeat("v", 43),
+		RedirectURI:  "https://app.example.com/auth/callback",
+	})
+	if err == nil {
+		t.Fatal("Google が拒否したのに成功として扱っている")
+	}
+}
+
+// Google の応答に id_token が無いのに成功扱いすると、空文字を検証しにいって
+// 分かりにくい失敗になる。ここで止める。
+func TestExchangerRequiresIDToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"only-this"}`))
+	}))
+	defer server.Close()
+
+	ex := NewExchanger("client-id", "client-secret", server.URL, http.DefaultClient)
+	if _, err := ex.Exchange(context.Background(), CodeGrant{
+		Code:         "c",
+		CodeVerifier: strings.Repeat("v", 43),
+		RedirectURI:  "https://app.example.com/auth/callback",
+	}); err == nil {
+		t.Fatal("id_token が無いのに成功として扱っている")
+	}
+}
+
+func TestCodeGrantValidation(t *testing.T) {
+	cases := map[string]CodeGrant{
+		"コードが空":            {Code: "", CodeVerifier: strings.Repeat("v", 43), RedirectURI: "https://a.example.com/cb"},
+		"code_verifier が空": {Code: "c", CodeVerifier: "", RedirectURI: "https://a.example.com/cb"},
+		"code_verifier が短い": {Code: "c", CodeVerifier: strings.Repeat("v", 42), RedirectURI: "https://a.example.com/cb"},
+		"code_verifier が長い": {Code: "c", CodeVerifier: strings.Repeat("v", 129), RedirectURI: "https://a.example.com/cb"},
+		"redirect_uri が空":  {Code: "c", CodeVerifier: strings.Repeat("v", 43), RedirectURI: ""},
+	}
+
+	for name, grant := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := grant.Validate(); err == nil {
+				t.Error("不正な入力を受け入れている")
+			}
+		})
+	}
+}
+
+func TestCodeGrantAcceptsValidInput(t *testing.T) {
+	// RFC 7636 は code_verifier を 43〜128 文字と定める
+	for _, length := range []int{43, 128} {
+		grant := CodeGrant{
+			Code:         "c",
+			CodeVerifier: strings.Repeat("v", length),
+			RedirectURI:  "https://a.example.com/cb",
+		}
+		if err := grant.Validate(); err != nil {
+			t.Errorf("長さ %d を拒否している: %v", length, err)
+		}
+	}
+}

--- a/backend/internal/usecase/auth_google_code_test.go
+++ b/backend/internal/usecase/auth_google_code_test.go
@@ -1,0 +1,149 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"healthfamily/internal/pkg/auth"
+	"healthfamily/internal/pkg/googleauth"
+)
+
+// 認可コードグラントでのログイン。
+//
+// ブラウザには一度きりの認可コードしか渡らず、ID トークンへの交換は
+// client_secret を持つサーバーだけが行える。ID トークンをブラウザに置く
+// 方式より、盗み見や保存の事故に強い。
+
+// 交換に渡された内容を記録する偽物。ID トークンの検証にも記録が要るので、
+// 既存の fakeGoogleVerifier ではなくこちらで受け取った資格情報を控える。
+type recordingVerifier struct {
+	claims     *googleauth.Claims
+	err        error
+	credential string
+}
+
+func (r *recordingVerifier) Verify(_ context.Context, credential string) (*googleauth.Claims, error) {
+	r.credential = credential
+	return r.claims, r.err
+}
+
+type stubExchanger struct {
+	gotGrant googleauth.CodeGrant
+	idToken  string
+	err      error
+	calls    int
+}
+
+func (s *stubExchanger) Exchange(_ context.Context, grant googleauth.CodeGrant) (string, error) {
+	s.calls++
+	s.gotGrant = grant
+	return s.idToken, s.err
+}
+
+func validGrant() googleauth.CodeGrant {
+	return googleauth.CodeGrant{
+		Code:         "the-code",
+		CodeVerifier: strings.Repeat("v", 43),
+		RedirectURI:  "https://app.example.com/auth/callback",
+	}
+}
+
+func newCodeGrantUsecase(
+	repo *fakeUserRepo, v googleauth.Verifier, ex googleauth.Exchanger,
+) *AuthUsecase {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	uc := NewAuthUsecase(repo, tm, nil, v)
+	uc.WithGoogleExchanger(ex)
+	return uc
+}
+
+func TestLoginWithGoogleCode_交換してから検証する(t *testing.T) {
+	repo := &fakeUserRepo{}
+	verifier := &recordingVerifier{claims: &googleauth.Claims{
+		Sub: "sub-1", Email: "user@example.com", EmailVerified: true,
+	}}
+	exchanger := &stubExchanger{idToken: "exchanged-id-token"}
+	uc := newCodeGrantUsecase(repo, verifier, exchanger)
+
+	token, user, err := uc.LoginWithGoogleCode(context.Background(), validGrant())
+	if err != nil {
+		t.Fatalf("ログインに失敗: %v", err)
+	}
+
+	if exchanger.calls != 1 {
+		t.Errorf("交換の回数 = %d, want 1", exchanger.calls)
+	}
+	if exchanger.gotGrant != validGrant() {
+		t.Errorf("交換に渡した内容が違う: %+v", exchanger.gotGrant)
+	}
+	if verifier.credential != "exchanged-id-token" {
+		t.Errorf("検証したのは %q。交換で得た ID トークンを検証していない", verifier.credential)
+	}
+	if token == "" || user == nil {
+		t.Fatal("トークンと利用者が返っていない")
+	}
+	if user.Email != "user@example.com" {
+		t.Errorf("email = %q", user.Email)
+	}
+}
+
+func TestLoginWithGoogleCode_壊れた入力はGoogleまで運ばない(t *testing.T) {
+	repo := &fakeUserRepo{}
+	exchanger := &stubExchanger{idToken: "x"}
+	uc := newCodeGrantUsecase(repo, &recordingVerifier{}, exchanger)
+
+	grant := validGrant()
+	grant.CodeVerifier = "too-short"
+
+	if _, _, err := uc.LoginWithGoogleCode(context.Background(), grant); err == nil {
+		t.Fatal("短い code_verifier を受け入れている")
+	}
+	if exchanger.calls != 0 {
+		t.Error("形式が壊れた入力を Google まで運んでいる")
+	}
+}
+
+func TestLoginWithGoogleCode_交換失敗の詳細を漏らさない(t *testing.T) {
+	repo := &fakeUserRepo{}
+	verifier := &recordingVerifier{}
+	exchanger := &stubExchanger{err: errors.New("google said invalid_grant for client 1234")}
+	uc := newCodeGrantUsecase(repo, verifier, exchanger)
+
+	_, _, err := uc.LoginWithGoogleCode(context.Background(), validGrant())
+	if err == nil {
+		t.Fatal("交換に失敗したのに成功として扱っている")
+	}
+	if strings.Contains(err.Error(), "1234") || strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("Google の応答をそのまま利用者に返している: %v", err)
+	}
+	if verifier.credential != "" {
+		t.Error("交換に失敗したのに検証まで進んでいる")
+	}
+}
+
+func TestLoginWithGoogleCode_未設定なら無効(t *testing.T) {
+	repo := &fakeUserRepo{}
+	uc := newCodeGrantUsecase(repo, &recordingVerifier{}, nil)
+
+	if _, _, err := uc.LoginWithGoogleCode(context.Background(), validGrant()); err == nil {
+		t.Fatal("未設定でも動くように見せている")
+	}
+}
+
+func TestLoginWithGoogleCode_メール未確認は拒否(t *testing.T) {
+	repo := &fakeUserRepo{}
+	verifier := &recordingVerifier{claims: &googleauth.Claims{
+		Sub: "sub-2", Email: "unverified@example.com", EmailVerified: false,
+	}}
+	uc := newCodeGrantUsecase(repo, verifier, &stubExchanger{idToken: "t"})
+
+	if _, _, err := uc.LoginWithGoogleCode(context.Background(), validGrant()); err == nil {
+		t.Fatal("Google 側で未確認のメールを受け入れている")
+	}
+	if repo.created != 0 {
+		t.Error("未確認のまま利用者を作っている")
+	}
+}

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -20,7 +20,40 @@ type AuthUsecase struct {
 	tokens *auth.TokenManager
 	mail   mailer.Mailer
 	google googleauth.Verifier // nil なら Google ログイン無効
-	now    func() time.Time
+	// nil なら認可コードグラントは無効。ID トークン方式とは別に設定する
+	exchange googleauth.Exchanger
+	now      func() time.Time
+}
+
+// WithGoogleExchanger は認可コードグラントを有効にする。
+//
+// client_secret を持つ設定でのみ呼ぶ。設定しなければ /google/callback は
+// 「利用できません」を返すだけで、中途半端に動くことはない。
+func (uc *AuthUsecase) WithGoogleExchanger(ex googleauth.Exchanger) *AuthUsecase {
+	uc.exchange = ex
+	return uc
+}
+
+// LoginWithGoogleCode は認可コードグラント (PKCE) でログインする。
+//
+// ブラウザから受け取るのは一度きりの認可コードだけで、ID トークンはここで
+// サーバー間通信により取得する。client_secret を知らない第三者は、
+// 認可コードを盗んでもトークンに換えられない。
+func (uc *AuthUsecase) LoginWithGoogleCode(ctx context.Context, grant googleauth.CodeGrant) (string, *entity.User, error) {
+	if uc.exchange == nil {
+		return "", nil, domain.NewValidation("Googleログインは現在利用できません")
+	}
+	// Google へ投げる前に形式を確かめる。壊れた入力を外部へ運ぶ理由がない
+	if err := grant.Validate(); err != nil {
+		return "", nil, domain.NewValidation("Google認証に失敗しました")
+	}
+
+	idToken, err := uc.exchange.Exchange(ctx, grant)
+	if err != nil {
+		// Google の応答内容は利用者に返さない。設定や状態が応答に混ざりうる
+		return "", nil, domain.NewValidation("Google認証に失敗しました")
+	}
+	return uc.LoginWithGoogle(ctx, idToken)
 }
 
 func NewAuthUsecase(users repository.UserRepository, tokens *auth.TokenManager, mail mailer.Mailer, google googleauth.Verifier) *AuthUsecase {


### PR DESCRIPTION
## Summary

- `/api/auth/google/callback` を追加し、認可コードをサーバー間で ID トークンに交換する
- ブラウザには一度きりの認可コードだけが渡り、ID トークン・リフレッシュトークンは渡らない
- `code_verifier` を RFC 7636 の 43〜128 文字で検証してから Google へ送る
- Google 側の失敗内容はそのまま利用者に返さない
- `GOOGLE_CLIENT_SECRET` が未設定なら該当経路は無効のまま（中途半端に有効化しない）
- 既存の ID トークン方式 `/api/auth/google` は残置

フロントエンドは #1170 で認可コード方式へ移行済みだが、対応する経路がバックエンドに無く Google ログインが機能していなかった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Google OAuthの認可コード方式によるログインに対応しました。
  - PKCEを用いた安全なログイン処理を追加しました。
  - ログイン成功時に、認証トークンとユーザー情報を返します。
  - Googleの認証設定が有効な場合のみ利用できます。
  - 認証コード、リダイレクトURIなどの入力を検証し、不正なリクエストを拒否します。
  - 未確認メールのアカウントはログインできません。
  - 認証コールバックには既存のIPレート制限を適用しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->