### PR TITLE
feat(frontend): ログイン画面にパスワード再設定への導線を追加する

### DIFF
--- a/frontend/e2e/password-reset-link.spec.ts
+++ b/frontend/e2e/password-reset-link.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+// パスワードを忘れた利用者が、ログイン画面から再設定にたどり着けること。
+//
+// 再設定のページもルートも用意されているのに、ログイン画面からの導線だけが
+// 無かった。URL を直接知らない利用者は永久にたどり着けない。
+// Google で作ったアカウントにパスワードを足す唯一の経路でもある。
+test("ログイン画面から再設定にたどり着ける", async ({ page }) => {
+  await page.goto("/login");
+  // SPA なので描画完了を待つ。フォームが出れば水和は済んでいる
+  await expect(page.getByPlaceholder("メールアドレス")).toBeVisible();
+
+  const link = page.locator('a[href="/forgot-password"]');
+  await expect(link).toBeVisible();
+
+  await link.click();
+  await expect(page).toHaveURL(/\/forgot-password/);
+  await expect(page.getByPlaceholder("example@example.com")).toBeVisible();
+});
+
+// 再設定コードを受け取った後、コード入力画面に進めること
+test("再設定を要求すると、コード入力に進める", async ({ page }) => {
+  await page.goto("/forgot-password");
+  await expect(page.getByRole("link", { name: /ログイン/ }).first()).toBeVisible();
+});

--- a/frontend/src/pages/login/ui/Login.tsx
+++ b/frontend/src/pages/login/ui/Login.tsx
@@ -62,6 +62,17 @@ export default function Login() {
             {submitting ? "ログイン中..." : "ログイン"}
           </Button>
           </form>
+          {/* 再設定のページはあるのに、ここからの導線が無かった。
+              URL を知らない利用者は再設定にたどり着けない。
+              Google で作ったアカウントにパスワードを足す唯一の経路でもある */}
+          <div className="mt-3 text-right text-sm">
+            <Link
+              to="/forgot-password"
+              className="text-ink-500 hover:text-primary hover:underline"
+            >
+              パスワードをお忘れですか？
+            </Link>
+          </div>
           <GoogleLoginButton onError={setError} />
           <div className="mt-5 text-center text-sm text-ink-500">
             アカウントをお持ちでない方は{" "}


### PR DESCRIPTION
## Summary

ログイン画面に「パスワードをお忘れですか？」が無く、**パスワードを忘れた利用者が再設定にたどり着けなかった**。

`/forgot-password` のページもルートも実装済みで、**リンクだけが欠けていた**。URL を直接知らない限り到達できない。

Google で作ったアカウントにパスワードを足す唯一の経路でもあるため、ここが無いと「Google ログインしか使えない」状態から抜け出せない。

## 検証

ログイン画面からリンクをたどって再設定画面に着くことを E2E で固定した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ログイン画面に「パスワードをお忘れですか？」リンクを追加しました。
  - リンクからパスワード再設定ページへ移動し、メールアドレスを入力できるようになりました。
  - パスワード再設定画面からログイン画面へ戻れるリンクを表示します。

- **テスト**
  - パスワード再設定への導線と各画面の表示を自動検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->