### PR TITLE
fix(security): ログインの応答時間から登録の有無が読めないようにする

### DIFF
--- a/backend/internal/pkg/auth/password.go
+++ b/backend/internal/pkg/auth/password.go
@@ -2,9 +2,16 @@ package auth
 
 import "golang.org/x/crypto/bcrypt"
 
-// HashPassword はパスワードをbcryptでハッシュ化する（cost=12、Next.js実装と同等）
+// BcryptCost は本物のハッシュとダミーの両方が守るコスト (Next.js 実装と同等)。
+//
+// 数値をここ以外に書くと、片方だけ上げたときにダミーが安くなり、
+// 「照合対象が無いときだけ応答が速い」という登録有無の漏れが戻る。
+// DummyPasswordHash はこの値で作り直すこと (password_test.go が見張っている)。
+const BcryptCost = 12
+
+// HashPassword はパスワードをbcryptでハッシュ化する
 func HashPassword(plain string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(plain), 12)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(plain), BcryptCost)
 	return string(bytes), err
 }
 
@@ -12,3 +19,7 @@ func HashPassword(plain string) (string, error) {
 func VerifyPassword(hashed, plain string) bool {
 	return bcrypt.CompareHashAndPassword([]byte(hashed), []byte(plain)) == nil
 }
+
+// DummyPasswordHash は照合対象のハッシュが無いときに VerifyPassword へ渡す身代わり。
+// 対応する平文はランダム生成なので実質存在せず、常に不一致になる。
+const DummyPasswordHash = "$2a$12$7OgpxKUj447TUBLao3sHcOli2AK8T3Tdvtu0ruvn/3IpulT7jHMXG"

--- a/backend/internal/pkg/auth/password_test.go
+++ b/backend/internal/pkg/auth/password_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ダミーハッシュのコストが本物と揃わなくなると、未登録メールのログインだけ
+// 計算が軽くなり、応答時間からアドレスの登録有無が読み取れる。
+// BcryptCost を上げたときにここが落ちれば、ダミーの張り替え忘れに気づける。
+func TestDummyPasswordHash_コストが本物と揃っている(t *testing.T) {
+	cost, err := bcrypt.Cost([]byte(DummyPasswordHash))
+	if err != nil {
+		t.Fatalf("bcryptハッシュとして解釈できない: %v", err)
+	}
+	if cost != BcryptCost {
+		t.Fatalf("ダミーの cost = %d, BcryptCost = %d。"+
+			"BcryptCost に合わせて DummyPasswordHash を作り直すこと", cost, BcryptCost)
+	}
+}
+
+// HashPassword が BcryptCost を使わずに独自の数値へ戻ると、
+// 上の照合が通っていてもダミーと本物のコストがずれる。
+func TestHashPassword_BcryptCostで作られる(t *testing.T) {
+	hashed, err := HashPassword("some-password")
+	if err != nil {
+		t.Fatalf("ハッシュ化に失敗: %v", err)
+	}
+	cost, err := bcrypt.Cost([]byte(hashed))
+	if err != nil {
+		t.Fatalf("bcryptハッシュとして解釈できない: %v", err)
+	}
+	if cost != BcryptCost {
+		t.Fatalf("HashPassword の cost = %d, want %d", cost, BcryptCost)
+	}
+}
+
+func TestDummyPasswordHash_どんなパスワードとも一致しない(t *testing.T) {
+	for _, plain := range []string{"", "password", "123456", DummyPasswordHash} {
+		if VerifyPassword(DummyPasswordHash, plain) {
+			t.Fatalf("ダミーハッシュに一致してしまった: %q", plain)
+		}
+	}
+}

--- a/backend/internal/usecase/auth_login_test.go
+++ b/backend/internal/usecase/auth_login_test.go
@@ -1,0 +1,170 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"healthfamily/internal/domain"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/pkg/auth"
+)
+
+// passwordVerifierSpy はパスワード照合に渡されたハッシュを記録する。
+// 実測時間で判定するテストは環境依存で不安定なため、
+// 「bcryptが必ず1回・実在するハッシュに対して走ったか」を代わりに観測する。
+type passwordVerifierSpy struct {
+	hashes []string
+	result bool
+}
+
+func (s *passwordVerifierSpy) verify(hashed, _ string) bool {
+	s.hashes = append(s.hashes, hashed)
+	return s.result
+}
+
+func newLoginUsecase(users []*entity.User, spy *passwordVerifierSpy) *AuthUsecase {
+	uc := NewAuthUsecase(
+		&fakeUserRepo{users: users},
+		auth.NewTokenManager("test-secret-0123456789abcdef", time.Hour),
+		nil, nil,
+	)
+	if spy != nil {
+		uc.verifyPassword = spy.verify
+	}
+	return uc
+}
+
+// bcryptHashLen は modular crypt 形式の bcrypt ハッシュの長さ。
+// 桁が欠けた値は bcrypt が鍵導出に入る前に弾くため、コストを払ったことにならない。
+const bcryptHashLen = 60
+
+func assertBcryptRanOnce(t *testing.T, hashes []string) {
+	t.Helper()
+	if len(hashes) != 1 {
+		t.Fatalf("パスワード照合の呼び出し回数 = %d, want 1 (0回だと応答が速くなり登録の有無が漏れる)", len(hashes))
+	}
+	if len(hashes[0]) != bcryptHashLen || !strings.HasPrefix(hashes[0], "$2") {
+		t.Fatalf("bcryptハッシュとして成立しない値で照合している (%d文字): %q", len(hashes[0]), hashes[0])
+	}
+}
+
+func TestLogin_未登録メールでもパスワード照合を1回走らせる(t *testing.T) {
+	spy := &passwordVerifierSpy{}
+	uc := newLoginUsecase(nil, spy)
+
+	if _, _, err := uc.Login(context.Background(), "nobody@example.test", "password123"); err == nil {
+		t.Fatal("未登録メールのログインは拒否されるべき")
+	}
+	assertBcryptRanOnce(t, spy.hashes)
+}
+
+// Googleログイン専用アカウントは Password が空。ここで bcrypt が即失敗すると
+// 「未登録」と「Google専用アカウント」の区別まで応答時間から読み取れてしまう。
+func TestLogin_Googleログイン専用アカウントでもパスワード照合を1回走らせる(t *testing.T) {
+	spy := &passwordVerifierSpy{result: true}
+	u := &entity.User{ID: "g1", Email: "google@example.test", Password: "", EmailVerified: true}
+	uc := newLoginUsecase([]*entity.User{u}, spy)
+
+	if _, _, err := uc.Login(context.Background(), "google@example.test", "password123"); err == nil {
+		t.Fatal("パスワード未設定のアカウントにパスワードでログインできてはならない")
+	}
+	assertBcryptRanOnce(t, spy.hashes)
+}
+
+func TestLogin_登録済みでも未登録でも照合回数とメッセージが同じ(t *testing.T) {
+	hashed, err := auth.HashPassword("correct-password")
+	if err != nil {
+		t.Fatalf("ハッシュ化に失敗: %v", err)
+	}
+	known := &entity.User{ID: "u1", Email: "known@example.test", Password: hashed, EmailVerified: true}
+
+	knownSpy := &passwordVerifierSpy{}
+	_, _, errKnown := newLoginUsecase([]*entity.User{known}, knownSpy).
+		Login(context.Background(), "known@example.test", "wrong-password")
+
+	unknownSpy := &passwordVerifierSpy{}
+	_, _, errUnknown := newLoginUsecase([]*entity.User{known}, unknownSpy).
+		Login(context.Background(), "unknown@example.test", "wrong-password")
+
+	if errKnown == nil || errUnknown == nil {
+		t.Fatal("どちらも拒否されるべき")
+	}
+	if errKnown.Error() != errUnknown.Error() {
+		t.Fatalf("メッセージが異なると存在有無が漏れる: %q vs %q", errKnown.Error(), errUnknown.Error())
+	}
+	assertBcryptRanOnce(t, knownSpy.hashes)
+	assertBcryptRanOnce(t, unknownSpy.hashes)
+}
+
+// 差し替え口は nil でも本物の bcrypt 照合へ落ちなければならない。
+// NewAuthUsecase を通さず AuthUsecase{...} を直接組まれたときに、
+// nil 呼び出しで落ちたり、照合が素通りになったりするのを防ぐ。
+func TestLogin_構造体リテラルで組んでも本物の照合が働く(t *testing.T) {
+	hashed, err := auth.HashPassword("correct-password")
+	if err != nil {
+		t.Fatalf("ハッシュ化に失敗: %v", err)
+	}
+	u := &entity.User{ID: "u1", Email: "user@example.test", Password: hashed, EmailVerified: true}
+	uc := &AuthUsecase{
+		users:  &fakeUserRepo{users: []*entity.User{u}},
+		tokens: auth.NewTokenManager("test-secret-0123456789abcdef", time.Hour),
+		now:    time.Now,
+	}
+
+	if _, _, err := uc.Login(context.Background(), "user@example.test", "correct-password"); err != nil {
+		t.Fatalf("正しいパスワードが拒否された: %v", err)
+	}
+	if _, _, err := uc.Login(context.Background(), "user@example.test", "wrong-password"); err == nil {
+		t.Fatal("誤ったパスワードが通った。照合が素通りしている")
+	}
+}
+
+func TestLogin_正しいパスワードでログインできる(t *testing.T) {
+	hashed, err := auth.HashPassword("correct-password")
+	if err != nil {
+		t.Fatalf("ハッシュ化に失敗: %v", err)
+	}
+	u := &entity.User{ID: "u1", Email: "user@example.test", Password: hashed, EmailVerified: true}
+	uc := newLoginUsecase([]*entity.User{u}, nil)
+
+	token, got, err := uc.Login(context.Background(), " User@Example.test ", "correct-password")
+	if err != nil {
+		t.Fatalf("正しいパスワードが拒否された: %v", err)
+	}
+	if token == "" || got == nil || got.ID != "u1" {
+		t.Fatalf("トークンとユーザーが返るべき: token=%q user=%v", token, got)
+	}
+}
+
+func TestLogin_誤ったパスワードを拒否する(t *testing.T) {
+	hashed, err := auth.HashPassword("correct-password")
+	if err != nil {
+		t.Fatalf("ハッシュ化に失敗: %v", err)
+	}
+	u := &entity.User{ID: "u1", Email: "user@example.test", Password: hashed, EmailVerified: true}
+	uc := newLoginUsecase([]*entity.User{u}, nil)
+
+	_, _, err = uc.Login(context.Background(), "user@example.test", "wrong-password")
+	var validation *domain.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("ValidationError を期待したが %T (%v)", err, err)
+	}
+}
+
+func TestLogin_メール未認証は拒否する(t *testing.T) {
+	hashed, err := auth.HashPassword("correct-password")
+	if err != nil {
+		t.Fatalf("ハッシュ化に失敗: %v", err)
+	}
+	u := &entity.User{ID: "u1", Email: "user@example.test", Password: hashed, EmailVerified: false}
+	uc := newLoginUsecase([]*entity.User{u}, nil)
+
+	_, _, err = uc.Login(context.Background(), "user@example.test", "correct-password")
+	var forbidden *domain.ForbiddenError
+	if !errors.As(err, &forbidden) {
+		t.Fatalf("ForbiddenError を期待したが %T (%v)", err, err)
+	}
+}

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -23,6 +23,22 @@ type AuthUsecase struct {
 	// nil なら認可コードグラントは無効。ID トークン方式とは別に設定する
 	exchange googleauth.Exchanger
 	now      func() time.Time
+	// verifyPassword は「bcryptが何回・どのハッシュで走ったか」をテストから
+	// 観測するための差し替え口。実測時間に頼るテストは環境依存で不安定になり、
+	// タイミング対策が外れても気づけないため、この観測点を置いている。
+	// nil のときは本物へ落ちる (passwordVerifier を参照)。
+	verifyPassword func(hashed, plain string) bool
+}
+
+// passwordVerifier は差し替えが無ければ本物の bcrypt 照合を返す。
+//
+// NewAuthUsecase を通さず AuthUsecase{...} を直接組まれても、nil を呼んで
+// 落ちたり、パスワード照合そのものが素通りになったりしないようにする。
+func (uc *AuthUsecase) passwordVerifier() func(hashed, plain string) bool {
+	if uc.verifyPassword == nil {
+		return auth.VerifyPassword
+	}
+	return uc.verifyPassword
 }
 
 // WithGoogleExchanger は認可コードグラントを有効にする。
@@ -169,7 +185,16 @@ func (uc *AuthUsecase) Login(ctx context.Context, email, password string) (strin
 	if err != nil {
 		return "", nil, err
 	}
-	if u == nil || !auth.VerifyPassword(u.Password, password) {
+	// 照合対象が無い場合もダミーハッシュで bcrypt を必ず1回走らせる。
+	// || の短絡評価で照合を飛ばすと、未登録メールへの応答だけ数百ms速くなる。
+	// 応答の中身は登録済みの場合と揃えてあるが、揃っているのは中身だけで、
+	// 時間差が残る限りそこから「そのアドレスは登録済みか」を読み取れてしまう。
+	hashed := auth.DummyPasswordHash
+	loginable := u != nil && u.Password != ""
+	if loginable {
+		hashed = u.Password
+	}
+	if !uc.passwordVerifier()(hashed, password) || !loginable {
 		return "", nil, domain.NewValidation("メールアドレスまたはパスワードが正しくありません")
 	}
 	if !u.EmailVerified {
@@ -215,9 +240,11 @@ func (uc *AuthUsecase) LoginWithGoogle(ctx context.Context, credential string) (
 			}
 		} else {
 			u = &entity.User{
-				ID:            auth.NewID(),
-				Email:         email,
-				Password:      "", // Googleログイン専用 (bcrypt検証は常に失敗するためパスワードログイン不可)
+				ID:    auth.NewID(),
+				Email: email,
+				// パスワード未設定。Login は空を見てダミーハッシュで照合したうえで、
+				// 照合結果によらず拒否するため、パスワードではログインできない
+				Password:      "",
 				DisplayName:   claims.Name,
 				CharacterType: "cat",
 				EmailVerified: true,


### PR DESCRIPTION
## Summary

Go の `||` は短絡評価なので、利用者が見つからないと bcrypt が走らず応答が数百ms速く返っていた。

```go
if u == nil || !auth.VerifyPassword(u.Password, password) {
```

| メールアドレス | 応答時間 | 応答の中身 |
|---|---|---|
| 登録済み | 約 250〜400ms | 同一 |
| 未登録 | 約 5〜20ms | 同一 |

応答の中身は揃えてあったが、**時間差が残る限りそこから「そのアドレスは登録済みか」を読み取れる**。`SignUp` / `Verify` / `ResendCode` / `ForgotPassword` では応答内容の穴を意図的に塞いでいたのに、ここだけ抜けていた。健康管理サービスでは利用の事実そのものが機微な情報になる。

### 変更

- 照合対象が無い場合もダミーハッシュで bcrypt を必ず1回走らせる
- ダミーは**実在する cost 12 のハッシュ**。空文字だと bcrypt が計算せず即座に失敗を返すため、かえって未登録を時間で教えることになる
- ハッシュ化コストを定数で共有。片方だけ上げるとダミーが安くなり、防御が静かに消えるのを防ぐ
- Google ログイン専用（パスワードが空）も同じ経路を通す

### 入れなかったもの

CPU 消費を縛るためのエンドポイント全体のレート制限は**意図的に見送った**。

- 攻撃者が送信元を2つ用意するだけで、**全利用者のログインを止められる**
- その枠は bcrypt を一切走らせない不正な JSON でも消費できる（レート制限はハンドラより前段で、`ShouldBindJSON` の失敗は 400 で返る）

守りたい対象を守らずに可用性だけを失う。IP 単位の 20回/分は据え置き、CPU 負荷は Cloud Run のオートスケール（maxScale 20）に委ねる。

### テストが形骸化していないことの確認

修正を短絡評価に戻すと3件が落ちる。

```
--- FAIL: TestLogin_未登録メールでもパスワード照合を1回走らせる
--- FAIL: TestLogin_Googleログイン専用アカウントでもパスワード照合を1回走らせる
--- FAIL: TestLogin_登録済みでも未登録でも照合回数とメッセージが同じ
```