### PR TITLE
fix(frontend): 狭い画面で薬名が一文字ずつ縦積みになるのを直す

### DIFF
--- a/frontend/e2e/medication-card-layout.spec.ts
+++ b/frontend/e2e/medication-card-layout.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+// スマホ幅で薬カードが崩れないこと。
+//
+// flex-1 は既定で min-width:auto なので縮まない。右の操作列に押されて
+// 薬名の列が幅ゼロ近くまで潰れ、一文字ずつ改行されていた。
+test.use({ viewport: { width: 390, height: 844 } });
+
+test("狭い画面で薬名が縦積みにならない", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByPlaceholder("メールアドレス").fill("ui2@example.test");
+  await page.getByPlaceholder("パスワード").fill("password123");
+  await page.getByRole("button", { name: "ログイン", exact: true }).click();
+  await expect(page).toHaveURL(/\/$|\/home/, { timeout: 15000 });
+
+  await page.goto("/medications");
+  const name = page.getByText("ステロップ").first();
+  await expect(name).toBeVisible({ timeout: 15000 });
+
+  const box = await name.boundingBox();
+  expect(box).not.toBeNull();
+
+  // 5文字が縦に積まれると高さが 100px を超え、幅は 30px 程度になる。
+  // 1行で収まっていれば高さは 1行分、幅は文字数ぶん出る
+  expect(box!.height, `薬名が縦積みになっている (h=${box!.height})`).toBeLessThan(60);
+  expect(box!.width, `薬名の幅が潰れている (w=${box!.width})`).toBeGreaterThan(60);
+});
+
+// 広い画面では従来どおり横並びのままであること
+test.describe("広い画面", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("薬名と操作が同じ行に並ぶ", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByPlaceholder("メールアドレス").fill("ui2@example.test");
+    await page.getByPlaceholder("パスワード").fill("password123");
+    await page.getByRole("button", { name: "ログイン", exact: true }).click();
+    await expect(page).toHaveURL(/\/$|\/home/, { timeout: 15000 });
+
+    await page.goto("/medications");
+    const name = page.getByText("ステロップ").first();
+    await expect(name).toBeVisible({ timeout: 15000 });
+
+    const nameBox = await name.boundingBox();
+    const del = page.getByRole("button", { name: "削除" }).first();
+    const delBox = await del.boundingBox();
+
+    // 縦積みになっていれば、削除ボタンは薬名よりずっと下に来る
+    expect(Math.abs(nameBox!.y - delBox!.y), "広い画面で行が分かれている").toBeLessThan(60);
+  });
+});

--- a/frontend/src/entities/medication/ui/MedicationList.tsx
+++ b/frontend/src/entities/medication/ui/MedicationList.tsx
@@ -257,7 +257,7 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
           isDimmed ? " opacity-60" : ""
         }`}
       >
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-y-2">
           {(onMoveUp || onMoveDown) && (
             <div className="flex flex-col mr-2 -my-1">
               <button
@@ -282,7 +282,9 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
               </button>
             </div>
           )}
-          <div className="flex-1">
+          {/* min-w-0 が無いと flex-1 は min-width:auto のままで縮まない。
+              狭い画面で右の操作列に押され、薬名が一文字ずつ改行されていた */}
+          <div className="w-full min-w-0 basis-full sm:w-auto sm:flex-1 sm:basis-0">
             <div className="flex items-center flex-wrap gap-x-2 gap-y-1">
               <Pill size={20} className="text-primary-600" />
               <p className="font-semibold text-ink-800">{displayInfo.name}</p>
@@ -313,7 +315,9 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
               )}
             </div>
           </div>
-          <div className="flex items-center space-x-2">
+          {/* 操作は縮めない。縮むとボタンの文字が縦積みになる。
+              代わりに狭い画面では折り返して次の行へ逃がす */}
+          <div className="flex w-full shrink-0 flex-wrap items-center justify-end gap-2 sm:ml-2 sm:w-auto">
             {onEdit && (
               <button
                 onClick={() => onEdit(medication)}


### PR DESCRIPTION
## Summary

スマホでお薬一覧を開くと、薬名が**一文字ずつ縦に積まれて**いた。

薬カードは「薬名の列」と「操作ボタンの列」を横に並べている。名前側の `flex-1` は**既定で `min-width: auto`** なので縮まないが、操作列も折り返さず幅を占有するため、狭い画面では名前の列が潰れる。

実測すると、**親は 324px あるのに名前の列は 26px** しか取れていなかった。

## 変更

- 名前の列に `min-w-0` を与えて縮められるようにする
- 狭い画面では2列を上下に分け、`sm` 以上では従来どおり横並びにする

`min-w-0` だけでは足りなかった。操作列が折り返さない限り名前の列に幅が回らないため、基準幅も切り替えている。

## 検証

| 幅 | 期待 | 結果 |
|---|---|---|
| 390px（スマホ） | 縦積みにならない | 高さ 120px → 1行に収まる |
| 1280px | 同じ行に並ぶ | 名前と削除ボタンが同じ行 |

両方を E2E で固定した。