### PR TITLE
feat(frontend): 今日の予定に出ない薬を一覧の先頭で知らせる

### DIFF
--- a/frontend/e2e/unscheduled-medications.spec.ts
+++ b/frontend/e2e/unscheduled-medications.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+// 予定に出ない薬を一覧から気づけること。
+//
+// 停止中や時刻未設定の薬は「今日の予定」に出ない。カード単位のバッジだけだと
+// 薬が増えるほど見落とすので、先頭でまとめて知らせる。
+test.use({ viewport: { width: 390, height: 844 } });
+
+test("予定に出ない薬が先頭でまとめて分かる", async ({ page }) => {
+  await page.goto("/login");
+  await page.getByPlaceholder("メールアドレス").fill("ui2@example.test");
+  await page.getByPlaceholder("パスワード").fill("password123");
+  await page.getByRole("button", { name: "ログイン", exact: true }).click();
+  await expect(page).toHaveURL(/\/$|\/home/, { timeout: 15000 });
+
+  await page.goto("/medications");
+  await expect(page.getByText("ステロップ").first()).toBeVisible({ timeout: 15000 });
+
+  // 何件がなぜ出ないのかが分かる
+  const banner = page.getByText(/件の薬は今日の予定に出ません/);
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("ステロップ");
+
+  // 時刻のバッジも停止中と分かる
+  await expect(page.getByText("停止中").first()).toBeVisible();
+});

--- a/frontend/src/entities/medication/ui/MedicationList.tsx
+++ b/frontend/src/entities/medication/ui/MedicationList.tsx
@@ -16,6 +16,8 @@ export interface MedicationScheduleInfo {
   scheduleId: string;
   time: string;
   label: string; // "毎日", "月・水・金", "21日毎" etc.
+  /** 停止中は「今日の予定」に出ない。出ていないのに時刻だけ見えると誤解する */
+  isEnabled: boolean;
 }
 
 export interface MedicationScheduleMap {
@@ -117,8 +119,26 @@ export const MedicationList: React.FC<MedicationListProps> = ({
     }, 400);
   };
 
+  // 予定が1件も無い、または全部止まっている薬は「今日の予定」に出てこない。
+  // カード単位のバッジだけだと、薬が多いほど見落とす。先頭でまとめて知らせる
+  const unscheduled = visibleList.filter((vm) => {
+    const list = scheduleMap?.[vm.medication.id];
+    return !list || list.length === 0 || list.every((s) => !s.isEnabled);
+  });
+
   return (
     <div className="space-y-3">
+      {unscheduled.length > 0 && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          <AlertCircle size={16} className="mt-0.5 shrink-0" />
+          <p>
+            <span className="font-medium">{unscheduled.length}件</span>
+            の薬は今日の予定に出ません（
+            {unscheduled.map((vm) => vm.medication.name).join("、")}）。
+            時刻の設定か、停止中の解除が必要です。
+          </p>
+        </div>
+      )}
       {visibleList.map((vm, index) => (
         <MedicationCard
           key={vm.medication.id}
@@ -375,13 +395,17 @@ const MedicationCard: React.FC<MedicationCardProps> = React.memo(
           {schedules && schedules.length > 0 ? (
             <div className="flex flex-wrap gap-1.5">
               {schedules.map((s) => {
-                const chipClass =
-                  "inline-flex items-center space-x-1 px-2 py-0.5 bg-primary-50 text-primary-700 rounded-full text-xs";
+                const chipClass = s.isEnabled
+                  ? "inline-flex items-center space-x-1 px-2 py-0.5 bg-primary-50 text-primary-700 rounded-full text-xs"
+                  : "inline-flex items-center space-x-1 px-2 py-0.5 bg-amber-50 text-amber-700 rounded-full text-xs";
                 const content = (
                   <>
                     <Clock size={10} />
                     <span>{s.time}</span>
-                    <span className="text-primary-500">{s.label}</span>
+                    <span className={s.isEnabled ? "text-primary-500" : "text-amber-600"}>
+                      {s.label}
+                    </span>
+                    {!s.isEnabled && <span className="font-medium">停止中</span>}
                   </>
                 );
                 return scheduleEditUrl ? (

--- a/frontend/src/widgets/member-medications/ui/MemberMedications.tsx
+++ b/frontend/src/widgets/member-medications/ui/MemberMedications.tsx
@@ -63,6 +63,7 @@ export function MemberMedications({ member, categoryFilter }: MemberMedicationsP
         scheduleId: s.id,
         time: s.scheduledTime,
         label: getScheduleLabel(s.daysOfWeek, s.intervalDays),
+        isEnabled: s.isEnabled,
       });
     }
     return map;


### PR DESCRIPTION
## Summary

薬は登録されているのに「今日の予定」に出てこない状態が、**一覧からは分からなかった**。

時刻のバッジは `daysOfWeek` しか見ておらず、**停止中でも「08:00 毎日」と表示される**。むしろ「出ていて当然」に見えるため、気づく手がかりが無かった。

## 変更

**バッジに停止中を反映** — 色と文言で区別する。「08:00 毎日 停止中」

**先頭でまとめて知らせる** — 予定が1件も無い、または全部停止している薬を検出し、件数・薬名・理由を出す。

```
⚠ 1件の薬は今日の予定に出ません（ステロップ）。
  時刻の設定か、停止中の解除が必要です。
```

カード単位のバッジだけでは、薬が増えるほど見落とす。実際に、飲む必要のある薬が予定に出ないまま気づかれずにいた。

## 検証

停止中を考慮しない判定（`list.length === 0` のみ）に戻すと検出できなくなることを確認した。

```
== 停止中を考慮しない状態 ==
✘ 予定に出ない薬が先頭でまとめて分かる
  Error: element(s) not found
```