### PR TITLE
fix(frontend): CSS検証のセレクタが2要素に一致していた

### DIFF
--- a/frontend/e2e/css-applied.spec.ts
+++ b/frontend/e2e/css-applied.spec.ts
@@ -6,7 +6,8 @@ import { expect, test } from "@playwright/test";
 test("ログイン画面にスタイルが当たっている", async ({ page }) => {
   await page.goto("/login");
 
-  const button = page.getByRole("button", { name: "ログイン" });
+  // 「Googleでログイン」も名前に一致するため、完全一致で絞る
+  const button = page.getByRole("button", { name: "ログイン", exact: true });
   await expect(button).toBeVisible();
 
   const style = await button.evaluate((el) => {


### PR DESCRIPTION
## Summary

#1189 で追加した CSS 検証の E2E が、本番に対して実行すると落ちていた。

```
Error: strict mode violation: getByRole('button', { name: 'ログイン' })
       resolved to 2 elements
```

「ログイン」で引くと「Googleでログイン」にも一致する。`exact: true` で絞った。

**スタイル自体は正常。** セレクタだけの問題で、修正後は本番・ローカルとも通過する。