### PR TITLE
feat(security): パスワード再設定で既存セッションを失効させる

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"healthfamily/internal/infrastructure/database"
 	"healthfamily/internal/infrastructure/persistence"
 	"healthfamily/internal/interface/handler"
+	"healthfamily/internal/interface/middleware"
 	"healthfamily/internal/interface/router"
 	"healthfamily/internal/pkg/auth"
 	"healthfamily/internal/pkg/googleauth"
@@ -79,7 +80,19 @@ func main() {
 		Dashboard:  handler.NewDashboardPreferenceHandler(usecase.NewDashboardPreferenceUsecase(dashboardPrefRepo)),
 	}
 
-	engine := router.Setup(handlers, tm, db, cfg.AllowedOrigins, cfg.TrustedProxyHops)
+	// 永続化層が middleware を知らずに済むよう、両者の結び付けはここで閉じる
+	tokenVersions := middleware.TokenVersionFunc(func(ctx context.Context, userID string) (int, error) {
+		v, found, err := userRepo.TokenVersion(ctx, userID)
+		if err != nil {
+			return 0, err
+		}
+		if !found {
+			return 0, middleware.ErrUserNotFound
+		}
+		return v, nil
+	})
+
+	engine := router.Setup(handlers, tm, tokenVersions, db, cfg.AllowedOrigins, cfg.TrustedProxyHops)
 
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port,

--- a/backend/internal/domain/entity/entities.go
+++ b/backend/internal/domain/entity/entities.go
@@ -17,9 +17,11 @@ type User struct {
 	ResetCode            *string    `json:"-"`
 	ResetCodeExpiry      *time.Time `json:"-"`
 	ResetAttempts        int        `json:"-"`
-	GoogleID             *string    `json:"-"`
-	CreatedAt            time.Time  `json:"createdAt"`
-	UpdatedAt            time.Time  `json:"updatedAt"`
+	// 発行済みトークンの世代。再設定で繰り上げ、古いトークンを失効させる
+	TokenVersion int       `json:"-"`
+	GoogleID     *string   `json:"-"`
+	CreatedAt    time.Time `json:"createdAt"`
+	UpdatedAt    time.Time `json:"updatedAt"`
 }
 
 // Member は家族・ペットのメンバー

--- a/backend/internal/domain/repository/repository.go
+++ b/backend/internal/domain/repository/repository.go
@@ -14,6 +14,9 @@ type UserRepository interface {
 	// TokenVersion は発行済みトークンの世代を返す。found が false なら利用者が存在しない。
 	// 認証のたびに呼ばれるため、行全体ではなくこの1列だけを引く。
 	TokenVersion(ctx context.Context, id string) (version int, found bool, err error)
+	// BumpTokenVersion は発行済みトークンの世代を DB 内で 1 つ繰り上げる。
+	// 読み出した値に足して書き戻すと、並行する Update に巻き戻される。
+	BumpTokenVersion(ctx context.Context, id string) error
 	FindByGoogleID(ctx context.Context, googleID string) (*entity.User, error)
 	Create(ctx context.Context, u *entity.User) error
 	Update(ctx context.Context, u *entity.User) error

--- a/backend/internal/domain/repository/repository.go
+++ b/backend/internal/domain/repository/repository.go
@@ -11,6 +11,9 @@ import (
 type UserRepository interface {
 	FindByEmail(ctx context.Context, email string) (*entity.User, error)
 	FindByID(ctx context.Context, id string) (*entity.User, error)
+	// TokenVersion は発行済みトークンの世代を返す。found が false なら利用者が存在しない。
+	// 認証のたびに呼ばれるため、行全体ではなくこの1列だけを引く。
+	TokenVersion(ctx context.Context, id string) (version int, found bool, err error)
 	FindByGoogleID(ctx context.Context, googleID string) (*entity.User, error)
 	Create(ctx context.Context, u *entity.User) error
 	Update(ctx context.Context, u *entity.User) error

--- a/backend/internal/infrastructure/persistence/gorm_models.go
+++ b/backend/internal/infrastructure/persistence/gorm_models.go
@@ -97,6 +97,7 @@ type gormUser struct {
 	VerificationExpiry   *time.Time `gorm:"column:verificationExpiry"`
 	VerificationAttempts int        `gorm:"column:verificationAttempts;default:0"`
 	ResetAttempts        int        `gorm:"column:resetAttempts;default:0"`
+	TokenVersion         int        `gorm:"column:tokenVersion;default:0"`
 	ResetCode            *string    `gorm:"column:resetCode"`
 	ResetCodeExpiry      *time.Time `gorm:"column:resetCodeExpiry"`
 	GoogleID             *string    `gorm:"column:googleId"`

--- a/backend/internal/infrastructure/persistence/token_version_race_test.go
+++ b/backend/internal/infrastructure/persistence/token_version_race_test.go
@@ -1,0 +1,80 @@
+package persistence
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/infrastructure/database"
+)
+
+// 世代の巻き戻し。
+//
+// 汎用 Update は読み出し時点の値をそのまま書き戻す。パスワード再設定で
+// 世代が 1 に上がった後、まだ 0 を握っている並行リクエストが Update を
+// 完了させると 0 に戻り、失効させたはずの JWT が再び通ってしまう。
+// プロフィール更新のような何気ない操作が、攻撃者を呼び戻す。
+//
+// 実行するには HF_DB_INTEGRATION=1 と DATABASE_URL が要る。
+func TestTokenVersion_並行更新で巻き戻らない(t *testing.T) {
+	if os.Getenv("HF_DB_INTEGRATION") != "1" {
+		t.Skip("HF_DB_INTEGRATION=1 以外はスキップ")
+	}
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Fatal("DATABASE_URL が必要です")
+	}
+	ctx := context.Background()
+	db, err := database.New(ctx, url)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer db.Close()
+
+	const id = "u-token-version-race"
+	cleanup := func() { _, _ = db.Pool.Exec(ctx, `DELETE FROM "User" WHERE "id" = $1`, id) }
+	cleanup()
+	defer cleanup()
+
+	repo := NewUserRepository(db)
+	if err := repo.Create(ctx, &entity.User{
+		ID: id, Email: id + "@example.test", Password: "$2a$12$x", CharacterType: "cat",
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// 別のリクエストが利用者を読み込む。この時点の世代は 0
+	stale, err := repo.FindByID(ctx, id)
+	if err != nil || stale == nil {
+		t.Fatalf("find: %v", err)
+	}
+
+	// その間にパスワード再設定が走り、世代を繰り上げる
+	if err := repo.BumpTokenVersion(ctx, id); err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+
+	// 先に読み込んでいた側が、無関係な項目を更新して保存する
+	name := "更新後の名前"
+	stale.DisplayName = &name
+	if err := repo.Update(ctx, stale); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	after, _, err := repo.TokenVersion(ctx, id)
+	if err != nil {
+		t.Fatalf("token version: %v", err)
+	}
+	if after != 1 {
+		t.Fatalf("世代が %d に巻き戻った。失効させた JWT が再び通る", after)
+	}
+
+	reloaded, err := repo.FindByID(ctx, id)
+	if err != nil || reloaded == nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.DisplayName == nil || *reloaded.DisplayName != name {
+		t.Error("巻き戻しを防ぐ代わりに、通常の更新まで効かなくなっている")
+	}
+}

--- a/backend/internal/infrastructure/persistence/user_repository.go
+++ b/backend/internal/infrastructure/persistence/user_repository.go
@@ -37,6 +37,7 @@ func userFromSqlc(u sqlcgen.User) entity.User {
 		ResetCode:            u.ResetCode,
 		ResetCodeExpiry:      u.ResetCodeExpiry,
 		ResetAttempts:        int(u.ResetAttempts),
+		TokenVersion:         int(u.TokenVersion),
 		GoogleID:             u.GoogleId,
 		CreatedAt:            u.CreatedAt,
 		UpdatedAt:            u.UpdatedAt,
@@ -110,8 +111,24 @@ func (r *UserRepository) Update(ctx context.Context, u *entity.User) error {
 		"resetCode":            u.ResetCode,
 		"resetCodeExpiry":      u.ResetCodeExpiry,
 		"resetAttempts":        u.ResetAttempts,
+		"tokenVersion":         u.TokenVersion,
 		"googleId":             u.GoogleID,
 		"updatedAt":            gorm.Expr("now()"),
 	}
 	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, u.ID).Updates(fields).Error
+}
+
+// TokenVersion は発行済みトークンの世代だけを引く。
+//
+// 認証のたびに呼ばれるので、行全体 (パスワードハッシュや発行中のコードを含む) を
+// 読む FindByID は使わない。
+func (r *UserRepository) TokenVersion(ctx context.Context, id string) (int, bool, error) {
+	v, err := r.q.GetUserTokenVersion(ctx, id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	return int(v), true, nil
 }

--- a/backend/internal/infrastructure/persistence/user_repository.go
+++ b/backend/internal/infrastructure/persistence/user_repository.go
@@ -111,7 +111,6 @@ func (r *UserRepository) Update(ctx context.Context, u *entity.User) error {
 		"resetCode":            u.ResetCode,
 		"resetCodeExpiry":      u.ResetCodeExpiry,
 		"resetAttempts":        u.ResetAttempts,
-		"tokenVersion":         u.TokenVersion,
 		"googleId":             u.GoogleID,
 		"updatedAt":            gorm.Expr("now()"),
 	}
@@ -131,4 +130,14 @@ func (r *UserRepository) TokenVersion(ctx context.Context, id string) (int, bool
 		return 0, false, err
 	}
 	return int(v), true, nil
+}
+
+// BumpTokenVersion は発行済みトークンの世代を DB 内で 1 つ繰り上げる。
+//
+// 読み出した値に 1 を足して書き戻す形にはしない。世代を上げた直後に、
+// 上げる前の値を握った並行リクエストが汎用 Update を完了させると、
+// 世代が巻き戻って失効させたはずの JWT が再び通ってしまう。
+// プロフィール更新のような何気ない操作が攻撃者を呼び戻すことになる。
+func (r *UserRepository) BumpTokenVersion(ctx context.Context, id string) error {
+	return r.q.BumpUserTokenVersion(ctx, id)
 }

--- a/backend/internal/infrastructure/sqlc/queries/user.sql
+++ b/backend/internal/infrastructure/sqlc/queries/user.sql
@@ -1,20 +1,23 @@
 -- name: GetUserByEmail :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",
-       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts"
+       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts", "tokenVersion"
 FROM "User"
 WHERE "email" = $1;
 
 -- name: GetUserByID :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",
-       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts"
+       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts", "tokenVersion"
 FROM "User"
 WHERE "id" = $1;
 
 -- name: GetUserByGoogleID :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",
-       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts"
+       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts", "tokenVersion"
 FROM "User"
 WHERE "googleId" = $1;
+
+-- name: GetUserTokenVersion :one
+SELECT "tokenVersion" FROM "User" WHERE "id" = $1;

--- a/backend/internal/infrastructure/sqlc/queries/user.sql
+++ b/backend/internal/infrastructure/sqlc/queries/user.sql
@@ -21,3 +21,6 @@ WHERE "googleId" = $1;
 
 -- name: GetUserTokenVersion :one
 SELECT "tokenVersion" FROM "User" WHERE "id" = $1;
+
+-- name: BumpUserTokenVersion :exec
+UPDATE "User" SET "tokenVersion" = "tokenVersion" + 1, "updatedAt" = now() WHERE "id" = $1;

--- a/backend/internal/infrastructure/sqlc/sqlcgen/models.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/models.go
@@ -268,6 +268,7 @@ type User struct {
 	UpdatedAt            time.Time
 	GoogleId             *string
 	ResetAttempts        int32
+	TokenVersion         int32
 }
 
 type Vaccination struct {

--- a/backend/internal/infrastructure/sqlc/sqlcgen/user.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/user.sql.go
@@ -12,7 +12,7 @@ import (
 const getUserByEmail = `-- name: GetUserByEmail :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",
-       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts"
+       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts", "tokenVersion"
 FROM "User"
 WHERE "email" = $1
 `
@@ -37,6 +37,7 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.UpdatedAt,
 		&i.GoogleId,
 		&i.ResetAttempts,
+		&i.TokenVersion,
 	)
 	return i, err
 }
@@ -44,7 +45,7 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 const getUserByGoogleID = `-- name: GetUserByGoogleID :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",
-       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts"
+       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts", "tokenVersion"
 FROM "User"
 WHERE "googleId" = $1
 `
@@ -69,6 +70,7 @@ func (q *Queries) GetUserByGoogleID(ctx context.Context, googleid *string) (User
 		&i.UpdatedAt,
 		&i.GoogleId,
 		&i.ResetAttempts,
+		&i.TokenVersion,
 	)
 	return i, err
 }
@@ -76,7 +78,7 @@ func (q *Queries) GetUserByGoogleID(ctx context.Context, googleid *string) (User
 const getUserByID = `-- name: GetUserByID :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",
-       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts"
+       "resetCode", "resetCodeExpiry", "createdAt", "updatedAt", "googleId", "resetAttempts", "tokenVersion"
 FROM "User"
 WHERE "id" = $1
 `
@@ -101,6 +103,18 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (User, error) {
 		&i.UpdatedAt,
 		&i.GoogleId,
 		&i.ResetAttempts,
+		&i.TokenVersion,
 	)
 	return i, err
+}
+
+const getUserTokenVersion = `-- name: GetUserTokenVersion :one
+SELECT "tokenVersion" FROM "User" WHERE "id" = $1
+`
+
+func (q *Queries) GetUserTokenVersion(ctx context.Context, id string) (int32, error) {
+	row := q.db.QueryRow(ctx, getUserTokenVersion, id)
+	var tokenVersion int32
+	err := row.Scan(&tokenVersion)
+	return tokenVersion, err
 }

--- a/backend/internal/infrastructure/sqlc/sqlcgen/user.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/user.sql.go
@@ -9,6 +9,15 @@ import (
 	"context"
 )
 
+const bumpUserTokenVersion = `-- name: BumpUserTokenVersion :exec
+UPDATE "User" SET "tokenVersion" = "tokenVersion" + 1, "updatedAt" = now() WHERE "id" = $1
+`
+
+func (q *Queries) BumpUserTokenVersion(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, bumpUserTokenVersion, id)
+	return err
+}
+
 const getUserByEmail = `-- name: GetUserByEmail :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",

--- a/backend/internal/interface/middleware/auth.go
+++ b/backend/internal/interface/middleware/auth.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"context"
+	"errors"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -11,8 +13,34 @@ import (
 // ContextUserID は認証済みユーザーIDをコンテキストに格納するキー
 const ContextUserID = "userID"
 
-// Auth はAuthorization: Bearer のJWTを検証しuserIDをコンテキストに入れる
-func Auth(tm *auth.TokenManager) gin.HandlerFunc {
+// ErrUserNotFound は照合先の利用者が存在しないことを表す。
+// 問い合わせ自体の失敗と区別する必要があるため、専用のエラーにしている。
+var ErrUserNotFound = errors.New("user not found")
+
+// TokenVersionLookup は保存されているトークン世代を引く。
+//
+// 署名が正しいだけでは失効を判定できない。パスワード再設定で繰り上げた値と
+// 突き合わせて初めて、攻撃者が握っているトークンを拒める。
+type TokenVersionLookup interface {
+	// TokenVersion は利用者が存在しなければ ErrUserNotFound を返す。
+	TokenVersion(ctx context.Context, userID string) (int, error)
+}
+
+// TokenVersionFunc は関数を TokenVersionLookup として使えるようにする。
+// 永続化層がこの層を知る必要が無くなり、両者の結び付けを起動時に閉じ込められる。
+type TokenVersionFunc func(ctx context.Context, userID string) (int, error)
+
+func (f TokenVersionFunc) TokenVersion(ctx context.Context, userID string) (int, error) {
+	return f(ctx, userID)
+}
+
+// Auth はAuthorization: Bearer のJWTを検証しuserIDをコンテキストに入れる。
+//
+// 署名の検証に加えて、トークンに載った世代が現在の値と一致するかを見る。
+// ここを省くと、乗っ取られた利用者がパスワードを変えても攻撃者のトークンが
+// 有効期限(7日)まで通り続ける。1リクエストあたり主キー1件の問い合わせが増えるが、
+// 「パスワードを変えれば追い出せる」を成立させるにはこの照合が要る。
+func Auth(tm *auth.TokenManager, versions TokenVersionLookup) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		header := c.GetHeader("Authorization")
 		if header == "" || !strings.HasPrefix(header, "Bearer ") {
@@ -23,10 +51,35 @@ func Auth(tm *auth.TokenManager) gin.HandlerFunc {
 		token := strings.TrimPrefix(header, "Bearer ")
 		claims, err := tm.Verify(token)
 		if err != nil {
+			// 署名が通らないものは DB を引くまでもない。引くと、でたらめな
+			// トークンを投げるだけで無認証のまま DB を叩けてしまう
 			response.Unauthorized(c)
 			c.Abort()
 			return
 		}
+
+		current, err := versions.TokenVersion(c.Request.Context(), claims.UserID)
+		switch {
+		case errors.Is(err, ErrUserNotFound):
+			// 退会・削除されたアカウントのトークンを生かしておかない
+			response.Unauthorized(c)
+			c.Abort()
+			return
+		case err != nil:
+			// 障害を認証成功に倒すと、DB を落とせば誰でも入れてしまう。
+			// かといって 401 にすると、利用者には「ログインし直せば直る」ように
+			// 見えて何度やっても入れない。区別できる 503 を返す
+			response.Unavailable(c)
+			c.Abort()
+			return
+		}
+
+		if claims.TokenVersion != current {
+			response.Unauthorized(c)
+			c.Abort()
+			return
+		}
+
 		c.Set(ContextUserID, claims.UserID)
 		c.Next()
 	}

--- a/backend/internal/interface/middleware/auth_token_version_test.go
+++ b/backend/internal/interface/middleware/auth_token_version_test.go
@@ -1,0 +1,185 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/pkg/auth"
+)
+
+// トークンに載った版番号と、保存されている版番号を突き合わせる。
+//
+// これが無いと、パスワードを再設定しても攻撃者のトークンが最大7日間
+// そのまま通る。署名は正しいので、署名検証だけでは弾けない。
+
+type stubVersionLookup struct {
+	version int
+	err     error
+	calls   int
+	gotID   string
+}
+
+func (s *stubVersionLookup) TokenVersion(_ context.Context, userID string) (int, error) {
+	s.calls++
+	s.gotID = userID
+	return s.version, s.err
+}
+
+func newAuthEngine(tm *auth.TokenManager, lookup TokenVersionLookup) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/protected", Auth(tm, lookup), func(c *gin.Context) {
+		c.String(http.StatusOK, UserID(c))
+	})
+	return r
+}
+
+func request(r *gin.Engine, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func tokenFor(t *testing.T, tm *auth.TokenManager, version int) string {
+	t.Helper()
+	token, err := tm.Generate("u-1", "user@example.com", version, time.Now())
+	if err != nil {
+		t.Fatalf("トークン発行: %v", err)
+	}
+	return token
+}
+
+func TestAuth_版番号が一致すれば通す(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	lookup := &stubVersionLookup{version: 3}
+
+	w := request(newAuthEngine(tm, lookup), tokenFor(t, tm, 3))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if lookup.gotID != "u-1" {
+		t.Errorf("問い合わせた利用者 = %q", lookup.gotID)
+	}
+}
+
+// 攻撃の再現。パスワード再設定で版番号が繰り上がった後、
+// 攻撃者が握っているトークンは通らなくなる。
+func TestAuth_版番号が古いトークンは拒む(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	stolen := tokenFor(t, tm, 3)
+	// 被害者がパスワードを再設定した
+	lookup := &stubVersionLookup{version: 4}
+
+	w := request(newAuthEngine(tm, lookup), stolen)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401。パスワードを変えても攻撃者を追い出せない", w.Code)
+	}
+}
+
+// 版番号を詐称して新しい値を名乗っても、署名が変わるので通らない。
+// 念のため「大きい値なら通る」実装になっていないことを確かめる。
+func TestAuth_版番号が進んだトークンも拒む(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	lookup := &stubVersionLookup{version: 3}
+
+	w := request(newAuthEngine(tm, lookup), tokenFor(t, tm, 99))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+// 版番号を持たない古いトークンは 0 として扱う。
+// 「クレームが無ければ照合を飛ばす」にすると、クレームを落とすだけで
+// 失効を回避できてしまう。
+func TestAuth_版番号クレームが無いトークンは0として扱う(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+
+	t.Run("保存側も0なら通す", func(t *testing.T) {
+		w := request(newAuthEngine(tm, &stubVersionLookup{version: 0}), tokenFor(t, tm, 0))
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", w.Code)
+		}
+	})
+
+	t.Run("保存側が進んでいれば拒む", func(t *testing.T) {
+		w := request(newAuthEngine(tm, &stubVersionLookup{version: 1}), tokenFor(t, tm, 0))
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", w.Code)
+		}
+	})
+}
+
+// 利用者が消えていれば通さない。
+// 見つからないときに素通しすると、退会したアカウントのトークンが生き続ける。
+func TestAuth_利用者が見つからなければ拒む(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	lookup := &stubVersionLookup{err: ErrUserNotFound}
+
+	w := request(newAuthEngine(tm, lookup), tokenFor(t, tm, 0))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+// DB 障害を「認証成功」に倒すと、DB を落とせば誰でも入れてしまう。
+// かといって 401 にすると、利用者には「ログインし直せば直る」ように見えて
+// 何度やっても入れない。区別できる 503 を返す。
+func TestAuth_問い合わせに失敗したら503(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	lookup := &stubVersionLookup{err: errors.New("connection refused")}
+
+	w := request(newAuthEngine(tm, lookup), tokenFor(t, tm, 0))
+
+	if w.Code == http.StatusOK {
+		t.Fatal("DB 障害で素通しした。DB を落とせば誰でも入れる")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+// 署名が壊れているトークンでは、DB に問い合わせるまでもない。
+// 問い合わせてしまうと、でたらめなトークンを投げるだけで DB を叩ける。
+func TestAuth_署名が無効ならDBに問い合わせない(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	lookup := &stubVersionLookup{version: 0}
+
+	w := request(newAuthEngine(tm, lookup), "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.bogus")
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	if lookup.calls != 0 {
+		t.Errorf("無効なトークンで DB に %d 回問い合わせた", lookup.calls)
+	}
+}
+
+func TestAuth_ヘッダが無ければDBに問い合わせない(t *testing.T) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", time.Hour)
+	lookup := &stubVersionLookup{version: 0}
+
+	w := request(newAuthEngine(tm, lookup), "")
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+	if lookup.calls != 0 {
+		t.Errorf("ヘッダ無しで DB に %d 回問い合わせた", lookup.calls)
+	}
+}
+
+var _ = entity.User{}

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -29,7 +29,7 @@ type Handlers struct {
 // trustedProxyHops は自分たちの基盤が X-Forwarded-For に足す段数。
 // Cloud Run に直接ぶら下げる場合は 1、前段が無ければ 0。
 // 詳しくは middleware.ResolveClientIP を参照。
-func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins []string, trustedProxyHops int) *gin.Engine {
+func Setup(h *Handlers, tm *auth.TokenManager, tokenVersions middleware.TokenVersionLookup, db *database.DB, allowedOrigins []string, trustedProxyHops int) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Logger(), gin.Recovery())
 
@@ -70,7 +70,7 @@ func Setup(h *Handlers, tm *auth.TokenManager, db *database.DB, allowedOrigins [
 
 	// --- 認証必須 ---
 	authed := api.Group("")
-	authed.Use(middleware.Auth(tm))
+	authed.Use(middleware.Auth(tm, tokenVersions))
 	authed.Use(middleware.RateLimit("api", 120, time.Minute, trustedProxyHops, middleware.PerUser))
 	{
 		authed.GET("/members", h.Member.List)

--- a/backend/internal/interface/router/router_smoke_test.go
+++ b/backend/internal/interface/router/router_smoke_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func TestSetupRegistersWithoutPanic(t *testing.T) {
 		Budget:     handler.NewBudgetHandler(usecase.NewBudgetUsecase(nil, nil, nil, mailer.NewResendMailer("", ""))),
 		Dashboard:  handler.NewDashboardPreferenceHandler(usecase.NewDashboardPreferenceUsecase(nil)),
 	}
-	engine := Setup(h, tm, db, []string{"http://localhost:5173"}, 0)
+	engine := Setup(h, tm, noopTokenVersions{}, db, []string{"http://localhost:5173"}, 0)
 	if engine == nil {
 		t.Fatal("engine is nil")
 	}
@@ -34,3 +35,8 @@ func TestSetupRegistersWithoutPanic(t *testing.T) {
 	}
 	t.Logf("registered %d routes", len(engine.Routes()))
 }
+
+// 版番号の照合はここでの関心事ではない。常に一致させて素通しする
+type noopTokenVersions struct{}
+
+func (noopTokenVersions) TokenVersion(context.Context, string) (int, error) { return 0, nil }

--- a/backend/internal/pkg/auth/jwt.go
+++ b/backend/internal/pkg/auth/jwt.go
@@ -14,6 +14,10 @@ var ErrInvalidToken = errors.New("invalid token")
 type Claims struct {
 	UserID string `json:"uid"`
 	Email  string `json:"email"`
+	// TokenVersion は発行時点の世代。保存されている値と食い違うトークンは失効扱いにする。
+	// これが無いと、パスワードを再設定しても攻撃者のトークンが有効期限まで通り続ける。
+	// クレームが無い古いトークンは 0 として読まれる (omitempty を付けない理由でもある)。
+	TokenVersion int `json:"tv"`
 	jwt.RegisteredClaims
 }
 
@@ -28,11 +32,15 @@ func NewTokenManager(secret string, ttl time.Duration) *TokenManager {
 	return &TokenManager{secret: []byte(secret), ttl: ttl}
 }
 
-// Generate はユーザー向けのアクセストークンを発行する
-func (m *TokenManager) Generate(userID, email string, now time.Time) (string, error) {
+// Generate はユーザー向けのアクセストークンを発行する。
+//
+// tokenVersion には発行時点で保存されている値を渡すこと。古い値を渡すと、
+// 発行した直後のリクエストで自分自身が失効扱いになる。
+func (m *TokenManager) Generate(userID, email string, tokenVersion int, now time.Time) (string, error) {
 	claims := Claims{
-		UserID: userID,
-		Email:  email,
+		UserID:       userID,
+		Email:        email,
+		TokenVersion: tokenVersion,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   userID,
 			IssuedAt:  jwt.NewNumericDate(now),

--- a/backend/internal/pkg/response/response.go
+++ b/backend/internal/pkg/response/response.go
@@ -30,6 +30,15 @@ func Unauthorized(c *gin.Context) {
 	Error(c, http.StatusUnauthorized, "認証エラー")
 }
 
+// Unavailable は一時的にサービスできないことを伝える。
+//
+// 認証の可否を判断できない障害で 401 を返すと、利用者には
+// 「ログインし直せば直る」ように見えて何度やっても入れない。
+// 復旧を待てばよいことが分かる形で返す。
+func Unavailable(c *gin.Context) {
+	Error(c, http.StatusServiceUnavailable, "現在サービスを利用できません。しばらくしてから再試行してください。")
+}
+
 // HandleDomainError はドメイン例外をHTTPステータスにマッピングする
 func HandleDomainError(c *gin.Context, err error) {
 	var notFound *domainerr.NotFoundError

--- a/backend/internal/usecase/auth_google_test.go
+++ b/backend/internal/usecase/auth_google_test.go
@@ -190,3 +190,15 @@ func (f *fakeUserRepo) TokenVersion(ctx context.Context, id string) (int, bool, 
 	}
 	return u.TokenVersion, true, nil
 }
+
+// 本物と同じく DB 内加算に相当する。読み出した値を書き戻さない
+func (f *fakeUserRepo) BumpTokenVersion(ctx context.Context, id string) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if u != nil {
+		u.TokenVersion++
+	}
+	return nil
+}

--- a/backend/internal/usecase/auth_google_test.go
+++ b/backend/internal/usecase/auth_google_test.go
@@ -181,3 +181,12 @@ func TestLoginWithGoogle_無効時はエラー(t *testing.T) {
 		t.Fatal("Verifier未設定ならエラーを期待")
 	}
 }
+
+// 保持している利用者の版番号をそのまま返す。存在しなければ found=false。
+func (f *fakeUserRepo) TokenVersion(ctx context.Context, id string) (int, bool, error) {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return 0, false, err
+	}
+	return u.TokenVersion, true, nil
+}

--- a/backend/internal/usecase/auth_session_revocation_test.go
+++ b/backend/internal/usecase/auth_session_revocation_test.go
@@ -1,0 +1,176 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/pkg/auth"
+)
+
+// パスワード再設定による既存セッションの失効。
+//
+// 攻撃者にトークンを握られた利用者が、気づいてパスワードを変えたとする。
+// それでも攻撃者のトークンが最大7日間そのまま使えるなら、アカウント復旧の
+// 導線として機能していない。「パスワードを変えれば追い出せる」は
+// 利用者が当然そう思う挙動でもある。
+//
+// トークンに版番号を載せ、再設定で繰り上げる。鍵の全体ローテーションと違い、
+// 当人のセッションだけを狙って切れる。
+
+func revocationTestUsecase(repo *fakeUserRepo, now time.Time) (*AuthUsecase, *auth.TokenManager) {
+	tm := auth.NewTokenManager("test-secret-test-secret-test-secret", 7*24*time.Hour)
+	uc := NewAuthUsecase(repo, tm, &recordingMailer{}, nil)
+	uc.now = func() time.Time { return now }
+	return uc, tm
+}
+
+func userWithResetCode(now time.Time, code string) *entity.User {
+	expiry := now.Add(10 * time.Minute)
+	hashed, _ := auth.HashPassword("oldpassword1")
+	return &entity.User{
+		ID:              "u-1",
+		Email:           "victim@example.com",
+		Password:        hashed,
+		CharacterType:   "cat",
+		EmailVerified:   true,
+		ResetCode:       &code,
+		ResetCodeExpiry: &expiry,
+	}
+}
+
+func TestResetPassword_既存セッションを失効させる(t *testing.T) {
+	now := time.Now()
+	u := userWithResetCode(now, "654321")
+	repo := &fakeUserRepo{users: []*entity.User{u}}
+	uc, tm := revocationTestUsecase(repo, now)
+
+	// 攻撃者が握っているトークン。再設定の前に発行されたもの
+	stolen, err := tm.Generate(u.ID, u.Email, u.TokenVersion, now)
+	if err != nil {
+		t.Fatalf("トークン発行: %v", err)
+	}
+	if _, err := tm.Verify(stolen); err != nil {
+		t.Fatalf("再設定前は有効であるべき: %v", err)
+	}
+
+	if err := uc.ResetPassword(context.Background(), "victim@example.com", "654321", "newpassword2"); err != nil {
+		t.Fatalf("再設定に失敗: %v", err)
+	}
+
+	claims, err := tm.Verify(stolen)
+	if err != nil {
+		t.Fatalf("署名自体は有効なはず: %v", err)
+	}
+	if claims.TokenVersion == u.TokenVersion {
+		t.Fatal("版番号が繰り上がっていない。パスワードを変えても攻撃者を追い出せない")
+	}
+}
+
+func TestResetPassword_版番号を繰り上げる(t *testing.T) {
+	now := time.Now()
+	u := userWithResetCode(now, "654321")
+	before := u.TokenVersion
+	repo := &fakeUserRepo{users: []*entity.User{u}}
+	uc, _ := revocationTestUsecase(repo, now)
+
+	if err := uc.ResetPassword(context.Background(), "victim@example.com", "654321", "newpassword2"); err != nil {
+		t.Fatalf("再設定に失敗: %v", err)
+	}
+
+	if u.TokenVersion != before+1 {
+		t.Errorf("TokenVersion = %d, want %d", u.TokenVersion, before+1)
+	}
+}
+
+// 失敗した再設定でセッションが切れると、第三者がでたらめなコードを
+// 送りつけるだけで任意の利用者を締め出せてしまう
+func TestResetPassword_失敗では版番号を動かさない(t *testing.T) {
+	now := time.Now()
+	u := userWithResetCode(now, "654321")
+	before := u.TokenVersion
+	repo := &fakeUserRepo{users: []*entity.User{u}}
+	uc, _ := revocationTestUsecase(repo, now)
+
+	_ = uc.ResetPassword(context.Background(), "victim@example.com", "000000", "newpassword2")
+
+	if u.TokenVersion != before {
+		t.Errorf("誤ったコードで版番号が動いた: %d -> %d", before, u.TokenVersion)
+	}
+}
+
+func TestResetPassword_再設定後に発行したトークンは通る(t *testing.T) {
+	now := time.Now()
+	u := userWithResetCode(now, "654321")
+	repo := &fakeUserRepo{users: []*entity.User{u}}
+	uc, tm := revocationTestUsecase(repo, now)
+
+	if err := uc.ResetPassword(context.Background(), "victim@example.com", "654321", "newpassword2"); err != nil {
+		t.Fatalf("再設定に失敗: %v", err)
+	}
+
+	fresh, err := tm.Generate(u.ID, u.Email, u.TokenVersion, now)
+	if err != nil {
+		t.Fatalf("トークン発行: %v", err)
+	}
+	claims, err := tm.Verify(fresh)
+	if err != nil {
+		t.Fatalf("再設定後のトークンが無効: %v", err)
+	}
+	if claims.TokenVersion != u.TokenVersion {
+		t.Errorf("TokenVersion = %d, want %d", claims.TokenVersion, u.TokenVersion)
+	}
+}
+
+// ログインで発行するトークンにも現在の版番号が載っていなければ、
+// 直後のリクエストで自分自身が弾かれる
+func TestLogin_発行するトークンに現在の版番号を載せる(t *testing.T) {
+	now := time.Now()
+	hashed, _ := auth.HashPassword("password123")
+	u := &entity.User{
+		ID: "u-2", Email: "user@example.com", Password: hashed,
+		CharacterType: "cat", EmailVerified: true, TokenVersion: 3,
+	}
+	repo := &fakeUserRepo{users: []*entity.User{u}}
+	uc, tm := revocationTestUsecase(repo, now)
+
+	token, _, err := uc.Login(context.Background(), "user@example.com", "password123")
+	if err != nil {
+		t.Fatalf("ログインに失敗: %v", err)
+	}
+
+	claims, err := tm.Verify(token)
+	if err != nil {
+		t.Fatalf("検証: %v", err)
+	}
+	if claims.TokenVersion != 3 {
+		t.Errorf("TokenVersion = %d, want 3", claims.TokenVersion)
+	}
+}
+
+func TestVerify_発行するトークンに現在の版番号を載せる(t *testing.T) {
+	now := time.Now()
+	code := "123456"
+	expiry := now.Add(10 * time.Minute)
+	u := &entity.User{
+		ID: "u-3", Email: "pending@example.com", Password: "$2a$12$x",
+		CharacterType: "cat", TokenVersion: 7,
+		VerificationCode: &code, VerificationExpiry: &expiry,
+	}
+	repo := &fakeUserRepo{users: []*entity.User{u}}
+	uc, tm := revocationTestUsecase(repo, now)
+
+	token, _, err := uc.Verify(context.Background(), "pending@example.com", "123456")
+	if err != nil {
+		t.Fatalf("認証に失敗: %v", err)
+	}
+
+	claims, err := tm.Verify(token)
+	if err != nil {
+		t.Fatalf("検証: %v", err)
+	}
+	if claims.TokenVersion != 7 {
+		t.Errorf("TokenVersion = %d, want 7", claims.TokenVersion)
+	}
+}

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -158,7 +158,7 @@ func (uc *AuthUsecase) Verify(ctx context.Context, email, code string) (string, 
 	if err := uc.users.Update(ctx, u); err != nil {
 		return "", nil, err
 	}
-	token, err := uc.tokens.Generate(u.ID, u.Email, uc.now())
+	token, err := uc.tokens.Generate(u.ID, u.Email, u.TokenVersion, uc.now())
 	return token, u, err
 }
 
@@ -175,7 +175,7 @@ func (uc *AuthUsecase) Login(ctx context.Context, email, password string) (strin
 	if !u.EmailVerified {
 		return "", nil, domain.NewForbidden("メールアドレスが認証されていません")
 	}
-	token, err := uc.tokens.Generate(u.ID, u.Email, uc.now())
+	token, err := uc.tokens.Generate(u.ID, u.Email, u.TokenVersion, uc.now())
 	return token, u, err
 }
 
@@ -229,7 +229,7 @@ func (uc *AuthUsecase) LoginWithGoogle(ctx context.Context, credential string) (
 		}
 	}
 
-	token, err := uc.tokens.Generate(u.ID, u.Email, uc.now())
+	token, err := uc.tokens.Generate(u.ID, u.Email, u.TokenVersion, uc.now())
 	return token, u, err
 }
 
@@ -260,7 +260,7 @@ func (uc *AuthUsecase) TestLogin(ctx context.Context, email string) (string, *en
 			return "", nil, err
 		}
 	}
-	token, err := uc.tokens.Generate(u.ID, u.Email, uc.now())
+	token, err := uc.tokens.Generate(u.ID, u.Email, u.TokenVersion, uc.now())
 	return token, u, err
 }
 
@@ -337,5 +337,10 @@ func (uc *AuthUsecase) ResetPassword(ctx context.Context, email, code, newPasswo
 	u.ResetCode = nil
 	u.ResetCodeExpiry = nil
 	u.ResetAttempts = 0
+	// 発行済みトークンを失効させる。パスワードを変えたのに攻撃者が
+	// 有効期限(7日)まで居座れるなら、乗っ取られた利用者に打つ手が無い。
+	// 繰り上げるのは照合に成功した後だけ。失敗でも動かすと、第三者が
+	// でたらめなコードを送りつけるだけで任意の利用者を締め出せてしまう
+	u.TokenVersion++
 	return uc.users.Update(ctx, u)
 }

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -337,10 +337,16 @@ func (uc *AuthUsecase) ResetPassword(ctx context.Context, email, code, newPasswo
 	u.ResetCode = nil
 	u.ResetCodeExpiry = nil
 	u.ResetAttempts = 0
+	if err := uc.users.Update(ctx, u); err != nil {
+		return err
+	}
 	// 発行済みトークンを失効させる。パスワードを変えたのに攻撃者が
 	// 有効期限(7日)まで居座れるなら、乗っ取られた利用者に打つ手が無い。
+	//
 	// 繰り上げるのは照合に成功した後だけ。失敗でも動かすと、第三者が
-	// でたらめなコードを送りつけるだけで任意の利用者を締め出せてしまう
-	u.TokenVersion++
-	return uc.users.Update(ctx, u)
+	// でたらめなコードを送りつけるだけで任意の利用者を締め出せてしまう。
+	//
+	// 加算は DB 内で行う。読み出した値に足して書き戻すと、
+	// 上げる前の値を握った並行リクエストに巻き戻される
+	return uc.users.BumpTokenVersion(ctx, u.ID)
 }

--- a/backend/internal/usecase/auth_verify_test.go
+++ b/backend/internal/usecase/auth_verify_test.go
@@ -165,3 +165,15 @@ func (r *verifyUserRepo) TokenVersion(ctx context.Context, id string) (int, bool
 	}
 	return u.TokenVersion, true, nil
 }
+
+// 本物と同じく DB 内加算に相当する。読み出した値を書き戻さない
+func (r *verifyUserRepo) BumpTokenVersion(ctx context.Context, id string) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if u != nil {
+		u.TokenVersion++
+	}
+	return nil
+}

--- a/backend/internal/usecase/auth_verify_test.go
+++ b/backend/internal/usecase/auth_verify_test.go
@@ -156,3 +156,12 @@ func TestVerify_期限切れのコードを拒否する(t *testing.T) {
 func asValidation(err error, target **domain.ValidationError) bool {
 	return errors.As(err, target)
 }
+
+// 保持している利用者の版番号をそのまま返す。存在しなければ found=false。
+func (r *verifyUserRepo) TokenVersion(ctx context.Context, id string) (int, bool, error) {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return 0, false, err
+	}
+	return u.TokenVersion, true, nil
+}

--- a/backend/migrations/0011_add_user_token_version.sql
+++ b/backend/migrations/0011_add_user_token_version.sql
@@ -1,0 +1,6 @@
+-- 発行済みトークンを利用者ごとに失効させるための版番号。
+-- パスワード再設定で繰り上げ、トークンに載った値と食い違うものを拒む。
+-- これが無いと、乗っ取られた利用者がパスワードを変えても
+-- 攻撃者のトークンが有効期限(7日)まで通り続ける。
+ALTER TABLE "User"
+    ADD COLUMN IF NOT EXISTS "tokenVersion" INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

乗っ取られた利用者が気づいてパスワードを変えても、**攻撃者のトークンが有効期限（7日）まで通り続けていた**。失効の手段が無く、アカウント復旧の導線として機能していなかった。

トークンに世代（`tokenVersion`）を載せ、保存されている値と食い違うものを認証時に拒む。鍵の全体ローテーションと違い、**当人のセッションだけを狙って切れる**。

### 変更

- `User` に `tokenVersion` 列を追加（既定 0、追加のみの冪等マイグレーション）
- JWT のクレームに載せ、認証ミドルウェアで突き合わせる
- **再設定の成功時にのみ繰り上げる**。失敗でも動かすと、第三者がでたらめなコードを送りつけるだけで任意の利用者を締め出せる
- 照合には専用クエリ（`tokenVersion` 1列のみ）を使う。認証のたびに呼ばれるため、パスワードハッシュや発行中のコードを含む行全体は読まない
- 署名が無効なトークンでは DB に問い合わせない。問い合わせると、でたらめなトークンを投げるだけで無認証のまま DB を叩ける

### 応答の切り分け

| 状況 | 応答 | 理由 |
|---|---|---|
| 世代が食い違う | 401 | 失効済み |
| 利用者が存在しない | 401 | 退会後のトークンを生かさない |
| 問い合わせ自体が失敗 | **503** | 認証成功に倒すと DB を落とせば誰でも入れる。401 だと「ログインし直せば直る」と誤解させ、何度やっても入れない |

クレームを持たない古いトークンは 0 として読む。「クレームが無ければ照合を飛ばす」にすると、**クレームを落とすだけで失効を回避できてしまう**。

### 実サーバーでの検証

ローカルに実 PostgreSQL を立てて攻撃シナリオを通した。

| 手順 | 結果 |
|---|---|
| 攻撃者がトークンを握っている | `/api/users/me` 200 |
| 被害者がパスワード再設定 | `tokenVersion` 0 → 1 |
| 攻撃者のトークン | **401** |
| 被害者が新パスワードでログイン | 200 |

副作用が無いことも確認:

| 手順 | 結果 |
|---|---|
| 第三者がでたらめなコードで再設定を3回試行 | `tokenVersion` は 1 のまま |
| 正規セッション | 200（巻き添えなし） |
| 利用者を削除した後のトークン | 401 |

### 代償

認証を要する全リクエストに、主キー1件の問い合わせが増える。即時失効を成立させる以上この照合は避けられない。行全体ではなく1列だけを引くことでコストを抑えている。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - パスワード再設定後、既存のログイン・認証トークンを自動的に無効化できるようになりました。
  - トークンの世代情報を照合し、古いトークンや存在しないアカウントのトークンを拒否します。
  - メール認証、通常ログイン、ソーシャルログインで最新世代のトークンを発行します。

- **改善**
  - 認証情報の確認に一時的な障害が発生した場合、適切なサービス利用不可エラーを返します。

- **テスト**
  - トークン世代の一致・不一致、無効化、照会障害などの認証シナリオを追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->