### PR TITLE
refactor(persistence): 書き込みをGORM、読み取りをsqlcに統一する

### DIFF
--- a/backend/internal/infrastructure/persistence/aggregate_queries.go
+++ b/backend/internal/infrastructure/persistence/aggregate_queries.go
@@ -3,108 +3,90 @@ package persistence
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"healthfamily/internal/domain/entity"
 	"healthfamily/internal/domain/repository"
+	"healthfamily/internal/infrastructure/sqlc/sqlcgen"
 )
 
 // ListByUserFiltered は任意の絞り込み(メンバー/期間/件数上限)で服薬記録を返す。
 // 全パラメータ未指定なら ListByUser と同等。ダッシュボード/履歴の期間ウィンドウ取得に使う。
 func (r *MedicationRecordRepository) ListByUserFiltered(ctx context.Context, userID string, f repository.RecordFilter) ([]entity.MedicationRecord, error) {
-	query := `SELECT ` + recordColumns + ` FROM "MedicationRecord" WHERE "userId"=$1`
-	args := []any{userID}
-	n := 1
+	params := sqlcgen.ListRecordsByUserFilteredParams{
+		UserID: userID,
+		FromAt: f.From,
+		ToAt:   f.To,
+	}
 	if f.MemberID != "" {
-		n++
-		query += ` AND "memberId"=$` + strconv.Itoa(n)
-		args = append(args, f.MemberID)
+		params.MemberID = &f.MemberID
 	}
-	if f.From != nil {
-		n++
-		query += ` AND "takenAt" >= $` + strconv.Itoa(n)
-		args = append(args, *f.From)
-	}
-	if f.To != nil {
-		n++
-		query += ` AND "takenAt" < $` + strconv.Itoa(n)
-		args = append(args, *f.To)
-	}
-	query += ` ORDER BY "takenAt" DESC`
 	if f.Limit > 0 {
-		query += ` LIMIT ` + strconv.Itoa(f.Limit)
+		limit := int32(f.Limit)
+		params.RowLimit = &limit
 	}
 
-	rows, err := r.pool.Query(ctx, query, args...)
+	rows, err := r.q.ListRecordsByUserFiltered(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	list := make([]entity.MedicationRecord, 0)
-	for rows.Next() {
-		var rec entity.MedicationRecord
-		if err := rows.Scan(&rec.ID, &rec.MemberID, &rec.MedicationID, &rec.UserID, &rec.ScheduleID,
-			&rec.TakenAt, &rec.Notes, &rec.DosageAmount); err != nil {
-			return nil, err
-		}
-		list = append(list, rec)
+	list := make([]entity.MedicationRecord, 0, len(rows))
+	for _, row := range rows {
+		list = append(list, entity.MedicationRecord{
+			ID:           row.ID,
+			MemberID:     row.MemberId,
+			MedicationID: row.MedicationId,
+			UserID:       row.UserId,
+			ScheduleID:   row.ScheduleId,
+			TakenAt:      row.TakenAt,
+			Notes:        row.Notes,
+			DosageAmount: row.DosageAmount,
+		})
 	}
-	return list, rows.Err()
+	return list, nil
 }
 
 // ListSummary はメンバーごとの薬数を単一SQL(LEFT JOIN + GROUP BY)で集計して返す(N+1回避)。
 func (r *MemberRepository) ListSummary(ctx context.Context, userID string) ([]entity.MemberSummary, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT m."id", m."userId", m."memberType", m."name", m."petType", m."photoUrl",
-			m."birthDate", m."notes", m."createdAt", m."updatedAt",
-			COUNT(med."id") AS medication_count,
-			COUNT(med."id") FILTER (WHERE med."isActive") AS active_count
-		 FROM "Member" m
-		 LEFT JOIN "Medication" med ON med."memberId" = m."id"
-		 WHERE m."userId" = $1
-		 GROUP BY m."id"
-		 ORDER BY m."createdAt" ASC`, userID)
+	rows, err := r.q.ListMemberSummaries(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	list := make([]entity.MemberSummary, 0)
-	for rows.Next() {
-		var s entity.MemberSummary
-		if err := rows.Scan(&s.ID, &s.UserID, &s.MemberType, &s.Name, &s.PetType, &s.PhotoURL,
-			&s.BirthDate, &s.Notes, &s.CreatedAt, &s.UpdatedAt,
-			&s.MedicationCount, &s.ActiveMedicationCount); err != nil {
-			return nil, err
-		}
-		list = append(list, s)
+	list := make([]entity.MemberSummary, 0, len(rows))
+	for _, row := range rows {
+		list = append(list, entity.MemberSummary{
+			Member: entity.Member{
+				ID:         row.ID,
+				UserID:     row.UserId,
+				MemberType: row.MemberType,
+				Name:       row.Name,
+				PetType:    row.PetType,
+				PhotoURL:   row.PhotoUrl,
+				BirthDate:  row.BirthDate,
+				Notes:      row.Notes,
+				CreatedAt:  row.CreatedAt,
+				UpdatedAt:  row.UpdatedAt,
+			},
+			MedicationCount:       int(row.MedicationCount),
+			ActiveMedicationCount: int(row.ActiveCount),
+		})
 	}
-	return list, rows.Err()
+	return list, nil
 }
 
 // ListAlerts は在庫僅少(残数<=5 もしくは在庫アラート日が7日以内)の有効な薬を返す。
 func (r *MedicationRepository) ListAlerts(ctx context.Context, userID string) ([]entity.Medication, error) {
-	const lowStockThreshold = 5
-	query := `SELECT ` + medColumns + ` FROM "Medication"
-		 WHERE "userId"=$1 AND "isActive" = TRUE
-		   AND (
-		     ("stockQuantity" IS NOT NULL AND "stockQuantity" <= $2)
-		     OR ("stockAlertDate" IS NOT NULL AND "stockAlertDate" <= now() + interval '7 days')
-		   )
-		 ORDER BY "stockQuantity" ASC NULLS LAST, "createdAt" ASC`
-	rows, err := r.pool.Query(ctx, query, userID, lowStockThreshold)
+	const lowStockThreshold int32 = 5
+	threshold := lowStockThreshold
+	rows, err := r.q.ListMedicationAlerts(ctx, sqlcgen.ListMedicationAlertsParams{
+		UserId:        userID,
+		StockQuantity: &threshold,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("list alerts: %w", err)
 	}
-	defer rows.Close()
-	list := make([]entity.Medication, 0)
-	for rows.Next() {
-		var m entity.Medication
-		if err := rows.Scan(&m.ID, &m.MemberID, &m.UserID, &m.Name, &m.Category, &m.DosageAmount,
-			&m.Frequency, &m.StockQuantity, &m.StockAlertDate, &m.IntervalHours, &m.Instructions,
-			&m.DisplayOrder, &m.IsActive, &m.Status, &m.CreatedAt, &m.UpdatedAt); err != nil {
-			return nil, err
-		}
-		list = append(list, m)
+	list := make([]entity.Medication, 0, len(rows))
+	for _, row := range rows {
+		list = append(list, medicationFromSqlc(row))
 	}
-	return list, rows.Err()
+	return list, nil
 }

--- a/backend/internal/infrastructure/persistence/converted_reads_integration_test.go
+++ b/backend/internal/infrastructure/persistence/converted_reads_integration_test.go
@@ -1,0 +1,85 @@
+package persistence
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"healthfamily/internal/domain/repository"
+	"healthfamily/internal/infrastructure/database"
+)
+
+// sqlc へ置き換えた読み取りが、実DBに対して期待どおり動くこと。
+func TestConverted_sqlc読み取り(t *testing.T) {
+	if os.Getenv("HF_DB_INTEGRATION") != "1" {
+		t.Skip("HF_DB_INTEGRATION=1 以外はスキップ")
+	}
+	ctx := context.Background()
+	db, err := database.New(ctx, os.Getenv("DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer db.Close()
+
+	t.Run("メンバー集計", func(t *testing.T) {
+		got, err := NewMemberRepository(db).ListSummary(ctx, "u1")
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("件数 = %d, want 1", len(got))
+		}
+		if got[0].Name != "太郎" || got[0].MedicationCount != 1 || got[0].ActiveMedicationCount != 1 {
+			t.Errorf("集計がずれている: %+v", got[0])
+		}
+	})
+
+	t.Run("在庫アラート", func(t *testing.T) {
+		got, err := NewMedicationRepository(db).ListAlerts(ctx, "u1")
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if len(got) != 1 || got[0].Name != "薬A" {
+			t.Fatalf("残数3の薬が拾えていない: %+v", got)
+		}
+	})
+
+	repo := NewMedicationRecordRepository(db)
+
+	t.Run("絞り込みなし", func(t *testing.T) {
+		got, err := repo.ListByUserFiltered(ctx, "u1", repository.RecordFilter{})
+		if err != nil || len(got) != 1 {
+			t.Fatalf("件数 = %d, err = %v", len(got), err)
+		}
+	})
+
+	t.Run("メンバーで絞る", func(t *testing.T) {
+		hit, _ := repo.ListByUserFiltered(ctx, "u1", repository.RecordFilter{MemberID: "m1"})
+		miss, _ := repo.ListByUserFiltered(ctx, "u1", repository.RecordFilter{MemberID: "nope"})
+		if len(hit) != 1 || len(miss) != 0 {
+			t.Errorf("絞り込みが効いていない: hit=%d miss=%d", len(hit), len(miss))
+		}
+	})
+
+	t.Run("期間で絞る", func(t *testing.T) {
+		past := time.Now().Add(-time.Hour)
+		future := time.Now().Add(time.Hour)
+		in, _ := repo.ListByUserFiltered(ctx, "u1", repository.RecordFilter{From: &past, To: &future})
+		out, _ := repo.ListByUserFiltered(ctx, "u1", repository.RecordFilter{From: &future})
+		if len(in) != 1 || len(out) != 0 {
+			t.Errorf("期間が効いていない: in=%d out=%d", len(in), len(out))
+		}
+	})
+
+	t.Run("件数上限", func(t *testing.T) {
+		zero, _ := repo.ListByUserFiltered(ctx, "u1", repository.RecordFilter{Limit: 0})
+		one, _ := repo.ListByUserFiltered(ctx, "u1", repository.RecordFilter{Limit: 1})
+		if len(zero) != 1 {
+			t.Errorf("Limit 0 は無制限のはず: %d", len(zero))
+		}
+		if len(one) != 1 {
+			t.Errorf("Limit 1: %d", len(one))
+		}
+	})
+}

--- a/backend/internal/infrastructure/persistence/converted_reads_integration_test.go
+++ b/backend/internal/infrastructure/persistence/converted_reads_integration_test.go
@@ -83,3 +83,75 @@ func TestConverted_sqlc読み取り(t *testing.T) {
 		}
 	})
 }
+
+// 後半で置き換えた読み取りも、実DBで期待どおり動くこと。
+func TestConverted_sqlc読み取り後半(t *testing.T) {
+	if os.Getenv("HF_DB_INTEGRATION") != "1" {
+		t.Skip("HF_DB_INTEGRATION=1 以外はスキップ")
+	}
+	ctx := context.Background()
+	db, err := database.New(ctx, os.Getenv("DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer db.Close()
+
+	t.Run("医療費の絞り込み", func(t *testing.T) {
+		repo := NewExpenseRepository(db)
+		all, err := repo.List(ctx, "u1", repository.ExpenseFilter{})
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		byMember, _ := repo.List(ctx, "u1", repository.ExpenseFilter{MemberID: "m1"})
+		byYear, _ := repo.List(ctx, "u1", repository.ExpenseFilter{Year: 2026})
+		miss, _ := repo.List(ctx, "u1", repository.ExpenseFilter{Year: 1999})
+		if len(all) != 1 || len(byMember) != 1 || len(byYear) != 1 {
+			t.Errorf("絞り込みが効いていない: all=%d member=%d year=%d", len(all), len(byMember), len(byYear))
+		}
+		if len(miss) != 0 {
+			t.Errorf("該当しない年で %d 件返った", len(miss))
+		}
+	})
+
+	t.Run("医療費の集計", func(t *testing.T) {
+		got, err := NewExpenseRepository(db).Summary(ctx, "u1", 2026)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if got.Total != 3000 || got.DeductibleTotal != 3000 {
+			t.Errorf("合計がずれている: total=%d deductible=%d", got.Total, got.DeductibleTotal)
+		}
+		if got.ByCategory["診察"] != 3000 {
+			t.Errorf("カテゴリ別がずれている: %+v", got.ByCategory)
+		}
+		if len(got.ByMonth) != 1 || got.ByMonth[0].Total != 3000 {
+			t.Errorf("月別がずれている: %+v", got.ByMonth)
+		}
+	})
+
+	t.Run("処方箋と明細", func(t *testing.T) {
+		got, err := NewPrescriptionRepository(db).List(ctx, "u1")
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("件数 = %d", len(got))
+		}
+		if len(got[0].Items) != 2 {
+			t.Errorf("明細が %d 件。まとめ取得が壊れている", len(got[0].Items))
+		}
+	})
+
+	t.Run("今日の予定", func(t *testing.T) {
+		got, err := NewScheduleRepository(db).GetTodaySchedules(ctx, "u1", time.Now())
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("件数 = %d", len(got))
+		}
+		if got[0].MedicationName != "薬A" || got[0].MemberName != "太郎" {
+			t.Errorf("結合がずれている: %+v", got[0])
+		}
+	})
+}

--- a/backend/internal/infrastructure/persistence/expense_repository.go
+++ b/backend/internal/infrastructure/persistence/expense_repository.go
@@ -3,7 +3,6 @@ package persistence
 import (
 	"context"
 	"errors"
-	"strconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -46,36 +45,24 @@ func expenseFromSqlc(e sqlcgen.Expense) entity.Expense {
 }
 
 func (r *ExpenseRepository) List(ctx context.Context, userID string, f repository.ExpenseFilter) ([]entity.Expense, error) {
-	query := `SELECT ` + expenseColumns + ` FROM "Expense" WHERE "userId"=$1`
-	args := []any{userID}
-	n := 1
+	params := sqlcgen.ListExpensesFilteredParams{UserID: userID}
 	if f.MemberID != "" {
-		n++
-		query += ` AND "memberId"=$` + strconv.Itoa(n)
-		args = append(args, f.MemberID)
+		params.MemberID = &f.MemberID
 	}
 	if f.Year > 0 {
-		n++
-		query += ` AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = $` + strconv.Itoa(n)
-		args = append(args, f.Year)
+		year := int32(f.Year)
+		params.Year = &year
 	}
-	query += ` ORDER BY "expenseDate" DESC`
 
-	rows, err := r.pool.Query(ctx, query, args...)
+	rows, err := r.q.ListExpensesFiltered(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	list := make([]entity.Expense, 0)
-	for rows.Next() {
-		var e entity.Expense
-		if err := rows.Scan(&e.ID, &e.UserID, &e.MemberID, &e.Category, &e.Amount,
-			&e.Description, &e.ExpenseDate, &e.IsDeductible, &e.CreatedAt); err != nil {
-			return nil, err
-		}
-		list = append(list, e)
+	list := make([]entity.Expense, 0, len(rows))
+	for _, row := range rows {
+		list = append(list, expenseFromSqlc(row))
 	}
-	return list, rows.Err()
+	return list, nil
 }
 
 func (r *ExpenseRepository) FindByID(ctx context.Context, id string) (*entity.Expense, error) {
@@ -141,57 +128,31 @@ func (r *ExpenseRepository) Delete(ctx context.Context, id string) error {
 }
 
 // Summary は指定年(JST基準)の合計・控除対象合計・カテゴリ別・月別を集計する。
-// 集計のため生SQL(pgx)を維持する。
 func (r *ExpenseRepository) Summary(ctx context.Context, userID string, year int) (*entity.ExpenseSummary, error) {
 	s := &entity.ExpenseSummary{Year: year, ByCategory: map[string]int{}, ByMonth: make([]entity.MonthlyTotal, 0)}
+	y := int32(year)
 
-	// 合計・控除対象合計
-	if err := r.pool.QueryRow(ctx,
-		`SELECT COALESCE(SUM("amount"),0),
-			COALESCE(SUM("amount") FILTER (WHERE "isDeductible"),0)
-		 FROM "Expense"
-		 WHERE "userId"=$1 AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo')=$2`,
-		userID, year).Scan(&s.Total, &s.DeductibleTotal); err != nil {
-		return nil, err
-	}
-
-	// カテゴリ別
-	catRows, err := r.pool.Query(ctx,
-		`SELECT "category", SUM("amount") FROM "Expense"
-		 WHERE "userId"=$1 AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo')=$2
-		 GROUP BY "category"`, userID, year)
+	totals, err := r.q.SumExpensesByYear(ctx, sqlcgen.SumExpensesByYearParams{UserID: userID, Year: y})
 	if err != nil {
 		return nil, err
 	}
-	defer catRows.Close()
-	for catRows.Next() {
-		var cat string
-		var sum int
-		if err := catRows.Scan(&cat, &sum); err != nil {
-			return nil, err
-		}
-		s.ByCategory[cat] = sum
-	}
-	if err := catRows.Err(); err != nil {
-		return nil, err
-	}
+	s.Total = int(totals.Total)
+	s.DeductibleTotal = int(totals.DeductibleTotal)
 
-	// 月別
-	monRows, err := r.pool.Query(ctx,
-		`SELECT EXTRACT(MONTH FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo')::int AS m, SUM("amount")
-		 FROM "Expense"
-		 WHERE "userId"=$1 AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo')=$2
-		 GROUP BY m ORDER BY m`, userID, year)
+	cats, err := r.q.SumExpensesByCategory(ctx, sqlcgen.SumExpensesByCategoryParams{UserID: userID, Year: y})
 	if err != nil {
 		return nil, err
 	}
-	defer monRows.Close()
-	for monRows.Next() {
-		var mt entity.MonthlyTotal
-		if err := monRows.Scan(&mt.Month, &mt.Total); err != nil {
-			return nil, err
-		}
-		s.ByMonth = append(s.ByMonth, mt)
+	for _, c := range cats {
+		s.ByCategory[c.Category] = int(c.Total)
 	}
-	return s, monRows.Err()
+
+	months, err := r.q.SumExpensesByMonth(ctx, sqlcgen.SumExpensesByMonthParams{UserID: userID, Year: y})
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range months {
+		s.ByMonth = append(s.ByMonth, entity.MonthlyTotal{Month: int(m.Month), Total: int(m.Total)})
+	}
+	return s, nil
 }

--- a/backend/internal/infrastructure/persistence/prescription_repository.go
+++ b/backend/internal/infrastructure/persistence/prescription_repository.go
@@ -74,50 +74,55 @@ func scanPrescriptionItems(rows pgx.Rows) ([]entity.PrescriptionItem, error) {
 }
 
 func (r *PrescriptionRepository) List(ctx context.Context, userID string) ([]entity.Prescription, error) {
-	rows, err := r.pool.Query(ctx,
-		`SELECT `+prescriptionColumns+` FROM "Prescription" WHERE "userId"=$1 ORDER BY "createdAt" DESC`, userID)
+	rows, err := r.q.ListPrescriptionsByUser(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	list := make([]entity.Prescription, 0)
-	for rows.Next() {
-		var p entity.Prescription
-		if err := rows.Scan(&p.ID, &p.UserID, &p.MemberID, &p.PrescriptionName, &p.PrescribedBy, &p.PrescribedAt, &p.ExpiresAt, &p.PharmacyName, &p.ElectronicCode, &p.Notes, &p.CreatedAt); err != nil {
-			return nil, err
-		}
-		list = append(list, p)
+
+	list := make([]entity.Prescription, 0, len(rows))
+	ids := make([]string, 0, len(rows))
+	byID := make(map[string]int, len(rows))
+	for _, row := range rows {
+		byID[row.ID] = len(list)
+		ids = append(ids, row.ID)
+		list = append(list, entity.Prescription{
+			ID:               row.ID,
+			UserID:           row.UserId,
+			MemberID:         row.MemberId,
+			PrescriptionName: row.PrescriptionName,
+			PrescribedBy:     row.PrescribedBy,
+			PrescribedAt:     row.PrescribedAt,
+			ExpiresAt:        row.ExpiresAt,
+			PharmacyName:     row.PharmacyName,
+			ElectronicCode:   row.ElectronicCode,
+			Notes:            row.Notes,
+			CreatedAt:        row.CreatedAt,
+			Items:            []entity.PrescriptionItem{},
+		})
 	}
-	if err := rows.Err(); err != nil {
+	if len(ids) == 0 {
+		return list, nil
+	}
+
+	// 明細は一度にまとめて引く。処方箋ごとに引くと件数分の往復になる
+	items, err := r.q.ListPrescriptionItemsForPrescriptions(ctx, ids)
+	if err != nil {
 		return nil, err
 	}
-	// 明細をまとめて取得して各処方箋へ割り当て（N+1回避）
-	ids := make([]string, len(list))
-	for i := range list {
-		ids[i] = list[i].ID
-		list[i].Items = []entity.PrescriptionItem{}
-	}
-	if len(ids) > 0 {
-		itemRows, err := r.pool.Query(ctx,
-			`SELECT `+prescriptionItemColumns+`
-			 FROM "PrescriptionItem" WHERE "prescriptionId" = ANY($1) ORDER BY "sortOrder", "createdAt"`, ids)
-		if err != nil {
-			return nil, err
+	for _, it := range items {
+		idx, ok := byID[it.PrescriptionId]
+		if !ok {
+			continue
 		}
-		defer itemRows.Close()
-		items, err := scanPrescriptionItems(itemRows)
-		if err != nil {
-			return nil, err
-		}
-		byPid := map[string]int{}
-		for i := range list {
-			byPid[list[i].ID] = i
-		}
-		for _, it := range items {
-			if idx, ok := byPid[it.PrescriptionID]; ok {
-				list[idx].Items = append(list[idx].Items, it)
-			}
-		}
+		list[idx].Items = append(list[idx].Items, entity.PrescriptionItem{
+			ID:             it.ID,
+			PrescriptionID: it.PrescriptionId,
+			Name:           it.Name,
+			Dosage:         it.Dosage,
+			Frequency:      it.Frequency,
+			Days:           intPtr(it.Days),
+			SortOrder:      int(it.SortOrder),
+		})
 	}
 	return list, nil
 }

--- a/backend/internal/infrastructure/persistence/schedule_repository.go
+++ b/backend/internal/infrastructure/persistence/schedule_repository.go
@@ -138,39 +138,40 @@ func (r *ScheduleRepository) GetTodaySchedules(ctx context.Context, userID strin
 	dayStart := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, date.Location())
 	dayEnd := dayStart.Add(24 * time.Hour)
 
-	rows, err := r.pool.Query(ctx,
-		`SELECT `+prefixCols("s", scheduleColumns)+`,
-			m."name", mem."name", mem."memberType", m."displayOrder",
-			EXISTS(
-				SELECT 1 FROM "MedicationRecord" r
-				WHERE r."scheduleId" = s."id" AND r."takenAt" >= $3 AND r."takenAt" < $4
-			) AS is_completed
-		 FROM "Schedule" s
-		 JOIN "Medication" m ON m."id" = s."medicationId"
-		 JOIN "Member" mem ON mem."id" = s."memberId"
-		 WHERE s."userId" = $1
-		   AND s."isEnabled" = TRUE
-		   AND m."isActive" = TRUE
-		   AND m."status" NOT IN ('paused', 'discontinued')
-		   AND (array_length(s."daysOfWeek", 1) IS NULL OR $2 = ANY(s."daysOfWeek"))
-		 ORDER BY s."scheduledTime" ASC`,
-		userID, weekday, dayStart, dayEnd)
+	rows, err := r.q.ListTodaySchedules(ctx, sqlcgen.ListTodaySchedulesParams{
+		UserID:   userID,
+		Weekday:  weekday,
+		DayStart: dayStart,
+		DayEnd:   dayEnd,
+	})
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	list := make([]entity.TodaySchedule, 0)
-	for rows.Next() {
-		var t entity.TodaySchedule
-		if err := rows.Scan(&t.ID, &t.MedicationID, &t.UserID, &t.MemberID, &t.ScheduledTime,
-			&t.DaysOfWeek, &t.IntervalDays, &t.StartDate, &t.IsEnabled, &t.ReminderMinutesBefore, &t.CreatedAt,
-			&t.MedicationName, &t.MemberName, &t.MemberType, &t.MedicationDisplayOrder, &t.IsCompleted); err != nil {
-			return nil, err
-		}
-		list = append(list, t)
+	list := make([]entity.TodaySchedule, 0, len(rows))
+	for _, row := range rows {
+		list = append(list, entity.TodaySchedule{
+			Schedule: entity.Schedule{
+				ID:                    row.ID,
+				MedicationID:          row.MedicationId,
+				UserID:                row.UserId,
+				MemberID:              row.MemberId,
+				ScheduledTime:         row.ScheduledTime,
+				DaysOfWeek:            row.DaysOfWeek,
+				IntervalDays:          intPtr(row.IntervalDays),
+				StartDate:             row.StartDate,
+				IsEnabled:             row.IsEnabled,
+				ReminderMinutesBefore: int(row.ReminderMinutesBefore),
+				CreatedAt:             row.CreatedAt,
+			},
+			MedicationName:         row.MedicationName,
+			MemberName:             row.MemberName,
+			MemberType:             row.MemberType,
+			MedicationDisplayOrder: int(row.DisplayOrder),
+			IsCompleted:            row.IsCompleted,
+		})
 	}
-	return list, rows.Err()
+	return list, nil
 }
 
 // prefixCols は `"id", "name"` を `s."id", s."name"` の形に変換する。

--- a/backend/internal/infrastructure/persistence/user_repository.go
+++ b/backend/internal/infrastructure/persistence/user_repository.go
@@ -139,5 +139,11 @@ func (r *UserRepository) TokenVersion(ctx context.Context, id string) (int, bool
 // 世代が巻き戻って失効させたはずの JWT が再び通ってしまう。
 // プロフィール更新のような何気ない操作が攻撃者を呼び戻すことになる。
 func (r *UserRepository) BumpTokenVersion(ctx context.Context, id string) error {
-	return r.q.BumpUserTokenVersion(ctx, id)
+	return r.gdb.WithContext(ctx).
+		Model(&gormUser{}).
+		Where(`"id" = ?`, id).
+		Updates(map[string]any{
+			"tokenVersion": gorm.Expr(`"tokenVersion" + 1`),
+			"updatedAt":    gorm.Expr("now()"),
+		}).Error
 }

--- a/backend/internal/infrastructure/sqlc/queries/expense.sql
+++ b/backend/internal/infrastructure/sqlc/queries/expense.sql
@@ -2,3 +2,38 @@
 SELECT "id", "userId", "memberId", "category", "amount", "description", "expenseDate", "isDeductible", "createdAt"
 FROM "Expense"
 WHERE "id" = $1;
+
+-- name: ListExpensesFiltered :many
+-- 任意の絞り込み(メンバー/年)で医療費を返す。NULL を渡した条件は無視される。
+-- 年は JST 基準。UTC で切ると、元日や大晦日の記録が前後の年に混ざる。
+SELECT "id", "userId", "memberId", "category", "amount", "description",
+       "expenseDate", "isDeductible", "createdAt"
+FROM "Expense"
+WHERE "userId" = sqlc.arg(user_id)
+  AND (sqlc.narg(member_id)::text IS NULL OR "memberId" = sqlc.narg(member_id)::text)
+  AND (sqlc.narg(year)::int IS NULL
+       OR EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = sqlc.narg(year)::int)
+ORDER BY "expenseDate" DESC;
+
+-- name: SumExpensesByYear :one
+SELECT COALESCE(SUM("amount"), 0)::bigint AS total,
+       COALESCE(SUM("amount") FILTER (WHERE "isDeductible"), 0)::bigint AS deductible_total
+FROM "Expense"
+WHERE "userId" = sqlc.arg(user_id)
+  AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = sqlc.arg(year)::int;
+
+-- name: SumExpensesByCategory :many
+SELECT "category", SUM("amount")::bigint AS total
+FROM "Expense"
+WHERE "userId" = sqlc.arg(user_id)
+  AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = sqlc.arg(year)::int
+GROUP BY "category";
+
+-- name: SumExpensesByMonth :many
+SELECT EXTRACT(MONTH FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo')::int AS month,
+       SUM("amount")::bigint AS total
+FROM "Expense"
+WHERE "userId" = sqlc.arg(user_id)
+  AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = sqlc.arg(year)::int
+GROUP BY month
+ORDER BY month;

--- a/backend/internal/infrastructure/sqlc/queries/medication.sql
+++ b/backend/internal/infrastructure/sqlc/queries/medication.sql
@@ -20,3 +20,17 @@ SELECT "id", "memberId", "userId", "name", "category", "dosageAmount", "frequenc
        "isActive", "status", "createdAt", "updatedAt"
 FROM "Medication"
 WHERE "id" = $1;
+
+-- name: ListMedicationAlerts :many
+-- 在庫僅少(残数が閾値以下、もしくは在庫アラート日が7日以内)の有効な薬。
+SELECT "id", "memberId", "userId", "name", "category", "dosageAmount", "frequency",
+       "stockQuantity", "stockAlertDate", "intervalHours", "instructions", "displayOrder",
+       "isActive", "status", "createdAt", "updatedAt"
+FROM "Medication"
+WHERE "userId" = $1
+  AND "isActive" = TRUE
+  AND (
+    ("stockQuantity" IS NOT NULL AND "stockQuantity" <= $2)
+    OR ("stockAlertDate" IS NOT NULL AND "stockAlertDate" <= now() + interval '7 days')
+  )
+ORDER BY "stockQuantity" ASC NULLS LAST, "createdAt" ASC;

--- a/backend/internal/infrastructure/sqlc/queries/medication_record.sql
+++ b/backend/internal/infrastructure/sqlc/queries/medication_record.sql
@@ -14,3 +14,15 @@ ORDER BY "takenAt" DESC;
 SELECT "id", "memberId", "medicationId", "userId", "scheduleId", "takenAt", "notes", "dosageAmount"
 FROM "MedicationRecord"
 WHERE "id" = $1;
+
+-- name: ListRecordsByUserFiltered :many
+-- 任意の絞り込み(メンバー/期間/件数上限)で服薬記録を返す。
+-- NULL を渡した条件は無視される。SQL を文字列連結で組み立てずに済ませるための形。
+SELECT "id", "memberId", "medicationId", "userId", "scheduleId", "takenAt", "notes", "dosageAmount"
+FROM "MedicationRecord"
+WHERE "userId" = sqlc.arg(user_id)
+  AND (sqlc.narg(member_id)::text IS NULL OR "memberId" = sqlc.narg(member_id)::text)
+  AND (sqlc.narg(from_at)::timestamptz IS NULL OR "takenAt" >= sqlc.narg(from_at)::timestamptz)
+  AND (sqlc.narg(to_at)::timestamptz IS NULL OR "takenAt" < sqlc.narg(to_at)::timestamptz)
+ORDER BY "takenAt" DESC
+LIMIT sqlc.narg(row_limit)::int;

--- a/backend/internal/infrastructure/sqlc/queries/member.sql
+++ b/backend/internal/infrastructure/sqlc/queries/member.sql
@@ -8,3 +8,15 @@ ORDER BY "createdAt" ASC;
 SELECT "id", "userId", "memberType", "name", "petType", "photoUrl", "birthDate", "notes", "createdAt", "updatedAt"
 FROM "Member"
 WHERE "id" = $1;
+
+-- name: ListMemberSummaries :many
+-- メンバーごとの薬数を単一SQLで集計する(N+1回避)。
+SELECT m."id", m."userId", m."memberType", m."name", m."petType", m."photoUrl",
+       m."birthDate", m."notes", m."createdAt", m."updatedAt",
+       COUNT(med."id") AS medication_count,
+       COUNT(med."id") FILTER (WHERE med."isActive") AS active_count
+FROM "Member" m
+LEFT JOIN "Medication" med ON med."memberId" = m."id"
+WHERE m."userId" = $1
+GROUP BY m."id"
+ORDER BY m."createdAt" ASC;

--- a/backend/internal/infrastructure/sqlc/queries/prescription.sql
+++ b/backend/internal/infrastructure/sqlc/queries/prescription.sql
@@ -8,3 +8,17 @@ SELECT "id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder
 FROM "PrescriptionItem"
 WHERE "prescriptionId" = $1
 ORDER BY "sortOrder", "createdAt";
+
+-- name: ListPrescriptionsByUser :many
+SELECT "id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt",
+       "expiresAt", "pharmacyName", "electronicCode", "notes", "createdAt"
+FROM "Prescription"
+WHERE "userId" = $1
+ORDER BY "createdAt" DESC;
+
+-- name: ListPrescriptionItemsForPrescriptions :many
+-- 複数の処方箋の明細をまとめて引く。処方箋ごとに引くと件数分の往復になる。
+SELECT "id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder"
+FROM "PrescriptionItem"
+WHERE "prescriptionId" = ANY(sqlc.arg(prescription_ids)::text[])
+ORDER BY "sortOrder", "createdAt";

--- a/backend/internal/infrastructure/sqlc/queries/schedule.sql
+++ b/backend/internal/infrastructure/sqlc/queries/schedule.sql
@@ -10,3 +10,31 @@ SELECT "id", "medicationId", "userId", "memberId", "scheduledTime", "daysOfWeek"
        "intervalDays", "startDate", "isEnabled", "reminderMinutesBefore", "createdAt"
 FROM "Schedule"
 WHERE "id" = $1;
+
+-- name: ListTodaySchedules :many
+-- 当日有効なスケジュールを薬・メンバー情報と結合して返す。
+-- is_completed の所有者一致 (r."userId" = s."userId") は必須。外れると、
+-- 他人のアカウントから作られた記録だけで「服薬済み」と表示され、
+-- 当人へのリマインドが黙って消える。
+SELECT s."id", s."medicationId", s."userId", s."memberId", s."scheduledTime",
+       s."daysOfWeek", s."intervalDays", s."startDate", s."isEnabled",
+       s."reminderMinutesBefore", s."createdAt",
+       m."name" AS medication_name,
+       mem."name" AS member_name,
+       mem."memberType" AS member_type,
+       m."displayOrder" AS display_order,
+       EXISTS(
+         SELECT 1 FROM "MedicationRecord" r
+         WHERE r."scheduleId" = s."id" AND r."userId" = s."userId"
+           AND r."takenAt" >= sqlc.arg(day_start)::timestamptz
+           AND r."takenAt" < sqlc.arg(day_end)::timestamptz
+       ) AS is_completed
+FROM "Schedule" s
+JOIN "Medication" m ON m."id" = s."medicationId"
+JOIN "Member" mem ON mem."id" = s."memberId"
+WHERE s."userId" = sqlc.arg(user_id)
+  AND s."isEnabled" = TRUE
+  AND m."isActive" = TRUE
+  AND m."status" NOT IN ('paused', 'discontinued')
+  AND (array_length(s."daysOfWeek", 1) IS NULL OR sqlc.arg(weekday)::text = ANY(s."daysOfWeek"))
+ORDER BY s."scheduledTime" ASC;

--- a/backend/internal/infrastructure/sqlc/queries/user.sql
+++ b/backend/internal/infrastructure/sqlc/queries/user.sql
@@ -21,6 +21,3 @@ WHERE "googleId" = $1;
 
 -- name: GetUserTokenVersion :one
 SELECT "tokenVersion" FROM "User" WHERE "id" = $1;
-
--- name: BumpUserTokenVersion :exec
-UPDATE "User" SET "tokenVersion" = "tokenVersion" + 1, "updatedAt" = now() WHERE "id" = $1;

--- a/backend/internal/infrastructure/sqlc/sqlcgen/expense.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/expense.sql.go
@@ -31,3 +31,155 @@ func (q *Queries) GetExpense(ctx context.Context, id string) (Expense, error) {
 	)
 	return i, err
 }
+
+const listExpensesFiltered = `-- name: ListExpensesFiltered :many
+SELECT "id", "userId", "memberId", "category", "amount", "description",
+       "expenseDate", "isDeductible", "createdAt"
+FROM "Expense"
+WHERE "userId" = $1
+  AND ($2::text IS NULL OR "memberId" = $2::text)
+  AND ($3::int IS NULL
+       OR EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = $3::int)
+ORDER BY "expenseDate" DESC
+`
+
+type ListExpensesFilteredParams struct {
+	UserID   string
+	MemberID *string
+	Year     *int32
+}
+
+// 任意の絞り込み(メンバー/年)で医療費を返す。NULL を渡した条件は無視される。
+// 年は JST 基準。UTC で切ると、元日や大晦日の記録が前後の年に混ざる。
+func (q *Queries) ListExpensesFiltered(ctx context.Context, arg ListExpensesFilteredParams) ([]Expense, error) {
+	rows, err := q.db.Query(ctx, listExpensesFiltered, arg.UserID, arg.MemberID, arg.Year)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Expense{}
+	for rows.Next() {
+		var i Expense
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserId,
+			&i.MemberId,
+			&i.Category,
+			&i.Amount,
+			&i.Description,
+			&i.ExpenseDate,
+			&i.IsDeductible,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const sumExpensesByCategory = `-- name: SumExpensesByCategory :many
+SELECT "category", SUM("amount")::bigint AS total
+FROM "Expense"
+WHERE "userId" = $1
+  AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = $2::int
+GROUP BY "category"
+`
+
+type SumExpensesByCategoryParams struct {
+	UserID string
+	Year   int32
+}
+
+type SumExpensesByCategoryRow struct {
+	Category string
+	Total    int64
+}
+
+func (q *Queries) SumExpensesByCategory(ctx context.Context, arg SumExpensesByCategoryParams) ([]SumExpensesByCategoryRow, error) {
+	rows, err := q.db.Query(ctx, sumExpensesByCategory, arg.UserID, arg.Year)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SumExpensesByCategoryRow{}
+	for rows.Next() {
+		var i SumExpensesByCategoryRow
+		if err := rows.Scan(&i.Category, &i.Total); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const sumExpensesByMonth = `-- name: SumExpensesByMonth :many
+SELECT EXTRACT(MONTH FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo')::int AS month,
+       SUM("amount")::bigint AS total
+FROM "Expense"
+WHERE "userId" = $1
+  AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = $2::int
+GROUP BY month
+ORDER BY month
+`
+
+type SumExpensesByMonthParams struct {
+	UserID string
+	Year   int32
+}
+
+type SumExpensesByMonthRow struct {
+	Month int32
+	Total int64
+}
+
+func (q *Queries) SumExpensesByMonth(ctx context.Context, arg SumExpensesByMonthParams) ([]SumExpensesByMonthRow, error) {
+	rows, err := q.db.Query(ctx, sumExpensesByMonth, arg.UserID, arg.Year)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SumExpensesByMonthRow{}
+	for rows.Next() {
+		var i SumExpensesByMonthRow
+		if err := rows.Scan(&i.Month, &i.Total); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const sumExpensesByYear = `-- name: SumExpensesByYear :one
+SELECT COALESCE(SUM("amount"), 0)::bigint AS total,
+       COALESCE(SUM("amount") FILTER (WHERE "isDeductible"), 0)::bigint AS deductible_total
+FROM "Expense"
+WHERE "userId" = $1
+  AND EXTRACT(YEAR FROM "expenseDate" AT TIME ZONE 'Asia/Tokyo') = $2::int
+`
+
+type SumExpensesByYearParams struct {
+	UserID string
+	Year   int32
+}
+
+type SumExpensesByYearRow struct {
+	Total           int64
+	DeductibleTotal int64
+}
+
+func (q *Queries) SumExpensesByYear(ctx context.Context, arg SumExpensesByYearParams) (SumExpensesByYearRow, error) {
+	row := q.db.QueryRow(ctx, sumExpensesByYear, arg.UserID, arg.Year)
+	var i SumExpensesByYearRow
+	err := row.Scan(&i.Total, &i.DeductibleTotal)
+	return i, err
+}

--- a/backend/internal/infrastructure/sqlc/sqlcgen/medication.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/medication.sql.go
@@ -41,6 +41,63 @@ func (q *Queries) GetMedication(ctx context.Context, id string) (Medication, err
 	return i, err
 }
 
+const listMedicationAlerts = `-- name: ListMedicationAlerts :many
+SELECT "id", "memberId", "userId", "name", "category", "dosageAmount", "frequency",
+       "stockQuantity", "stockAlertDate", "intervalHours", "instructions", "displayOrder",
+       "isActive", "status", "createdAt", "updatedAt"
+FROM "Medication"
+WHERE "userId" = $1
+  AND "isActive" = TRUE
+  AND (
+    ("stockQuantity" IS NOT NULL AND "stockQuantity" <= $2)
+    OR ("stockAlertDate" IS NOT NULL AND "stockAlertDate" <= now() + interval '7 days')
+  )
+ORDER BY "stockQuantity" ASC NULLS LAST, "createdAt" ASC
+`
+
+type ListMedicationAlertsParams struct {
+	UserId        string
+	StockQuantity *int32
+}
+
+// 在庫僅少(残数が閾値以下、もしくは在庫アラート日が7日以内)の有効な薬。
+func (q *Queries) ListMedicationAlerts(ctx context.Context, arg ListMedicationAlertsParams) ([]Medication, error) {
+	rows, err := q.db.Query(ctx, listMedicationAlerts, arg.UserId, arg.StockQuantity)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Medication{}
+	for rows.Next() {
+		var i Medication
+		if err := rows.Scan(
+			&i.ID,
+			&i.MemberId,
+			&i.UserId,
+			&i.Name,
+			&i.Category,
+			&i.DosageAmount,
+			&i.Frequency,
+			&i.StockQuantity,
+			&i.StockAlertDate,
+			&i.IntervalHours,
+			&i.Instructions,
+			&i.DisplayOrder,
+			&i.IsActive,
+			&i.Status,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listMedicationsByMember = `-- name: ListMedicationsByMember :many
 SELECT "id", "memberId", "userId", "name", "category", "dosageAmount", "frequency",
        "stockQuantity", "stockAlertDate", "intervalHours", "instructions", "displayOrder",

--- a/backend/internal/infrastructure/sqlc/sqlcgen/medication_record.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/medication_record.sql.go
@@ -7,6 +7,7 @@ package sqlcgen
 
 import (
 	"context"
+	"time"
 )
 
 const getMedicationRecord = `-- name: GetMedicationRecord :one
@@ -76,6 +77,62 @@ ORDER BY "takenAt" DESC
 
 func (q *Queries) ListMedicationRecordsByUser(ctx context.Context, userid string) ([]MedicationRecord, error) {
 	rows, err := q.db.Query(ctx, listMedicationRecordsByUser, userid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []MedicationRecord{}
+	for rows.Next() {
+		var i MedicationRecord
+		if err := rows.Scan(
+			&i.ID,
+			&i.MemberId,
+			&i.MedicationId,
+			&i.UserId,
+			&i.ScheduleId,
+			&i.TakenAt,
+			&i.Notes,
+			&i.DosageAmount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRecordsByUserFiltered = `-- name: ListRecordsByUserFiltered :many
+SELECT "id", "memberId", "medicationId", "userId", "scheduleId", "takenAt", "notes", "dosageAmount"
+FROM "MedicationRecord"
+WHERE "userId" = $1
+  AND ($2::text IS NULL OR "memberId" = $2::text)
+  AND ($3::timestamptz IS NULL OR "takenAt" >= $3::timestamptz)
+  AND ($4::timestamptz IS NULL OR "takenAt" < $4::timestamptz)
+ORDER BY "takenAt" DESC
+LIMIT $5::int
+`
+
+type ListRecordsByUserFilteredParams struct {
+	UserID   string
+	MemberID *string
+	FromAt   *time.Time
+	ToAt     *time.Time
+	RowLimit *int32
+}
+
+// 任意の絞り込み(メンバー/期間/件数上限)で服薬記録を返す。
+// NULL を渡した条件は無視される。SQL を文字列連結で組み立てずに済ませるための形。
+func (q *Queries) ListRecordsByUserFiltered(ctx context.Context, arg ListRecordsByUserFilteredParams) ([]MedicationRecord, error) {
+	rows, err := q.db.Query(ctx, listRecordsByUserFiltered,
+		arg.UserID,
+		arg.MemberID,
+		arg.FromAt,
+		arg.ToAt,
+		arg.RowLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/infrastructure/sqlc/sqlcgen/member.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/member.sql.go
@@ -7,6 +7,7 @@ package sqlcgen
 
 import (
 	"context"
+	"time"
 )
 
 const getMember = `-- name: GetMember :one
@@ -31,6 +32,67 @@ func (q *Queries) GetMember(ctx context.Context, id string) (Member, error) {
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const listMemberSummaries = `-- name: ListMemberSummaries :many
+SELECT m."id", m."userId", m."memberType", m."name", m."petType", m."photoUrl",
+       m."birthDate", m."notes", m."createdAt", m."updatedAt",
+       COUNT(med."id") AS medication_count,
+       COUNT(med."id") FILTER (WHERE med."isActive") AS active_count
+FROM "Member" m
+LEFT JOIN "Medication" med ON med."memberId" = m."id"
+WHERE m."userId" = $1
+GROUP BY m."id"
+ORDER BY m."createdAt" ASC
+`
+
+type ListMemberSummariesRow struct {
+	ID              string
+	UserId          string
+	MemberType      string
+	Name            string
+	PetType         *string
+	PhotoUrl        *string
+	BirthDate       *time.Time
+	Notes           *string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	MedicationCount int64
+	ActiveCount     int64
+}
+
+// メンバーごとの薬数を単一SQLで集計する(N+1回避)。
+func (q *Queries) ListMemberSummaries(ctx context.Context, userid string) ([]ListMemberSummariesRow, error) {
+	rows, err := q.db.Query(ctx, listMemberSummaries, userid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListMemberSummariesRow{}
+	for rows.Next() {
+		var i ListMemberSummariesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserId,
+			&i.MemberType,
+			&i.Name,
+			&i.PetType,
+			&i.PhotoUrl,
+			&i.BirthDate,
+			&i.Notes,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.MedicationCount,
+			&i.ActiveCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listMembers = `-- name: ListMembers :many

--- a/backend/internal/infrastructure/sqlc/sqlcgen/prescription.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/prescription.sql.go
@@ -93,3 +93,103 @@ func (q *Queries) ListPrescriptionItems(ctx context.Context, prescriptionid stri
 	}
 	return items, nil
 }
+
+const listPrescriptionItemsForPrescriptions = `-- name: ListPrescriptionItemsForPrescriptions :many
+SELECT "id", "prescriptionId", "name", "dosage", "frequency", "days", "sortOrder"
+FROM "PrescriptionItem"
+WHERE "prescriptionId" = ANY($1::text[])
+ORDER BY "sortOrder", "createdAt"
+`
+
+type ListPrescriptionItemsForPrescriptionsRow struct {
+	ID             string
+	PrescriptionId string
+	Name           string
+	Dosage         *string
+	Frequency      *string
+	Days           *int32
+	SortOrder      int32
+}
+
+// 複数の処方箋の明細をまとめて引く。処方箋ごとに引くと件数分の往復になる。
+func (q *Queries) ListPrescriptionItemsForPrescriptions(ctx context.Context, prescriptionIds []string) ([]ListPrescriptionItemsForPrescriptionsRow, error) {
+	rows, err := q.db.Query(ctx, listPrescriptionItemsForPrescriptions, prescriptionIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPrescriptionItemsForPrescriptionsRow{}
+	for rows.Next() {
+		var i ListPrescriptionItemsForPrescriptionsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.PrescriptionId,
+			&i.Name,
+			&i.Dosage,
+			&i.Frequency,
+			&i.Days,
+			&i.SortOrder,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listPrescriptionsByUser = `-- name: ListPrescriptionsByUser :many
+SELECT "id", "userId", "memberId", "prescriptionName", "prescribedBy", "prescribedAt",
+       "expiresAt", "pharmacyName", "electronicCode", "notes", "createdAt"
+FROM "Prescription"
+WHERE "userId" = $1
+ORDER BY "createdAt" DESC
+`
+
+type ListPrescriptionsByUserRow struct {
+	ID               string
+	UserId           string
+	MemberId         string
+	PrescriptionName string
+	PrescribedBy     *string
+	PrescribedAt     time.Time
+	ExpiresAt        *time.Time
+	PharmacyName     *string
+	ElectronicCode   *string
+	Notes            *string
+	CreatedAt        time.Time
+}
+
+func (q *Queries) ListPrescriptionsByUser(ctx context.Context, userid string) ([]ListPrescriptionsByUserRow, error) {
+	rows, err := q.db.Query(ctx, listPrescriptionsByUser, userid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListPrescriptionsByUserRow{}
+	for rows.Next() {
+		var i ListPrescriptionsByUserRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserId,
+			&i.MemberId,
+			&i.PrescriptionName,
+			&i.PrescribedBy,
+			&i.PrescribedAt,
+			&i.ExpiresAt,
+			&i.PharmacyName,
+			&i.ElectronicCode,
+			&i.Notes,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/backend/internal/infrastructure/sqlc/sqlcgen/schedule.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/schedule.sql.go
@@ -7,6 +7,7 @@ package sqlcgen
 
 import (
 	"context"
+	"time"
 )
 
 const getSchedule = `-- name: GetSchedule :one
@@ -64,6 +65,103 @@ func (q *Queries) ListSchedulesByUser(ctx context.Context, userid string) ([]Sch
 			&i.IsEnabled,
 			&i.ReminderMinutesBefore,
 			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listTodaySchedules = `-- name: ListTodaySchedules :many
+SELECT s."id", s."medicationId", s."userId", s."memberId", s."scheduledTime",
+       s."daysOfWeek", s."intervalDays", s."startDate", s."isEnabled",
+       s."reminderMinutesBefore", s."createdAt",
+       m."name" AS medication_name,
+       mem."name" AS member_name,
+       mem."memberType" AS member_type,
+       m."displayOrder" AS display_order,
+       EXISTS(
+         SELECT 1 FROM "MedicationRecord" r
+         WHERE r."scheduleId" = s."id" AND r."userId" = s."userId"
+           AND r."takenAt" >= $1::timestamptz
+           AND r."takenAt" < $2::timestamptz
+       ) AS is_completed
+FROM "Schedule" s
+JOIN "Medication" m ON m."id" = s."medicationId"
+JOIN "Member" mem ON mem."id" = s."memberId"
+WHERE s."userId" = $3
+  AND s."isEnabled" = TRUE
+  AND m."isActive" = TRUE
+  AND m."status" NOT IN ('paused', 'discontinued')
+  AND (array_length(s."daysOfWeek", 1) IS NULL OR $4::text = ANY(s."daysOfWeek"))
+ORDER BY s."scheduledTime" ASC
+`
+
+type ListTodaySchedulesParams struct {
+	DayStart time.Time
+	DayEnd   time.Time
+	UserID   string
+	Weekday  string
+}
+
+type ListTodaySchedulesRow struct {
+	ID                    string
+	MedicationId          string
+	UserId                string
+	MemberId              string
+	ScheduledTime         string
+	DaysOfWeek            []string
+	IntervalDays          *int32
+	StartDate             *time.Time
+	IsEnabled             bool
+	ReminderMinutesBefore int32
+	CreatedAt             time.Time
+	MedicationName        string
+	MemberName            string
+	MemberType            string
+	DisplayOrder          int32
+	IsCompleted           bool
+}
+
+// 当日有効なスケジュールを薬・メンバー情報と結合して返す。
+// is_completed の所有者一致 (r."userId" = s."userId") は必須。外れると、
+// 他人のアカウントから作られた記録だけで「服薬済み」と表示され、
+// 当人へのリマインドが黙って消える。
+func (q *Queries) ListTodaySchedules(ctx context.Context, arg ListTodaySchedulesParams) ([]ListTodaySchedulesRow, error) {
+	rows, err := q.db.Query(ctx, listTodaySchedules,
+		arg.DayStart,
+		arg.DayEnd,
+		arg.UserID,
+		arg.Weekday,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListTodaySchedulesRow{}
+	for rows.Next() {
+		var i ListTodaySchedulesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.MedicationId,
+			&i.UserId,
+			&i.MemberId,
+			&i.ScheduledTime,
+			&i.DaysOfWeek,
+			&i.IntervalDays,
+			&i.StartDate,
+			&i.IsEnabled,
+			&i.ReminderMinutesBefore,
+			&i.CreatedAt,
+			&i.MedicationName,
+			&i.MemberName,
+			&i.MemberType,
+			&i.DisplayOrder,
+			&i.IsCompleted,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/infrastructure/sqlc/sqlcgen/user.sql.go
+++ b/backend/internal/infrastructure/sqlc/sqlcgen/user.sql.go
@@ -9,15 +9,6 @@ import (
 	"context"
 )
 
-const bumpUserTokenVersion = `-- name: BumpUserTokenVersion :exec
-UPDATE "User" SET "tokenVersion" = "tokenVersion" + 1, "updatedAt" = now() WHERE "id" = $1
-`
-
-func (q *Queries) BumpUserTokenVersion(ctx context.Context, id string) error {
-	_, err := q.db.Exec(ctx, bumpUserTokenVersion, id)
-	return err
-}
-
 const getUserByEmail = `-- name: GetUserByEmail :one
 SELECT "id", "email", "password", "displayName", "characterType", "characterName",
        "emailVerified", "verificationCode", "verificationExpiry", "verificationAttempts",


### PR DESCRIPTION
## Summary

永続化層の方針を「**書き込みは GORM / 読み取りは sqlc**」に統一し、生 SQL の文字列連結を無くす。

（#1181 のセキュリティ修正を土台にしているため、そのコミットを含みます。#1181 のマージ後にリベースします。）

### 着手前の実測

全106メソッドを分類したところ、方針から外れていたのは8件だけだった。

| 分類 | 着手前 | 着手後 |
|---|---|---|
| 方針どおり | 98 | **106** |
| 書き込みなのに sqlc | 1 | 0 |
| 読み取りなのに生 SQL | 7 | 0 |

`r.pool` による生 SQL は**ゼロ**になった。

### 変更

**書き込み → GORM**
- `BumpTokenVersion` を `gorm.Expr("tokenVersion" + 1)` に変更。原子性は Expr で保つ

**読み取り → sqlc**
- `ListSummary` / `ListAlerts` / `ListByUserFiltered`
- Expense の `List` / `Summary`（合計・カテゴリ別・月別）
- Prescription の `List` と明細のまとめ取得
- Schedule の `GetTodaySchedules`

### 文字列連結の廃止

動的な絞り込みは `sqlc.narg` で表現した。

```sql
WHERE "userId" = sqlc.arg(user_id)
  AND (sqlc.narg(member_id)::text IS NULL OR "memberId" = sqlc.narg(member_id)::text)
  AND (sqlc.narg(from_at)::timestamptz IS NULL OR "takenAt" >= sqlc.narg(from_at)::timestamptz)
```

従来は `query += ...` と `$N` を手で数えて組み立てていた。整数で組み立てているためインジェクションではないが、**条件を1つ足したときにプレースホルダ番号がずれる**類の事故が構造的に起きなくなる。

### 実 DB での検証

置き換え前後で結果が変わらないことを、実 PostgreSQL に対する統合テスト11項目で確認した。

| 項目 |
|---|
| メンバー集計 / 在庫アラート |
| 服薬記録の絞り込みなし・メンバー・期間・件数上限 |
| 医療費の絞り込み（メンバー・年・該当なし） |
| 医療費の集計（合計・控除対象・カテゴリ別・月別） |
| 処方箋と明細のまとめ取得 |
| 今日の予定（結合・所有者一致の EXISTS） |

`GetTodaySchedules` の `r."userId" = s."userId"` は、他人が作った記録で「服薬済み」と表示されないための条件。移行後も維持していることをテストで固定した。