### PR TITLE
fix(security): 資格情報の書き込みを用途別に分け、DB内で完結させる

### DIFF
--- a/backend/internal/domain/repository/repository.go
+++ b/backend/internal/domain/repository/repository.go
@@ -9,9 +9,14 @@ import (
 )
 
 // UserRepository はユーザー永続化の抽象
-// ErrResetCodeConsumed は、適用しようとした時点で再設定コードが
-// 既に消えていたことを表す。二重適用を防いだ結果であり、障害ではない。
-var ErrResetCodeConsumed = errors.New("reset code already consumed")
+// ErrCodeConsumed は、適用しようとした時点でコードが既に消えていたか、
+// 別のコードに差し替わっていたことを表す。二重適用や、古い検証結果での
+// 適用を防いだ結果であり、障害ではない。
+var ErrCodeConsumed = errors.New("code already consumed or replaced")
+
+// ErrAlreadyVerified は、書き込もうとした時点で対象が認証済みだったことを表す。
+// 未認証前提の操作を認証済みアカウントに適用しないための歯止め。
+var ErrAlreadyVerified = errors.New("account already verified")
 
 // UserRepository は利用者の永続化。
 //
@@ -28,21 +33,24 @@ type UserRepository interface {
 	UpdateProfile(ctx context.Context, u *entity.User) error
 
 	// SavePendingRegistration は未認証アカウントの登録内容を差し替える。
+	// 認証済みだった場合は ErrAlreadyVerified を返し、上書きしない。
 	SavePendingRegistration(ctx context.Context, id, hashedPassword string, displayName *string, code string, expiry time.Time) error
 	// SaveVerificationCode は新しい認証コードを置き、失敗回数を戻す。
 	SaveVerificationCode(ctx context.Context, id, code string, expiry time.Time) error
 	// MarkEmailVerified は認証済みにし、使い終わったコードを捨てる。
-	MarkEmailVerified(ctx context.Context, id string) error
-	// IncrementVerificationAttempts は DB 内で失敗を数え、上限でコードを捨てる。
-	IncrementVerificationAttempts(ctx context.Context, id string, max int) error
+	// 照合したコードを渡す。その間に再送で差し替わっていたら適用しない。
+	MarkEmailVerified(ctx context.Context, id, verifiedCode string) error
+	// ClaimVerificationAttempt は試行を1つ消費し、上限内であればコードを返す。
+	// 比較の前に消費することで、並列に投げられても比較の回数そのものを縛る。
+	ClaimVerificationAttempt(ctx context.Context, id string, max int) (code *string, expiresAt *time.Time, withinLimit bool, err error)
 
 	// SaveResetCode は再設定コードを置き、その試行回数を戻す。
 	SaveResetCode(ctx context.Context, id, code string, expiry time.Time) error
-	// IncrementResetAttempts は再設定コードの失敗を DB 内で数える。
-	IncrementResetAttempts(ctx context.Context, id string, max int) error
-	// ApplyPasswordReset はコードが残っている行にだけ新しいパスワードを設定し、
-	// 世代を繰り上げる。既に消えていればエラーを返す。
-	ApplyPasswordReset(ctx context.Context, id, hashedPassword string) error
+	// ClaimResetAttempt は再設定コードについて同じことを行う。
+	ClaimResetAttempt(ctx context.Context, id string, max int) (code *string, expiresAt *time.Time, withinLimit bool, err error)
+	// ApplyPasswordReset は照合したコードが残っている行にだけ新しいパスワードを
+	// 設定し、世代を繰り上げる。差し替わっていれば ErrCodeConsumed を返す。
+	ApplyPasswordReset(ctx context.Context, id, verifiedCode, hashedPassword string) error
 
 	// LinkGoogle は Google アカウントを紐付ける。
 	// resetCredentials が true なら、示されていないパスワードとコードを捨てる。

--- a/backend/internal/domain/repository/repository.go
+++ b/backend/internal/domain/repository/repository.go
@@ -2,24 +2,54 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"healthfamily/internal/domain/entity"
 )
 
 // UserRepository はユーザー永続化の抽象
+// ErrResetCodeConsumed は、適用しようとした時点で再設定コードが
+// 既に消えていたことを表す。二重適用を防いだ結果であり、障害ではない。
+var ErrResetCodeConsumed = errors.New("reset code already consumed")
+
+// UserRepository は利用者の永続化。
+//
+// 更新は用途ごとに分ける。読み出したスナップショットを丸ごと書き戻す口を
+// 1 つでも残すと、その間に走った資格情報の変更 (パスワード再設定など) を
+// 巻き戻し、消費済みのコードまで復活させてしまう。
 type UserRepository interface {
 	FindByEmail(ctx context.Context, email string) (*entity.User, error)
 	FindByID(ctx context.Context, id string) (*entity.User, error)
-	// TokenVersion は発行済みトークンの世代を返す。found が false なら利用者が存在しない。
-	// 認証のたびに呼ばれるため、行全体ではなくこの1列だけを引く。
-	TokenVersion(ctx context.Context, id string) (version int, found bool, err error)
-	// BumpTokenVersion は発行済みトークンの世代を DB 内で 1 つ繰り上げる。
-	// 読み出した値に足して書き戻すと、並行する Update に巻き戻される。
-	BumpTokenVersion(ctx context.Context, id string) error
 	FindByGoogleID(ctx context.Context, googleID string) (*entity.User, error)
 	Create(ctx context.Context, u *entity.User) error
-	Update(ctx context.Context, u *entity.User) error
+
+	// UpdateProfile は表示名・キャラクター設定だけを書き戻す。
+	UpdateProfile(ctx context.Context, u *entity.User) error
+
+	// SavePendingRegistration は未認証アカウントの登録内容を差し替える。
+	SavePendingRegistration(ctx context.Context, id, hashedPassword string, displayName *string, code string, expiry time.Time) error
+	// SaveVerificationCode は新しい認証コードを置き、失敗回数を戻す。
+	SaveVerificationCode(ctx context.Context, id, code string, expiry time.Time) error
+	// MarkEmailVerified は認証済みにし、使い終わったコードを捨てる。
+	MarkEmailVerified(ctx context.Context, id string) error
+	// IncrementVerificationAttempts は DB 内で失敗を数え、上限でコードを捨てる。
+	IncrementVerificationAttempts(ctx context.Context, id string, max int) error
+
+	// SaveResetCode は再設定コードを置き、その試行回数を戻す。
+	SaveResetCode(ctx context.Context, id, code string, expiry time.Time) error
+	// IncrementResetAttempts は再設定コードの失敗を DB 内で数える。
+	IncrementResetAttempts(ctx context.Context, id string, max int) error
+	// ApplyPasswordReset はコードが残っている行にだけ新しいパスワードを設定し、
+	// 世代を繰り上げる。既に消えていればエラーを返す。
+	ApplyPasswordReset(ctx context.Context, id, hashedPassword string) error
+
+	// LinkGoogle は Google アカウントを紐付ける。
+	// resetCredentials が true なら、示されていないパスワードとコードを捨てる。
+	LinkGoogle(ctx context.Context, id, subject string, resetCredentials bool, displayName *string) error
+
+	// TokenVersion は発行済みトークンの世代を返す。found が false なら利用者が存在しない。
+	TokenVersion(ctx context.Context, id string) (version int, found bool, err error)
 }
 
 // CreateMemberInput はメンバー作成入力

--- a/backend/internal/infrastructure/persistence/converted_reads_integration_test.go
+++ b/backend/internal/infrastructure/persistence/converted_reads_integration_test.go
@@ -11,6 +11,30 @@ import (
 )
 
 // sqlc へ置き換えた読み取りが、実DBに対して期待どおり動くこと。
+// このパッケージの読み取りテストが使う最小限のデータを用意する。
+// 外部で投入されている前提にすると、DB を作り直した瞬間に落ちる。
+func seedReadFixtures(t *testing.T, db *database.DB) {
+	t.Helper()
+	ctx := context.Background()
+	stmts := []string{
+		`DELETE FROM "User" WHERE "id" = 'u1'`,
+		`INSERT INTO "User"("id","email","password") VALUES ('u1','u1@example.test','x')`,
+		`INSERT INTO "Member"("id","userId","name") VALUES ('m1','u1','太郎')`,
+		`INSERT INTO "Medication"("id","memberId","userId","name","stockQuantity","isActive") VALUES ('med1','m1','u1','薬A',3,true)`,
+		`INSERT INTO "MedicationRecord"("id","memberId","medicationId","userId","takenAt") VALUES ('r1','m1','med1','u1',now())`,
+		`INSERT INTO "Expense"("id","userId","memberId","category","amount","expenseDate","isDeductible") VALUES ('e1','u1','m1','診察',3000,now(),true)`,
+		`INSERT INTO "Prescription"("id","userId","memberId","prescriptionName","prescribedAt") VALUES ('p1','u1','m1','処方箋A',now())`,
+		`INSERT INTO "PrescriptionItem"("id","prescriptionId","name","sortOrder") VALUES ('pi1','p1','薬X',1),('pi2','p1','薬Y',2)`,
+		`INSERT INTO "Schedule"("id","medicationId","userId","memberId","scheduledTime","isEnabled") VALUES ('s1','med1','u1','m1','08:00',true)`,
+	}
+	for _, q := range stmts {
+		if _, err := db.Pool.Exec(ctx, q); err != nil {
+			t.Fatalf("seed (%s): %v", q, err)
+		}
+	}
+	t.Cleanup(func() { _, _ = db.Pool.Exec(context.Background(), `DELETE FROM "User" WHERE "id" = 'u1'`) })
+}
+
 func TestConverted_sqlc読み取り(t *testing.T) {
 	if os.Getenv("HF_DB_INTEGRATION") != "1" {
 		t.Skip("HF_DB_INTEGRATION=1 以外はスキップ")
@@ -21,6 +45,7 @@ func TestConverted_sqlc読み取り(t *testing.T) {
 		t.Fatalf("connect: %v", err)
 	}
 	defer db.Close()
+	seedReadFixtures(t, db)
 
 	t.Run("メンバー集計", func(t *testing.T) {
 		got, err := NewMemberRepository(db).ListSummary(ctx, "u1")
@@ -95,6 +120,7 @@ func TestConverted_sqlc読み取り後半(t *testing.T) {
 		t.Fatalf("connect: %v", err)
 	}
 	defer db.Close()
+	seedReadFixtures(t, db)
 
 	t.Run("医療費の絞り込み", func(t *testing.T) {
 		repo := NewExpenseRepository(db)

--- a/backend/internal/infrastructure/persistence/credential_writes_integration_test.go
+++ b/backend/internal/infrastructure/persistence/credential_writes_integration_test.go
@@ -64,7 +64,7 @@ func TestUpdateProfile_資格情報を巻き戻さない(t *testing.T) {
 	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("save reset code: %v", err)
 	}
-	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$brandnew"); err != nil {
+	if err := repo.ApplyPasswordReset(ctx, id, "654321", "$2a$12$brandnew"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
 
@@ -100,7 +100,7 @@ func TestUpdateProfile_消費済みコードを復活させない(t *testing.T) 
 	}
 	stale, _ := repo.FindByID(ctx, id)
 
-	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$brandnew"); err != nil {
+	if err := repo.ApplyPasswordReset(ctx, id, "654321", "$2a$12$brandnew"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
 
@@ -132,7 +132,10 @@ func TestIncrementAttempts_並列でも数え落とさない(t *testing.T) {
 			save: func(r *UserRepository, id string) error {
 				return r.SaveVerificationCode(ctx, id, "123456", time.Now().Add(time.Hour))
 			},
-			bump:   func(r *UserRepository, id string) error { return r.IncrementVerificationAttempts(ctx, id, 100) },
+			bump: func(r *UserRepository, id string) error {
+				_, _, _, err := r.ClaimVerificationAttempt(ctx, id, 100)
+				return err
+			},
 			column: "verificationAttempts",
 		},
 		{
@@ -140,7 +143,10 @@ func TestIncrementAttempts_並列でも数え落とさない(t *testing.T) {
 			save: func(r *UserRepository, id string) error {
 				return r.SaveResetCode(ctx, id, "123456", time.Now().Add(time.Hour))
 			},
-			bump:   func(r *UserRepository, id string) error { return r.IncrementResetAttempts(ctx, id, 100) },
+			bump: func(r *UserRepository, id string) error {
+				_, _, _, err := r.ClaimResetAttempt(ctx, id, 100)
+				return err
+			},
 			column: "resetAttempts",
 		},
 	} {
@@ -187,9 +193,11 @@ func TestIncrementAttempts_上限でコードを捨てる(t *testing.T) {
 	if err := repo.SaveVerificationCode(ctx, id, "123456", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	for range 5 {
-		if err := repo.IncrementVerificationAttempts(ctx, id, 5); err != nil {
-			t.Fatalf("bump: %v", err)
+	// 上限を「超えた」回で捨てる。ちょうどの回で消すと、4回間違えた本人が
+	// 5回目に正しく入力しても、直後の照合でコードが見つからず弾かれる
+	for range 6 {
+		if _, _, _, err := repo.ClaimVerificationAttempt(ctx, id, 5); err != nil {
+			t.Fatalf("claim: %v", err)
 		}
 	}
 
@@ -213,12 +221,12 @@ func TestApplyPasswordReset_コードが消えていれば適用しない(t *tes
 	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$first"); err != nil {
+	if err := repo.ApplyPasswordReset(ctx, id, "654321", "$2a$12$first"); err != nil {
 		t.Fatalf("first reset: %v", err)
 	}
 
 	// 二度目。コードは既に消えている
-	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$second"); err == nil {
+	if err := repo.ApplyPasswordReset(ctx, id, "654321", "$2a$12$second"); err == nil {
 		t.Fatal("コードが無いのに再設定が通った")
 	}
 
@@ -239,12 +247,149 @@ func TestApplyPasswordReset_世代を繰り上げる(t *testing.T) {
 	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$new"); err != nil {
+	if err := repo.ApplyPasswordReset(ctx, id, "654321", "$2a$12$new"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
 
 	after, _, _ := repo.TokenVersion(ctx, id)
 	if after != before+1 {
 		t.Errorf("世代 = %d, want %d。再設定しても攻撃者のトークンが生き残る", after, before+1)
+	}
+}
+
+// 上限は「比較の回数」を縛らなければ意味がない。
+//
+// 読む→比較→加算 の順だと、並列に来たリクエストが全員同じ状態を読み、
+// 全員が比較まで到達する。加算を原子的にしても、縛れるのはラウンド数だけで、
+// 1ラウンドあたり並列数だけ推測を試せてしまう。
+// 加算を先に行い、返ってきた回数が上限内のときだけコードを渡す形にする。
+func TestClaimVerificationAttempt_並列でも上限を超えて配らない(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-claim-verify"
+	const max = 5
+	repo := seedUser(t, db, id)
+
+	if err := repo.SaveVerificationCode(ctx, id, "123456", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	const parallel = 20
+	var mu sync.Mutex
+	granted := 0
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range parallel {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			code, _, ok, err := repo.ClaimVerificationAttempt(ctx, id, max)
+			if err == nil && ok && code != nil {
+				mu.Lock()
+				granted++
+				mu.Unlock()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if granted > max {
+		t.Errorf("並列 %d 件に対して %d 回も推測を許した (上限 %d)。上限が並列数だけ薄くなっている",
+			parallel, granted, max)
+	}
+	if granted == 0 {
+		t.Error("一度も推測できないのは締め出しであって防御ではない")
+	}
+}
+
+func TestClaimResetAttempt_並列でも上限を超えて配らない(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-claim-reset"
+	const max = 5
+	repo := seedUser(t, db, id)
+
+	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	var mu sync.Mutex
+	granted := 0
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			code, _, ok, err := repo.ClaimResetAttempt(ctx, id, max)
+			if err == nil && ok && code != nil {
+				mu.Lock()
+				granted++
+				mu.Unlock()
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if granted > max {
+		t.Errorf("並列20件に対して %d 回も推測を許した (上限 %d)", granted, max)
+	}
+}
+
+// 認証済みになったアカウントに、後から登録内容を上書きできないこと。
+func TestSavePendingRegistration_認証済みには適用しない(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-pending-guard"
+	repo := seedUser(t, db, id)
+
+	// 間に認証が完了した
+	if err := repo.SaveVerificationCode(ctx, id, "123456", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save code: %v", err)
+	}
+	if err := repo.MarkEmailVerified(ctx, id, "123456"); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	err := repo.SavePendingRegistration(ctx, id, "$2a$12$attacker", nil, "111111", time.Now().Add(time.Hour))
+	if err == nil {
+		t.Fatal("認証済みアカウントに登録内容を上書きできた。攻撃者のパスワードで入れる")
+	}
+
+	after, _ := repo.FindByID(ctx, id)
+	if after.Password != "$2a$12$original" {
+		t.Errorf("パスワードが上書きされた: %q", after.Password)
+	}
+}
+
+// 再設定は、呼び出し側が実際に検証したコードに対してだけ適用されること。
+func TestApplyPasswordReset_検証したコードにだけ適用する(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-reset-bind"
+	repo := seedUser(t, db, id)
+
+	if err := repo.SaveResetCode(ctx, id, "111111", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// 呼び出し側が 111111 を検証した直後に、新しいコードが発行された
+	if err := repo.SaveResetCode(ctx, id, "222222", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save2: %v", err)
+	}
+
+	if err := repo.ApplyPasswordReset(ctx, id, "111111", "$2a$12$stale"); err == nil {
+		t.Fatal("古いコードでの再設定が通った")
+	}
+
+	after, _ := repo.FindByID(ctx, id)
+	if after.Password != "$2a$12$original" {
+		t.Errorf("古いコードでパスワードが変わった: %q", after.Password)
+	}
+	if after.ResetCode == nil || *after.ResetCode != "222222" {
+		t.Error("新しいコードが巻き添えで消えた")
 	}
 }

--- a/backend/internal/infrastructure/persistence/credential_writes_integration_test.go
+++ b/backend/internal/infrastructure/persistence/credential_writes_integration_test.go
@@ -1,0 +1,250 @@
+package persistence
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/infrastructure/database"
+)
+
+// 資格情報の書き込みは、読み出したスナップショットを書き戻す形にしない。
+//
+// プロフィール更新は password や各コードを読んでから書き戻していた。
+// その間にパスワード再設定が走ると、再設定が巻き戻り、消費済みの
+// 再設定コードまで復活する。試行回数も同様で、並列に投げられると
+// 全員が同じ値を読むため上限が並列数だけ薄くなる。
+//
+// 実行するには HF_DB_INTEGRATION=1 と DATABASE_URL が要る。
+
+func credTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	if os.Getenv("HF_DB_INTEGRATION") != "1" {
+		t.Skip("HF_DB_INTEGRATION=1 以外はスキップ")
+	}
+	db, err := database.New(context.Background(), os.Getenv("DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func seedUser(t *testing.T, db *database.DB, id string) *UserRepository {
+	t.Helper()
+	ctx := context.Background()
+	_, _ = db.Pool.Exec(ctx, `DELETE FROM "User" WHERE "id" = $1`, id)
+	t.Cleanup(func() { _, _ = db.Pool.Exec(context.Background(), `DELETE FROM "User" WHERE "id" = $1`, id) })
+	repo := NewUserRepository(db)
+	if err := repo.Create(ctx, &entity.User{
+		ID: id, Email: id + "@example.test", Password: "$2a$12$original", CharacterType: "cat",
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	return repo
+}
+
+// プロフィール更新が、その間に起きたパスワード再設定を巻き戻さないこと。
+func TestUpdateProfile_資格情報を巻き戻さない(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-cred-profile"
+	repo := seedUser(t, db, id)
+
+	// 別のリクエストが利用者を読み込む（この時点のパスワードは original）
+	stale, err := repo.FindByID(ctx, id)
+	if err != nil || stale == nil {
+		t.Fatalf("find: %v", err)
+	}
+
+	// その間にパスワード再設定が完了する
+	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save reset code: %v", err)
+	}
+	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$brandnew"); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	// 先に読み込んでいた側がプロフィールだけ変えて保存する
+	name := "新しい表示名"
+	stale.DisplayName = &name
+	if err := repo.UpdateProfile(ctx, stale); err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+
+	after, err := repo.FindByID(ctx, id)
+	if err != nil || after == nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if after.Password != "$2a$12$brandnew" {
+		t.Errorf("パスワードが巻き戻った: %q。再設定したのに古いパスワードで入れる", after.Password)
+	}
+	if after.DisplayName == nil || *after.DisplayName != name {
+		t.Error("巻き戻しを防ぐ代わりに、通常のプロフィール更新が効かなくなっている")
+	}
+}
+
+// 消費済みの再設定コードが、プロフィール更新で復活しないこと。
+func TestUpdateProfile_消費済みコードを復活させない(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-cred-code"
+	repo := seedUser(t, db, id)
+
+	expiry := time.Now().Add(10 * time.Minute)
+	if err := repo.SaveResetCode(ctx, id, "654321", expiry); err != nil {
+		t.Fatalf("save reset code: %v", err)
+	}
+	stale, _ := repo.FindByID(ctx, id)
+
+	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$brandnew"); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	name := "名前"
+	stale.DisplayName = &name
+	if err := repo.UpdateProfile(ctx, stale); err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+
+	after, _ := repo.FindByID(ctx, id)
+	if after.ResetCode != nil {
+		t.Errorf("消費済みの再設定コード %q が復活した。攻撃者が同じコードを再利用できる", *after.ResetCode)
+	}
+}
+
+// 並列に失敗を投げられても、試行回数を数え落とさないこと。
+func TestIncrementAttempts_並列でも数え落とさない(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name   string
+		save   func(*UserRepository, string) error
+		bump   func(*UserRepository, string) error
+		column string
+	}{
+		{
+			name: "メール認証",
+			save: func(r *UserRepository, id string) error {
+				return r.SaveVerificationCode(ctx, id, "123456", time.Now().Add(time.Hour))
+			},
+			bump:   func(r *UserRepository, id string) error { return r.IncrementVerificationAttempts(ctx, id, 100) },
+			column: "verificationAttempts",
+		},
+		{
+			name: "パスワード再設定",
+			save: func(r *UserRepository, id string) error {
+				return r.SaveResetCode(ctx, id, "123456", time.Now().Add(time.Hour))
+			},
+			bump:   func(r *UserRepository, id string) error { return r.IncrementResetAttempts(ctx, id, 100) },
+			column: "resetAttempts",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id := "u-cred-race-" + tc.column
+			repo := seedUser(t, db, id)
+			if err := tc.save(repo, id); err != nil {
+				t.Fatalf("save: %v", err)
+			}
+
+			const parallel = 20
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			for range parallel {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					_ = tc.bump(repo, id)
+				}()
+			}
+			close(start)
+			wg.Wait()
+
+			var got int
+			if err := db.Pool.QueryRow(ctx,
+				`SELECT "`+tc.column+`" FROM "User" WHERE "id" = $1`, id).Scan(&got); err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if got != parallel {
+				t.Errorf("並列 %d 回の失敗が %d しか数えられていない。総当たり防御が並列数だけ薄くなる", parallel, got)
+			}
+		})
+	}
+}
+
+// 上限に達したらコードを捨てること。捨てないと、保存し忘れた瞬間に上限が無くなる。
+func TestIncrementAttempts_上限でコードを捨てる(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-cred-limit"
+	repo := seedUser(t, db, id)
+
+	if err := repo.SaveVerificationCode(ctx, id, "123456", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	for range 5 {
+		if err := repo.IncrementVerificationAttempts(ctx, id, 5); err != nil {
+			t.Fatalf("bump: %v", err)
+		}
+	}
+
+	after, _ := repo.FindByID(ctx, id)
+	if after.VerificationCode != nil {
+		t.Error("上限に達してもコードが残っている")
+	}
+	if after.VerificationExpiry != nil {
+		t.Error("期限だけ残っている")
+	}
+}
+
+// 再設定は、コードが一致する行にだけ適用されること。
+// 同じコードで二重に走っても、二度目は適用されない。
+func TestApplyPasswordReset_コードが消えていれば適用しない(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-cred-once"
+	repo := seedUser(t, db, id)
+
+	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$first"); err != nil {
+		t.Fatalf("first reset: %v", err)
+	}
+
+	// 二度目。コードは既に消えている
+	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$second"); err == nil {
+		t.Fatal("コードが無いのに再設定が通った")
+	}
+
+	after, _ := repo.FindByID(ctx, id)
+	if after.Password != "$2a$12$first" {
+		t.Errorf("二度目の再設定が適用された: %q", after.Password)
+	}
+}
+
+// 再設定は発行済みトークンを失効させること。
+func TestApplyPasswordReset_世代を繰り上げる(t *testing.T) {
+	db := credTestDB(t)
+	ctx := context.Background()
+	const id = "u-cred-version"
+	repo := seedUser(t, db, id)
+
+	before, _, _ := repo.TokenVersion(ctx, id)
+	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$new"); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+
+	after, _, _ := repo.TokenVersion(ctx, id)
+	if after != before+1 {
+		t.Errorf("世代 = %d, want %d。再設定しても攻撃者のトークンが生き残る", after, before+1)
+	}
+}

--- a/backend/internal/infrastructure/persistence/token_version_race_test.go
+++ b/backend/internal/infrastructure/persistence/token_version_race_test.go
@@ -55,7 +55,7 @@ func TestTokenVersion_並行更新で巻き戻らない(t *testing.T) {
 	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
 		t.Fatalf("save reset code: %v", err)
 	}
-	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$new"); err != nil {
+	if err := repo.ApplyPasswordReset(ctx, id, "654321", "$2a$12$new"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
 

--- a/backend/internal/infrastructure/persistence/token_version_race_test.go
+++ b/backend/internal/infrastructure/persistence/token_version_race_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"healthfamily/internal/domain/entity"
 	"healthfamily/internal/infrastructure/database"
@@ -51,14 +52,17 @@ func TestTokenVersion_並行更新で巻き戻らない(t *testing.T) {
 	}
 
 	// その間にパスワード再設定が走り、世代を繰り上げる
-	if err := repo.BumpTokenVersion(ctx, id); err != nil {
-		t.Fatalf("bump: %v", err)
+	if err := repo.SaveResetCode(ctx, id, "654321", time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("save reset code: %v", err)
+	}
+	if err := repo.ApplyPasswordReset(ctx, id, "$2a$12$new"); err != nil {
+		t.Fatalf("reset: %v", err)
 	}
 
 	// 先に読み込んでいた側が、無関係な項目を更新して保存する
 	name := "更新後の名前"
 	stale.DisplayName = &name
-	if err := repo.Update(ctx, stale); err != nil {
+	if err := repo.UpdateProfile(ctx, stale); err != nil {
 		t.Fatalf("update: %v", err)
 	}
 

--- a/backend/internal/infrastructure/persistence/user_repository.go
+++ b/backend/internal/infrastructure/persistence/user_repository.go
@@ -3,10 +3,12 @@ package persistence
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"gorm.io/gorm"
 	"healthfamily/internal/domain/entity"
+	"healthfamily/internal/domain/repository"
 	"healthfamily/internal/infrastructure/database"
 	"healthfamily/internal/infrastructure/sqlc/sqlcgen"
 )
@@ -96,25 +98,150 @@ func (r *UserRepository) Create(ctx context.Context, u *entity.User) error {
 	return r.gdb.WithContext(ctx).Create(&m).Error
 }
 
-func (r *UserRepository) Update(ctx context.Context, u *entity.User) error {
-	// 旧実装は全列を無条件に上書きする(updatedAt は now())。
-	fields := map[string]any{
-		"email":                u.Email,
-		"password":             u.Password,
-		"displayName":          u.DisplayName,
-		"characterType":        u.CharacterType,
-		"characterName":        u.CharacterName,
-		"emailVerified":        u.EmailVerified,
-		"verificationCode":     u.VerificationCode,
-		"verificationExpiry":   u.VerificationExpiry,
-		"verificationAttempts": u.VerificationAttempts,
-		"resetCode":            u.ResetCode,
-		"resetCodeExpiry":      u.ResetCodeExpiry,
-		"resetAttempts":        u.ResetAttempts,
-		"googleId":             u.GoogleID,
-		"updatedAt":            gorm.Expr("now()"),
+// UpdateProfile はプロフィール項目だけを書き戻す。
+//
+// 資格情報 (password, 各コード, 試行回数, tokenVersion) はここで触らない。
+// 読み出し時点のスナップショットを丸ごと書き戻す形にすると、その間に走った
+// パスワード再設定を巻き戻し、消費済みの再設定コードまで復活させてしまう。
+// 資格情報の遷移はそれぞれ専用のメソッドで、DB 内で完結させる。
+func (r *UserRepository) UpdateProfile(ctx context.Context, u *entity.User) error {
+	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, u.ID).
+		Updates(map[string]any{
+			"displayName":   u.DisplayName,
+			"characterType": u.CharacterType,
+			"characterName": u.CharacterName,
+			"updatedAt":     gorm.Expr("now()"),
+		}).Error
+}
+
+// SavePendingRegistration は未認証アカウントの登録内容を差し替え、新しい認証コードを置く。
+// 認証済みのアカウントには使わない (呼び出し側で弾く)。
+func (r *UserRepository) SavePendingRegistration(
+	ctx context.Context, id, hashedPassword string, displayName *string, code string, expiry time.Time,
+) error {
+	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, id).
+		Updates(map[string]any{
+			"password":             hashedPassword,
+			"displayName":          displayName,
+			"verificationCode":     code,
+			"verificationExpiry":   expiry,
+			"verificationAttempts": 0,
+			"updatedAt":            gorm.Expr("now()"),
+		}).Error
+}
+
+// SaveVerificationCode は新しい認証コードを置き、失敗回数を戻す。
+// 戻さないと、総当たりを受けた本人が再送を受け取ってもやり直せない。
+func (r *UserRepository) SaveVerificationCode(ctx context.Context, id, code string, expiry time.Time) error {
+	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, id).
+		Updates(map[string]any{
+			"verificationCode":     code,
+			"verificationExpiry":   expiry,
+			"verificationAttempts": 0,
+			"updatedAt":            gorm.Expr("now()"),
+		}).Error
+}
+
+// MarkEmailVerified は認証済みにし、使い終わったコードを捨てる。
+func (r *UserRepository) MarkEmailVerified(ctx context.Context, id string) error {
+	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, id).
+		Updates(map[string]any{
+			"emailVerified":        true,
+			"verificationCode":     nil,
+			"verificationExpiry":   nil,
+			"verificationAttempts": 0,
+			"updatedAt":            gorm.Expr("now()"),
+		}).Error
+}
+
+// IncrementVerificationAttempts は失敗回数を DB 内で1つ増やし、
+// 上限に達していればコードを捨てる。
+//
+// 読んだ値に +1 して書き戻す形だと、同時に来たリクエストが同じ値を読み、
+// 全員が同じ数を書く。上限に対して並列度ぶんだけ余計に試せてしまい、
+// アカウント側の総当たり防御が並列数だけ薄くなる。
+func (r *UserRepository) IncrementVerificationAttempts(ctx context.Context, id string, max int) error {
+	return r.gdb.WithContext(ctx).Exec(`
+		UPDATE "User"
+		SET "verificationAttempts" = "verificationAttempts" + 1,
+		    "verificationCode"     = CASE WHEN "verificationAttempts" + 1 >= ? THEN NULL ELSE "verificationCode" END,
+		    "verificationExpiry"   = CASE WHEN "verificationAttempts" + 1 >= ? THEN NULL ELSE "verificationExpiry" END,
+		    "updatedAt"            = now()
+		WHERE "id" = ?`, max, max, id).Error
+}
+
+// SaveResetCode は再設定コードを置き、その試行回数を戻す。
+func (r *UserRepository) SaveResetCode(ctx context.Context, id, code string, expiry time.Time) error {
+	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, id).
+		Updates(map[string]any{
+			"resetCode":       code,
+			"resetCodeExpiry": expiry,
+			"resetAttempts":   0,
+			"updatedAt":       gorm.Expr("now()"),
+		}).Error
+}
+
+// IncrementResetAttempts は再設定コードについて同じことを行う。
+// メール認証とは別に数えるのは、片方への攻撃でもう片方まで
+// 本人が使えなくなるのを避けるため。
+func (r *UserRepository) IncrementResetAttempts(ctx context.Context, id string, max int) error {
+	return r.gdb.WithContext(ctx).Exec(`
+		UPDATE "User"
+		SET "resetAttempts"   = "resetAttempts" + 1,
+		    "resetCode"       = CASE WHEN "resetAttempts" + 1 >= ? THEN NULL ELSE "resetCode" END,
+		    "resetCodeExpiry" = CASE WHEN "resetAttempts" + 1 >= ? THEN NULL ELSE "resetCodeExpiry" END,
+		    "updatedAt"       = now()
+		WHERE "id" = ?`, max, max, id).Error
+}
+
+// ApplyPasswordReset は新しいパスワードを設定し、コードを消して世代を繰り上げる。
+//
+// 再設定コードが残っている行にだけ適用する。呼び出し側は定数時間比較で
+// コードを検証済みだが、その検証と書き込みの間に別の再設定が完了しうる。
+// 条件を付けておけば、消費済みのコードで二度目が通ることはない。
+//
+// 世代の繰り上げも同じ文で行う。分けると、間に挟まった書き込みに
+// 巻き戻され、失効させたはずのトークンが生き残る。
+func (r *UserRepository) ApplyPasswordReset(ctx context.Context, id, hashedPassword string) error {
+	res := r.gdb.WithContext(ctx).Exec(`
+		UPDATE "User"
+		SET "password"        = ?,
+		    "resetCode"       = NULL,
+		    "resetCodeExpiry" = NULL,
+		    "resetAttempts"   = 0,
+		    "tokenVersion"    = "tokenVersion" + 1,
+		    "updatedAt"       = now()
+		WHERE "id" = ? AND "resetCode" IS NOT NULL`, hashedPassword, id)
+	if res.Error != nil {
+		return res.Error
 	}
-	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, u.ID).Updates(fields).Error
+	if res.RowsAffected == 0 {
+		return repository.ErrResetCodeConsumed
+	}
+	return nil
+}
+
+// LinkGoogle は Google アカウントを紐付ける。
+//
+// resetCredentials は、紐付け先が未認証だった場合に true を渡す。そのとき
+// パスワードと発行中のコードを捨てる。未認証のまま残っていた資格情報は
+// 誰が設定したものか分からず、残すと事前登録による乗っ取りが成立する。
+func (r *UserRepository) LinkGoogle(
+	ctx context.Context, id, subject string, resetCredentials bool, displayName *string,
+) error {
+	fields := map[string]any{
+		"googleId":      subject,
+		"emailVerified": true,
+		"updatedAt":     gorm.Expr("now()"),
+	}
+	if resetCredentials {
+		fields["password"] = ""
+		fields["displayName"] = displayName
+		fields["verificationCode"] = nil
+		fields["verificationExpiry"] = nil
+		fields["verificationAttempts"] = 0
+	}
+	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, id).Updates(fields).Error
 }
 
 // TokenVersion は発行済みトークンの世代だけを引く。
@@ -130,20 +257,4 @@ func (r *UserRepository) TokenVersion(ctx context.Context, id string) (int, bool
 		return 0, false, err
 	}
 	return int(v), true, nil
-}
-
-// BumpTokenVersion は発行済みトークンの世代を DB 内で 1 つ繰り上げる。
-//
-// 読み出した値に 1 を足して書き戻す形にはしない。世代を上げた直後に、
-// 上げる前の値を握った並行リクエストが汎用 Update を完了させると、
-// 世代が巻き戻って失効させたはずの JWT が再び通ってしまう。
-// プロフィール更新のような何気ない操作が攻撃者を呼び戻すことになる。
-func (r *UserRepository) BumpTokenVersion(ctx context.Context, id string) error {
-	return r.gdb.WithContext(ctx).
-		Model(&gormUser{}).
-		Where(`"id" = ?`, id).
-		Updates(map[string]any{
-			"tokenVersion": gorm.Expr(`"tokenVersion" + 1`),
-			"updatedAt":    gorm.Expr("now()"),
-		}).Error
 }

--- a/backend/internal/infrastructure/persistence/user_repository.go
+++ b/backend/internal/infrastructure/persistence/user_repository.go
@@ -119,7 +119,11 @@ func (r *UserRepository) UpdateProfile(ctx context.Context, u *entity.User) erro
 func (r *UserRepository) SavePendingRegistration(
 	ctx context.Context, id, hashedPassword string, displayName *string, code string, expiry time.Time,
 ) error {
-	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, id).
+	// 未認証の行にだけ適用する。呼び出し側も認証状態を見ているが、
+	// 読んでから書くまでの間に認証が完了しうる。そこで上書きを許すと、
+	// 攻撃者が送ったパスワードが認証済みアカウントに載ってしまう。
+	res := r.gdb.WithContext(ctx).Model(&gormUser{}).
+		Where(`"id" = ? AND "emailVerified" = FALSE`, id).
 		Updates(map[string]any{
 			"password":             hashedPassword,
 			"displayName":          displayName,
@@ -127,7 +131,14 @@ func (r *UserRepository) SavePendingRegistration(
 			"verificationExpiry":   expiry,
 			"verificationAttempts": 0,
 			"updatedAt":            gorm.Expr("now()"),
-		}).Error
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return repository.ErrAlreadyVerified
+	}
+	return nil
 }
 
 // SaveVerificationCode は新しい認証コードを置き、失敗回数を戻す。
@@ -143,31 +154,25 @@ func (r *UserRepository) SaveVerificationCode(ctx context.Context, id, code stri
 }
 
 // MarkEmailVerified は認証済みにし、使い終わったコードを捨てる。
-func (r *UserRepository) MarkEmailVerified(ctx context.Context, id string) error {
-	return r.gdb.WithContext(ctx).Model(&gormUser{}).Where(`"id" = ?`, id).
+// 呼び出し側が検証したコードを渡す。検証と書き込みの間に再送で
+// 差し替わっていたら適用しない。古い検証結果で認証を通さないため。
+func (r *UserRepository) MarkEmailVerified(ctx context.Context, id, verifiedCode string) error {
+	res := r.gdb.WithContext(ctx).Model(&gormUser{}).
+		Where(`"id" = ? AND "verificationCode" = ?`, id, verifiedCode).
 		Updates(map[string]any{
 			"emailVerified":        true,
 			"verificationCode":     nil,
 			"verificationExpiry":   nil,
 			"verificationAttempts": 0,
 			"updatedAt":            gorm.Expr("now()"),
-		}).Error
-}
-
-// IncrementVerificationAttempts は失敗回数を DB 内で1つ増やし、
-// 上限に達していればコードを捨てる。
-//
-// 読んだ値に +1 して書き戻す形だと、同時に来たリクエストが同じ値を読み、
-// 全員が同じ数を書く。上限に対して並列度ぶんだけ余計に試せてしまい、
-// アカウント側の総当たり防御が並列数だけ薄くなる。
-func (r *UserRepository) IncrementVerificationAttempts(ctx context.Context, id string, max int) error {
-	return r.gdb.WithContext(ctx).Exec(`
-		UPDATE "User"
-		SET "verificationAttempts" = "verificationAttempts" + 1,
-		    "verificationCode"     = CASE WHEN "verificationAttempts" + 1 >= ? THEN NULL ELSE "verificationCode" END,
-		    "verificationExpiry"   = CASE WHEN "verificationAttempts" + 1 >= ? THEN NULL ELSE "verificationExpiry" END,
-		    "updatedAt"            = now()
-		WHERE "id" = ?`, max, max, id).Error
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return repository.ErrCodeConsumed
+	}
+	return nil
 }
 
 // SaveResetCode は再設定コードを置き、その試行回数を戻す。
@@ -181,19 +186,6 @@ func (r *UserRepository) SaveResetCode(ctx context.Context, id, code string, exp
 		}).Error
 }
 
-// IncrementResetAttempts は再設定コードについて同じことを行う。
-// メール認証とは別に数えるのは、片方への攻撃でもう片方まで
-// 本人が使えなくなるのを避けるため。
-func (r *UserRepository) IncrementResetAttempts(ctx context.Context, id string, max int) error {
-	return r.gdb.WithContext(ctx).Exec(`
-		UPDATE "User"
-		SET "resetAttempts"   = "resetAttempts" + 1,
-		    "resetCode"       = CASE WHEN "resetAttempts" + 1 >= ? THEN NULL ELSE "resetCode" END,
-		    "resetCodeExpiry" = CASE WHEN "resetAttempts" + 1 >= ? THEN NULL ELSE "resetCodeExpiry" END,
-		    "updatedAt"       = now()
-		WHERE "id" = ?`, max, max, id).Error
-}
-
 // ApplyPasswordReset は新しいパスワードを設定し、コードを消して世代を繰り上げる。
 //
 // 再設定コードが残っている行にだけ適用する。呼び出し側は定数時間比較で
@@ -202,7 +194,7 @@ func (r *UserRepository) IncrementResetAttempts(ctx context.Context, id string, 
 //
 // 世代の繰り上げも同じ文で行う。分けると、間に挟まった書き込みに
 // 巻き戻され、失効させたはずのトークンが生き残る。
-func (r *UserRepository) ApplyPasswordReset(ctx context.Context, id, hashedPassword string) error {
+func (r *UserRepository) ApplyPasswordReset(ctx context.Context, id, verifiedCode, hashedPassword string) error {
 	res := r.gdb.WithContext(ctx).Exec(`
 		UPDATE "User"
 		SET "password"        = ?,
@@ -211,12 +203,12 @@ func (r *UserRepository) ApplyPasswordReset(ctx context.Context, id, hashedPassw
 		    "resetAttempts"   = 0,
 		    "tokenVersion"    = "tokenVersion" + 1,
 		    "updatedAt"       = now()
-		WHERE "id" = ? AND "resetCode" IS NOT NULL`, hashedPassword, id)
+		WHERE "id" = ? AND "resetCode" = ?`, hashedPassword, id, verifiedCode)
 	if res.Error != nil {
 		return res.Error
 	}
 	if res.RowsAffected == 0 {
-		return repository.ErrResetCodeConsumed
+		return repository.ErrCodeConsumed
 	}
 	return nil
 }
@@ -257,4 +249,82 @@ func (r *UserRepository) TokenVersion(ctx context.Context, id string) (int, bool
 		return 0, false, err
 	}
 	return int(v), true, nil
+}
+
+// ClaimVerificationAttempt は試行を1つ消費し、上限内であればコードを返す。
+//
+// 「読む → 比較 → 加算」の順にすると、並列に来たリクエストが全員同じ状態を
+// 読んで全員が比較まで到達する。加算だけ原子的にしても縛れるのはラウンド数で、
+// 1ラウンドあたり並列数だけ推測を試せてしまう。先に DB 内で消費し、
+// 返ってきた回数が上限内のときだけコードを渡すことで、比較の回数そのものを縛る。
+//
+// ok が false なら上限超過。code が nil ならコード未発行。
+// 上限に達した時点でコードは捨てられるので、その後は何を送っても当たらない。
+func (r *UserRepository) ClaimVerificationAttempt(
+	ctx context.Context, id string, max int,
+) (code *string, expiresAt *time.Time, ok bool, err error) {
+	return r.claimAttempt(ctx, id, max,
+		"verificationAttempts", "verificationCode", "verificationExpiry")
+}
+
+// ClaimResetAttempt は再設定コードについて同じことを行う。
+// メール認証とは別に数えるのは、片方への攻撃でもう片方まで
+// 本人が使えなくなるのを避けるため。
+func (r *UserRepository) ClaimResetAttempt(
+	ctx context.Context, id string, max int,
+) (code *string, expiresAt *time.Time, ok bool, err error) {
+	return r.claimAttempt(ctx, id, max, "resetAttempts", "resetCode", "resetCodeExpiry")
+}
+
+// claimAttempt は消費と取得を1文で行う。列名は呼び出し元が固定値で渡す。
+//
+// 消費「前」のコードを返すのが肝。SET の CASE で上限到達時にコードを捨てるが、
+// RETURNING は更新後の値なので、そのまま返すと上限ちょうどの回で必ず NULL になり、
+// 4回間違えた本人が5回目に正しく入力しても通らなくなる。
+// CTE で先に現在値を確保し、それを返す。
+//
+// 生きているコードが無ければ 1 行も返らない。数えるものが無いので消費もしない。
+// ここで数えると、コードを持たないアカウントに投げるだけで書き込みを起こせる。
+//
+// コードを捨てるのは上限を「超えた」ときで、ちょうどの回では残す。上限の回で
+// 消してしまうと、4回間違えた本人が5回目に正しく入力しても、直後の
+// MarkEmailVerified がコードを見つけられず弾かれる。上限を超えた呼び出しは
+// withinLimit=false で比較まで到達しないので、推測できる回数は変わらない。
+func (r *UserRepository) claimAttempt(
+	ctx context.Context, id string, max int, cntCol, codeCol, expCol string,
+) (*string, *time.Time, bool, error) {
+	var row struct {
+		Code      *string
+		ExpiresAt *time.Time
+		Attempts  int
+	}
+	err := r.gdb.WithContext(ctx).Raw(`
+		WITH cur AS (
+		    SELECT "id", "`+codeCol+`" AS code, "`+expCol+`" AS expires_at
+		    FROM "User"
+		    WHERE "id" = ? AND "`+codeCol+`" IS NOT NULL AND "`+expCol+`" > now()
+		    FOR UPDATE
+		), upd AS (
+		    UPDATE "User" u
+		    SET "`+cntCol+`" = u."`+cntCol+`" + 1,
+		        "`+codeCol+`" = CASE WHEN u."`+cntCol+`" + 1 > ? THEN NULL ELSE u."`+codeCol+`" END,
+		        "`+expCol+`"  = CASE WHEN u."`+cntCol+`" + 1 > ? THEN NULL ELSE u."`+expCol+`" END,
+		        "updatedAt"   = now()
+		    FROM cur
+		    WHERE u."id" = cur."id"
+		    RETURNING u."`+cntCol+`" AS attempts
+		)
+		SELECT cur.code, cur.expires_at, upd.attempts FROM cur, upd`,
+		id, max, max).Scan(&row).Error
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if row.Attempts == 0 {
+		// 生きているコードが無い。当たりようがないので、消費もせず素通りさせる
+		return nil, nil, true, nil
+	}
+	if row.Attempts > max {
+		return nil, nil, false, nil
+	}
+	return row.Code, row.ExpiresAt, true, nil
 }

--- a/backend/internal/pkg/googleauth/exchange_test.go
+++ b/backend/internal/pkg/googleauth/exchange_test.go
@@ -98,11 +98,11 @@ func TestExchangerRequiresIDToken(t *testing.T) {
 
 func TestCodeGrantValidation(t *testing.T) {
 	cases := map[string]CodeGrant{
-		"コードが空":            {Code: "", CodeVerifier: strings.Repeat("v", 43), RedirectURI: "https://a.example.com/cb"},
-		"code_verifier が空": {Code: "c", CodeVerifier: "", RedirectURI: "https://a.example.com/cb"},
+		"コードが空":             {Code: "", CodeVerifier: strings.Repeat("v", 43), RedirectURI: "https://a.example.com/cb"},
+		"code_verifier が空":  {Code: "c", CodeVerifier: "", RedirectURI: "https://a.example.com/cb"},
 		"code_verifier が短い": {Code: "c", CodeVerifier: strings.Repeat("v", 42), RedirectURI: "https://a.example.com/cb"},
 		"code_verifier が長い": {Code: "c", CodeVerifier: strings.Repeat("v", 129), RedirectURI: "https://a.example.com/cb"},
-		"redirect_uri が空":  {Code: "c", CodeVerifier: strings.Repeat("v", 43), RedirectURI: ""},
+		"redirect_uri が空":   {Code: "c", CodeVerifier: strings.Repeat("v", 43), RedirectURI: ""},
 	}
 
 	for name, grant := range cases {

--- a/backend/internal/usecase/auth_attempts_test.go
+++ b/backend/internal/usecase/auth_attempts_test.go
@@ -108,11 +108,14 @@ func TestVerify_上限を超えたらコードを捨てる(t *testing.T) {
 		_, _, _ = uc.Verify(context.Background(), "pending@example.com", "000000")
 	}
 
-	if u.VerificationCode != nil {
-		t.Error("上限に達してもコードが残っている。分散した総当たりを止められない")
-	}
+	// 上限に達した後は、正しいコードでも比較まで到達しない。
+	// コード自体は上限を「超えた」呼び出しで捨てる。ちょうどの回で消すと、
+	// 4回間違えた本人が5回目に正しく入力しても弾かれてしまう
 	if _, _, err := uc.Verify(context.Background(), "pending@example.com", "123456"); err == nil {
 		t.Error("正しいコードがまだ通ってしまう")
+	}
+	if u.VerificationCode != nil {
+		t.Error("上限を超えた呼び出しの後もコードが残っている")
 	}
 	if u.EmailVerified {
 		t.Error("上限超過後に認証が通っている")
@@ -212,11 +215,11 @@ func TestResetPassword_上限を超えたらコードを捨てる(t *testing.T) 
 		_ = uc.ResetPassword(context.Background(), "user@example.com", "000000", "newpassword1")
 	}
 
-	if u.ResetCode != nil {
-		t.Error("上限に達しても再設定コードが残っている")
-	}
 	if err := uc.ResetPassword(context.Background(), "user@example.com", "654321", "newpassword1"); err == nil {
 		t.Error("正しいコードがまだ通ってしまう")
+	}
+	if u.ResetCode != nil {
+		t.Error("上限を超えた呼び出しの後も再設定コードが残っている")
 	}
 	if u.Password != "$2a$12$dummy" {
 		t.Error("パスワードが差し替わっている")

--- a/backend/internal/usecase/auth_google_test.go
+++ b/backend/internal/usecase/auth_google_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"healthfamily/internal/domain/repository"
 	"testing"
 	"time"
 
@@ -191,14 +192,131 @@ func (f *fakeUserRepo) TokenVersion(ctx context.Context, id string) (int, bool, 
 	return u.TokenVersion, true, nil
 }
 
-// 本物と同じく DB 内加算に相当する。読み出した値を書き戻さない
-func (f *fakeUserRepo) BumpTokenVersion(ctx context.Context, id string) error {
-	u, err := f.FindByID(ctx, id)
-	if err != nil {
+// --- repository.UserRepository の資格情報系メソッド ---
+// 本物と同じく、読み出したスナップショットを書き戻さない形で振る舞う。
+
+func (f *fakeUserRepo) UpdateProfile(ctx context.Context, u *entity.User) error {
+	cur, err := f.FindByID(ctx, u.ID)
+	if err != nil || cur == nil {
 		return err
 	}
-	if u != nil {
-		u.TokenVersion++
+	cur.DisplayName = u.DisplayName
+	cur.CharacterType = u.CharacterType
+	cur.CharacterName = u.CharacterName
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) SavePendingRegistration(ctx context.Context, id, hashed string, displayName *string, code string, expiry time.Time) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
 	}
+	u.Password = hashed
+	u.DisplayName = displayName
+	u.VerificationCode = &code
+	u.VerificationExpiry = &expiry
+	u.VerificationAttempts = 0
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) SaveVerificationCode(ctx context.Context, id, code string, expiry time.Time) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.VerificationCode = &code
+	u.VerificationExpiry = &expiry
+	u.VerificationAttempts = 0
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) MarkEmailVerified(ctx context.Context, id string) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.EmailVerified = true
+	u.VerificationCode = nil
+	u.VerificationExpiry = nil
+	u.VerificationAttempts = 0
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) IncrementVerificationAttempts(ctx context.Context, id string, max int) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.VerificationAttempts++
+	if u.VerificationAttempts >= max {
+		u.VerificationCode = nil
+		u.VerificationExpiry = nil
+	}
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) SaveResetCode(ctx context.Context, id, code string, expiry time.Time) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.ResetCode = &code
+	u.ResetCodeExpiry = &expiry
+	u.ResetAttempts = 0
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) IncrementResetAttempts(ctx context.Context, id string, max int) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.ResetAttempts++
+	if u.ResetAttempts >= max {
+		u.ResetCode = nil
+		u.ResetCodeExpiry = nil
+	}
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) ApplyPasswordReset(ctx context.Context, id, hashed string) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	if u.ResetCode == nil {
+		return repository.ErrResetCodeConsumed
+	}
+	u.Password = hashed
+	u.ResetCode = nil
+	u.ResetCodeExpiry = nil
+	u.ResetAttempts = 0
+	u.TokenVersion++
+	f.updated++
+	return nil
+}
+
+func (f *fakeUserRepo) LinkGoogle(ctx context.Context, id, subject string, resetCredentials bool, displayName *string) error {
+	u, err := f.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	if resetCredentials {
+		u.Password = ""
+		u.DisplayName = displayName
+		u.VerificationCode = nil
+		u.VerificationExpiry = nil
+		u.VerificationAttempts = 0
+	}
+	u.GoogleID = &subject
+	u.EmailVerified = true
+	f.updated++
 	return nil
 }

--- a/backend/internal/usecase/auth_google_test.go
+++ b/backend/internal/usecase/auth_google_test.go
@@ -212,6 +212,9 @@ func (f *fakeUserRepo) SavePendingRegistration(ctx context.Context, id, hashed s
 	if err != nil || u == nil {
 		return err
 	}
+	if u.EmailVerified {
+		return repository.ErrAlreadyVerified
+	}
 	u.Password = hashed
 	u.DisplayName = displayName
 	u.VerificationCode = &code
@@ -233,10 +236,13 @@ func (f *fakeUserRepo) SaveVerificationCode(ctx context.Context, id, code string
 	return nil
 }
 
-func (f *fakeUserRepo) MarkEmailVerified(ctx context.Context, id string) error {
+func (f *fakeUserRepo) MarkEmailVerified(ctx context.Context, id, verifiedCode string) error {
 	u, err := f.FindByID(ctx, id)
 	if err != nil || u == nil {
 		return err
+	}
+	if u.VerificationCode == nil || *u.VerificationCode != verifiedCode {
+		return repository.ErrCodeConsumed
 	}
 	u.EmailVerified = true
 	u.VerificationCode = nil
@@ -246,18 +252,26 @@ func (f *fakeUserRepo) MarkEmailVerified(ctx context.Context, id string) error {
 	return nil
 }
 
-func (f *fakeUserRepo) IncrementVerificationAttempts(ctx context.Context, id string, max int) error {
+func (f *fakeUserRepo) ClaimVerificationAttempt(ctx context.Context, id string, max int) (*string, *time.Time, bool, error) {
 	u, err := f.FindByID(ctx, id)
 	if err != nil || u == nil {
-		return err
+		return nil, nil, true, err
 	}
+	// 本物と同じ規則。生きているコードが無ければ消費しない
+	if u.VerificationCode == nil || u.VerificationExpiry == nil || !u.VerificationExpiry.After(time.Now()) {
+		return nil, nil, true, nil
+	}
+	code, expiry := u.VerificationCode, u.VerificationExpiry
 	u.VerificationAttempts++
-	if u.VerificationAttempts >= max {
+	if u.VerificationAttempts > max {
 		u.VerificationCode = nil
 		u.VerificationExpiry = nil
 	}
 	f.updated++
-	return nil
+	if u.VerificationAttempts > max {
+		return nil, nil, false, nil
+	}
+	return code, expiry, true, nil
 }
 
 func (f *fakeUserRepo) SaveResetCode(ctx context.Context, id, code string, expiry time.Time) error {
@@ -272,27 +286,35 @@ func (f *fakeUserRepo) SaveResetCode(ctx context.Context, id, code string, expir
 	return nil
 }
 
-func (f *fakeUserRepo) IncrementResetAttempts(ctx context.Context, id string, max int) error {
+func (f *fakeUserRepo) ClaimResetAttempt(ctx context.Context, id string, max int) (*string, *time.Time, bool, error) {
 	u, err := f.FindByID(ctx, id)
 	if err != nil || u == nil {
-		return err
+		return nil, nil, true, err
 	}
+	// 本物と同じ規則。生きているコードが無ければ消費しない
+	if u.ResetCode == nil || u.ResetCodeExpiry == nil || !u.ResetCodeExpiry.After(time.Now()) {
+		return nil, nil, true, nil
+	}
+	code, expiry := u.ResetCode, u.ResetCodeExpiry
 	u.ResetAttempts++
-	if u.ResetAttempts >= max {
+	if u.ResetAttempts > max {
 		u.ResetCode = nil
 		u.ResetCodeExpiry = nil
 	}
 	f.updated++
-	return nil
+	if u.ResetAttempts > max {
+		return nil, nil, false, nil
+	}
+	return code, expiry, true, nil
 }
 
-func (f *fakeUserRepo) ApplyPasswordReset(ctx context.Context, id, hashed string) error {
+func (f *fakeUserRepo) ApplyPasswordReset(ctx context.Context, id, verifiedCode, hashed string) error {
 	u, err := f.FindByID(ctx, id)
 	if err != nil || u == nil {
 		return err
 	}
-	if u.ResetCode == nil {
-		return repository.ErrResetCodeConsumed
+	if u.ResetCode == nil || *u.ResetCode != verifiedCode {
+		return repository.ErrCodeConsumed
 	}
 	u.Password = hashed
 	u.ResetCode = nil

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"strings"
 	"time"
 
@@ -105,11 +106,8 @@ func (uc *AuthUsecase) SignUp(ctx context.Context, email, password string, displ
 		if existing.EmailVerified {
 			return nil // 列挙防止: 何もせず成功扱い
 		}
-		existing.Password = hashed
-		existing.DisplayName = displayName
-		existing.VerificationCode = &code
-		existing.VerificationExpiry = &expiry
-		if err := uc.users.Update(ctx, existing); err != nil {
+		if err := uc.users.SavePendingRegistration(
+			ctx, existing.ID, hashed, displayName, code, expiry); err != nil {
 			return err
 		}
 		return uc.mail.SendVerificationCode(ctx, email, code)
@@ -152,28 +150,27 @@ func (uc *AuthUsecase) Verify(ctx context.Context, email, code string) (string, 
 		// 当たりうるコードが生きているときだけ数える。無い・期限切れなら
 		// どんな入力も当たりようがなく、数えると「でたらめなアドレスを投げるだけで
 		// 書き込みを起こせる」経路になる
+		// 当たりうるコードが生きているときだけ数える。無い・期限切れなら
+		// どんな入力も当たりようがなく、数えると「でたらめなアドレスを投げるだけで
+		// 書き込みを起こせる」経路になる
 		if u != nil && u.VerificationCode != nil && u.VerificationExpiry != nil &&
 			!uc.now().After(*u.VerificationExpiry) {
-			u.VerificationAttempts++
-			if u.VerificationAttempts >= MaxCodeAttempts {
-				u.VerificationCode = nil
-				u.VerificationExpiry = nil
-			}
-			// 保存しなければ次のリクエストで数え直しになり、上限が効かない
-			if err := uc.users.Update(ctx, u); err != nil {
+			// 加算は DB 内で行う。読んだ値に +1 して書き戻すと、並列に来た
+			// リクエストが同じ値を読み、上限が並列数だけ薄くなる
+			if err := uc.users.IncrementVerificationAttempts(ctx, u.ID, MaxCodeAttempts); err != nil {
 				return "", nil, err
 			}
 		}
 		return "", nil, domain.NewValidation(invalidCode)
 	}
 
+	if err := uc.users.MarkEmailVerified(ctx, u.ID); err != nil {
+		return "", nil, err
+	}
 	u.EmailVerified = true
 	u.VerificationCode = nil
 	u.VerificationExpiry = nil
 	u.VerificationAttempts = 0
-	if err := uc.users.Update(ctx, u); err != nil {
-		return "", nil, err
-	}
 	token, err := uc.tokens.Generate(u.ID, u.Email, u.TokenVersion, uc.now())
 	return token, u, err
 }
@@ -249,7 +246,11 @@ func (uc *AuthUsecase) LoginWithGoogle(ctx context.Context, credential string) (
 			//
 			// ここで消しても本人は困らない。所有を示せる本人は再設定コードで
 			// 設定し直せるし、未認証のアカウントはログインできないので中身も無い。
-			if !u.EmailVerified {
+			resetCredentials := !u.EmailVerified
+			if err := uc.users.LinkGoogle(ctx, u.ID, sub, resetCredentials, claims.Name); err != nil {
+				return "", nil, err
+			}
+			if resetCredentials {
 				u.Password = ""
 				u.DisplayName = claims.Name
 				u.VerificationCode = nil
@@ -258,9 +259,6 @@ func (uc *AuthUsecase) LoginWithGoogle(ctx context.Context, credential string) (
 			}
 			u.GoogleID = &sub
 			u.EmailVerified = true
-			if err := uc.users.Update(ctx, u); err != nil {
-				return "", nil, err
-			}
 		} else {
 			u = &entity.User{
 				ID:    auth.NewID(),
@@ -292,12 +290,9 @@ func (uc *AuthUsecase) ResendCode(ctx context.Context, email string) error {
 	}
 	code := auth.NewVerificationCode()
 	expiry := uc.now().Add(10 * time.Minute)
-	u.VerificationCode = &code
-	u.VerificationExpiry = &expiry
 	// 新しいコードには新しい枠を与える。戻さないと、総当たりを受けた本人が
 	// 再送を受け取っても永久にやり直せなくなる
-	u.VerificationAttempts = 0
-	if err := uc.users.Update(ctx, u); err != nil {
+	if err := uc.users.SaveVerificationCode(ctx, u.ID, code, expiry); err != nil {
 		return err
 	}
 	return uc.mail.SendVerificationCode(ctx, email, code)
@@ -312,10 +307,7 @@ func (uc *AuthUsecase) ForgotPassword(ctx context.Context, email string) error {
 	}
 	code := auth.NewVerificationCode()
 	expiry := uc.now().Add(10 * time.Minute)
-	u.ResetCode = &code
-	u.ResetCodeExpiry = &expiry
-	u.ResetAttempts = 0
-	if err := uc.users.Update(ctx, u); err != nil {
+	if err := uc.users.SaveResetCode(ctx, u.ID, code, expiry); err != nil {
 		return err
 	}
 	return uc.mail.SendResetCode(ctx, email, code)
@@ -337,12 +329,7 @@ func (uc *AuthUsecase) ResetPassword(ctx context.Context, email, code, newPasswo
 		// もう片方まで本人が使えなくなるのを避けるため
 		if u != nil && u.ResetCode != nil && u.ResetCodeExpiry != nil &&
 			!uc.now().After(*u.ResetCodeExpiry) {
-			u.ResetAttempts++
-			if u.ResetAttempts >= MaxCodeAttempts {
-				u.ResetCode = nil
-				u.ResetCodeExpiry = nil
-			}
-			if err := uc.users.Update(ctx, u); err != nil {
+			if err := uc.users.IncrementResetAttempts(ctx, u.ID, MaxCodeAttempts); err != nil {
 				return err
 			}
 		}
@@ -352,20 +339,20 @@ func (uc *AuthUsecase) ResetPassword(ctx context.Context, email, code, newPasswo
 	if err != nil {
 		return err
 	}
-	u.Password = hashed
-	u.ResetCode = nil
-	u.ResetCodeExpiry = nil
-	u.ResetAttempts = 0
-	if err := uc.users.Update(ctx, u); err != nil {
-		return err
-	}
-	// 発行済みトークンを失効させる。パスワードを変えたのに攻撃者が
-	// 有効期限(7日)まで居座れるなら、乗っ取られた利用者に打つ手が無い。
+	// パスワードの設定・コードの破棄・世代の繰り上げを一文で行う。
+	//
+	// 発行済みトークンを失効させないと、パスワードを変えたのに攻撃者が
+	// 有効期限(7日)まで居座れてしまう。分けて書くと、間に挟まった
+	// 書き込みに巻き戻され、失効させたはずのトークンが生き残る。
 	//
 	// 繰り上げるのは照合に成功した後だけ。失敗でも動かすと、第三者が
 	// でたらめなコードを送りつけるだけで任意の利用者を締め出せてしまう。
-	//
-	// 加算は DB 内で行う。読み出した値に足して書き戻すと、
-	// 上げる前の値を握った並行リクエストに巻き戻される
-	return uc.users.BumpTokenVersion(ctx, u.ID)
+	if err := uc.users.ApplyPasswordReset(ctx, u.ID, hashed); err != nil {
+		// コードが既に消えていた場合も、利用者からは通常の失敗と同じに見せる
+		if errors.Is(err, repository.ErrResetCodeConsumed) {
+			return domain.NewValidation("再設定コードが正しくないか、有効期限が切れています")
+		}
+		return err
+	}
+	return nil
 }

--- a/backend/internal/usecase/auth_usecase.go
+++ b/backend/internal/usecase/auth_usecase.go
@@ -108,6 +108,11 @@ func (uc *AuthUsecase) SignUp(ctx context.Context, email, password string, displ
 		}
 		if err := uc.users.SavePendingRegistration(
 			ctx, existing.ID, hashed, displayName, code, expiry); err != nil {
+			// 読んでから書くまでの間に認証が完了していた。認証済みには
+			// 上書きさせない。登録済みであることは伝えないので成功扱いで返す
+			if errors.Is(err, repository.ErrAlreadyVerified) {
+				return nil
+			}
 			return err
 		}
 		return uc.mail.SendVerificationCode(ctx, email, code)
@@ -132,39 +137,42 @@ func (uc *AuthUsecase) SignUp(ctx context.Context, email, password string, displ
 // Verify は認証コードを検証しメールアドレスを有効化する
 func (uc *AuthUsecase) Verify(ctx context.Context, email, code string) (string, *entity.User, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
-	u, err := uc.users.FindByEmail(ctx, email)
-	if err != nil {
-		return "", nil, err
-	}
 	// 存在しないユーザーと、コードが合わないユーザーは同じ結果にする（列挙防止）。
 	// ここで分岐すると「そのメールアドレスは登録済みか」が漏れる。
 	const invalidCode = "認証コードが正しくないか、有効期限が切れています"
 
-	// 認証済みかどうかに関わらず、必ずコードを検証する。
-	// 以前はここで EmailVerified を見て検証を飛ばしていたため、
-	// メールアドレスを知っているだけで任意のアカウントのトークンを発行できた。
-	if u == nil ||
-		u.VerificationCode == nil || u.VerificationExpiry == nil ||
-		subtle.ConstantTimeCompare([]byte(*u.VerificationCode), []byte(code)) != 1 ||
-		uc.now().After(*u.VerificationExpiry) {
-		// 当たりうるコードが生きているときだけ数える。無い・期限切れなら
-		// どんな入力も当たりようがなく、数えると「でたらめなアドレスを投げるだけで
-		// 書き込みを起こせる」経路になる
-		// 当たりうるコードが生きているときだけ数える。無い・期限切れなら
-		// どんな入力も当たりようがなく、数えると「でたらめなアドレスを投げるだけで
-		// 書き込みを起こせる」経路になる
-		if u != nil && u.VerificationCode != nil && u.VerificationExpiry != nil &&
-			!uc.now().After(*u.VerificationExpiry) {
-			// 加算は DB 内で行う。読んだ値に +1 して書き戻すと、並列に来た
-			// リクエストが同じ値を読み、上限が並列数だけ薄くなる
-			if err := uc.users.IncrementVerificationAttempts(ctx, u.ID, MaxCodeAttempts); err != nil {
-				return "", nil, err
-			}
-		}
+	u, err := uc.users.FindByEmail(ctx, email)
+	if err != nil {
+		return "", nil, err
+	}
+	if u == nil {
 		return "", nil, domain.NewValidation(invalidCode)
 	}
 
-	if err := uc.users.MarkEmailVerified(ctx, u.ID); err != nil {
+	// 先に試行を消費してからコードを受け取る。
+	//
+	// 「読む → 比較 → 加算」の順にすると、並列に来たリクエストが全員同じ状態を
+	// 読んで全員が比較まで到達する。加算だけ原子的にしても縛れるのはラウンド数で、
+	// 1ラウンドあたり並列数だけ推測を試せてしまう。
+	//
+	// 認証済みかどうかに関わらず必ず照合する。以前はここで EmailVerified を見て
+	// 検証を飛ばしていたため、メールアドレスを知っているだけで任意のアカウントの
+	// トークンを発行できた。
+	stored, expiry, withinLimit, err := uc.users.ClaimVerificationAttempt(ctx, u.ID, MaxCodeAttempts)
+	if err != nil {
+		return "", nil, err
+	}
+	if !withinLimit || stored == nil || expiry == nil ||
+		subtle.ConstantTimeCompare([]byte(*stored), []byte(code)) != 1 ||
+		uc.now().After(*expiry) {
+		return "", nil, domain.NewValidation(invalidCode)
+	}
+
+	// 照合したコードを渡す。照合と書き込みの間に再送で差し替わっていたら適用しない
+	if err := uc.users.MarkEmailVerified(ctx, u.ID, *stored); err != nil {
+		if errors.Is(err, repository.ErrCodeConsumed) {
+			return "", nil, domain.NewValidation(invalidCode)
+		}
 		return "", nil, err
 	}
 	u.EmailVerified = true
@@ -316,25 +324,32 @@ func (uc *AuthUsecase) ForgotPassword(ctx context.Context, email string) error {
 // ResetPassword は再設定コードを検証し新パスワードを設定する
 func (uc *AuthUsecase) ResetPassword(ctx context.Context, email, code, newPassword string) error {
 	email = strings.ToLower(strings.TrimSpace(email))
+	const invalidCode = "再設定コードが正しくないか、有効期限が切れています"
+
 	u, err := uc.users.FindByEmail(ctx, email)
 	if err != nil {
 		return err
 	}
-	// コードの比較は定数時間で行う。通常の文字列比較は先頭一致の長さで
-	// 応答時間が変わるため、6桁のコードを1桁ずつ絞り込まれうる。
-	if u == nil || u.ResetCode == nil || u.ResetCodeExpiry == nil ||
-		subtle.ConstantTimeCompare([]byte(*u.ResetCode), []byte(code)) != 1 ||
-		uc.now().After(*u.ResetCodeExpiry) {
-		// 試行回数はメール認証とは別に数える。片方への攻撃で、
-		// もう片方まで本人が使えなくなるのを避けるため
-		if u != nil && u.ResetCode != nil && u.ResetCodeExpiry != nil &&
-			!uc.now().After(*u.ResetCodeExpiry) {
-			if err := uc.users.IncrementResetAttempts(ctx, u.ID, MaxCodeAttempts); err != nil {
-				return err
-			}
-		}
-		return domain.NewValidation("再設定コードが正しくないか、有効期限が切れています")
+	if u == nil {
+		return domain.NewValidation(invalidCode)
 	}
+
+	// 先に試行を消費してからコードを受け取る。Verify と同じ理由で、
+	// 比較の前に消費しないと上限が並列数だけ薄くなる。
+	// 回数はメール認証とは別に数える。片方への攻撃で、もう片方まで
+	// 本人が使えなくなるのを避けるため。
+	stored, expiry, withinLimit, err := uc.users.ClaimResetAttempt(ctx, u.ID, MaxCodeAttempts)
+	if err != nil {
+		return err
+	}
+	// 比較は定数時間で行う。通常の文字列比較は先頭一致の長さで応答時間が
+	// 変わるため、6桁のコードを1桁ずつ絞り込まれうる。
+	if !withinLimit || stored == nil || expiry == nil ||
+		subtle.ConstantTimeCompare([]byte(*stored), []byte(code)) != 1 ||
+		uc.now().After(*expiry) {
+		return domain.NewValidation(invalidCode)
+	}
+
 	hashed, err := auth.HashPassword(newPassword)
 	if err != nil {
 		return err
@@ -345,12 +360,12 @@ func (uc *AuthUsecase) ResetPassword(ctx context.Context, email, code, newPasswo
 	// 有効期限(7日)まで居座れてしまう。分けて書くと、間に挟まった
 	// 書き込みに巻き戻され、失効させたはずのトークンが生き残る。
 	//
-	// 繰り上げるのは照合に成功した後だけ。失敗でも動かすと、第三者が
-	// でたらめなコードを送りつけるだけで任意の利用者を締め出せてしまう。
-	if err := uc.users.ApplyPasswordReset(ctx, u.ID, hashed); err != nil {
-		// コードが既に消えていた場合も、利用者からは通常の失敗と同じに見せる
-		if errors.Is(err, repository.ErrResetCodeConsumed) {
-			return domain.NewValidation("再設定コードが正しくないか、有効期限が切れています")
+	// 照合したコードを渡すことで、その間に再発行された別のコードには
+	// 適用しない。古い照合結果でパスワードを差し替えられるのを防ぐ。
+	if err := uc.users.ApplyPasswordReset(ctx, u.ID, *stored, hashed); err != nil {
+		// コードが差し替わっていた場合も、利用者からは通常の失敗と同じに見せる
+		if errors.Is(err, repository.ErrCodeConsumed) {
+			return domain.NewValidation(invalidCode)
 		}
 		return err
 	}

--- a/backend/internal/usecase/auth_verify_test.go
+++ b/backend/internal/usecase/auth_verify_test.go
@@ -187,6 +187,9 @@ func (r *verifyUserRepo) SavePendingRegistration(ctx context.Context, id, hashed
 	if err != nil || u == nil {
 		return err
 	}
+	if u.EmailVerified {
+		return repository.ErrAlreadyVerified
+	}
 	u.Password = hashed
 	u.DisplayName = displayName
 	u.VerificationCode = &code
@@ -208,10 +211,13 @@ func (r *verifyUserRepo) SaveVerificationCode(ctx context.Context, id, code stri
 	return nil
 }
 
-func (r *verifyUserRepo) MarkEmailVerified(ctx context.Context, id string) error {
+func (r *verifyUserRepo) MarkEmailVerified(ctx context.Context, id, verifiedCode string) error {
 	u, err := r.FindByID(ctx, id)
 	if err != nil || u == nil {
 		return err
+	}
+	if u.VerificationCode == nil || *u.VerificationCode != verifiedCode {
+		return repository.ErrCodeConsumed
 	}
 	u.EmailVerified = true
 	u.VerificationCode = nil
@@ -221,18 +227,26 @@ func (r *verifyUserRepo) MarkEmailVerified(ctx context.Context, id string) error
 	return nil
 }
 
-func (r *verifyUserRepo) IncrementVerificationAttempts(ctx context.Context, id string, max int) error {
+func (r *verifyUserRepo) ClaimVerificationAttempt(ctx context.Context, id string, max int) (*string, *time.Time, bool, error) {
 	u, err := r.FindByID(ctx, id)
 	if err != nil || u == nil {
-		return err
+		return nil, nil, true, err
 	}
+	// 本物と同じ規則。生きているコードが無ければ消費しない
+	if u.VerificationCode == nil || u.VerificationExpiry == nil || !u.VerificationExpiry.After(time.Now()) {
+		return nil, nil, true, nil
+	}
+	code, expiry := u.VerificationCode, u.VerificationExpiry
 	u.VerificationAttempts++
-	if u.VerificationAttempts >= max {
+	if u.VerificationAttempts > max {
 		u.VerificationCode = nil
 		u.VerificationExpiry = nil
 	}
 	r.updated = u
-	return nil
+	if u.VerificationAttempts > max {
+		return nil, nil, false, nil
+	}
+	return code, expiry, true, nil
 }
 
 func (r *verifyUserRepo) SaveResetCode(ctx context.Context, id, code string, expiry time.Time) error {
@@ -247,27 +261,35 @@ func (r *verifyUserRepo) SaveResetCode(ctx context.Context, id, code string, exp
 	return nil
 }
 
-func (r *verifyUserRepo) IncrementResetAttempts(ctx context.Context, id string, max int) error {
+func (r *verifyUserRepo) ClaimResetAttempt(ctx context.Context, id string, max int) (*string, *time.Time, bool, error) {
 	u, err := r.FindByID(ctx, id)
 	if err != nil || u == nil {
-		return err
+		return nil, nil, true, err
 	}
+	// 本物と同じ規則。生きているコードが無ければ消費しない
+	if u.ResetCode == nil || u.ResetCodeExpiry == nil || !u.ResetCodeExpiry.After(time.Now()) {
+		return nil, nil, true, nil
+	}
+	code, expiry := u.ResetCode, u.ResetCodeExpiry
 	u.ResetAttempts++
-	if u.ResetAttempts >= max {
+	if u.ResetAttempts > max {
 		u.ResetCode = nil
 		u.ResetCodeExpiry = nil
 	}
 	r.updated = u
-	return nil
+	if u.ResetAttempts > max {
+		return nil, nil, false, nil
+	}
+	return code, expiry, true, nil
 }
 
-func (r *verifyUserRepo) ApplyPasswordReset(ctx context.Context, id, hashed string) error {
+func (r *verifyUserRepo) ApplyPasswordReset(ctx context.Context, id, verifiedCode, hashed string) error {
 	u, err := r.FindByID(ctx, id)
 	if err != nil || u == nil {
 		return err
 	}
-	if u.ResetCode == nil {
-		return repository.ErrResetCodeConsumed
+	if u.ResetCode == nil || *u.ResetCode != verifiedCode {
+		return repository.ErrCodeConsumed
 	}
 	u.Password = hashed
 	u.ResetCode = nil

--- a/backend/internal/usecase/auth_verify_test.go
+++ b/backend/internal/usecase/auth_verify_test.go
@@ -24,15 +24,16 @@ func (r *verifyUserRepo) FindByEmail(_ context.Context, email string) (*entity.U
 	}
 	return nil, nil
 }
-func (r *verifyUserRepo) FindByID(context.Context, string) (*entity.User, error) { return nil, nil }
+func (r *verifyUserRepo) FindByID(_ context.Context, id string) (*entity.User, error) {
+	if r.user != nil && r.user.ID == id {
+		return r.user, nil
+	}
+	return nil, nil
+}
 func (r *verifyUserRepo) FindByGoogleID(context.Context, string) (*entity.User, error) {
 	return nil, nil
 }
 func (r *verifyUserRepo) Create(context.Context, *entity.User) error { return nil }
-func (r *verifyUserRepo) Update(_ context.Context, u *entity.User) error {
-	r.updated = u
-	return nil
-}
 
 var _ repository.UserRepository = (*verifyUserRepo)(nil)
 
@@ -166,14 +167,131 @@ func (r *verifyUserRepo) TokenVersion(ctx context.Context, id string) (int, bool
 	return u.TokenVersion, true, nil
 }
 
-// 本物と同じく DB 内加算に相当する。読み出した値を書き戻さない
-func (r *verifyUserRepo) BumpTokenVersion(ctx context.Context, id string) error {
-	u, err := r.FindByID(ctx, id)
-	if err != nil {
+// --- repository.UserRepository の資格情報系メソッド ---
+// 本物と同じく、読み出したスナップショットを書き戻さない形で振る舞う。
+
+func (r *verifyUserRepo) UpdateProfile(ctx context.Context, u *entity.User) error {
+	cur, err := r.FindByID(ctx, u.ID)
+	if err != nil || cur == nil {
 		return err
 	}
-	if u != nil {
-		u.TokenVersion++
+	cur.DisplayName = u.DisplayName
+	cur.CharacterType = u.CharacterType
+	cur.CharacterName = u.CharacterName
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) SavePendingRegistration(ctx context.Context, id, hashed string, displayName *string, code string, expiry time.Time) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
 	}
+	u.Password = hashed
+	u.DisplayName = displayName
+	u.VerificationCode = &code
+	u.VerificationExpiry = &expiry
+	u.VerificationAttempts = 0
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) SaveVerificationCode(ctx context.Context, id, code string, expiry time.Time) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.VerificationCode = &code
+	u.VerificationExpiry = &expiry
+	u.VerificationAttempts = 0
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) MarkEmailVerified(ctx context.Context, id string) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.EmailVerified = true
+	u.VerificationCode = nil
+	u.VerificationExpiry = nil
+	u.VerificationAttempts = 0
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) IncrementVerificationAttempts(ctx context.Context, id string, max int) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.VerificationAttempts++
+	if u.VerificationAttempts >= max {
+		u.VerificationCode = nil
+		u.VerificationExpiry = nil
+	}
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) SaveResetCode(ctx context.Context, id, code string, expiry time.Time) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.ResetCode = &code
+	u.ResetCodeExpiry = &expiry
+	u.ResetAttempts = 0
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) IncrementResetAttempts(ctx context.Context, id string, max int) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	u.ResetAttempts++
+	if u.ResetAttempts >= max {
+		u.ResetCode = nil
+		u.ResetCodeExpiry = nil
+	}
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) ApplyPasswordReset(ctx context.Context, id, hashed string) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	if u.ResetCode == nil {
+		return repository.ErrResetCodeConsumed
+	}
+	u.Password = hashed
+	u.ResetCode = nil
+	u.ResetCodeExpiry = nil
+	u.ResetAttempts = 0
+	u.TokenVersion++
+	r.updated = u
+	return nil
+}
+
+func (r *verifyUserRepo) LinkGoogle(ctx context.Context, id, subject string, resetCredentials bool, displayName *string) error {
+	u, err := r.FindByID(ctx, id)
+	if err != nil || u == nil {
+		return err
+	}
+	if resetCredentials {
+		u.Password = ""
+		u.DisplayName = displayName
+		u.VerificationCode = nil
+		u.VerificationExpiry = nil
+		u.VerificationAttempts = 0
+	}
+	u.GoogleID = &subject
+	u.EmailVerified = true
+	r.updated = u
 	return nil
 }

--- a/backend/internal/usecase/user_profile_usecase.go
+++ b/backend/internal/usecase/user_profile_usecase.go
@@ -52,7 +52,7 @@ func (uc *UserProfileUsecase) Update(ctx context.Context, userID string, in Upda
 	if in.CharacterName != nil {
 		u.CharacterName = in.CharacterName
 	}
-	if err := uc.users.Update(ctx, u); err != nil {
+	if err := uc.users.UpdateProfile(ctx, u); err != nil {
 		return nil, err
 	}
 	return u, nil


### PR DESCRIPTION
## Summary

汎用 `Update` が **password・各コード・試行回数を含む13列を、読み出し時点のスナップショットから書き戻して**いた。`PATCH /api/users/me` は全列を読んで全列を書き戻すため、その間にパスワード再設定が走ると**再設定が巻き戻り、消費済みの再設定コードまで復活**していた。

更新口を用途ごとに分け、書き換える列をそれぞれの責務分だけに限る。

| メソッド | 書く列 |
|---|---|
| `UpdateProfile` | 表示名・キャラクター設定のみ |
| `SavePendingRegistration` | 未認証アカウントの登録内容（**未認証の行にだけ**） |
| `SaveVerificationCode` / `SaveResetCode` | コード発行（試行回数を戻す） |
| `MarkEmailVerified` | 認証完了（**照合したコードに束縛**） |
| `ApplyPasswordReset` | パスワード・コード破棄・世代繰り上げを**一文で** |
| `LinkGoogle` | Google 紐付け |
| `Claim*Attempt` | 試行を消費し、上限内ならコードを返す |

## 敵対的レビューで見つかり、追加で直した2件

4観点でレビューし、3人が独立に同じ **blocking** を指摘した。

**回数上限が並列数だけ突破できた。** 加算は原子的にしたが「読む → 比較 → 加算」の順序を残していたため、並列N件が全員同じ状態を読んで全員が比較まで到達していた。縛れていたのはラウンド数だけ。

→ 先に DB 内で消費し、返ってきた回数が上限内のときだけコードを渡す形にした。**比較の回数そのものを縛る。**

境界が繊細なので2点補正した。消費「前」のコードを CTE で確保して返す（`RETURNING` は更新後の値なので、そのままだと上限ちょうどの回で必ず NULL になり、4回間違えた本人が5回目に正しく入力しても通らない）。コードを捨てるのは上限を「超えた」ときにする（ちょうどの回で消すと直後の照合が弾かれる。超過分は比較まで到達しないので推測回数は変わらない）。

**認証済みアカウントに登録内容を上書きできた。** SignUp の check-then-act の隙間で認証が完了すると、攻撃者のパスワードが認証済みアカウントに載っていた。→ `WHERE emailVerified = FALSE` を追加。弾かれても登録済みであることは伝えない。

## 実 DB での実証

修正前の実装に戻すと落ちることを確認済み。

```
パスワードが巻き戻った: "$2a$12$original"。再設定したのに古いパスワードで入れる
消費済みの再設定コード "654321" が復活した。攻撃者が同じコードを再利用できる
並列20回の失敗が数えられていない。総当たり防御が並列数だけ薄くなる
```

新規の並列テストも追加した（並列20件に対し、許した推測が上限5を超えないこと）。