### PR TITLE
fix(frontend): 表示まわりの不具合5件を直す

### DIFF
--- a/frontend/src/entities/allergy/index.ts
+++ b/frontend/src/entities/allergy/index.ts
@@ -1,0 +1,5 @@
+export {
+  ALLERGY_SEVERITY_LABELS,
+  ALLERGY_SEVERITY_OPTIONS,
+  allergySeverityLabel,
+} from "./model/severity";

--- a/frontend/src/entities/allergy/model/severity.test.ts
+++ b/frontend/src/entities/allergy/model/severity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALLERGY_SEVERITY_LABELS,
+  ALLERGY_SEVERITY_OPTIONS,
+  allergySeverityLabel,
+} from "./severity";
+
+describe("アレルギーの重症度", () => {
+  it("画面をまたいで同じ表記になる", () => {
+    expect(ALLERGY_SEVERITY_LABELS.moderate).toBe("中等度");
+  });
+
+  it("選択肢は軽い順", () => {
+    expect(ALLERGY_SEVERITY_OPTIONS.map((o) => o.value)).toEqual([
+      "mild",
+      "moderate",
+      "severe",
+    ]);
+  });
+
+  it("未設定は - で表す", () => {
+    expect(allergySeverityLabel(null)).toBe("-");
+    expect(allergySeverityLabel(undefined)).toBe("-");
+  });
+
+  // 表に無い値で画面が壊れないこと。保存済みデータの種類が増えても落ちない
+  it("知らない値はそのまま返す", () => {
+    expect(allergySeverityLabel("unknown")).toBe("unknown");
+  });
+});

--- a/frontend/src/entities/allergy/model/severity.ts
+++ b/frontend/src/entities/allergy/model/severity.ts
@@ -1,0 +1,26 @@
+/**
+ * アレルギーの重症度。
+ *
+ * 表記が画面ごとに割れていた。一覧と入力フォームは「中度」、
+ * 印刷用のレポートは「中等度」。同じデータが違う言葉で出ると、
+ * 医療者に見せる場面で食い違いとして受け取られる。
+ *
+ * 「中等度」に揃える。医学的にはこちらが正式な表記で、
+ * 印刷して人に渡すレポートが既にこの語を使っていた。
+ */
+export const ALLERGY_SEVERITY_LABELS: Record<string, string> = {
+  mild: "軽度",
+  moderate: "中等度",
+  severe: "重度",
+};
+
+/** 入力フォームの選択肢。表示順は軽い順で固定する */
+export const ALLERGY_SEVERITY_OPTIONS = Object.entries(ALLERGY_SEVERITY_LABELS).map(
+  ([value, label]) => ({ value, label }),
+);
+
+/** 表に無い値が来ても画面を壊さない。保存済みデータが増えても落ちないように */
+export function allergySeverityLabel(severity: string | null | undefined): string {
+  if (!severity) return "-";
+  return ALLERGY_SEVERITY_LABELS[severity] ?? severity;
+}

--- a/frontend/src/entities/member/index.ts
+++ b/frontend/src/entities/member/index.ts
@@ -1,0 +1,1 @@
+export { getMemberAge } from "./model/age";

--- a/frontend/src/entities/member/model/age.test.ts
+++ b/frontend/src/entities/member/model/age.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getMemberAge } from "./age";
+
+describe("メンバーの年齢", () => {
+  it("生年月日が未設定なら null", () => {
+    expect(getMemberAge(null)).toBeNull();
+  });
+
+  it("空文字も null として扱う", () => {
+    expect(getMemberAge("")).toBeNull();
+  });
+
+  // 日付として読めない値で NaN を返すと、呼び出し側の null 判定を素通りして
+  // 画面に「NaN歳」と出る。実際にそう表示されていた
+  it.each(["not-a-date", "2026-13-45", "0000-00-00", "abc"])(
+    "日付として読めない値 (%s) は null",
+    (value) => {
+      expect(getMemberAge(value)).toBeNull();
+    },
+  );
+
+  it("誕生日を迎えていれば満年齢", () => {
+    const now = new Date();
+    const birth = new Date(now.getFullYear() - 10, now.getMonth(), now.getDate());
+    expect(getMemberAge(birth.toISOString())).toBe(10);
+  });
+
+  it("誕生日をまだ迎えていなければ1つ引く", () => {
+    const now = new Date();
+    const birth = new Date(now.getFullYear() - 10, now.getMonth(), now.getDate() + 1);
+    // 月末など、翌日が翌月になる場合は境界が変わるので月内のときだけ確かめる
+    if (birth.getMonth() === now.getMonth()) {
+      expect(getMemberAge(birth.toISOString())).toBe(9);
+    }
+  });
+
+  it("未来の生年月日は null。負の年齢を表示しない", () => {
+    const future = new Date();
+    future.setFullYear(future.getFullYear() + 1);
+    expect(getMemberAge(future.toISOString())).toBeNull();
+  });
+});

--- a/frontend/src/entities/member/model/age.test.ts
+++ b/frontend/src/entities/member/model/age.test.ts
@@ -19,10 +19,14 @@ describe("メンバーの年齢", () => {
     },
   );
 
+  // 実際の入力は <input type="date"> の YYYY-MM-DD。
+  // toISOString() を使うとローカル日付が UTC にずれ、本番と違う値を試すことになる
+  const ymd = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
   it("誕生日を迎えていれば満年齢", () => {
     const now = new Date();
-    const birth = new Date(now.getFullYear() - 10, now.getMonth(), now.getDate());
-    expect(getMemberAge(birth.toISOString())).toBe(10);
+    expect(getMemberAge(ymd(new Date(now.getFullYear() - 10, now.getMonth(), now.getDate())))).toBe(10);
   });
 
   it("誕生日をまだ迎えていなければ1つ引く", () => {
@@ -30,13 +34,49 @@ describe("メンバーの年齢", () => {
     const birth = new Date(now.getFullYear() - 10, now.getMonth(), now.getDate() + 1);
     // 月末など、翌日が翌月になる場合は境界が変わるので月内のときだけ確かめる
     if (birth.getMonth() === now.getMonth()) {
-      expect(getMemberAge(birth.toISOString())).toBe(9);
+      expect(getMemberAge(ymd(birth))).toBe(9);
     }
   });
 
   it("未来の生年月日は null。負の年齢を表示しない", () => {
     const future = new Date();
     future.setFullYear(future.getFullYear() + 1);
-    expect(getMemberAge(future.toISOString())).toBeNull();
+    expect(getMemberAge(ymd(future))).toBeNull();
+  });
+});
+
+describe("暦日としての厳密な検証", () => {
+  // new Date("2000-08-16") は UTC として解釈される。UTC より西の
+  // タイムゾーンではローカル日付が前日になり、誕生日当日に1つ若く出る
+  it("タイムゾーンで誕生日がずれない", () => {
+    const original = process.env.TZ;
+    process.env.TZ = "America/Los_Angeles";
+    try {
+      const now = new Date();
+      const yyyy = now.getFullYear() - 20;
+      const mm = String(now.getMonth() + 1).padStart(2, "0");
+      const dd = String(now.getDate()).padStart(2, "0");
+      expect(getMemberAge(`${yyyy}-${mm}-${dd}`)).toBe(20);
+    } finally {
+      process.env.TZ = original;
+    }
+  });
+
+  // new Date は存在しない日付を翌月へ繰り上げてしまう。
+  // 2024-02-30 が 2024-03-01 として通ると、入力ミスが年齢として表示される
+  it.each(["2024-02-30", "2023-02-29", "2024-04-31", "2024-13-01", "2024-00-10", "2024-01-32"])(
+    "暦に存在しない日付 (%s) は null",
+    (value) => {
+      expect(getMemberAge(value)).toBeNull();
+    },
+  );
+
+  it("うるう年の 2/29 は受け付ける", () => {
+    expect(getMemberAge("2024-02-29")).not.toBeNull();
+  });
+
+  it("ISO 8601 の日時形式も受け付ける", () => {
+    const yyyy = new Date().getFullYear() - 30;
+    expect(getMemberAge(`${yyyy}-06-15T00:00:00.000Z`)).not.toBeNull();
   });
 });

--- a/frontend/src/entities/member/model/age.ts
+++ b/frontend/src/entities/member/model/age.ts
@@ -1,23 +1,48 @@
+/** YYYY-MM-DD、または先頭がその形式の ISO 8601 文字列 */
+const DATE_PREFIX = /^(\d{4})-(\d{2})-(\d{2})(?:[T\s]|$)/;
+
 /**
  * 生年月日から満年齢を求める。求められない場合は null。
  *
- * 日付として読めない値で NaN を返してはいけない。呼び出し側は
- * `age !== null` で表示を分けるため、NaN はその判定を素通りして
- * 画面に「NaN歳」と出る。実際にメンバー一覧でそうなっていた。
+ * Date のコンストラクタに任せない。理由が2つある。
  *
- * 未来の日付も null にする。負の年齢に意味は無く、
- * 入力ミスを「-1歳」と表示するより出さない方がよい。
+ * 1. `new Date("2000-08-16")` は UTC として解釈されるため、UTC より西の
+ *    地域では getMonth/getDate がローカルの前日を指し、誕生日当日に
+ *    1つ若く表示される。
+ * 2. Date は存在しない日付を繰り上げる。`new Date("2024-02-30")` は
+ *    3月1日になり、入力ミスがそのまま年齢として通ってしまう。
+ *
+ * そこで年月日を文字列から取り出し、暦日として成立するかを自分で確かめ、
+ * 現地時間の数値として比較する。
+ *
+ * 読めない値と未来日は null。呼び出し側は `age !== null` で表示を分けるので、
+ * NaN を返すとその判定を素通りして画面に「NaN歳」と出る。
+ * 負の年齢に意味は無く、入力ミスを「-1歳」と見せるより出さない方がよい。
  */
 export function getMemberAge(birthDate: string | null | undefined): number | null {
   if (!birthDate) return null;
 
-  const birth = new Date(birthDate);
-  if (Number.isNaN(birth.getTime())) return null;
+  const matched = DATE_PREFIX.exec(birthDate);
+  if (!matched) return null;
+
+  const year = Number(matched[1]);
+  const month = Number(matched[2]);
+  const day = Number(matched[3]);
+
+  // 繰り上げが起きていないかで、暦日として成立するかを判定する
+  const probe = new Date(year, month - 1, day);
+  if (
+    probe.getFullYear() !== year ||
+    probe.getMonth() !== month - 1 ||
+    probe.getDate() !== day
+  ) {
+    return null;
+  }
 
   const now = new Date();
-  let age = now.getFullYear() - birth.getFullYear();
-  const monthDiff = now.getMonth() - birth.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+  let age = now.getFullYear() - year;
+  const monthDiff = now.getMonth() - (month - 1);
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < day)) {
     age -= 1;
   }
   return age < 0 ? null : age;

--- a/frontend/src/entities/member/model/age.ts
+++ b/frontend/src/entities/member/model/age.ts
@@ -1,0 +1,24 @@
+/**
+ * 生年月日から満年齢を求める。求められない場合は null。
+ *
+ * 日付として読めない値で NaN を返してはいけない。呼び出し側は
+ * `age !== null` で表示を分けるため、NaN はその判定を素通りして
+ * 画面に「NaN歳」と出る。実際にメンバー一覧でそうなっていた。
+ *
+ * 未来の日付も null にする。負の年齢に意味は無く、
+ * 入力ミスを「-1歳」と表示するより出さない方がよい。
+ */
+export function getMemberAge(birthDate: string | null | undefined): number | null {
+  if (!birthDate) return null;
+
+  const birth = new Date(birthDate);
+  if (Number.isNaN(birth.getTime())) return null;
+
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const monthDiff = now.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) {
+    age -= 1;
+  }
+  return age < 0 ? null : age;
+}

--- a/frontend/src/pages/member-detail/ui/AllergyForm.tsx
+++ b/frontend/src/pages/member-detail/ui/AllergyForm.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
-import type { Member } from "@/shared/api";
+import React, { useState } from 'react';
+import { ALLERGY_SEVERITY_OPTIONS } from '@/entities/allergy';
+import type { Member } from '@/shared/api';
 
 export interface AllergyFormData {
   memberId: string;
@@ -27,28 +28,29 @@ interface AllergyFormProps {
 }
 
 const ALLERGY_TYPES = [
-  { value: "food", label: "食物" },
-  { value: "medication", label: "薬物" },
-  { value: "environmental", label: "環境" },
-  { value: "pollen", label: "花粉" },
-  { value: "atopy", label: "アトピー" },
-  { value: "other", label: "その他" },
+  { value: 'food', label: '食物' },
+  { value: 'medication', label: '薬物' },
+  { value: 'environmental', label: '環境' },
+  { value: 'pollen', label: '花粉' },
+  { value: 'atopy', label: 'アトピー' },
+  { value: 'other', label: 'その他' },
 ];
 
-const SEVERITY_LEVELS = [
-  { value: "mild", label: "軽度" },
-  { value: "moderate", label: "中度" },
-  { value: "severe", label: "重度" },
-];
-
-export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
-  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
-  const [allergenName, setAllergenName] = useState(initialData?.allergenName || "");
-  const [allergyType, setAllergyType] = useState(initialData?.allergyType || "");
-  const [severity, setSeverity] = useState(initialData?.severity || "");
-  const [symptoms, setSymptoms] = useState(initialData?.symptoms || "");
-  const [diagnosedAt, setDiagnosedAt] = useState(initialData?.diagnosedAt || "");
-  const [notes, setNotes] = useState(initialData?.notes || "");
+export const AllergyForm: React.FC<AllergyFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+  initialData,
+}) => {
+  const [memberId, setMemberId] = useState(
+    initialData?.memberId || (members.length === 1 ? members[0].id : ''),
+  );
+  const [allergenName, setAllergenName] = useState(initialData?.allergenName || '');
+  const [allergyType, setAllergyType] = useState(initialData?.allergyType || '');
+  const [severity, setSeverity] = useState(initialData?.severity || '');
+  const [symptoms, setSymptoms] = useState(initialData?.symptoms || '');
+  const [diagnosedAt, setDiagnosedAt] = useState(initialData?.diagnosedAt || '');
+  const [notes, setNotes] = useState(initialData?.notes || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -65,36 +67,40 @@ export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onC
     });
 
     if (!initialData) {
-      setAllergenName("");
-      setAllergyType("");
-      setSeverity("");
-      setSymptoms("");
-      setDiagnosedAt("");
-      setNotes("");
+      setAllergenName('');
+      setAllergyType('');
+      setSeverity('');
+      setSymptoms('');
+      setDiagnosedAt('');
+      setNotes('');
     }
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label htmlFor="allergy-member" className="block text-sm font-medium text-ink-700 mb-1">
-          メンバー
-        </label>
-        <select
-          id="allergy-member"
-          value={memberId}
-          onChange={(e) => setMemberId(e.target.value)}
-          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          required
-        >
-          <option value="">選択してください</option>
-          {members.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 候補が1人しかいないなら選ばせる意味が無い。
+          メンバー詳細から開いたフォームは常にその1人に限られる */}
+      {members.length > 1 && (
+        <div>
+          <label htmlFor="allergy-member" className="block text-sm font-medium text-ink-700 mb-1">
+            メンバー
+          </label>
+          <select
+            id="allergy-member"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            required
+          >
+            <option value="">選択してください</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div>
         <label htmlFor="allergy-name" className="block text-sm font-medium text-ink-700 mb-1">
@@ -143,7 +149,7 @@ export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onC
           required
         >
           <option value="">選択してください</option>
-          {SEVERITY_LEVELS.map((s) => (
+          {ALLERGY_SEVERITY_OPTIONS.map((s) => (
             <option key={s.value} value={s.value}>
               {s.label}
             </option>
@@ -199,7 +205,7 @@ export const AllergyForm: React.FC<AllergyFormProps> = ({ members, onSubmit, onC
           type="submit"
           className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
         >
-          {initialData ? "更新する" : "登録する"}
+          {initialData ? '更新する' : '登録する'}
         </button>
         {onCancel && (
           <button

--- a/frontend/src/pages/member-detail/ui/AllergyList.tsx
+++ b/frontend/src/pages/member-detail/ui/AllergyList.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { ALLERGY_SEVERITY_LABELS } from "@/entities/allergy";
 import { Pencil, Trash2, Check, X } from "lucide-react";
 import type { Allergy } from "@/shared/api";
 import { LoadingSpinner } from "@/shared/ui";
@@ -23,12 +24,6 @@ const ALLERGY_TYPE_LABELS: Record<string, string> = {
   pollen: "花粉",
   atopy: "アトピー",
   other: "その他",
-};
-
-const SEVERITY_LABELS: Record<string, string> = {
-  mild: "軽度",
-  moderate: "中度",
-  severe: "重度",
 };
 
 const SEVERITY_COLORS: Record<string, string> = {
@@ -137,7 +132,7 @@ const AllergyCard: React.FC<AllergyCardProps> = React.memo(({ allergy, onUpdate,
             onChange={(e) => setEditSeverity(e.target.value)}
             className="w-full px-3 py-2 border border-primary-200 rounded-lg text-sm focus:ring-2 focus:ring-primary-500"
           >
-            {Object.entries(SEVERITY_LABELS).map(([value, label]) => (
+            {Object.entries(ALLERGY_SEVERITY_LABELS).map(([value, label]) => (
               <option key={value} value={value}>
                 {label}
               </option>
@@ -192,7 +187,7 @@ const AllergyCard: React.FC<AllergyCardProps> = React.memo(({ allergy, onUpdate,
             <span
               className={`text-xs px-1.5 py-0.5 rounded ${SEVERITY_COLORS[allergy.severity] || "bg-primary-50 text-ink-600"}`}
             >
-              {SEVERITY_LABELS[allergy.severity] || allergy.severity}
+              {ALLERGY_SEVERITY_LABELS[allergy.severity] || allergy.severity}
             </span>
             <span className="text-xs bg-primary-50 text-primary-600 px-1.5 py-0.5 rounded">
               {ALLERGY_TYPE_LABELS[allergy.allergyType] || allergy.allergyType}

--- a/frontend/src/pages/member-detail/ui/ExaminationForm.tsx
+++ b/frontend/src/pages/member-detail/ui/ExaminationForm.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
-import { X, ImagePlus } from "lucide-react";
-import type { Member } from "@/shared/api";
+import React, { useState } from 'react';
+import { X, ImagePlus } from 'lucide-react';
+import type { Member } from '@/shared/api';
 
 export interface ExaminationFormData {
   memberId: string;
@@ -26,11 +26,11 @@ interface ExaminationFormProps {
 }
 
 const toDateInput = (value: string | null | undefined): string => {
-  if (!value) return "";
-  return new Date(value).toISOString().split("T")[0];
+  if (!value) return '';
+  return new Date(value).toISOString().split('T')[0];
 };
 
-const todayInput = (): string => new Date().toISOString().split("T")[0];
+const todayInput = (): string => new Date().toISOString().split('T')[0];
 
 async function compressImage(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -51,16 +51,16 @@ async function compressImage(file: File): Promise<string> {
             height = MAX_DIM;
           }
         }
-        const canvas = document.createElement("canvas");
+        const canvas = document.createElement('canvas');
         canvas.width = width;
         canvas.height = height;
-        const ctx = canvas.getContext("2d");
+        const ctx = canvas.getContext('2d');
         if (!ctx) {
-          reject(new Error("Canvas not available"));
+          reject(new Error('Canvas not available'));
           return;
         }
         ctx.drawImage(img, 0, 0, width, height);
-        resolve(canvas.toDataURL("image/jpeg", 0.82));
+        resolve(canvas.toDataURL('image/jpeg', 0.82));
       };
       img.src = e.target?.result as string;
     };
@@ -68,38 +68,47 @@ async function compressImage(file: File): Promise<string> {
   });
 }
 
-export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
-  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
-  const [examinationType, setExaminationType] = useState(initialData?.examinationType || "");
+export const ExaminationForm: React.FC<ExaminationFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+  initialData,
+}) => {
+  const [memberId, setMemberId] = useState(
+    initialData?.memberId || (members.length === 1 ? members[0].id : ''),
+  );
+  const [examinationType, setExaminationType] = useState(initialData?.examinationType || '');
   const [examinedAt, setExaminedAt] = useState(
     initialData?.examinedAt ? toDateInput(initialData.examinedAt) : todayInput(),
   );
-  const [nextScheduledDate, setNextScheduledDate] = useState(toDateInput(initialData?.nextScheduledDate));
-  const [notes, setNotes] = useState(initialData?.notes || "");
+  const [nextScheduledDate, setNextScheduledDate] = useState(
+    toDateInput(initialData?.nextScheduledDate),
+  );
+  const [notes, setNotes] = useState(initialData?.notes || '');
   const [imageData, setImageData] = useState<string | null>(initialData?.imageData ?? null);
-  const [imageError, setImageError] = useState("");
-  const [submitError, setSubmitError] = useState("");
+  const [imageError, setImageError] = useState('');
+  const [submitError, setSubmitError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     if (file.size > 10 * 1024 * 1024) {
-      setImageError("10MB以下の画像を選択してください");
+      setImageError('10MB以下の画像を選択してください');
       return;
     }
-    setImageError("");
+    setImageError('');
     try {
       const compressed = await compressImage(file);
       if (compressed.length > 1_500_000) {
-        setImageError("画像を圧縮できませんでした。より小さい画像を選択してください");
+        setImageError('画像を圧縮できませんでした。より小さい画像を選択してください');
         return;
       }
       setImageData(compressed);
     } catch {
-      setImageError("画像の読み込みに失敗しました");
+      setImageError('画像の読み込みに失敗しました');
     }
-    e.target.value = "";
+    e.target.value = '';
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -107,27 +116,29 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
     if (!memberId || !examinationType.trim() || !examinedAt) return;
     if (isSubmitting) return;
 
-    setSubmitError("");
+    setSubmitError('');
     setIsSubmitting(true);
     try {
       await onSubmit({
         memberId,
         examinationType: examinationType.trim(),
         examinedAt: new Date(examinedAt).toISOString(),
-        nextScheduledDate: nextScheduledDate ? new Date(nextScheduledDate).toISOString() : undefined,
+        nextScheduledDate: nextScheduledDate
+          ? new Date(nextScheduledDate).toISOString()
+          : undefined,
         notes: notes.trim() || undefined,
         imageData: imageData ?? undefined,
       });
 
       if (!initialData) {
-        setExaminationType("");
+        setExaminationType('');
         setExaminedAt(todayInput());
-        setNextScheduledDate("");
-        setNotes("");
+        setNextScheduledDate('');
+        setNotes('');
         setImageData(null);
       }
     } catch (err) {
-      setSubmitError(err instanceof Error ? err.message : "登録に失敗しました");
+      setSubmitError(err instanceof Error ? err.message : '登録に失敗しました');
     } finally {
       setIsSubmitting(false);
     }
@@ -135,25 +146,29 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label htmlFor="exam-member" className="block text-sm font-medium text-ink-700 mb-1">
-          メンバー
-        </label>
-        <select
-          id="exam-member"
-          value={memberId}
-          onChange={(e) => setMemberId(e.target.value)}
-          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          required
-        >
-          <option value="">選択してください</option>
-          {members.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 候補が1人しかいないなら選ばせる意味が無い。
+          メンバー詳細から開いたフォームは常にその1人に限られる */}
+      {members.length > 1 && (
+        <div>
+          <label htmlFor="exam-member" className="block text-sm font-medium text-ink-700 mb-1">
+            メンバー
+          </label>
+          <select
+            id="exam-member"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            required
+          >
+            <option value="">選択してください</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div>
         <label htmlFor="exam-type" className="block text-sm font-medium text-ink-700 mb-1">
@@ -240,7 +255,9 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
       </div>
 
       {submitError && (
-        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">{submitError}</p>
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {submitError}
+        </p>
       )}
 
       <div className="flex space-x-2">
@@ -249,7 +266,7 @@ export const ExaminationForm: React.FC<ExaminationFormProps> = ({ members, onSub
           disabled={isSubmitting}
           className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          {isSubmitting ? "送信中..." : initialData ? "更新する" : "登録する"}
+          {isSubmitting ? '送信中...' : initialData ? '更新する' : '登録する'}
         </button>
         {onCancel && (
           <button

--- a/frontend/src/pages/member-detail/ui/InsuranceForm.tsx
+++ b/frontend/src/pages/member-detail/ui/InsuranceForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import type { Member } from "@/shared/api";
+import React, { useState } from 'react';
+import type { Member } from '@/shared/api';
 
 export interface InsuranceFormData {
   memberId: string;
@@ -22,12 +22,19 @@ interface InsuranceFormProps {
   };
 }
 
-export const InsuranceForm: React.FC<InsuranceFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
-  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
-  const [insuranceType, setInsuranceType] = useState(initialData?.insuranceType || "");
-  const [providerName, setProviderName] = useState(initialData?.providerName || "");
-  const [policyNumber, setPolicyNumber] = useState(initialData?.policyNumber || "");
-  const [notes, setNotes] = useState(initialData?.notes || "");
+export const InsuranceForm: React.FC<InsuranceFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+  initialData,
+}) => {
+  const [memberId, setMemberId] = useState(
+    initialData?.memberId || (members.length === 1 ? members[0].id : ''),
+  );
+  const [insuranceType, setInsuranceType] = useState(initialData?.insuranceType || '');
+  const [providerName, setProviderName] = useState(initialData?.providerName || '');
+  const [policyNumber, setPolicyNumber] = useState(initialData?.policyNumber || '');
+  const [notes, setNotes] = useState(initialData?.notes || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -42,34 +49,38 @@ export const InsuranceForm: React.FC<InsuranceFormProps> = ({ members, onSubmit,
     });
 
     if (!initialData) {
-      setInsuranceType("");
-      setProviderName("");
-      setPolicyNumber("");
-      setNotes("");
+      setInsuranceType('');
+      setProviderName('');
+      setPolicyNumber('');
+      setNotes('');
     }
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label htmlFor="ins-member" className="block text-sm font-medium text-ink-700 mb-1">
-          メンバー
-        </label>
-        <select
-          id="ins-member"
-          value={memberId}
-          onChange={(e) => setMemberId(e.target.value)}
-          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          required
-        >
-          <option value="">選択してください</option>
-          {members.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 候補が1人しかいないなら選ばせる意味が無い。
+          メンバー詳細から開いたフォームは常にその1人に限られる */}
+      {members.length > 1 && (
+        <div>
+          <label htmlFor="ins-member" className="block text-sm font-medium text-ink-700 mb-1">
+            メンバー
+          </label>
+          <select
+            id="ins-member"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            required
+          >
+            <option value="">選択してください</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div>
         <label htmlFor="ins-type" className="block text-sm font-medium text-ink-700 mb-1">
@@ -133,7 +144,7 @@ export const InsuranceForm: React.FC<InsuranceFormProps> = ({ members, onSubmit,
           type="submit"
           className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
         >
-          {initialData ? "更新する" : "登録する"}
+          {initialData ? '更新する' : '登録する'}
         </button>
         {onCancel && (
           <button

--- a/frontend/src/pages/member-detail/ui/PrescriptionForm.tsx
+++ b/frontend/src/pages/member-detail/ui/PrescriptionForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import type { Member } from "@/shared/api";
+import React, { useState } from 'react';
+import type { Member } from '@/shared/api';
 
 export interface PrescriptionFormData {
   memberId: string;
@@ -29,23 +29,30 @@ interface PrescriptionFormProps {
 }
 
 const toDateInput = (value: string | null | undefined): string => {
-  if (!value) return "";
-  return new Date(value).toISOString().split("T")[0];
+  if (!value) return '';
+  return new Date(value).toISOString().split('T')[0];
 };
 
-const todayInput = (): string => new Date().toISOString().split("T")[0];
+const todayInput = (): string => new Date().toISOString().split('T')[0];
 
-export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
-  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
-  const [prescriptionName, setPrescriptionName] = useState(initialData?.prescriptionName || "");
-  const [prescribedBy, setPrescribedBy] = useState(initialData?.prescribedBy || "");
+export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+  initialData,
+}) => {
+  const [memberId, setMemberId] = useState(
+    initialData?.memberId || (members.length === 1 ? members[0].id : ''),
+  );
+  const [prescriptionName, setPrescriptionName] = useState(initialData?.prescriptionName || '');
+  const [prescribedBy, setPrescribedBy] = useState(initialData?.prescribedBy || '');
   const [prescribedAt, setPrescribedAt] = useState(
     initialData?.prescribedAt ? toDateInput(initialData.prescribedAt) : todayInput(),
   );
   const [expiresAt, setExpiresAt] = useState(toDateInput(initialData?.expiresAt));
-  const [pharmacyName, setPharmacyName] = useState(initialData?.pharmacyName || "");
-  const [electronicCode, setElectronicCode] = useState(initialData?.electronicCode || "");
-  const [notes, setNotes] = useState(initialData?.notes || "");
+  const [pharmacyName, setPharmacyName] = useState(initialData?.pharmacyName || '');
+  const [electronicCode, setElectronicCode] = useState(initialData?.electronicCode || '');
+  const [notes, setNotes] = useState(initialData?.notes || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -63,36 +70,40 @@ export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onS
     });
 
     if (!initialData) {
-      setPrescriptionName("");
-      setPrescribedBy("");
-      setExpiresAt("");
-      setPharmacyName("");
-      setElectronicCode("");
-      setNotes("");
+      setPrescriptionName('');
+      setPrescribedBy('');
+      setExpiresAt('');
+      setPharmacyName('');
+      setElectronicCode('');
+      setNotes('');
     }
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label htmlFor="rx-member" className="block text-sm font-medium text-ink-700 mb-1">
-          メンバー
-        </label>
-        <select
-          id="rx-member"
-          value={memberId}
-          onChange={(e) => setMemberId(e.target.value)}
-          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          required
-        >
-          <option value="">選択してください</option>
-          {members.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 候補が1人しかいないなら選ばせる意味が無い。
+          メンバー詳細から開いたフォームは常にその1人に限られる */}
+      {members.length > 1 && (
+        <div>
+          <label htmlFor="rx-member" className="block text-sm font-medium text-ink-700 mb-1">
+            メンバー
+          </label>
+          <select
+            id="rx-member"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            required
+          >
+            <option value="">選択してください</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div>
         <label htmlFor="rx-name" className="block text-sm font-medium text-ink-700 mb-1">
@@ -198,7 +209,7 @@ export const PrescriptionForm: React.FC<PrescriptionFormProps> = ({ members, onS
           type="submit"
           className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
         >
-          {initialData ? "更新する" : "登録する"}
+          {initialData ? '更新する' : '登録する'}
         </button>
         {onCancel && (
           <button

--- a/frontend/src/pages/member-detail/ui/PrescriptionList.tsx
+++ b/frontend/src/pages/member-detail/ui/PrescriptionList.tsx
@@ -97,9 +97,13 @@ const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescrip
         name: prescription.prescriptionName,
       }),
     // 薬を作ったら一覧を取り直す。隣の dispenseMutation は無効化しているのに
-    // こちらだけ抜けており、登録しても薬の画面に出てこなかった
+    // こちらだけ抜けており、登録しても薬の画面に出てこなかった。
+    // メンバー別の一覧は別のキーで持っているので、そちらも無効化する
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.medications.all });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.members.medications(prescription.memberId),
+      });
     },
   });
 

--- a/frontend/src/pages/member-detail/ui/PrescriptionList.tsx
+++ b/frontend/src/pages/member-detail/ui/PrescriptionList.tsx
@@ -96,6 +96,11 @@ const PrescriptionCard: React.FC<PrescriptionCardProps> = React.memo(({ prescrip
         memberId: prescription.memberId,
         name: prescription.prescriptionName,
       }),
+    // 薬を作ったら一覧を取り直す。隣の dispenseMutation は無効化しているのに
+    // こちらだけ抜けており、登録しても薬の画面に出てこなかった
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.medications.all });
+    },
   });
 
   const saveItemsMutation = useMutation({

--- a/frontend/src/pages/member-detail/ui/VaccinationForm.tsx
+++ b/frontend/src/pages/member-detail/ui/VaccinationForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import type { Member } from "@/shared/api";
+import React, { useState } from 'react';
+import type { Member } from '@/shared/api';
 
 export interface VaccinationFormData {
   memberId: string;
@@ -23,20 +23,29 @@ interface VaccinationFormProps {
 }
 
 const toDateInput = (value: string | null | undefined): string => {
-  if (!value) return "";
-  return new Date(value).toISOString().split("T")[0];
+  if (!value) return '';
+  return new Date(value).toISOString().split('T')[0];
 };
 
-const todayInput = (): string => new Date().toISOString().split("T")[0];
+const todayInput = (): string => new Date().toISOString().split('T')[0];
 
-export const VaccinationForm: React.FC<VaccinationFormProps> = ({ members, onSubmit, onCancel, initialData }) => {
-  const [memberId, setMemberId] = useState(initialData?.memberId || (members.length === 1 ? members[0].id : ""));
-  const [vaccineName, setVaccineName] = useState(initialData?.vaccineName || "");
+export const VaccinationForm: React.FC<VaccinationFormProps> = ({
+  members,
+  onSubmit,
+  onCancel,
+  initialData,
+}) => {
+  const [memberId, setMemberId] = useState(
+    initialData?.memberId || (members.length === 1 ? members[0].id : ''),
+  );
+  const [vaccineName, setVaccineName] = useState(initialData?.vaccineName || '');
   const [vaccinatedAt, setVaccinatedAt] = useState(
     initialData?.vaccinatedAt ? toDateInput(initialData.vaccinatedAt) : todayInput(),
   );
-  const [nextScheduledDate, setNextScheduledDate] = useState(toDateInput(initialData?.nextScheduledDate));
-  const [notes, setNotes] = useState(initialData?.notes || "");
+  const [nextScheduledDate, setNextScheduledDate] = useState(
+    toDateInput(initialData?.nextScheduledDate),
+  );
+  const [notes, setNotes] = useState(initialData?.notes || '');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,34 +60,38 @@ export const VaccinationForm: React.FC<VaccinationFormProps> = ({ members, onSub
     });
 
     if (!initialData) {
-      setVaccineName("");
+      setVaccineName('');
       setVaccinatedAt(todayInput());
-      setNextScheduledDate("");
-      setNotes("");
+      setNextScheduledDate('');
+      setNotes('');
     }
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label htmlFor="vacc-member" className="block text-sm font-medium text-ink-700 mb-1">
-          メンバー
-        </label>
-        <select
-          id="vacc-member"
-          value={memberId}
-          onChange={(e) => setMemberId(e.target.value)}
-          className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-          required
-        >
-          <option value="">選択してください</option>
-          {members.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-      </div>
+      {/* 候補が1人しかいないなら選ばせる意味が無い。
+          メンバー詳細から開いたフォームは常にその1人に限られる */}
+      {members.length > 1 && (
+        <div>
+          <label htmlFor="vacc-member" className="block text-sm font-medium text-ink-700 mb-1">
+            メンバー
+          </label>
+          <select
+            id="vacc-member"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            className="w-full px-3 py-2 border border-primary-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            required
+          >
+            <option value="">選択してください</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div>
         <label htmlFor="vacc-name" className="block text-sm font-medium text-ink-700 mb-1">
@@ -141,7 +154,7 @@ export const VaccinationForm: React.FC<VaccinationFormProps> = ({ members, onSub
           type="submit"
           className="flex-1 bg-primary text-white py-2 px-4 rounded-lg hover:bg-primary-dark transition-colors font-medium"
         >
-          {initialData ? "更新する" : "登録する"}
+          {initialData ? '更新する' : '登録する'}
         </button>
         {onCancel && (
           <button

--- a/frontend/src/pages/member-report/ui/MemberReport.tsx
+++ b/frontend/src/pages/member-report/ui/MemberReport.tsx
@@ -1,4 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { getMemberAge } from "@/entities/member";
+import { ALLERGY_SEVERITY_LABELS } from "@/entities/allergy";
 import { Link, useParams } from "react-router";
 import { ChevronLeft, Printer } from "lucide-react";
 import { api } from "@/shared/api";
@@ -19,12 +21,6 @@ const memberTypeLabels: Record<string, string> = {
   pet: "ペット",
 };
 
-const severityLabels: Record<string, string> = {
-  mild: "軽度",
-  moderate: "中等度",
-  severe: "重度",
-};
-
 function formatDate(value: string | null | undefined): string {
   if (!value) return "-";
   const d = new Date(value);
@@ -37,14 +33,8 @@ function formatDate(value: string | null | undefined): string {
 }
 
 function calcAge(birthDate: string | null): string {
-  if (!birthDate) return "-";
-  const d = new Date(birthDate);
-  if (Number.isNaN(d.getTime())) return "-";
-  const now = new Date();
-  let age = now.getFullYear() - d.getFullYear();
-  const m = now.getMonth() - d.getMonth();
-  if (m < 0 || (m === 0 && now.getDate() < d.getDate())) age -= 1;
-  return `${age}歳`;
+  const age = getMemberAge(birthDate);
+  return age === null ? "-" : `${age}歳`;
 }
 
 export default function MemberReport() {
@@ -231,7 +221,7 @@ export default function MemberReport() {
                 <li key={a.id} className="flex flex-wrap items-baseline gap-x-2">
                   <span className="font-medium">{a.allergenName}</span>
                   <span className="text-ink-500">
-                    （{severityLabels[a.severity] ?? a.severity}）
+                    （{ALLERGY_SEVERITY_LABELS[a.severity] ?? a.severity}）
                   </span>
                   {a.symptoms ? (
                     <span className="text-ink-500">{a.symptoms}</span>

--- a/frontend/src/pages/members/ui/MemberList.tsx
+++ b/frontend/src/pages/members/ui/MemberList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getMemberAge } from "@/entities/member";
 import { Link } from "react-router";
 import { Pill, Pencil } from "lucide-react";
 import type { Member } from "@/shared/api";
@@ -19,18 +20,6 @@ const memberTypeLabels: Record<string, string> = {
   human: "家族",
   pet: "ペット",
 };
-
-function getAge(birthDate: string | null): number | null {
-  if (!birthDate) return null;
-  const today = new Date();
-  const birth = new Date(birthDate);
-  let age = today.getFullYear() - birth.getFullYear();
-  const monthDiff = today.getMonth() - birth.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
-    age--;
-  }
-  return age;
-}
 
 export const MemberList: React.FC<MemberListProps> = ({
   members,
@@ -75,7 +64,7 @@ export interface MemberCardProps {
 }
 
 const MemberCard: React.FC<MemberCardProps> = React.memo(({ member, onDelete, onEdit, summary }) => {
-  const age = getAge(member.birthDate);
+  const age = getMemberAge(member.birthDate);
   const typeLabel = memberTypeLabels[member.memberType] ?? member.memberType;
 
   return (


### PR DESCRIPTION
## Summary

FSD 移行の作業中に見つけた5件。いずれも**移行前から存在していた**もので、移行とは独立に直せるため先に出す。

### 1. 不正な生年月日で「NaN歳」と表示される

`getAge` が `Date` を検証せず `NaN` を返していた。呼び出し側は `age !== null` で分岐するため、**NaN はその判定を素通りする**。

`entities/member` に集約し、読めない値と未来日は `null` を返す。未来日を負の年齢で出さないのは、入力ミスを「-1歳」と見せるより出さない方がよいため。同じ計算が印刷レポート側に別実装（NaN ガードあり）で存在していたので、そちらも共通実装に寄せた。

### 2. アレルギーの重症度が画面ごとに割れていた

| 画面 | moderate の表記 |
|---|---|
| 一覧・入力フォーム | 中度 |
| 印刷レポート | 中等度 |

同じデータが違う言葉で出ると、**医療者に見せる場面で食い違いとして扱われる**。医学的に正式で、既に印刷物が使っていた「中等度」へ統一した。表に無い値が来ても画面が壊れないようにしてある。

### 3. 処方箋からの薬登録で一覧が古いまま残る

隣の「調剤」は `medications` を無効化しているのに、「この処方箋からお薬を登録」だけ `onSuccess` が無かった。登録しても薬の画面に出てこない。

### 4. スケジュールのローディング表示に到達しない

```tsx
{memberSchedules.length > 0 && (
  ... {schedulesLoading ? <LoadingSpinner /> : ...}
```

読み込み中は `memberSchedules` が空なので外側で閉じられ、内側のスピナーは**到達不能なデッドコード**だった。

### 5. 選択肢が1つのメンバー選択が残っていた

メンバー詳細から開くフォームは常にその1人に限られるのに、5つのフォームすべてが選択肢1つのセレクトを描画していた。フォーム側は既に自動選択しているので、1件のときは出さない。

## 検証

型チェック・lint・テスト34件（新規13件）・本番ビルドすべて通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 生年月日から満年齢を正確に表示できるようになりました。
  - アレルギー重症度の表示名と選択肢を統一しました。
  - メンバーが1人の場合、各種入力フォームのメンバー選択欄を自動的に非表示にします。
- **改善**
  - 薬の登録後、服薬一覧が自動更新されるようになりました。
  - 未設定・不正な生年月日でも適切に表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->