### PR TITLE
fix(security): 信頼するプロキシ段数を明示し、デプロイ後に守りを実物で検証する

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -41,11 +41,27 @@ jobs:
             --quiet
 
       - name: Verify health
+        id: health
         run: |
           URL=$(gcloud run services describe healthfamily-api \
             --region asia-northeast1 \
             --project "${{ secrets.GCP_PROJECT_ID }}" \
             --format 'value(status.url)')
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
           code=$(curl -s -o /dev/null -w "%{http_code}" -m 30 "$URL/health")
           echo "health -> HTTP $code"
           [ "$code" = "200" ]
+
+      # 単体テストが緑でも、本番に届いていなければ意味がない。
+      # 実際に「修正を直接デプロイ → 修正の入っていない main から自動デプロイされて
+      # 巻き戻る」という事故が起きた。デプロイのたびに、守れていることを実物で確かめる。
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Verify security invariants against the deployed service
+        working-directory: backend
+        env:
+          SMOKE_BASE_URL: ${{ steps.health.outputs.url }}
+        run: go test ./internal/smoke/ -v -count=1

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -79,7 +79,7 @@ func main() {
 		Dashboard:  handler.NewDashboardPreferenceHandler(usecase.NewDashboardPreferenceUsecase(dashboardPrefRepo)),
 	}
 
-	engine := router.Setup(handlers, tm, db, cfg.AllowedOrigins)
+	engine := router.Setup(handlers, tm, db, cfg.AllowedOrigins, cfg.TrustedProxyHops)
 
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -22,6 +23,25 @@ type Config struct {
 	GoogleClientSecret string
 	// E2Eテスト用ログインバイパスの共有シークレット。空なら無効(本番)。
 	E2ETestLoginSecret string
+	// 自分たちの基盤が X-Forwarded-For に足す段数。
+	// Cloud Run に直接ぶら下げるなら 1、前段が無ければ 0。
+	// 既定を 0 にしているのは、設定し忘れたときに「クライアントの言い値を信じる」
+	// 側へ倒れると、ヘッダを名乗るだけでレート制限を回避されるため。
+	TrustedProxyHops int
+}
+
+// trustedProxyHops は TRUSTED_PROXY_HOPS を読む。
+// 未設定・不正な値・負の値は 0 (ヘッダを信用しない) として扱う。
+func trustedProxyHops() int {
+	raw := os.Getenv("TRUSTED_PROXY_HOPS")
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
 }
 
 // Load は環境変数から設定を読み込む
@@ -36,6 +56,7 @@ func Load() (*Config, error) {
 		GoogleClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		GoogleClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
 		E2ETestLoginSecret: os.Getenv("E2E_TEST_LOGIN_SECRET"),
+		TrustedProxyHops:   trustedProxyHops(),
 	}
 
 	origins := getEnv("ALLOWED_ORIGINS", "http://localhost:5173")

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -30,15 +30,33 @@ type Config struct {
 	TrustedProxyHops int
 }
 
-// trustedProxyHops は TRUSTED_PROXY_HOPS を読む。
-// 未設定・不正な値・負の値は 0 (ヘッダを信用しない) として扱う。
+// trustedProxyHops は、自分たちの基盤が X-Forwarded-For に足す段数を決める。
+//
+// 設定を人手に委ねると、付け忘れた瞬間に静かに壊れる。Cloud Run 上で 0 だと
+// 全利用者が 1 つの枠を共有し、数人が使っただけで全員が締め出される。
+// 逆に前段の無い環境で 1 だと、ヘッダを名乗るだけで上限を回避される。
+// どちらも設定ミスで起きてはならないので、実行環境から既定を決める。
+//
+// K_SERVICE は Cloud Run が必ず設定する。実行環境が与えるものであり
+// リクエストから注入できないため、判定の根拠にしてよい。
+// TRUSTED_PROXY_HOPS を明示すればそちらが優先される。
 func trustedProxyHops() int {
-	raw := os.Getenv("TRUSTED_PROXY_HOPS")
-	if raw == "" {
-		return 0
+	fallback := 0
+	if os.Getenv("K_SERVICE") != "" {
+		// Cloud Run のフロントエンドが右端に実接続元を足す
+		fallback = 1
 	}
-	n, err := strconv.Atoi(strings.TrimSpace(raw))
-	if err != nil || n < 0 {
+
+	raw := strings.TrimSpace(os.Getenv("TRUSTED_PROXY_HOPS"))
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		// 壊れた値で緩む側にも絞りすぎる側にも倒さず、環境から決めた既定に戻す
+		return fallback
+	}
+	if n < 0 {
 		return 0
 	}
 	return n

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,65 @@
+package config
+
+import "testing"
+
+// 信頼するプロキシ段数。
+//
+// 設定を人手に委ねると、付け忘れた瞬間に静かに壊れる。0 のままだと
+// Cloud Run 上では全利用者が 1 つの枠を共有し、数人が使っただけで
+// 全員が締め出される。1 を既定にすると、前段の無い環境で
+// ヘッダを名乗るだけで上限を回避される。どちらも設定ミスで起きてはならない。
+//
+// Cloud Run は K_SERVICE を必ず設定する。これは実行環境が与えるもので
+// リクエストから注入できないため、判定の根拠にしてよい。
+func TestTrustedProxyHops(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want int
+	}{
+		{
+			name: "Cloud Run 上では既定で1段",
+			env:  map[string]string{"K_SERVICE": "healthfamily-api"},
+			want: 1,
+		},
+		{
+			name: "前段の無い環境では既定で0段",
+			env:  map[string]string{},
+			want: 0,
+		},
+		{
+			name: "明示した値が優先される",
+			env:  map[string]string{"K_SERVICE": "healthfamily-api", "TRUSTED_PROXY_HOPS": "2"},
+			want: 2,
+		},
+		{
+			name: "Cloud Run 上でも0を明示できる",
+			env:  map[string]string{"K_SERVICE": "healthfamily-api", "TRUSTED_PROXY_HOPS": "0"},
+			want: 0,
+		},
+		{
+			name: "壊れた値は既定に落とす",
+			env:  map[string]string{"K_SERVICE": "healthfamily-api", "TRUSTED_PROXY_HOPS": "いくつか"},
+			want: 1,
+		},
+		{
+			name: "負の値は0として扱う",
+			env:  map[string]string{"TRUSTED_PROXY_HOPS": "-3"},
+			want: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("K_SERVICE", "")
+			t.Setenv("TRUSTED_PROXY_HOPS", "")
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			if got := trustedProxyHops(); got != tc.want {
+				t.Errorf("trustedProxyHops() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/interface/middleware/clientip.go
+++ b/backend/internal/interface/middleware/clientip.go
@@ -8,46 +8,52 @@ import (
 
 // ResolveClientIP はレート制限の識別子に使う接続元を返す。
 //
-// Cloud Run のフロントエンドは X-Forwarded-For の「右端」に実際の接続元を足す。
-// クライアントが自分で付けた値は必ずその左側に残るため、右端だけを見れば詐称できない。
+// X-Forwarded-For はクライアントが自由に書ける。信用してよいのは
+// 「自分たちの基盤が付け足した分」だけで、それが何段あるかは配置で決まる。
+// trustedHops はその段数。Cloud Run に直接ぶら下げる場合は 1
+// (フロントエンドが右端に実接続元を足す)。前段が無ければ 0。
 //
-// gin の ClientIP() は既定ですべてのプロキシ (0.0.0.0/0) を信頼し、
-// 右から左へ走査して最後まで到達した結果「左端」を返す。左端はクライアントが
-// 自由に書ける値なので、ヘッダを1リクエストごとに変えるだけで上限が消えていた。
-// 6桁コードの総当たりがそのまま通る状態だったため、ここは gin に任せない。
+// 0 のときはヘッダを一切見ない。「前段に必ずプロキシがいる」を暗黙の前提に
+// すると、直接到達できる経路ができた瞬間に、ヘッダを名乗るだけで上限を
+// 回避されるのに誰も気づけない。設定し忘れたときは緩む側ではなく絞る側に倒す。
 //
-// リバースプロキシを増やす場合は「右端が自分たちの基盤が付けた値である」ことが
-// 前提になる。前段を足すときは、この関数と一緒に見直すこと。
-func ResolveClientIP(r *http.Request) string {
-	if ip := rightmostForwardedFor(r.Header.Get("X-Forwarded-For")); ip != "" {
+// gin の ClientIP() を使わないのは、既定で全プロキシ (0.0.0.0/0) を信頼し、
+// 右から左へ走査した末に「左端」を返すため。左端はクライアントの言い値であり、
+// 実際にこれで認証系のレート制限が丸ごと無効になっていた。
+func ResolveClientIP(r *http.Request, trustedHops int) string {
+	if ip := forwardedForAt(r.Header.Get("X-Forwarded-For"), trustedHops); ip != "" {
 		return ip
 	}
-	// ヘッダが無い・壊れている場合は接続元に退避する。
-	// 「識別できないから通す」ではなく「まとめて絞る」側に倒す
+	// 識別できないときは通し放題にせず、接続元単位でまとめて絞る
 	return remoteAddrIP(r.RemoteAddr)
 }
 
-// rightmostForwardedFor は X-Forwarded-For の右端を返す。IP として読めなければ空文字。
+// forwardedForAt は、右から trustedHops 番目 (1 始まり) の値を返す。
+// 段数が 0 以下、要素が足りない、IP として読めない場合は空文字。
 //
-// 右端が壊れている場合に左へ遡らないのは、遡った先がクライアントの書いた値であり、
-// 壊れた値を送るだけで好きな識別子を名乗れてしまうため。
-func rightmostForwardedFor(header string) string {
-	if header == "" {
+// 足りないときに左へ遡らないのは、遡った先がクライアントの書いた値であり、
+// 短いヘッダを送るだけで好きな識別子を名乗れてしまうため。
+func forwardedForAt(header string, trustedHops int) string {
+	if trustedHops <= 0 || header == "" {
 		return ""
 	}
 	hops := strings.Split(header, ",")
-	last := strings.TrimSpace(hops[len(hops)-1])
-	if last == "" {
+	idx := len(hops) - trustedHops
+	if idx < 0 {
+		return ""
+	}
+	candidate := strings.TrimSpace(hops[idx])
+	if candidate == "" {
 		return ""
 	}
 	// "[2001:db8::1]:443" のような形も受け付ける
-	if host, _, err := net.SplitHostPort(last); err == nil {
-		last = host
+	if host, _, err := net.SplitHostPort(candidate); err == nil {
+		candidate = host
 	}
-	if net.ParseIP(last) == nil {
+	if net.ParseIP(candidate) == nil {
 		return ""
 	}
-	return last
+	return candidate
 }
 
 func remoteAddrIP(remoteAddr string) string {

--- a/backend/internal/interface/middleware/clientip_test.go
+++ b/backend/internal/interface/middleware/clientip_test.go
@@ -7,63 +7,102 @@ import (
 
 // レート制限の識別子は、攻撃者が書き換えられない値でなければ意味がない。
 //
-// Cloud Run のフロントエンドは X-Forwarded-For の「右端」に実際の接続元を足す。
-// クライアントが自分で付けた値は必ずその左側に残るので、右端だけを見れば詐称できない。
-// gin の既定はすべてのプロキシを信頼して「左端」を採るため、
-// ヘッダを1リクエストごとに変えるだけで上限が消えていた。
+// X-Forwarded-For はクライアントが自由に書ける。信用してよいのは
+// 「自分たちの基盤が付け足した分」だけで、それが何段あるかは配置で決まる。
+// 段数を設定として明示し、既定は 0 (ヘッダを一切信用しない) にする。
+//
+// 「前段に必ずプロキシがいる」を暗黙の前提にすると、直接到達できる経路が
+// できた瞬間に、ヘッダを名乗るだけで上限を回避されるのに誰も気づけない。
 func TestResolveClientIP(t *testing.T) {
 	cases := []struct {
-		name       string
+		name         string
+		trustedHops  int
 		forwardedFor string
-		remoteAddr string
-		want       string
+		remoteAddr   string
+		want         string
 	}{
 		{
-			name:         "ヘッダが無ければ接続元をそのまま使う",
-			forwardedFor: "",
+			name:         "段数0ならヘッダを一切見ない",
+			trustedHops:  0,
+			forwardedFor: "1.2.3.4",
 			remoteAddr:   "203.0.113.10:54321",
 			want:         "203.0.113.10",
 		},
 		{
-			name:         "1段なら、その値が実クライアント",
+			name:         "段数0では、何を名乗られても接続元だけを見る",
+			trustedHops:  0,
+			forwardedFor: "1.2.3.4, 5.6.7.8, 9.9.9.9",
+			remoteAddr:   "203.0.113.10:54321",
+			want:         "203.0.113.10",
+		},
+		{
+			name:         "段数1なら右端を採る",
+			trustedHops:  1,
 			forwardedFor: "203.0.113.10",
 			remoteAddr:   "169.254.1.1:8080",
 			want:         "203.0.113.10",
 		},
 		{
-			name:         "詐称された値を左に並べられても、右端を採る",
+			name:         "段数1で、詐称された値を左に並べられても右端を採る",
+			trustedHops:  1,
 			forwardedFor: "1.2.3.4, 5.6.7.8, 203.0.113.10",
 			remoteAddr:   "169.254.1.1:8080",
 			want:         "203.0.113.10",
 		},
 		{
+			name:         "段数2なら右から2番目を採る",
+			trustedHops:  2,
+			forwardedFor: "1.2.3.4, 203.0.113.10, 10.0.0.1",
+			remoteAddr:   "169.254.1.1:8080",
+			want:         "203.0.113.10",
+		},
+		{
 			name:         "空白の入り方が違っても揺れない",
+			trustedHops:  1,
 			forwardedFor: "1.2.3.4,203.0.113.10",
 			remoteAddr:   "169.254.1.1:8080",
 			want:         "203.0.113.10",
 		},
 		{
 			name:         "IPv6 でも同じ",
+			trustedHops:  1,
 			forwardedFor: "1.2.3.4, 2001:db8::1",
 			remoteAddr:   "169.254.1.1:8080",
 			want:         "2001:db8::1",
 		},
 		{
-			name:         "右端が IP として壊れていれば接続元へ退避する",
+			name:         "段数より要素が少なければ接続元へ退避する",
+			trustedHops:  2,
+			forwardedFor: "203.0.113.10",
+			remoteAddr:   "169.254.1.1:8080",
+			want:         "169.254.1.1",
+		},
+		{
+			name:         "採るべき位置が IP として壊れていれば接続元へ退避する",
+			trustedHops:  1,
 			forwardedFor: "203.0.113.10, not-an-ip",
 			remoteAddr:   "169.254.1.1:8080",
 			want:         "169.254.1.1",
 		},
 		{
-			name:         "空要素だけを並べても接続元へ退避する",
-			forwardedFor: " , ",
-			remoteAddr:   "169.254.1.1:8080",
-			want:         "169.254.1.1",
+			name:         "ヘッダが無ければ接続元をそのまま使う",
+			trustedHops:  1,
+			forwardedFor: "",
+			remoteAddr:   "203.0.113.10:54321",
+			want:         "203.0.113.10",
 		},
 		{
 			name:         "ポートが付いていない接続元も扱える",
+			trustedHops:  0,
 			forwardedFor: "",
 			remoteAddr:   "203.0.113.10",
+			want:         "203.0.113.10",
+		},
+		{
+			name:         "負の段数は 0 として扱う",
+			trustedHops:  -1,
+			forwardedFor: "1.2.3.4",
+			remoteAddr:   "203.0.113.10:54321",
 			want:         "203.0.113.10",
 		},
 	}
@@ -76,8 +115,8 @@ func TestResolveClientIP(t *testing.T) {
 				req.Header.Set("X-Forwarded-For", tc.forwardedFor)
 			}
 
-			if got := ResolveClientIP(req); got != tc.want {
-				t.Errorf("ResolveClientIP() = %q, want %q", got, tc.want)
+			if got := ResolveClientIP(req, tc.trustedHops); got != tc.want {
+				t.Errorf("ResolveClientIP(hops=%d) = %q, want %q", tc.trustedHops, got, tc.want)
 			}
 		})
 	}
@@ -85,18 +124,25 @@ func TestResolveClientIP(t *testing.T) {
 
 // 攻撃の再現。ヘッダを毎回変えても、同じ枠として数えられなければならない。
 func TestRotatingForwardedHeaderCannotCreateNewBudgets(t *testing.T) {
-	seen := map[string]bool{}
-
-	for i := range 20 {
-		req := httptest.NewRequest("POST", "/api/auth/reset-password", nil)
-		req.RemoteAddr = "169.254.1.1:8080"
-		// 攻撃者が名乗る値だけを変える。右端は Cloud Run が足した実接続元で固定
-		req.Header.Set("X-Forwarded-For", "10.0.0."+string(rune('0'+i%10))+", 203.0.113.10")
-		seen[ResolveClientIP(req)] = true
-	}
-
-	if len(seen) != 1 {
-		t.Errorf("識別子が %d 種類に分かれた。ヘッダを変えるだけで上限を回避できる: %v", len(seen), seen)
+	for _, hops := range []int{0, 1} {
+		seen := map[string]bool{}
+		for i := range 20 {
+			req := httptest.NewRequest("POST", "/api/auth/reset-password", nil)
+			req.RemoteAddr = "169.254.1.1:8080"
+			spoofed := "10.0.0." + string(rune('0'+i%10))
+			if hops == 1 {
+				// 基盤が右端に実接続元を足す配置
+				req.Header.Set("X-Forwarded-For", spoofed+", 203.0.113.10")
+			} else {
+				// 前段が無い配置。攻撃者の値しか入らない
+				req.Header.Set("X-Forwarded-For", spoofed)
+			}
+			seen[ResolveClientIP(req, hops)] = true
+		}
+		if len(seen) != 1 {
+			t.Errorf("段数 %d で識別子が %d 種類に分かれた。ヘッダを変えるだけで上限を回避できる: %v",
+				hops, len(seen), seen)
+		}
 	}
 }
 
@@ -106,7 +152,9 @@ func TestRealIPHeaderIsIgnored(t *testing.T) {
 	req.RemoteAddr = "203.0.113.10:1234"
 	req.Header.Set("X-Real-IP", "1.2.3.4")
 
-	if got := ResolveClientIP(req); got != "203.0.113.10" {
-		t.Errorf("X-Real-IP を信用している: %q", got)
+	for _, hops := range []int{0, 1} {
+		if got := ResolveClientIP(req, hops); got != "203.0.113.10" {
+			t.Errorf("段数 %d で X-Real-IP を信用している: %q", hops, got)
+		}
 	}
 }

--- a/backend/internal/interface/middleware/ratelimit.go
+++ b/backend/internal/interface/middleware/ratelimit.go
@@ -85,7 +85,10 @@ func (rl *rateLimiter) allow(key string, now time.Time) bool {
 
 // RateLimit はユーザーIDまたはIP単位でリクエストを制限する。
 // keyFunc が空文字を返した場合はIPアドレスをキーに使う。
-func RateLimit(name string, max int, window time.Duration, keyFunc func(c *gin.Context) string) gin.HandlerFunc {
+//
+// trustedHops は自分たちの基盤が X-Forwarded-For に足す段数。
+// 0 ならヘッダを一切信用しない。詳しくは ResolveClientIP を参照。
+func RateLimit(name string, max int, window time.Duration, trustedHops int, keyFunc func(c *gin.Context) string) gin.HandlerFunc {
 	rl := getLimiter(name, max, window)
 	return func(c *gin.Context) {
 		key := ""
@@ -96,7 +99,7 @@ func RateLimit(name string, max int, window time.Duration, keyFunc func(c *gin.C
 			// gin の ClientIP() は使わない。既定ですべてのプロキシを信頼し、
 			// クライアントが自由に書ける X-Forwarded-For の左端を返すため、
 			// ヘッダを変えるだけで上限を回避できてしまう
-			key = ResolveClientIP(c.Request)
+			key = ResolveClientIP(c.Request, trustedHops)
 		}
 		if !rl.allow(name+":"+key, time.Now()) {
 			response.Error(c, 429, "リクエストが多すぎます。しばらくしてから再試行してください。")

--- a/backend/internal/interface/middleware/ratelimit_spoof_test.go
+++ b/backend/internal/interface/middleware/ratelimit_spoof_test.go
@@ -21,9 +21,11 @@ func TestRateLimitIgnoresSpoofedForwardedFor(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	const limit = 5
+	// 基盤が右端に実接続元を足す配置 (Cloud Run 直下) を想定する
+	const trustedHops = 1
 	r := gin.New()
 	r.POST("/api/auth/reset-password",
-		RateLimit("spoof-test", limit, time.Minute, nil),
+		RateLimit("spoof-test", limit, time.Minute, trustedHops, nil),
 		func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	send := func(forwardedFor string) int {
@@ -56,9 +58,10 @@ func TestRateLimitStillSeparatesRealClients(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	const limit = 5
+	const trustedHops = 1
 	r := gin.New()
 	r.POST("/api/auth/forgot-password",
-		RateLimit("separation-test", limit, time.Minute, nil),
+		RateLimit("separation-test", limit, time.Minute, trustedHops, nil),
 		func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	send := func(clientIP string) int {

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -25,7 +25,11 @@ type Handlers struct {
 }
 
 // Setup はGinエンジンを構築する
-func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins []string) *gin.Engine {
+//
+// trustedProxyHops は自分たちの基盤が X-Forwarded-For に足す段数。
+// Cloud Run に直接ぶら下げる場合は 1、前段が無ければ 0。
+// 詳しくは middleware.ResolveClientIP を参照。
+func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins []string, trustedProxyHops int) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -48,7 +52,7 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 	authGroup := api.Group("/auth")
 	{
 		ipLimit := func(name string, max int) gin.HandlerFunc {
-			return middleware.RateLimit(name, max, time.Minute, nil)
+			return middleware.RateLimit(name, max, time.Minute, trustedProxyHops, nil)
 		}
 		authGroup.POST("/signup", ipLimit("signup", 10), h.Auth.SignUp)
 		authGroup.POST("/verify", ipLimit("verify", 20), h.Auth.Verify)
@@ -67,7 +71,7 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 	// --- 認証必須 ---
 	authed := api.Group("")
 	authed.Use(middleware.Auth(tm))
-	authed.Use(middleware.RateLimit("api", 120, time.Minute, middleware.PerUser))
+	authed.Use(middleware.RateLimit("api", 120, time.Minute, trustedProxyHops, middleware.PerUser))
 	{
 		authed.GET("/members", h.Member.List)
 		authed.GET("/members/summary", h.Member.Summary)

--- a/backend/internal/interface/router/router_smoke_test.go
+++ b/backend/internal/interface/router/router_smoke_test.go
@@ -25,7 +25,7 @@ func TestSetupRegistersWithoutPanic(t *testing.T) {
 		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(nil, nil, nil, mailer.NewResendMailer("", ""))),
 		Dashboard:  handler.NewDashboardPreferenceHandler(usecase.NewDashboardPreferenceUsecase(nil)),
 	}
-	engine := Setup(h, tm, db, []string{"http://localhost:5173"})
+	engine := Setup(h, tm, db, []string{"http://localhost:5173"}, 0)
 	if engine == nil {
 		t.Fatal("engine is nil")
 	}

--- a/backend/internal/smoke/security_smoke_test.go
+++ b/backend/internal/smoke/security_smoke_test.go
@@ -1,0 +1,173 @@
+// Package smoke は、デプロイ済みのサービスに対して守れていることを確かめる。
+//
+// 単体テストが通っていても、本番に届いていなければ意味がない。実際に
+// 「修正をローカルから直接デプロイ → 別の PR がマージされ、修正の入っていない
+// main から自動デプロイされて巻き戻る」という事故が起きた。単体テストは
+// 全て緑のまま、本番だけが脆弱な状態に戻っていた。
+//
+// ここは SMOKE_BASE_URL が指すサービスへ実際にリクエストを投げる。
+// 指定が無ければスキップするので、通常の go test ./... では走らない。
+package smoke
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+const (
+	// 実在しないアドレス。.invalid は RFC 2606 で予約されており、
+	// 誰かに本当のメールが飛ぶことはない
+	probeEmail = "deploy-smoke-probe@example.invalid"
+
+	// forgot-password の上限。router.go の ipLimit と揃える
+	forgotPasswordLimit = 5
+)
+
+func baseURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("SMOKE_BASE_URL")
+	if url == "" {
+		t.Skip("SMOKE_BASE_URL が未設定のためスキップする")
+	}
+	return url
+}
+
+func client() *http.Client {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func postJSON(t *testing.T, url, path, body string, headers map[string]string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url+path, bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("リクエストを組み立てられない: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	res, err := client().Do(req)
+	if err != nil {
+		t.Fatalf("%s へのリクエストが失敗: %v", path, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	return res.StatusCode
+}
+
+// これが落ちたら、メールアドレスを知っているだけで任意アカウントを
+// 乗っ取れる状態になっている。デプロイを止めること。
+func TestRateLimitCannotBeBypassedByForwardedHeader(t *testing.T) {
+	url := baseURL(t)
+
+	// 上限まで使い切る。ヘッダは毎回変えるが、実接続元は同じ
+	for i := range forgotPasswordLimit {
+		code := postJSON(t, url, "/api/auth/forgot-password",
+			fmt.Sprintf(`{"email":%q}`, probeEmail),
+			map[string]string{"X-Forwarded-For": fmt.Sprintf("192.0.2.%d", i+1)})
+		if code != http.StatusOK {
+			t.Fatalf("上限内の %d 回目で %d が返った。前提が崩れている", i+1, code)
+		}
+	}
+
+	// ここから先は、名乗る値を変えても止まらなければならない
+	for i := range 5 {
+		code := postJSON(t, url, "/api/auth/forgot-password",
+			fmt.Sprintf(`{"email":%q}`, probeEmail),
+			map[string]string{"X-Forwarded-For": fmt.Sprintf("198.51.100.%d", i+1)})
+		if code != http.StatusTooManyRequests {
+			t.Fatalf(
+				"X-Forwarded-For を変えるだけでレート制限を回避できる (%d 回目に %d)。"+
+					"6桁コードの総当たりが通り、任意アカウントを乗っ取られる",
+				i+1, code)
+		}
+	}
+}
+
+// 認証コードを検証せずにトークンを出していないか。
+// 移植元にはこの穴があり、メールアドレスだけで他人になりすませた。
+func TestVerifyDoesNotIssueTokenForBogusCode(t *testing.T) {
+	url := baseURL(t)
+
+	code := postJSON(t, url, "/api/auth/verify",
+		fmt.Sprintf(`{"email":%q,"code":"000000"}`, probeEmail), nil)
+
+	if code == http.StatusOK {
+		t.Fatal("でたらめなコードで認証が通った。認証バイパスが復活している")
+	}
+	if code != http.StatusBadRequest && code != http.StatusTooManyRequests {
+		t.Errorf("想定外の応答: %d", code)
+	}
+}
+
+func TestProtectedEndpointsRequireAuth(t *testing.T) {
+	url := baseURL(t)
+
+	for _, path := range []string{"/api/members", "/api/medications", "/api/users/me"} {
+		req, err := http.NewRequest(http.MethodGet, url+path, nil)
+		if err != nil {
+			t.Fatalf("リクエストを組み立てられない: %v", err)
+		}
+		res, err := client().Do(req)
+		if err != nil {
+			t.Fatalf("%s へのリクエストが失敗: %v", path, err)
+		}
+		status := res.StatusCode
+		_ = res.Body.Close()
+
+		if status != http.StatusUnauthorized {
+			t.Errorf("%s がトークン無しで %d を返した。認可が外れている", path, status)
+		}
+	}
+}
+
+// 署名を検証せずにトークンを受け入れていないか
+func TestForgedTokenIsRejected(t *testing.T) {
+	url := baseURL(t)
+
+	forged := []struct {
+		name  string
+		token string
+	}{
+		{"署名が壊れている", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ4In0.invalid"},
+		{"alg:none", "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ4In0."},
+		{"JWT ですらない", "not-a-token"},
+	}
+
+	for _, f := range forged {
+		t.Run(f.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, url+"/api/users/me", nil)
+			if err != nil {
+				t.Fatalf("リクエストを組み立てられない: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+f.token)
+			res, err := client().Do(req)
+			if err != nil {
+				t.Fatalf("リクエストが失敗: %v", err)
+			}
+			status := res.StatusCode
+			_ = res.Body.Close()
+
+			if status != http.StatusUnauthorized {
+				t.Errorf("偽造トークンが %d で通った", status)
+			}
+		})
+	}
+}
+
+func TestHealthCheckResponds(t *testing.T) {
+	url := baseURL(t)
+
+	res, err := client().Get(url + "/health")
+	if err != nil {
+		t.Fatalf("/health に到達できない: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("/health = %d", res.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

### 直した設計上の弱点

先の修正は `X-Forwarded-For` の右端を無条件に採っており、「前段に必ずプロキシがいる」を暗黙の前提にしていた。Cloud Run では成立するが、直接到達できる経路ができた瞬間に、ヘッダを名乗るだけでレート制限を回避されるのに誰も気づけない。

信頼する段数を明示する設計に変更し、**既定は実行環境から自動で決める**。

- `ResolveClientIP(r, trustedHops)` — 右から `trustedHops` 番目を採る。0 なら XFF を見ない
- 既定は Cloud Run 上（`K_SERVICE` あり）なら `1`、それ以外は `0`
- `TRUSTED_PROXY_HOPS` で明示すればそちらが優先
- 要素が足りない・IP として壊れている場合は `RemoteAddr` に退避（左へ遡らない。遡った先はクライアントの言い値）

段数を人手の設定だけに委ねると、付け忘れた瞬間に静かに壊れる。Cloud Run 上で 0 だと**全利用者が1つの枠を共有し、数人が使っただけで全員が締め出される**。`K_SERVICE` は実行環境が与えるもので、リクエストから注入できないため判定の根拠にしてよい。

### デプロイ後の検証を追加

単体テストが緑でも、本番に届いていなければ意味がない。実際に「修正を直接デプロイ → 修正の入っていない main から自動デプロイされて巻き戻る」という事故が起きており、**そのとき単体テストは全て緑のままだった**。

`internal/smoke` に、デプロイ済みサービスへ実際にリクエストを投げる検証を追加し、`deploy-backend.yml` のデプロイ後に実行する。破れていたらデプロイが失敗する。

| 検証項目 | 落ちたときの意味 |
|---|---|
| ヘッダ詐称でレート制限を回避できない | 6桁コードの総当たりが通り、任意アカウントを乗っ取られる |
| でたらめなコードで認証が通らない | 認証バイパスの復活 |
| 認証必須の経路がトークン無しで 401 | 認可が外れている |
| 偽造トークン（壊れた署名 / `alg:none` / 非JWT）を拒否 | 署名検証が効いていない |

`SMOKE_BASE_URL` 未設定ならスキップするので、通常の `go test ./...` では走らない。宛先は `.invalid`（RFC 2606 予約）なので実際のメールは飛ばない。

### 検証装置が機能することの確認

対比で確かめた。

- 修正を外したビルド → `X-Forwarded-For を変えるだけでレート制限を回避できる (1 回目に 200)` で**落ちる**
- 修正版（前段なし・段数0）→ **通る**

追加の設定作業は不要。