### PR TITLE
feat(frontend): 停止中のスケジュールを見えるようにし、その場で再開できるようにする

### DIFF
--- a/frontend/e2e/paused-schedule.spec.ts
+++ b/frontend/e2e/paused-schedule.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+// 停止中のスケジュールが画面から分かり、その場で再開できること。
+//
+// 停止中は「今日の予定」に出ない。画面に区別が無かったため、薬は
+// 登録されているのに予定に現れない状態から利用者が自力で戻せなかった。
+const MEMBER_ID = "ece70a59-0144-4632-aebb-e38fc53a24e7";
+
+test("停止中と分かり、その場で再開できる", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByPlaceholder("メールアドレス").fill("ui@example.test");
+  await page.getByPlaceholder("パスワード").fill("password123");
+  await page.getByRole("button", { name: "ログイン", exact: true }).click();
+  await expect(page).toHaveURL(/\/$|\/home/, { timeout: 15000 });
+
+  await page.goto(`/members/${MEMBER_ID}/medications`);
+
+  // 停止していることが分かる
+  await expect(page.getByText("停止中").first()).toBeVisible({ timeout: 15000 });
+  await expect(page.getByText(/件が停止中/)).toBeVisible();
+
+  // その場で再開できる
+  await page.getByRole("button", { name: "再開" }).click();
+  await expect(page.getByRole("button", { name: "停止" })).toBeVisible({ timeout: 15000 });
+
+  // 再開したら今日の予定に出る
+  await page.goto("/");
+  await expect(page.getByText("クラリチン").first()).toBeVisible({ timeout: 15000 });
+});

--- a/frontend/src/features/manage-schedules/api/mutations.test.tsx
+++ b/frontend/src/features/manage-schedules/api/mutations.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryWrapper } from "@/shared/test/queryWrapper";
+import { queryKeys } from "@/shared/api";
+import { useSetScheduleEnabled } from "./mutations";
+
+const patch = vi.fn().mockResolvedValue({ id: "s-1" });
+
+vi.mock("@/shared/api", async () => {
+  const actual = await vi.importActual<typeof import("@/shared/api")>("@/shared/api");
+  return { ...actual, api: { patch: (...a: unknown[]) => patch(...a) } };
+});
+
+const covers = (invalidated: unknown[][], key: readonly unknown[]) =>
+  invalidated.some((k) => key.every((part, i) => Object.is(part, k[i])));
+
+describe("スケジュールの再開と停止", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("再開すると isEnabled を true にして送る", async () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSetScheduleEnabled(), { wrapper });
+
+    result.current.mutate({ id: "s-1", isEnabled: true });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(patch).toHaveBeenCalledWith("/schedules/s-1", { isEnabled: true });
+  });
+
+  it("停止すると isEnabled を false にして送る", async () => {
+    const { wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSetScheduleEnabled(), { wrapper });
+
+    result.current.mutate({ id: "s-1", isEnabled: false });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(patch).toHaveBeenCalledWith("/schedules/s-1", { isEnabled: false });
+  });
+
+  // 再開したら「今日の予定」にも出るようになる。
+  // スケジュールだけ取り直しても、ホームは別のキーで持っているので変わらない
+  it("スケジュールと今日の予定の両方を取り直す", async () => {
+    const { wrapper, invalidated } = createQueryWrapper();
+    const { result } = renderHook(() => useSetScheduleEnabled(), { wrapper });
+
+    result.current.mutate({ id: "s-1", isEnabled: true });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(covers(invalidated, queryKeys.schedules.all)).toBe(true);
+    expect(covers(invalidated, queryKeys.schedules.today)).toBe(true);
+  });
+});

--- a/frontend/src/features/manage-schedules/api/mutations.ts
+++ b/frontend/src/features/manage-schedules/api/mutations.ts
@@ -34,3 +34,25 @@ export function useDeleteSchedule() {
     onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.schedules.all }),
   });
 }
+
+/**
+ * スケジュールの再開・停止。
+ *
+ * 停止したスケジュールは「今日の予定」に出なくなる。画面に区別が
+ * 出ていなかったため、薬は登録されているのに予定に出ない状態から
+ * 利用者が自力で復帰できなかった。ここを操作できるようにする。
+ *
+ * 今日の予定は別のキーで持っているので、そちらも取り直す。
+ * 片方だけだと、再開しても当日の一覧に現れない。
+ */
+export function useSetScheduleEnabled() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, isEnabled }: { id: string; isEnabled: boolean }) =>
+      api.patch<Schedule>(`/schedules/${id}`, { isEnabled }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.all });
+      qc.invalidateQueries({ queryKey: queryKeys.schedules.today });
+    },
+  });
+}

--- a/frontend/src/features/manage-schedules/index.ts
+++ b/frontend/src/features/manage-schedules/index.ts
@@ -1,3 +1,3 @@
 // features/manage-schedules の Public API。
-export { useCreateSchedule, useDeleteSchedule } from "./api/mutations";
+export { useCreateSchedule, useDeleteSchedule, useSetScheduleEnabled } from "./api/mutations";
 export type { CreateScheduleBody } from "./api/mutations";

--- a/frontend/src/pages/member-medications/ui/MemberMedications.tsx
+++ b/frontend/src/pages/member-medications/ui/MemberMedications.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useCreateMedicationRaw, useDeleteMedication } from "@/features/manage-medications";
-import { useCreateSchedule, useDeleteSchedule } from "@/features/manage-schedules";
+import { useCreateSchedule, useDeleteSchedule, useSetScheduleEnabled } from "@/features/manage-schedules";
 import { useSchedules } from "@/entities/schedule";
 import { useMemberMedications } from "@/entities/medication";
 import { useNavigate, useParams } from "react-router";
@@ -45,6 +45,10 @@ export default function MemberMedications() {
     [allSchedules, memberId],
   );
 
+  // 停止中は「今日の予定」に出ない。薬は登録されているのに予定に現れない
+  // 状態になるので、件数を出して気づけるようにする
+  const pausedCount = memberSchedules.filter((s) => !s.isEnabled).length;
+
   const medicationName = (id: string) =>
     medications.find((m) => m.id === id)?.name ?? "";
 
@@ -65,6 +69,7 @@ export default function MemberMedications() {
     setScheduleError(null);
   });
   const deleteScheduleMutation = useDeleteSchedule();
+  const setEnabledMutation = useSetScheduleEnabled();
 
   // 作成の失敗はこの画面のフォーム内に出す。features 側で固定すると
   // 画面ごとの出し分けができない
@@ -274,20 +279,45 @@ export default function MemberMedications() {
 
         {memberSchedules.length > 0 && (
           <div id="schedules" className="mt-6">
-            <h2 className="text-sm font-medium text-ink-600 mb-3">スケジュール管理</h2>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-medium text-ink-600">スケジュール管理</h2>
+              {pausedCount > 0 && (
+                <span className="text-xs text-amber-700">
+                  {pausedCount}件が停止中（今日の予定に出ません）
+                </span>
+              )}
+            </div>
             {schedulesLoading ? (
               <LoadingSpinner />
             ) : (
               <div className="space-y-2">
                 {memberSchedules.map((schedule) => (
-                  <Card key={schedule.id} className="flex items-center justify-between">
+                  <Card
+                    key={schedule.id}
+                    className={`flex items-center justify-between${schedule.isEnabled ? "" : " bg-ink-50"}`}
+                  >
                     <div className="flex items-center gap-3">
-                      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+                      <span
+                        className={`flex h-9 w-9 items-center justify-center rounded-full ${
+                          schedule.isEnabled
+                            ? "bg-primary/10 text-primary"
+                            : "bg-ink-100 text-ink-400"
+                        }`}
+                      >
                         <Clock className="h-5 w-5" />
                       </span>
                       <div>
-                        <p className="font-medium text-ink-800">
+                        <p
+                          className={`font-medium ${
+                            schedule.isEnabled ? "text-ink-800" : "text-ink-500"
+                          }`}
+                        >
                           {medicationName(schedule.medicationId)}
+                          {!schedule.isEnabled && (
+                            <span className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-normal text-amber-800">
+                              停止中
+                            </span>
+                          )}
                         </p>
                         <p className="text-xs text-ink-500">
                           {schedule.scheduledTime}
@@ -297,13 +327,31 @@ export default function MemberMedications() {
                         </p>
                       </div>
                     </div>
-                    <button
-                      onClick={() => deleteScheduleMutation.mutate(schedule.id)}
-                      className="text-ink-400 hover:text-red-500"
-                      aria-label="削除"
-                    >
-                      <Trash2 className="h-5 w-5" />
-                    </button>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() =>
+                          setEnabledMutation.mutate({
+                            id: schedule.id,
+                            isEnabled: !schedule.isEnabled,
+                          })
+                        }
+                        disabled={setEnabledMutation.isPending}
+                        className={`rounded-full px-3 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+                          schedule.isEnabled
+                            ? "bg-ink-100 text-ink-600 hover:bg-ink-200"
+                            : "bg-primary text-white hover:bg-primary-dark"
+                        }`}
+                      >
+                        {schedule.isEnabled ? "停止" : "再開"}
+                      </button>
+                      <button
+                        onClick={() => deleteScheduleMutation.mutate(schedule.id)}
+                        className="text-ink-400 hover:text-red-500"
+                        aria-label="削除"
+                      >
+                        <Trash2 className="h-5 w-5" />
+                      </button>
+                    </div>
                   </Card>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

停止中（`isEnabled = false`）のスケジュールは「今日の予定」に出ないが、**画面のどこにもその区別が出ていなかった**。

結果、薬は一覧にあるのに予定に現れない状態から、利用者が自力で戻す手段がなかった。実際に、飲む必要のある薬のスケジュールが停止されたまま気づかれずにいた。

## 変更

- 停止中の行に「**停止中**」バッジを出し、色を落とす
- 見出しに「**N件が停止中（今日の予定に出ません）**」と件数を出す
- 各行に「**再開 / 停止**」ボタンを置き、その場で切り替えられるようにする

再開時はスケジュールと**今日の予定の両方**のキャッシュを取り直す。片方だけだと、再開しても当日の一覧に現れない。

## 検証

本番と同じ状態をローカルで再現した。

```
停止中スケジュールを用意
今日の予定の件数: 0    ← 薬はあるのに出ない
```

ブラウザで「停止中」と分かること、その場で再開できること、再開後に今日の予定へ出ることを E2E で固定した。

API（`PATCH /schedules/:id`）は元から `isEnabled` を受け付けていたので、バックエンドの変更は無い。