### PR TITLE
fix: 「今日」をJSTで切り、宛先ログとE2Eバイパスを除去する

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -70,7 +70,7 @@ func main() {
 	}
 
 	handlers := &router.Handlers{
-		Auth:       handler.NewAuthHandler(authUsecase, cfg.E2ETestLoginSecret),
+		Auth:       handler.NewAuthHandler(authUsecase),
 		Member:     handler.NewMemberHandler(usecase.NewMemberUsecase(memberRepo)),
 		Medication: handler.NewMedicationHandler(usecase.NewMedicationUsecase(medRepo, memberRepo)),
 		Schedule:   handler.NewScheduleHandler(usecase.NewScheduleUsecase(schedRepo, medRepo)),

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -21,8 +21,6 @@ type Config struct {
 	// 認可コードグラント用のクライアントシークレット。
 	// 空なら /google/callback は無効。ID トークン方式 (/google) だけが残る。
 	GoogleClientSecret string
-	// E2Eテスト用ログインバイパスの共有シークレット。空なら無効(本番)。
-	E2ETestLoginSecret string
 	// 自分たちの基盤が X-Forwarded-For に足す段数。
 	// Cloud Run に直接ぶら下げるなら 1、前段が無ければ 0。
 	// 既定を 0 にしているのは、設定し忘れたときに「クライアントの言い値を信じる」
@@ -73,7 +71,6 @@ func Load() (*Config, error) {
 		AppBaseURL:         getEnv("APP_BASE_URL", "http://localhost:5173"),
 		GoogleClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		GoogleClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
-		E2ETestLoginSecret: os.Getenv("E2E_TEST_LOGIN_SECRET"),
 		TrustedProxyHops:   trustedProxyHops(),
 	}
 

--- a/backend/internal/interface/handler/auth_handler.go
+++ b/backend/internal/interface/handler/auth_handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"crypto/subtle"
 	"github.com/gin-gonic/gin"
 
 	"healthfamily/internal/pkg/googleauth"
@@ -11,40 +10,11 @@ import (
 
 // AuthHandler は認証エンドポイント
 type AuthHandler struct {
-	uc              *usecase.AuthUsecase
-	testLoginSecret string // 空ならテストログイン無効
+	uc *usecase.AuthUsecase // 空ならテストログイン無効
 }
 
-func NewAuthHandler(uc *usecase.AuthUsecase, testLoginSecret string) *AuthHandler {
-	return &AuthHandler{uc: uc, testLoginSecret: testLoginSecret}
-}
-
-// TestLoginEnabled はテスト用ログインバイパスが有効か
-func (h *AuthHandler) TestLoginEnabled() bool { return h.testLoginSecret != "" }
-
-type testLoginRequest struct {
-	Email string `json:"email" binding:"required,email"`
-}
-
-// TestLogin はE2E用のログインバイパス。X-E2E-Secret が一致した場合のみ JWT を返す。
-func (h *AuthHandler) TestLogin(c *gin.Context) {
-	// シークレットの比較は定数時間で行う。応答時間の差から1文字ずつ絞り込まれうる。
-	if h.testLoginSecret == "" ||
-		subtle.ConstantTimeCompare([]byte(c.GetHeader("X-E2E-Secret")), []byte(h.testLoginSecret)) != 1 {
-		response.Error(c, 403, "テストログインは無効です")
-		return
-	}
-	var req testLoginRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		response.Error(c, 400, "メールアドレスが正しくありません")
-		return
-	}
-	token, user, err := h.uc.TestLogin(c.Request.Context(), req.Email)
-	if err != nil {
-		response.HandleDomainError(c, err)
-		return
-	}
-	response.Success(c, gin.H{"token": token, "user": user})
+func NewAuthHandler(uc *usecase.AuthUsecase) *AuthHandler {
+	return &AuthHandler{uc: uc}
 }
 
 type googleLoginRequest struct {

--- a/backend/internal/interface/handler/auth_handler.go
+++ b/backend/internal/interface/handler/auth_handler.go
@@ -10,7 +10,7 @@ import (
 
 // AuthHandler は認証エンドポイント
 type AuthHandler struct {
-	uc *usecase.AuthUsecase // 空ならテストログイン無効
+	uc *usecase.AuthUsecase
 }
 
 func NewAuthHandler(uc *usecase.AuthUsecase) *AuthHandler {

--- a/backend/internal/interface/router/router.go
+++ b/backend/internal/interface/router/router.go
@@ -62,10 +62,6 @@ func Setup(h *Handlers, tm *auth.TokenManager, tokenVersions middleware.TokenVer
 		authGroup.POST("/resend-code", ipLimit("resend", 5), h.Auth.ResendCode)
 		authGroup.POST("/forgot-password", ipLimit("forgot", 5), h.Auth.ForgotPassword)
 		authGroup.POST("/reset-password", ipLimit("reset", 5), h.Auth.ResetPassword)
-		// E2Eテスト用ログインバイパス（E2E_TEST_LOGIN_SECRET 設定時のみ登録。本番では無効）
-		if h.Auth.TestLoginEnabled() {
-			authGroup.POST("/test-login", h.Auth.TestLogin)
-		}
 	}
 
 	// --- 認証必須 ---

--- a/backend/internal/interface/router/router_smoke_test.go
+++ b/backend/internal/interface/router/router_smoke_test.go
@@ -17,7 +17,7 @@ func TestSetupRegistersWithoutPanic(t *testing.T) {
 	db := &database.DB{}
 	tm := auth.NewTokenManager("test-secret", time.Hour)
 	h := &Handlers{
-		Auth:       handler.NewAuthHandler(usecase.NewAuthUsecase(nil, tm, mailer.NewResendMailer("", ""), nil), ""),
+		Auth:       handler.NewAuthHandler(usecase.NewAuthUsecase(nil, tm, mailer.NewResendMailer("", ""), nil)),
 		Member:     handler.NewMemberHandler(usecase.NewMemberUsecase(nil)),
 		Medication: handler.NewMedicationHandler(usecase.NewMedicationUsecase(nil, nil)),
 		Schedule:   handler.NewScheduleHandler(usecase.NewScheduleUsecase(nil, nil)),

--- a/backend/internal/pkg/mailer/mailer.go
+++ b/backend/internal/pkg/mailer/mailer.go
@@ -30,7 +30,9 @@ func NewResendMailer(apiKey, from string) *ResendMailer {
 func (m *ResendMailer) send(ctx context.Context, to, subject, html string) error {
 	// APIキー未設定時は開発用にログ出力のみ（送信スキップ）
 	if m.apiKey == "" {
-		fmt.Printf("[mailer] (skipped, no API key) to=%s subject=%s\n", to, subject)
+		// 宛先は出さない。APIキーの設定漏れでログが「登録を試みた人の一覧」になる。
+		// 開発時に知りたいのは「送信が起きたか」であって誰宛かではない
+		fmt.Printf("[mailer] (skipped, no API key) subject=%s\n", subject)
 		return nil
 	}
 	payload, _ := json.Marshal(map[string]any{

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -204,8 +204,6 @@ func (uc *AuthUsecase) Login(ctx context.Context, email, password string) (strin
 	return token, u, err
 }
 
-// TestLogin はE2Eテスト用のログインバイパス。指定メールの検証済みユーザーを
-// 取得（無ければ作成）してJWTを発行する。ハンドラ側でシークレット検証済み前提。
 // LoginWithGoogle は Google の ID トークン (OIDC) を検証してログインする。
 // googleId 一致 → 既存メールへの紐付け → 新規作成 の順で解決する。
 func (uc *AuthUsecase) LoginWithGoogle(ctx context.Context, credential string) (string, *entity.User, error) {
@@ -281,37 +279,6 @@ func (uc *AuthUsecase) LoginWithGoogle(ctx context.Context, credential string) (
 		}
 	}
 
-	token, err := uc.tokens.Generate(u.ID, u.Email, u.TokenVersion, uc.now())
-	return token, u, err
-}
-
-func (uc *AuthUsecase) TestLogin(ctx context.Context, email string) (string, *entity.User, error) {
-	email = strings.ToLower(strings.TrimSpace(email))
-	if email == "" {
-		return "", nil, domain.NewValidation("メールアドレスが必要です")
-	}
-	u, err := uc.users.FindByEmail(ctx, email)
-	if err != nil {
-		return "", nil, err
-	}
-	if u == nil {
-		hashed, herr := auth.HashPassword(auth.NewID())
-		if herr != nil {
-			return "", nil, herr
-		}
-		name := "E2E Test User"
-		u = &entity.User{
-			ID:            auth.NewID(),
-			Email:         email,
-			Password:      hashed,
-			DisplayName:   &name,
-			CharacterType: "cat",
-			EmailVerified: true,
-		}
-		if err := uc.users.Create(ctx, u); err != nil {
-			return "", nil, err
-		}
-	}
 	token, err := uc.tokens.Generate(u.ID, u.Email, u.TokenVersion, uc.now())
 	return token, u, err
 }

--- a/backend/internal/usecase/budget_usecase.go
+++ b/backend/internal/usecase/budget_usecase.go
@@ -11,8 +11,6 @@ import (
 	"healthfamily/internal/pkg/mailer"
 )
 
-var jst = time.FixedZone("Asia/Tokyo", 9*60*60)
-
 // BudgetUsecase は月次予算（パーソナライズ）と予算超過アラートのビジネスロジック
 type BudgetUsecase struct {
 	budgets  repository.BudgetRepository

--- a/backend/internal/usecase/schedule_timezone_test.go
+++ b/backend/internal/usecase/schedule_timezone_test.go
@@ -1,0 +1,59 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
+)
+
+// 「今日」は JST で切る。
+//
+// 本番コンテナは distroless/static で tzdata を含まないため time.Local は UTC。
+// UTC のまま日付を切ると、日本時間の 0〜9 時は前日として扱われ、
+// 毎朝その時間帯だけ前日の服薬予定が表示される。
+
+type recordingScheduleRepo struct {
+	repository.ScheduleRepository
+	gotDate time.Time
+}
+
+func (r *recordingScheduleRepo) GetTodaySchedules(_ context.Context, _ string, date time.Time) ([]entity.TodaySchedule, error) {
+	r.gotDate = date
+	return nil, nil
+}
+
+func TestToday_UTCで渡されてもJSTの日付で切る(t *testing.T) {
+	cases := []struct {
+		name    string
+		utc     string
+		wantYMD string
+	}{
+		{"日本時間の朝8時 (UTCでは前日23時)", "2026-08-16T23:00:00Z", "2026-08-17"},
+		{"日本時間の午前0時ちょうど", "2026-08-16T15:00:00Z", "2026-08-17"},
+		{"日本時間の昼", "2026-08-17T03:00:00Z", "2026-08-17"},
+		{"日本時間の23時台", "2026-08-17T14:59:00Z", "2026-08-17"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &recordingScheduleRepo{}
+			uc := &ScheduleUsecase{schedules: repo}
+			at, _ := time.Parse(time.RFC3339, tc.utc)
+
+			if _, err := uc.Today(context.Background(), "u-1", at); err != nil {
+				t.Fatalf("%v", err)
+			}
+
+			got := repo.gotDate.Format("2006-01-02")
+			if got != tc.wantYMD {
+				t.Errorf("渡された日付 = %s, want %s (前日の予定が出る)", got, tc.wantYMD)
+			}
+			if _, offset := repo.gotDate.Zone(); offset != 9*60*60 {
+				t.Errorf("JST で渡されていない: offset=%d", offset)
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/schedule_usecase.go
+++ b/backend/internal/usecase/schedule_usecase.go
@@ -37,8 +37,13 @@ func (uc *ScheduleUsecase) List(ctx context.Context, userID string) ([]entity.Sc
 	return uc.schedules.ListByUser(ctx, userID)
 }
 
+// Today は「今日」の服薬予定を返す。
+//
+// 受け取った時刻を必ず JST に直してから渡す。GetTodaySchedules は
+// date.Location() から曜日と一日の範囲を導くので、UTC のまま渡すと
+// 日本時間の 0〜9 時に前日の予定が返る。
 func (uc *ScheduleUsecase) Today(ctx context.Context, userID string, date time.Time) ([]entity.TodaySchedule, error) {
-	return uc.schedules.GetTodaySchedules(ctx, userID, date)
+	return uc.schedules.GetTodaySchedules(ctx, userID, date.In(jst))
 }
 
 func (uc *ScheduleUsecase) Create(ctx context.Context, in repository.CreateScheduleInput) (*entity.Schedule, error) {

--- a/backend/internal/usecase/timezone.go
+++ b/backend/internal/usecase/timezone.go
@@ -1,0 +1,15 @@
+package usecase
+
+import "time"
+
+// jst はこのアプリの基準時間帯。
+//
+// 「今日」の境界も、医療費の年度の区切りも JST で決まる。実行環境の
+// time.Local には頼れない。本番コンテナは distroless/static で tzdata を
+// 含まないため time.Local は UTC になり、そのまま「今日」を切ると
+// 日本時間の 0〜9 時に前日の予定が返ってしまう。毎朝、服薬リマインドが
+// 一日ずれる形で壊れる。
+//
+// time.LoadLocation ではなく FixedZone にしているのは、tzdata が無い
+// 環境でも必ず成立させるため。日本には夏時間が無いので固定で足りる。
+var jst = time.FixedZone("Asia/Tokyo", 9*60*60)


### PR DESCRIPTION
## Summary

スキーマ全体監査で見つかった、互いに独立した3件を直す。いずれも DDL 不要。

### 1. 「今日」の予定が毎朝ずれていた

本番コンテナは `distroless/static` で **tzdata を含まない**ため `time.Local` は UTC。`GetTodaySchedules` は渡された時刻の `Location()` から曜日と一日の範囲を導くので、**日本時間 0〜9 時は前日として扱われて**いた。服薬リマインドという中核機能が、毎朝その時間帯だけ一日ずれる。

`jst` を usecase 共通に置き、`Today` で必ず JST に直してから渡す。tzdata の無い環境でも成立するよう `LoadLocation` ではなく `FixedZone` を使う（日本に夏時間は無いので固定で足りる）。

修正を外すとテストが落ちることを確認済み:

```
--- FAIL: .../日本時間の朝8時_(UTCでは前日23時)
    渡された日付 = 2026-08-16, want 2026-08-17 (前日の予定が出る)
--- FAIL: .../日本時間の午前0時ちょうど
```

### 2. 宛先メールアドレスをログに出していた

`RESEND_API_KEY` 未設定時に `to=%s` を出力していた。本番で設定漏れが起きると、**Cloud Logging が「登録や再設定を試みた人の一覧」になる**。開発時に知りたいのは送信が起きたかどうかであって、誰宛かではない。件名のみ残した。

### 3. E2E ログインバイパスを削除

`POST /api/auth/test-login` は任意のメールアドレスで7日間有効な JWT を発行し、アカウントが無ければ**認証済みで作成**する。公開の認証グループで**唯一レート制限が無い**経路だった。

シークレット比較は定数時間で行われており、`E2E_TEST_LOGIN_SECRET` 未設定なら登録もされないため本番では無効。ただし設定が漏れた瞬間に全アカウントが危険にさらされる。実際には使われておらず（参照はコメント1件のみ、E2E は通常のパスワードログインを使用）、存在自体が不要なリスクなので削除した。

## 監査で誤りだった指摘

同じ監査が挙げた 2件は、確認したところ成立しなかったので対応していない。

- `NotificationSetting.updatedAt` に DEFAULT が無く保存が 500 する → **本番ダンプに `DEFAULT now()` が存在**
- `Medication.isActive` を誰も書かない → **書き込みあり**（`medication_repository.go:137`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - E2Eテスト向けのログインバイパス機能と専用エンドポイントを削除しました。
  - 通常のログイン、Googleログイン、認証コードによるログインは引き続き利用できます。

- **バグ修正**
  - スケジュールの日付判定を日本時間（JST）基準に統一しました。
  - UTCとの日付境界付近でも、正しい服薬予定が表示されるようになりました。

- **セキュリティ**
  - メール送信スキップ時のログに宛先メールアドレスを出力しないよう変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->